### PR TITLE
External links have external view metadata

### DIFF
--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -266,4 +266,24 @@ class SearchTest < IntegrationTest
     assert_match "<span>45</span>", last_response.body # TODO: how do I test the life in the UK thing?
     assert_match "Specialist guidance <span>5</span>", last_response.body
   end
+
+  def test_should_show_external_links_with_a_separate_list_class
+    external_document = Document.from_hash({
+      "title" => "A title",
+      "description" => "This is a description",
+      "format" => "recommended-link",
+      "link" => "http://twitter.com",
+      "section" => "driving"
+    })
+
+    @primary_solr.stubs(:search).returns([external_document])
+
+    get :search, {q: "bleh"}
+
+    assert last_response.ok?
+    assert_response_text "1 result"
+    assert_match "Driving <span>1</span>", last_response.body
+    assert_match "<li class=\"section-driving type-guide external\">", last_response.body
+    assert_match "rel=\"external\"", last_response.body
+  end
 end

--- a/views/search.erb
+++ b/views/search.erb
@@ -19,11 +19,7 @@
               <% else %>
               <li class="section-<%= result.section %> type-<%= result.presentation_format %>">
               <% end %>
-              <% if result.presentation_format == "recommended_link" %>
-                <p class="search-result-title"><a href="<%= result.link %>" title="View <%=h result.title %>" rel="external"><%=h result.title %></a></p>
-              <% else %>
-                <p class="search-result-title"><a href="<%= result.link %>" title="View <%=h result.title %>"><%=h result.title %></a></p>
-              <% end %>
+                <p class="search-result-title"><a href="<%= result.link %>" title="View <%=h result.title %>"<% if result.presentation_format == "recommended_link" %> rel="external"<% end %>><%=h result.title %></a></p>
                 <p><%= h result.description %></p>
 
                 <ul class="result-meta">

--- a/views/search.erb
+++ b/views/search.erb
@@ -14,11 +14,17 @@
         <div class="results-wrapper">
           <ul class="results-list">
             <% @results.each do |result| %>
+              <% if result.presentation_format == "recommended_link" %>
+              <li class="section-<%= result.section %> type-guide external">
+              <% else %>
               <li class="section-<%= result.section %> type-<%= result.presentation_format %>">
-                <p class="search-result-title"><a href="<%= result.link %>" title= "View <%=h result.title %>"><%=h result.title %></a></p>
-                <p>
-                  <%= h result.description %>
-                </p>
+              <% end %>
+              <% if result.presentation_format == "recommended_link" %>
+                <p class="search-result-title"><a href="<%= result.link %>" title="View <%=h result.title %>" rel="external"><%=h result.title %></a></p>
+              <% else %>
+                <p class="search-result-title"><a href="<%= result.link %>" title="View <%=h result.title %>"><%=h result.title %></a></p>
+              <% end %>
+                <p><%= h result.description %></p>
 
                 <ul class="result-meta">
                   <li class="<%= result.presentation_format %>"><%=h result.humanized_format %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>


### PR DESCRIPTION
External links (currently referred to as recommended links due to the
repo of the same name that exists) should have slightly different view
classes and attributes to take advantage of the design work that we
already have in place.

These are purely cosmetic changes and the tests make sure that these
attributes are correctly set in the event that results show external
(recommended) links in the output.
