### PR TITLE
Remove search results filter

### DIFF
--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -165,7 +165,6 @@ class SearchTest < IntegrationTest
 
     assert last_response.ok?
     assert_response_text "1 result"
-    assert_match "Driving <span>1</span>", last_response.body
     assert_match "<li class=\"section-driving type-guide external\">", last_response.body
     assert_match "rel=\"external\"", last_response.body
     assert_match "<li>External site</li>", last_response.body

--- a/test/functional/secondary_search_test.rb
+++ b/test/functional/secondary_search_test.rb
@@ -8,37 +8,6 @@ class SecondarySearchTest < IntegrationTest
     stub_primary_and_secondary_searches
   end
 
-  def test_should_not_show_secondary_solr_guidance_filter_when_no_secondary_solr_results_present
-    @primary_search.stubs(:search).returns([sample_document, sample_document])
-    @secondary_search.stubs(:search).returns([])
-
-    get "/search", {q: "1.21 gigawatts?!"}
-
-    assert last_response.ok?
-    assert_response_text "2 results"
-    assert_equal false, last_response.body.include?("Specialist guidance")
-  end
-
-  def test_should_show_secondary_solr_guidance_filter_when_secondary_solr_results_exist
-    @primary_search.stubs(:search).returns([sample_document])
-    @secondary_search.stubs(:search).returns([sample_document])
-
-    get "/search", {q: "Are you telling me that you built a time machine... out of a DeLorean?"}
-
-    assert last_response.ok?
-    assert_equal true, last_response.body.include?("Specialist guidance")
-  end
-
-  def test_should_include_secondary_solr_results_when_provided_results_count
-    @primary_search.stubs(:search).returns([sample_document])
-    @secondary_search.stubs(:search).returns([sample_document])
-
-    get "/search", {q: "If my calculations are correct, when this baby hits 88 miles per hour... you're gonna see some serious shit."}
-
-    assert last_response.ok?
-    assert_response_text "2 results"
-  end
-
   def test_should_include_secondary_results_in_json_response
     @primary_search.stubs(:search).returns([sample_document])
     sample_specialist_document = sample_document.tap do |document|
@@ -52,16 +21,6 @@ class SecondarySearchTest < IntegrationTest
       [sample_document.link, "/specialist-link"],
       JSON.parse(last_response.body).map { |r| r["link"] }
     )
-  end
-
-  def test_should_show_secondary_solr_results_count_next_to_secondary_solr_filter
-    @primary_search.stubs(:search).returns([sample_document])
-    @secondary_search.stubs(:search).returns([sample_document])
-
-    get "/search", {q: "This is heavy."}
-
-    assert last_response.ok?
-    assert_match "Specialist guidance <span>1</span>", last_response.body
   end
 
   def test_should_show_secondary_solr_results_after_the_primary_solr_results
@@ -85,40 +44,6 @@ class SecondarySearchTest < IntegrationTest
     assert_match "<a href=\"/browse/de-lorean\">De lorean</a><", last_response.body
   end
 
-  def test_should_limit_results
-    example_secondary_solr_result = {
-      "title" => "Back to the Future",
-      "description" => "In 1985, Doc Brown invents time travel; in 1955, Marty McFly accidentally prevents his parents from meeting, putting his own existence at stake.",
-      "format" => "local_transaction",
-      "section" => "de-lorean",
-      "link" => "/1-21-gigawatts"
-    }
 
-    @primary_search.stubs(:search).returns(Array.new(75, sample_document))
-    @secondary_search.stubs(:search).returns([])
 
-    get :search, {q: "Test"}
-
-    assert_response_text "50 results"
-    assert_match "<span>50</span>", last_response.body
-  end
-
-  def test_should_only_show_limited_main_and_limited_secondary_results
-    example_secondary_solr_result = {
-      "title" => "Back to the Future",
-      "description" => "In 1985, Doc Brown invents time travel; in 1955, Marty McFly accidentally prevents his parents from meeting, putting his own existence at stake.",
-      "format" => "local_transaction",
-      "section" => "de-lorean",
-      "link" => "/1-21-gigawatts"
-    }
-
-    @primary_search.stubs(:search).returns(Array.new(52, sample_document))
-    @secondary_search.stubs(:search).returns(Array.new(7, Document.from_hash(example_secondary_solr_result)))
-
-    get :search, {q: "Test"}
-
-    assert_response_text "50 results"
-    assert_match "<span>45</span>", last_response.body # TODO: how do I test the life in the UK thing?
-    assert_match "Specialist guidance <span>5</span>", last_response.body
-  end
 end

