### PR TITLE
Set dismax min match to 75%

### DIFF
--- a/lib/solr_wrapper.rb
+++ b/lib/solr_wrapper.rb
@@ -47,7 +47,8 @@ class SolrWrapper
       "hl.fl" => "description,indexable_content",
       "hl.simple.pre"  => HIGHLIGHT_START,
       "hl.simple.post" => HIGHLIGHT_END,
-      :limit  => 50
+      :limit  => 50,
+      :mm     => "75%"
     )) { |results, doc|
       doc.highlight = %w[ description indexable_content ].map { |f|
         results.highlights_for(doc.link, f)

--- a/test/unit/solr_wrapper_test.rb
+++ b/test/unit/solr_wrapper_test.rb
@@ -237,4 +237,9 @@ class SolrWrapperTest < Test::Unit::TestCase
     @client.expects(:optimize!)
     @wrapper.delete_all
   end
+
+  def test_should_limit_minimum_field_match_to_75_percent
+    @client.expects(:query).with(anything, has_entry(mm: "75%"))
+    @wrapper.search("foo")
+  end
 end


### PR DESCRIPTION
The Solr DisMax minimum match (mm) parameter defines how many
should match for the query to be valid. Previously this was
defaulting to 100% due to defaultOp being set to AND in the schema.xml.

The previous configuration was causing problems for queries with more
terms. For example with mm set to 100% the query "school term times"
does not return /school-term-holiday-dates because the term 'times' does
not appear in the document. Reducing the mm to 75% brings the document
up to position 2.
