### PR TITLE
Specialist search results styling

### DIFF
--- a/views/search.erb
+++ b/views/search.erb
@@ -14,7 +14,6 @@
         <div class="results-wrapper">
           <% if @results.any? %>
             <div class="results-block">
-              <h2>GOV.UK Results</h2>
               <ul class="results-list">
               <% @results.each do |result| %>
                 <li class="section-<%= result.section %> type-<%= result.presentation_format %>">
@@ -32,7 +31,7 @@
 
           <% if @secondary_results.any? %>
             <div class="results-block">
-              <h2>Elsewhere on Specialist guidance</h2>
+              <h2>Specialist guidance</h2>
               <ul class="results-list">
               <% @secondary_results.each do |result| %>
                 <li class="section-specialist type-<%= result.presentation_format %>">

--- a/views/search.erb
+++ b/views/search.erb
@@ -12,31 +12,43 @@
     <div class="group">
       <div class="results">
         <div class="results-wrapper">
-          <ul class="results-list">
-            <% @results.each do |result| %>
-              <li class="section-<%= result.section %> type-<%= result.presentation_format %>">
-                <p class="search-result-title"><a href="<%= result.link %>" title= "View <%=h result.title %>"><%=h result.title %></a></p>
-                <p>
-                  <%= h result.description %>
-                </p>
+          <% if @results.any? %>
+            <div class="results-block">
+              <h2>GOV.UK Results</h2>
+              <ul class="results-list">
+              <% @results.each do |result| %>
+                <li class="section-<%= result.section %> type-<%= result.presentation_format %>">
+                  <p class="search-result-title"><a href="<%= result.link %>" title= "View <%=h result.title %>"><%=h result.title %></a></p>
+                  <p><%= h result.description %></p>
 
-                <ul class="result-meta">
-                  <li class="<%= result.presentation_format %>"><%=h result.humanized_format %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>
-                </ul>
-              </li>
-            <% end %>
+                  <ul class="result-meta">
+                    <li class="<%= result.presentation_format %>"><%=h result.humanized_format %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>
+                  </ul>
+                </li>
+              <% end %>
+              </ul>
+            </div>
+          <% end %>
 
-            <% @secondary_results.each do |result| %>
-              <li class="section-specialist type-<%= result.presentation_format %>">
-                <p class="search-result-title"><a href="<%= result.link %>" title= "View <%=h result.title %>"><%=h result.title %></a></p>
-                <p><%= h result.description %></p>
-
-                <ul class="result-meta">
-                  <li class="<%= result.presentation_format %>"><%=h result.humanized_format %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>
-                </ul>
-              </li>
-            <% end %>
-          </ul>
+          <% if @secondary_results.any? %>
+            <div class="results-block">
+              <h2>Elsewhere on Specialist guidance</h2>
+              <ul class="results-list">
+              <% @secondary_results.each do |result| %>
+                <li class="section-specialist type-<%= result.presentation_format %>">
+                  <p class="search-result-title"><a href="<%= result.link %>" title= "View <%=h result.title %>"><%=h result.title %></a></p>
+                  <p><%= h result.description %></p>
+                  <ul class="result-meta">
+                    <li class="<%= result.presentation_format %>"><%=h result.humanized_format %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>
+                  </ul>
+                </li>
+              <% end %>
+              </ul>
+              <% if @more_secondary_results or true %>
+                <p class="more-results"><a href="/specailst?q=<%= h @query %>">More results from Specialist guidance</a></p>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
 


### PR DESCRIPTION
Make the search results mirror the 'elsewhere' style as implemented on
the inside-gov specialist results. There is a separate commit on static
to handle styling and interaction of the new content.

See: alphagov/static#16