--- a/views/search.erb
+++ b/views/search.erb
@@ -43,22 +43,6 @@
         </div>
       </div>
 
-      <aside class="filters group">
-          <h2 class="visuallyhidden">Filter by Section</h2>
-
-          <ul>
-            <li data-filter="*" class="active"><a href="#">All results <span><%= capped_search_set_size %></span><span class="visuallyhidden"> results</span></a></li>
-            <% @results.group_by(&:section).sort_by { |section, results_in_section|
-                 results_in_section.size
-               }.reverse_each do |section, results_in_section| %>
-              <% next unless section %>
-              <li data-filter="section-<%= section %>"><a href="#"><%= formatted_section_name(section) %> <span><%= results_in_section.size %></span><span class="visuallyhidden"> results</span></a></li>
-            <% end %>
-            <% if not @secondary_results.empty? %>
-              <li data-filter="section-specialist"><a href="#">Specialist guidance <span><%= @secondary_results.count %></span><span class="visuallyhidden"> results</span></a></li>
-            <% end %>
-          </ul>
-      </aside>
     </div>
   </div>
 </section>

--- a/views/search.erb
+++ b/views/search.erb
@@ -9,41 +9,35 @@
       </fieldset>
     </form>
 
-    <div class="group">
-      <div class="results">
-        <div class="results-wrapper">
-          <ul class="results-list">
-            <% @results.each do |result| %>
-              <% if result.presentation_format == "recommended_link" %>
-              <li class="section-<%= result.section %> type-guide external">
-              <% else %>
-              <li class="section-<%= result.section %> type-<%= result.presentation_format %>">
-              <% end %>
-                <p class="search-result-title"><a href="<%= result.link %>" title="View <%=h result.title %>"<% if result.presentation_format == "recommended_link" %> rel="external"<% end %>><%=h result.title %></a></p>
-                <p><%= h result.description %></p>
-                <% if result.presentation_format == "recommended_link" %>
-                <ul class="result-meta">
-                  <li>External site</li>
-                </ul>
-                <% end %>
-              </li>
-            <% end %>
-
-            <% @secondary_results.each do |result| %>
-              <li class="section-specialist type-<%= result.presentation_format %>">
-                <p class="search-result-title"><a href="<%= result.link %>" title= "View <%=h result.title %>"><%=h result.title %></a></p>
-                <p><%= h result.description %></p>
-
-                <ul class="result-meta">
-                  <li class="<%= result.presentation_format %>"><%=h result.humanized_format %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>
-                </ul>
-              </li>
-            <% end %>
+    <ul class="results-list">
+      <% @results.each do |result| %>
+        <% if result.presentation_format == "recommended_link" %>
+        <li class="section-<%= result.section %> type-guide external">
+        <% else %>
+        <li class="section-<%= result.section %> type-<%= result.presentation_format %>">
+        <% end %>
+          <p class="search-result-title"><a href="<%= result.link %>" title="View <%=h result.title %>"<% if result.presentation_format == "recommended_link" %> rel="external"<% end %>><%=h result.title %></a></p>
+          <p><%= h result.description %></p>
+          <% if result.presentation_format == "recommended_link" %>
+          <ul class="result-meta">
+            <li>External site</li>
           </ul>
-        </div>
-      </div>
+          <% end %>
+        </li>
+      <% end %>
 
-    </div>
+      <% @secondary_results.each do |result| %>
+        <li class="section-specialist type-<%= result.presentation_format %>">
+          <p class="search-result-title"><a href="<%= result.link %>" title= "View <%=h result.title %>"><%=h result.title %></a></p>
+          <p><%= h result.description %></p>
+
+          <ul class="result-meta">
+            <li class="<%= result.presentation_format %>"><%=h result.humanized_format %></li><% if result.section %><li><a href="/browse/<%= result.section %>"><%= formatted_section_name(result.section) %></a></li><% end %>
+          </ul>
+        </li>
+      <% end %>
+    </ul>
+
   </div>
 </section>
 


### PR DESCRIPTION
Remove the filter from the left hand side of search results.

This is a temporary measure until the new design of search pages are built next week. This will also be superseded by the work to move search results into frontend next week.
