### PR TITLE
Use Document as source of truth for humanized format name.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -55,7 +55,11 @@ get prefixed_path("/search.?:format?") do
 
   if request.accept.include?("application/json") or params['format'] == 'json'
     content_type :json
-    JSON.dump(@results.map { |r| r.to_hash.merge(highlight: r.highlight) })
+    JSON.dump(@results.map { |r| r.to_hash.merge(
+      highlight: r.highlight,
+      presentation_format: r.presentation_format,
+      humanized_format: r.humanized_format
+    ) })
   else
     @page_section = "Search"
     @page_section_link = "/search"
@@ -93,7 +97,10 @@ get prefixed_path("/autocomplete") do
   expires 3600, :public if query.length < 5
 
   results = solr.complete(query, params["format_filter"]) rescue []
-  JSON.dump(results.map { |r| r.to_hash })
+  JSON.dump(results.map { |r| r.to_hash.merge(
+    presentation_format: r.presentation_format,
+    humanized_format: r.humanized_format
+  ) })
 end
 
 get prefixed_path("/sitemap.xml") do

--- a/config.rb
+++ b/config.rb
@@ -26,10 +26,11 @@ set :boost_csv, "data/boosted_links.csv"
 set :format_order, ['transaction', 'answer', 'programme', 'guide']
 
 set :format_name_alternatives, {
-  "programme" => "Benefits and schemes",
+  "programme" => "Benefits & Credits",
   "transaction" => "Services",
   "local_transaction" => "Services",
-  "answer" => "Quick answers",
+  "place" => "Services",
+  "answer" => "Quick Answers"
 }
 
 configure :development do

--- a/helpers.rb
+++ b/helpers.rb
@@ -42,12 +42,6 @@ module Helpers
     @results.count == 1 ? singular : plural
   end
 
-  def formatted_format_name(name)
-    alt = settings.format_name_alternatives[name]
-    return alt if alt
-    return "#{name.capitalize}s"
-  end
-
   def include(name)
     begin
       File.open("views/_#{name}.html").read
@@ -112,25 +106,11 @@ module Helpers
   end
 
   def group_by_format(results)
-    results.group_by do |result|
-      humanize_format_name(result.presentation_format)
-    end.sort_by do |presentation_format_name, results|
+    results.group_by(&:humanized_format).sort_by do |presentation_format_name, results|
       sort_order = ['Quick Answers', 'Guides', 'Services', 'Benefits & Credits']
       sort_order.find_index(presentation_format_name) || sort_order.size
     end
   end
-
-  def humanize_format_name(format_name)
-    case format_name
-    when "transaction", "local_transaction", "place" then "Services"
-    when "answer", "calendar", "smart_answer", "custom-application" then "Quick Answers"
-    when "guide" then "Guides"
-    when "programme" then "Benefits & Credits"
-    else
-      format_name.gsub(/[_-]/, ' ').capitalize
-    end
-  end
-
 end
 
 class HelperAccessor

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -1,4 +1,5 @@
 require "delsolr"
+require "active_support/inflector"
 
 class Link
   def self.auto_keys(*names)
@@ -97,19 +98,30 @@ class Document < Link
     }
   end
 
-  FORMAT_TRANSLATION = {
+  PRESENTATION_FORMAT_TRANSLATION = {
     "planner" => "answer",
     "smart_answer" => "answer",
     "calculator" => "answer",
     "licence_finder" => "answer",
-    "custom-application" => "answer"
+    "custom_application" => "answer",
+    "calendar" => "answer"
   }
 
   def presentation_format
-    FORMAT_TRANSLATION.fetch(format, format)
+    PRESENTATION_FORMAT_TRANSLATION.fetch(normalized_format, normalized_format)
+  end
+
+  def humanized_format
+    settings.format_name_alternatives[presentation_format] || presentation_format.titleize.pluralize
   end
 
   def highlight
     @highlight || description
+  end
+
+  private
+
+  def normalized_format
+    format ? format.gsub("-", "_") : 'unknown'
   end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -18,6 +18,8 @@ module IntegrationFixtures
       "title" => "TITLE1",
       "description" => "DESCRIPTION",
       "format" => "local_transaction",
+      "humanized_format" => "Services",
+      "presentation_format" => "local_transaction",
       "section" => "life-in-the-uk",
       "link" => "/URL"
     }

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -123,6 +123,34 @@ class DocumentTest < Test::Unit::TestCase
     assert_equal "guide", document.presentation_format
   end
 
+  def test_takes_humanized_format_from_settings_if_present
+    hash = {:format => "map"}
+
+    settings.stubs(:format_name_alternatives).returns("map" => "Atlas")
+
+    document = Document.from_hash(hash)
+    assert_equal "Atlas", document.humanized_format
+  end
+
+  def test_uses_presentation_format_to_find_alternative_format_name
+    hash = {:format => "map"}
+
+    settings.stubs(:format_name_alternatives).returns("plan" => "Atlas")
+
+    document = Document.from_hash(hash)
+    document.stubs(:presentation_format).returns("plan")
+    assert_equal "Atlas", document.humanized_format
+  end
+
+  def test_generates_humanized_format_if_not_present_in_settings
+    hash = {:format => "map"}
+
+    settings.stubs(:format_name_alternatives).returns({})
+
+    document = Document.from_hash(hash)
+    assert_equal "Maps", document.humanized_format
+  end
+
   def self.assert_field_exported_to_delsolr_collaborator(field_name)
     define_method "test_should_export_#{field_name}_to_delsolr_collaborator" do
       document = Document.new
@@ -228,7 +256,7 @@ class DocumentTest < Test::Unit::TestCase
       "title" => "TITLE",
       "description" => "DESCRIPTION",
       "format" => "guide",
-      "link" => "/an-example-guide",
+      "link" => "/an-example-guide"
     }
 
     document = Document.from_hash(hash)

--- a/test/unit/helpers_test.rb
+++ b/test/unit/helpers_test.rb
@@ -11,15 +11,6 @@ class HelperTest < Test::Unit::TestCase
     HelperAccessor.new
   end
 
-  def test_formatting_format_name
-    assert_equal "Tests", h.formatted_format_name("test")
-  end
-
-  def test_formatting_format_name_with_replacement
-    app.settings.stubs(:format_name_alternatives).returns({"clark kent" => "superman"})
-    assert_equal "superman", h.formatted_format_name("clark kent")
-  end
-
   def test_include_throws_no_error_on_non_existent_file
     assert_equal nil, h.include("really_doesnt_exist.html")
   end

--- a/views/search.erb
+++ b/views/search.erb
@@ -21,7 +21,7 @@
                 </p>
 
                 <ul class="result-meta">
-                  <li class="<%= result.presentation_format %>"><%= formatted_format_name(result.presentation_format) %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>
+                  <li class="<%= result.presentation_format %>"><%= result.humanized_format %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>
                 </ul>
               </li>
             <% end %>


### PR DESCRIPTION
The logic to choose the format name to display was split between
two helper methods, each of which gave slightly different answers.

Inside Government also needs access to this information, so rather
than duplicating the logic again, the presentation format and
humanized format name are now returned in the JSON results, to be
used to build the Inside Government search results page.
