### PR TITLE
Log in directory

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -20,7 +20,9 @@ require_relative 'helpers'
 require_relative 'config'
 
 def solr
-  @solr ||= SolrWrapper.new(DelSolr::Client.new(settings.solr), settings.recommended_format)
+  @solr ||= SolrWrapper.new(DelSolr::Client.new(settings.solr),
+                            settings.recommended_format,
+                            logger)
 end
 
 helpers do

--- a/config.ru
+++ b/config.ru
@@ -9,9 +9,13 @@ Bundler.require(:default, ENV['RACK_ENV'])
 require "app"
 
 enable :logging, :dump_errors, :raise_errors
+in_development = ENV['RACK_ENV'] == 'development'
+if in_development
+  Dir.mkdir 'log' unless Dir.exists? 'log'
+end
 
-log = File.new("sinatra.log", "a")
-if ENV['RACK_ENV'] == "development"
+log = File.new("log/sinatra.log", "a")
+if in_development
   log.sync = true
 end
 STDOUT.reopen(log)

--- a/config.ru
+++ b/config.ru
@@ -6,10 +6,21 @@ require "env"
 require "bundler"
 Bundler.require(:default, ENV['RACK_ENV'])
 
+require "logger"
+
 require "app"
 
-enable :logging, :dump_errors, :raise_errors
 in_development = ENV['RACK_ENV'] == 'development'
+in_preview = ENV['FACTER_govuk_platform'] == 'preview'
+
+if in_development or in_preview
+  set :logging, Logger::INFO
+else
+  enable :logging
+end
+
+enable :dump_errors, :raise_errors
+
 if in_development
   Dir.mkdir 'log' unless Dir.exists? 'log'
 end

--- a/lib/solr_wrapper.rb
+++ b/lib/solr_wrapper.rb
@@ -6,8 +6,8 @@ class SolrWrapper
   HIGHLIGHT_END   = "HIGHLIGHT_END"
   COMMIT_WITHIN = 5 * 60 * 1000 # 5m in ms
 
-  def initialize(client, recommended_format)
-    @client, @recommended_format = client, recommended_format
+  def initialize(client, recommended_format, logger=Rack::NullLogger.instance)
+    @client, @recommended_format, @logger = client, recommended_format, logger
   end
 
   def add(documents)
@@ -107,7 +107,7 @@ private
   end
 
   def log(message)
-    Logger.new(STDOUT).info(message)
+    @logger.info(message)
     message
   end
 end

--- a/lib/solr_wrapper.rb
+++ b/lib/solr_wrapper.rb
@@ -1,12 +1,13 @@
 require "document"
 require "section"
+require "logger"
 
 class SolrWrapper
   HIGHLIGHT_START = "HIGHLIGHT_START"
   HIGHLIGHT_END   = "HIGHLIGHT_END"
   COMMIT_WITHIN = 5 * 60 * 1000 # 5m in ms
 
-  def initialize(client, recommended_format, logger=Rack::NullLogger.instance)
+  def initialize(client, recommended_format, logger=Logger.new('/dev/null'))
     @client, @recommended_format, @logger = client, recommended_format, logger
   end
 


### PR DESCRIPTION
Put Rummager’s log into the log directory (symlinked on preview/production) and pass loggers around rather than logging to STDOUT.
