### PR TITLE
Combine mainstream and secondary results to a total of 50

### DIFF
--- a/helpers.rb
+++ b/helpers.rb
@@ -14,8 +14,7 @@ module Helpers
   end
 
   def capped_search_set_size
-    total_count = @results.count
-    total_count += @secondary_results.count if settings.feature_flags[:use_secondary_solr_index]
+    total_count = @total_results
     [total_count, (settings.top_results + settings.max_more_results)].min
   end
 

--- a/views/search.erb
+++ b/views/search.erb
@@ -13,7 +13,7 @@
       <div class="results">
         <div class="results-wrapper">
           <ul class="results-list">
-            <% non_recommended_results.each do |result| %>
+            <% @results.each do |result| %>
               <li class="section-<%= result.section %> type-<%= result.presentation_format %>">
                 <p class="search-result-title"><a href="<%= result.link %>" title= "View <%=h result.title %>"><%=h result.title %></a></p>
                 <p>
@@ -45,7 +45,7 @@
 
           <ul>
             <li data-filter="*" class="active"><a href="#">All results <span><%= capped_search_set_size %></span><span class="visuallyhidden"> results</span></a></li>
-            <% non_recommended_results.group_by(&:section).sort_by { |section, results_in_section|
+            <% @results.group_by(&:section).sort_by { |section, results_in_section|
                  results_in_section.size
                }.reverse_each do |section, results_in_section| %>
               <% next unless section %>


### PR DESCRIPTION
This fetches 50 results from the main index, then 5 from the secondary index,
and combines them to create up to 45 + 5 results as specified by the feature.
