### PR TITLE
Exclude frame options from Rack::Protection

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -32,6 +32,8 @@ set :format_name_alternatives, {
   "answer" => "Quick answers",
 }
 
+set :protection, :except => [:escaped_params, :frame_options]
+
 configure :development do
   set :protection, false
   use Slimmer::App, prefix: settings.router[:path_prefix], asset_host: settings.slimmer_asset_host


### PR DESCRIPTION
Right now we can't load any browse pages inside frames due to Rack::Protection sending the X-Frame-Options header, which is causing havoc in Review-o-matic. This commit should fix this.

Note we have to specify to also exclude "escaped_params" here as we're overriding the Sinatra default.
