### PR TITLE
Parameters should be html escaped

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -50,8 +50,16 @@ get prefixed_path("/search.?:format?") do
     return erb(:no_search_term)
   end
 
+  @query = CGI.escapeHTML(@query)
+
+  if params["format_filter"] == "" or params["format_filter"].nil?
+    format_filter = params["format_filter"]
+  else
+    format_filter = CGI.escapeHTML(params["format_filter"])
+  end
+
   expires 3600, :public if @query.length < 20
-  @results = solr.search(@query, params["format_filter"])
+  @results = solr.search(@query, format_filter)
 
   if request.accept.include?("application/json") or params['format'] == 'json'
     content_type :json

--- a/app.rb
+++ b/app.rb
@@ -51,7 +51,7 @@ get prefixed_path("/search.?:format?") do
   end
 
   expires 3600, :public if @query.length < 20
-  @results = solr.search(@query, format_filter)
+  @results = solr.search(@query, params["format_filter"])
 
   if request.accept.include?("application/json") or params['format'] == 'json'
     content_type :json

--- a/app.rb
+++ b/app.rb
@@ -50,14 +50,6 @@ get prefixed_path("/search.?:format?") do
     return erb(:no_search_term)
   end
 
-  @query = CGI.escapeHTML(@query)
-
-  if params["format_filter"] == "" or params["format_filter"].nil?
-    format_filter = params["format_filter"]
-  else
-    format_filter = CGI.escapeHTML(params["format_filter"])
-  end
-
   expires 3600, :public if @query.length < 20
   @results = solr.search(@query, format_filter)
 

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -140,4 +140,12 @@ class SearchTest < IntegrationTest
       get "/search", {q: "bob"}
     end
   end
+
+  def test_should_not_allow_xss_vulnerabilites_as_search_terms
+    @solr.stubs(:search).returns([])
+    get "/search", {q: "1+\"><script+src%3Dhttp%3A%2F%2F88.151.219.231%2F4><%2Fscript>"}
+
+    assert_response_text "Sorry, we can’t find any results for"
+    assert_match "\"1+&amp;quot;&amp;gt;&amp;lt;script+src%3Dhttp%3A%2F%2F88.151.219.231%2F4&amp;gt;&amp;lt;%2Fscript&amp;gt;\"", last_response.body
+  end
 end

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -146,6 +146,6 @@ class SearchTest < IntegrationTest
     get "/search", {q: "1+\"><script+src%3Dhttp%3A%2F%2F88.151.219.231%2F4><%2Fscript>"}
 
     assert_response_text "Sorry, we can’t find any results for"
-    assert_match "\"1+&amp;quot;&amp;gt;&amp;lt;script+src%3Dhttp%3A%2F%2F88.151.219.231%2F4&amp;gt;&amp;lt;%2Fscript&amp;gt;\"", last_response.body
+    assert_match "\"1+&quot;&gt;&lt;script+src%3Dhttp%3A%2F%2F88.151.219.231%2F4&gt;&lt;%2Fscript&gt;\"", last_response.body
   end
 end

--- a/views/search.erb
+++ b/views/search.erb
@@ -5,7 +5,7 @@
       <fieldset>
         <legend class="visuallyhidden">Search gov.uk</legend>
         <label for="search-main" ><%= capped_search_set_size %> <%= pluralize("result", "results") %> found for </label>
-        <input type="search" name="q" value="<%= @query %>" id="search-main" /> <input type="submit" value="Search" class="button">
+        <input type="search" name="q" value="<%= h @query %>" id="search-main" /> <input type="submit" value="Search" class="button">
       </fieldset>
     </form>
 


### PR DESCRIPTION
Make sure that parameters passed through to rummager are correctly
HTML escaped to prevent XSS issues from appearing.
