### PR TITLE
Use latest version of slimmer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       builder (>= 2.1.2)
     crack (0.3.1)
     erubis (2.7.0)
-    gds-api-adapters (0.0.48)
+    gds-api-adapters (0.0.50)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -27,7 +27,7 @@ GEM
       kramdown (~> 0.13.3)
     htmlentities (4.3.1)
     i18n (0.6.0)
-    json (1.6.6)
+    json (1.7.3)
     kramdown (0.13.7)
     lrucache (0.1.3)
       PriorityQueue (~> 0.1.2)
@@ -35,7 +35,7 @@ GEM
     mocha (0.10.0)
       metaclass (~> 0.0.1)
     multi_json (1.0.4)
-    nokogiri (1.5.2)
+    nokogiri (1.5.5)
     null_logger (0.0.1)
     plek (0.1.23)
       builder
@@ -62,8 +62,8 @@ GEM
       tilt (~> 1.3, >= 1.3.3)
     sinatra-content-for (0.1)
       sinatra
-    slimmer (1.1.39)
-      gds-api-adapters (~> 0.0.33)
+    slimmer (1.1.43)
+      gds-api-adapters (>= 0.0.33, < 0.2.0)
       json
       nokogiri (~> 1.5.0)
       null_logger

--- a/config.rb
+++ b/config.rb
@@ -38,7 +38,7 @@ configure :development do
 end
 
 configure :production do
-  use Slimmer::App, prefix: settings.router[:path_prefix], asset_host: settings.slimmer_asset_host, cache_templates: true
+  use Slimmer::App, prefix: settings.router[:path_prefix], asset_host: settings.slimmer_asset_host, use_cache: true
 end
 
 configure :test do


### PR DESCRIPTION
This later version of slimmer includes the accidental change to the option
key name from `:cache_templates` to `:use_cache`, as explained
in this comment [1].

[1] https://github.com/alphagov/slimmer/commit/a901a0ee067dfd56740d516eaa78c0c9ccf0c997#commitcomment-1555481
