### PR TITLE
Include secondary results in JSON responses

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -74,7 +74,7 @@ get prefixed_path("/search.?:format?") do
 
   if request.accept.include?("application/json") or params['format'] == 'json'
     content_type :json
-    JSON.dump(@results.map { |r| r.to_hash.merge(
+    JSON.dump((@results + @secondary_results).map { |r| r.to_hash.merge(
       highlight: r.highlight,
       presentation_format: r.presentation_format,
       humanized_format: r.humanized_format

--- a/test/functional/secondary_search_test.rb
+++ b/test/functional/secondary_search_test.rb
@@ -39,6 +39,21 @@ class SecondarySearchTest < IntegrationTest
     assert_response_text "2 results"
   end
 
+  def test_should_include_secondary_results_in_json_response
+    @primary_search.stubs(:search).returns([sample_document])
+    sample_specialist_document = sample_document.tap do |document|
+      document.link = "/specialist-link"
+    end
+    @secondary_search.stubs(:search).returns([sample_specialist_document])
+
+    get "/search.json", q: "Not a quote from Back To The Future"
+    assert last_response.ok?
+    assert_equal(
+      [sample_document.link, "/specialist-link"],
+      JSON.parse(last_response.body).map { |r| r["link"] }
+    )
+  end
+
   def test_should_show_secondary_solr_results_count_next_to_secondary_solr_filter
     @primary_search.stubs(:search).returns([sample_document])
     @secondary_search.stubs(:search).returns([sample_document])


### PR DESCRIPTION
This should be a trivial change, unless someone is depending on this not returning any secondary results.
