### PR TITLE
Make rummager app ID and router paths configurable for whitehall.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,21 +19,23 @@ namespace :router do
     @logger.level = Logger::DEBUG
 
     @router = Router::Client.new :logger => @logger
+    @application_id = ENV["RUMMAGER_APPLICATION_ID"] || "search"
   end
 
   task :register_application => :router_environment do
     platform = ENV['FACTER_govuk_platform']
-    url = "search.#{platform}.alphagov.co.uk/"
-    @logger.info "Registering application..."
-    @router.applications.update application_id: "search", backend_url: url
+    url = "#{@application_id}.#{platform}.alphagov.co.uk/"
+    @logger.info %{Registering application "#{application_id}"...}
+    @router.applications.update application_id: @application_id, backend_url: url
   end
 
   task :register_routes => [ :router_environment ] do
-    @logger.info "Registering prefix /search and /autocomplete"
-    @router.routes.update application_id: "search", route_type: :prefix,
-      incoming_path: "/search"
-    @router.routes.update application_id: "search", route_type: :prefix,
-      incoming_path: "/autocomplete"
+    path_prefix = ENV["RUMMAGER_PATH_PREFIX"]
+    @logger.info "Registering prefix #{path_prefix}/search and #{path_prefix}/autocomplete"
+    @router.routes.update application_id: @application_id, route_type: :prefix,
+      incoming_path: "#{path_prefix}/search"
+    @router.routes.update application_id: @application_id, route_type: :prefix,
+      incoming_path: "#{path_prefix}/autocomplete"
   end
 
   desc "Register search application and routes with the router (run this task on server in cluster)"


### PR DESCRIPTION
The whitehall app needs to run a separate instance of Rummager (whitehall-rummager in alphagov-deployment) and this needs to register paths with a different prefix with the router to discriminate them from the citizen search paths. Also it needs to register these paths against a different backend URL, i.e. the one for the whitehall instance of Rummager.

See alphagov/alphagov-deployment@806185123dfb751e546fd50129aa17adb6691592 for the capistrano task that makes use of the environment variables in this commit.

@craigw suggested in Campfire that Rummager shouldn't be registering its backed URL using a public DNS entry. Does anyone have a recommendation for what it should use instead. Ideally I'd like to use the same mechanism for both citizen and whitehall instances of Rummager.
