### PR TITLE
Remove deprecated citizen class

### DIFF
--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -96,18 +96,6 @@ class SearchTest < IntegrationTest
     assert_equal "0", last_response.headers["X-Slimmer-Result-Count"]
   end
 
-  def test_should_set_body_class_based_on_proposition_header
-    app.settings.stubs(:slimmer_headers).returns(
-      section:     "x",
-      format:      "y",
-      proposition: "blah"
-    )
-    @primary_solr.stubs(:search).returns([])
-    get "/search", {q: "bob"}
-    # the mainstream class is temporarily hardcoded while we switch to using it
-    assert_match /<body class="blah mainstream"/, last_response.body
-  end
-
   def test_should_respond_with_json_when_requested
     @primary_solr.stubs(:search).returns([
       sample_document

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -9,9 +9,7 @@
   <%- end -%>
   <% yield_content :head %>
 </head>
-<%# The citizen class (what proposition returns) is going to be deprecated, to be replaced with mainstream. %>
-<%# Added the mainstream class in preparation for the change. %>
-<body class="<%= proposition %> mainstream">
+<body class="mainstream">
   <div id="wrapper" class="wrapper">
     <%= yield %>
   </div>


### PR DESCRIPTION
Everything that was using it has now been switched to reference
mainstream.
