### PR TITLE
Introduce named backends with dedicated urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,9 @@ end
 
 gem "unicorn"
 gem "sinatra"
+gem "sinatra-contrib"
 gem "delsolr", :git => "https://github.com/alphagov/delsolr.git"
-gem 'rake', '0.9.2'
+gem 'rake', '0.9.2', :require => false
 gem 'slimmer', '1.2.4'
 gem 'erubis'
 gem 'json'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ end
 
 gem "unicorn"
 gem "sinatra"
-gem "sinatra-contrib"
 gem "delsolr", :git => "https://github.com/alphagov/delsolr.git"
 gem 'rake', '0.9.2', :require => false
 gem 'slimmer', '1.2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,13 +18,11 @@ GEM
       mail (> 2.2.5)
       mime-types
       xml-simple
-    backports (2.6.4)
     builder (3.0.0)
     ci_reporter (1.6.9)
       builder (>= 2.1.2)
     crack (0.3.1)
     erubis (2.7.0)
-    eventmachine (1.0.0)
     gds-api-adapters (0.0.48)
       lrucache (~> 0.1.1)
       null_logger
@@ -75,13 +73,6 @@ GEM
       tilt (~> 1.3, >= 1.3.3)
     sinatra-content-for (0.1)
       sinatra
-    sinatra-contrib (1.3.1)
-      backports (>= 2.0)
-      eventmachine
-      rack-protection
-      rack-test
-      sinatra (~> 1.3.0)
-      tilt (~> 1.3)
     slimmer (1.2.4)
       gds-api-adapters (>= 0.0.33, < 0.3.0)
       json
@@ -129,7 +120,6 @@ DEPENDENCIES
   simplecov-rcov
   sinatra
   sinatra-content-for (= 0.1)
-  sinatra-contrib
   slimmer (= 1.2.4)
   test-unit
   unicorn

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,11 +18,13 @@ GEM
       mail (> 2.2.5)
       mime-types
       xml-simple
+    backports (2.6.4)
     builder (3.0.0)
     ci_reporter (1.6.9)
       builder (>= 2.1.2)
     crack (0.3.1)
     erubis (2.7.0)
+    eventmachine (1.0.0)
     gds-api-adapters (0.0.48)
       lrucache (~> 0.1.1)
       null_logger
@@ -73,6 +75,13 @@ GEM
       tilt (~> 1.3, >= 1.3.3)
     sinatra-content-for (0.1)
       sinatra
+    sinatra-contrib (1.3.1)
+      backports (>= 2.0)
+      eventmachine
+      rack-protection
+      rack-test
+      sinatra (~> 1.3.0)
+      tilt (~> 1.3)
     slimmer (1.2.4)
       gds-api-adapters (>= 0.0.33, < 0.3.0)
       json
@@ -120,6 +129,7 @@ DEPENDENCIES
   simplecov-rcov
   sinatra
   sinatra-content-for (= 0.1)
+  sinatra-contrib
   slimmer (= 1.2.4)
   test-unit
   unicorn

--- a/app.rb
+++ b/app.rb
@@ -28,11 +28,11 @@ def backends
 end
 
 def primary_search
-  backends.primary_search
+  backends[:primary]
 end
 
 def secondary_search
-  backends.secondary_search
+  backends[:secondary]
 end
 
 helpers do

--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,6 @@
 end
 
 require 'sinatra'
-require 'sinatra/namespace'
 require 'slimmer'
 require 'erubis'
 require 'json'

--- a/app.rb
+++ b/app.rb
@@ -44,168 +44,168 @@ before do
 end
 
 namespace settings.router[:path_prefix] || "" do
-  get "/search.?:format?" do
-    @query = params["q"].to_s.gsub(/[\u{0}-\u{1f}]/, "").strip
+get "/search.?:format?" do
+  @query = params["q"].to_s.gsub(/[\u{0}-\u{1f}]/, "").strip
 
-    if @query == ""
-      expires 3600, :public
-      @page_section = "Search"
-      @page_section_link = "/search"
-      @page_title = "Search | GOV.UK Beta (Test)"
-      return erb(:no_search_term)
-    end
-
-    expires 3600, :public if @query.length < 20
-
-    results = primary_search.search(@query, params["format_filter"])
-    secondary_results = secondary_search.search(@query)
-
-    logger.info "Found #{secondary_results.count} secondary results"
-
-    @secondary_results = secondary_results.take(5)
-    @more_secondary_results = secondary_results.length > 5
-    @results = results.take(50 - @secondary_results.length)
-    @total_results = @results.length + @secondary_results.length
-
-    if request.accept.include?("application/json") or params['format'] == 'json'
-      content_type :json
-      JSON.dump((@results + @secondary_results).map { |r| r.to_hash.merge(
-        highlight: r.highlight,
-        presentation_format: r.presentation_format,
-        humanized_format: r.humanized_format
-      ) })
-    else
-      @page_section = "Search"
-      @page_section_link = "/search"
-      @page_title = "#{@query} | Search | GOV.UK Beta (Test)"
-
-      headers SlimmerHeaders.headers(settings.slimmer_headers.merge(result_count: @results.length))
-
-      if @results.any?
-        erb(:search)
-      else
-        erb(:no_search_results)
-      end
-    end
+  if @query == ""
+    expires 3600, :public
+    @page_section = "Search"
+    @page_section_link = "/search"
+    @page_title = "Search | GOV.UK Beta (Test)"
+    return erb(:no_search_term)
   end
 
-  get "/preload-autocomplete" do
-    # Eventually this is likely to be a list of commonly searched for terms
-    # so searching for those is really fast. For the beta, this is just a list
-    # of all terms.
-    expires 86400, :public
+  expires 3600, :public if @query.length < 20
+
+  results = primary_search.search(@query, params["format_filter"])
+  secondary_results = secondary_search.search(@query)
+
+  logger.info "Found #{secondary_results.count} secondary results"
+
+  @secondary_results = secondary_results.take(5)
+  @more_secondary_results = secondary_results.length > 5
+  @results = results.take(50 - @secondary_results.length)
+  @total_results = @results.length + @secondary_results.length
+
+  if request.accept.include?("application/json") or params['format'] == 'json'
     content_type :json
-    results = primary_search.autocomplete_cache rescue []
-    JSON.dump(results.map { |r| r.to_hash })
-  end
-
-  get "/autocomplete" do
-    content_type :json
-    query = params['q']
-
-    unless query
-      expires 86400, :public
-      return '[]'
-    end
-
-    expires 3600, :public if query.length < 5
-
-    results = primary_search.complete(query, params["format_filter"]) rescue []
-    JSON.dump(results.map { |r| r.to_hash.merge(
+    JSON.dump((@results + @secondary_results).map { |r| r.to_hash.merge(
+      highlight: r.highlight,
       presentation_format: r.presentation_format,
       humanized_format: r.humanized_format
     ) })
-  end
+  else
+    @page_section = "Search"
+    @page_section_link = "/search"
+    @page_title = "#{@query} | Search | GOV.UK Beta (Test)"
 
-  get "/sitemap.xml" do
-    expires 86400, :public
-    # Site maps can have up to 50,000 links in them.
-    # We use one for / so we can have up to 49,999 others.
-    documents = primary_search.all_documents limit: 49_999
-    builder do |xml|
-      xml.instruct!
-      xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
-        xml.url do
-  	xml.loc "#{base_url}#{"/"}"
-        end
-        documents.each do |document|
-  	xml.url do
-  	  url = document.link
-            url = "#{base_url}#{url}" if url =~ /^\//
-  	  xml.loc url
-  	end
-        end
-      end
-    end
-  end
+    headers SlimmerHeaders.headers(settings.slimmer_headers.merge(result_count: @results.length))
 
-  post "/documents" do
-    request.body.rewind
-    documents = [JSON.parse(request.body.read)].flatten.map { |hash|
-      Document.from_hash(hash)
-    }
-
-    boosts = {}
-    CSV.foreach(settings.boost_csv) { |row|
-      link, phrases = row
-      boosts[link] = phrases
-    }
-
-    better_documents = boost_documents(documents, boosts)
-
-    simple_json_result(primary_search.add(better_documents))
-  end
-
-  post "/commit" do
-    simple_json_result(primary_search.commit)
-  end
-
-  get "/documents/*" do
-    document = primary_search.get(params["splat"].first)
-    halt 404 unless document
-    content_type :json
-    JSON.dump document.to_hash
-  end
-
-  delete "/documents/*" do
-    simple_json_result(primary_search.delete(params["splat"].first))
-  end
-
-  post "/documents/*" do
-    def text_error(content)
-      halt 403, {"Content-Type" => "text/plain"}, content
-    end
-
-    unless request.form_data?
-      halt(
-        415,
-        {"Content-Type" => "text/plain"},
-        "Amendments require application/x-www-form-urlencoded data"
-      )
-    end
-    document = primary_search.get(params["splat"].first)
-    halt 404 unless document
-    text_error "Cannot change document links" if request.POST.include? 'link'
-
-    # Note: this expects application/x-www-form-urlencoded data, not JSON
-    request.POST.each_pair do |key, value|
-      begin
-        document.set key, value
-      rescue NoMethodError
-        text_error "Unrecognised field '#{key}'"
-      end
-    end
-    simple_json_result(primary_search.add([document]))
-  end
-
-  delete "/documents" do
-    if params['delete_all']
-      action = primary_search.delete_all
+    if @results.any?
+      erb(:search)
     else
-      action = primary_search.delete(params["link"])
+      erb(:no_search_results)
     end
-    simple_json_result(action)
   end
+end
+
+get "/preload-autocomplete" do
+  # Eventually this is likely to be a list of commonly searched for terms
+  # so searching for those is really fast. For the beta, this is just a list
+  # of all terms.
+  expires 86400, :public
+  content_type :json
+  results = primary_search.autocomplete_cache rescue []
+  JSON.dump(results.map { |r| r.to_hash })
+end
+
+get "/autocomplete" do
+  content_type :json
+  query = params['q']
+
+  unless query
+    expires 86400, :public
+    return '[]'
+  end
+
+  expires 3600, :public if query.length < 5
+
+  results = primary_search.complete(query, params["format_filter"]) rescue []
+  JSON.dump(results.map { |r| r.to_hash.merge(
+    presentation_format: r.presentation_format,
+    humanized_format: r.humanized_format
+  ) })
+end
+
+get "/sitemap.xml" do
+  expires 86400, :public
+  # Site maps can have up to 50,000 links in them.
+  # We use one for / so we can have up to 49,999 others.
+  documents = primary_search.all_documents limit: 49_999
+  builder do |xml|
+    xml.instruct!
+    xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
+      xml.url do
+	xml.loc "#{base_url}#{"/"}"
+      end
+      documents.each do |document|
+	xml.url do
+	  url = document.link
+          url = "#{base_url}#{url}" if url =~ /^\//
+	  xml.loc url
+	end
+      end
+    end
+  end
+end
+
+post "/documents" do
+  request.body.rewind
+  documents = [JSON.parse(request.body.read)].flatten.map { |hash|
+    Document.from_hash(hash)
+  }
+
+  boosts = {}
+  CSV.foreach(settings.boost_csv) { |row|
+    link, phrases = row
+    boosts[link] = phrases
+  }
+
+  better_documents = boost_documents(documents, boosts)
+
+  simple_json_result(primary_search.add(better_documents))
+end
+
+post "/commit" do
+  simple_json_result(primary_search.commit)
+end
+
+get "/documents/*" do
+  document = primary_search.get(params["splat"].first)
+  halt 404 unless document
+  content_type :json
+  JSON.dump document.to_hash
+end
+
+delete "/documents/*" do
+  simple_json_result(primary_search.delete(params["splat"].first))
+end
+
+post "/documents/*" do
+  def text_error(content)
+    halt 403, {"Content-Type" => "text/plain"}, content
+  end
+
+  unless request.form_data?
+    halt(
+      415,
+      {"Content-Type" => "text/plain"},
+      "Amendments require application/x-www-form-urlencoded data"
+    )
+  end
+  document = primary_search.get(params["splat"].first)
+  halt 404 unless document
+  text_error "Cannot change document links" if request.POST.include? 'link'
+
+  # Note: this expects application/x-www-form-urlencoded data, not JSON
+  request.POST.each_pair do |key, value|
+    begin
+      document.set key, value
+    rescue NoMethodError
+      text_error "Unrecognised field '#{key}'"
+    end
+  end
+  simple_json_result(primary_search.add([document]))
+end
+
+delete "/documents" do
+  if params['delete_all']
+    action = primary_search.delete_all
+  else
+    action = primary_search.delete(params["link"])
+  end
+  simple_json_result(action)
+end
 end
 
 if settings.router[:path_prefix].empty?

--- a/app.rb
+++ b/app.rb
@@ -18,7 +18,6 @@ require 'null_backend'
 require 'slimmer_headers'
 require 'sinatra/content_for'
 
-
 require_relative 'config'
 require_relative 'helpers'
 require_relative 'backends'
@@ -145,7 +144,7 @@ get prefixed_path("/sitemap.xml") do
 end
 
 if settings.router[:path_prefix].empty?
-  get prefixed_path("/browse.?:format?") do
+  get "/browse.?:format?" do
     headers SlimmerHeaders.headers(settings.slimmer_headers.merge(section: "Section nav"))
     expires 3600, :public
     @results = primary_search.facet('section')
@@ -189,14 +188,14 @@ if settings.router[:path_prefix].empty?
     as_hash
   end
 
-  get prefixed_path("/browse/:section.json") do
+  get "/browse/:section.json" do
     expires 86400, :public
     assemble_section_details(params[:section])
     content_type :json
     JSON.dump(compile_section_json(@results))
   end
 
-  get prefixed_path("/browse/:section") do
+  get "/browse/:section" do
     expires 86400, :public
     headers SlimmerHeaders.headers(settings.slimmer_headers.merge(section: "Section nav"))
     assemble_section_details(params[:section])

--- a/app.rb
+++ b/app.rb
@@ -44,168 +44,168 @@ before do
 end
 
 namespace settings.router[:path_prefix] || "" do
-get "/search.?:format?" do
-  @query = params["q"].to_s.gsub(/[\u{0}-\u{1f}]/, "").strip
+  get "/search.?:format?" do
+    @query = params["q"].to_s.gsub(/[\u{0}-\u{1f}]/, "").strip
 
-  if @query == ""
-    expires 3600, :public
-    @page_section = "Search"
-    @page_section_link = "/search"
-    @page_title = "Search | GOV.UK Beta (Test)"
-    return erb(:no_search_term)
+    if @query == ""
+      expires 3600, :public
+      @page_section = "Search"
+      @page_section_link = "/search"
+      @page_title = "Search | GOV.UK Beta (Test)"
+      return erb(:no_search_term)
+    end
+
+    expires 3600, :public if @query.length < 20
+
+    results = primary_search.search(@query, params["format_filter"])
+    secondary_results = secondary_search.search(@query)
+
+    logger.info "Found #{secondary_results.count} secondary results"
+
+    @secondary_results = secondary_results.take(5)
+    @more_secondary_results = secondary_results.length > 5
+    @results = results.take(50 - @secondary_results.length)
+    @total_results = @results.length + @secondary_results.length
+
+    if request.accept.include?("application/json") or params['format'] == 'json'
+      content_type :json
+      JSON.dump((@results + @secondary_results).map { |r| r.to_hash.merge(
+        highlight: r.highlight,
+        presentation_format: r.presentation_format,
+        humanized_format: r.humanized_format
+      ) })
+    else
+      @page_section = "Search"
+      @page_section_link = "/search"
+      @page_title = "#{@query} | Search | GOV.UK Beta (Test)"
+
+      headers SlimmerHeaders.headers(settings.slimmer_headers.merge(result_count: @results.length))
+
+      if @results.any?
+        erb(:search)
+      else
+        erb(:no_search_results)
+      end
+    end
   end
 
-  expires 3600, :public if @query.length < 20
-
-  results = primary_search.search(@query, params["format_filter"])
-  secondary_results = secondary_search.search(@query)
-
-  logger.info "Found #{secondary_results.count} secondary results"
-
-  @secondary_results = secondary_results.take(5)
-  @more_secondary_results = secondary_results.length > 5
-  @results = results.take(50 - @secondary_results.length)
-  @total_results = @results.length + @secondary_results.length
-
-  if request.accept.include?("application/json") or params['format'] == 'json'
+  get "/preload-autocomplete" do
+    # Eventually this is likely to be a list of commonly searched for terms
+    # so searching for those is really fast. For the beta, this is just a list
+    # of all terms.
+    expires 86400, :public
     content_type :json
-    JSON.dump((@results + @secondary_results).map { |r| r.to_hash.merge(
-      highlight: r.highlight,
+    results = primary_search.autocomplete_cache rescue []
+    JSON.dump(results.map { |r| r.to_hash })
+  end
+
+  get "/autocomplete" do
+    content_type :json
+    query = params['q']
+
+    unless query
+      expires 86400, :public
+      return '[]'
+    end
+
+    expires 3600, :public if query.length < 5
+
+    results = primary_search.complete(query, params["format_filter"]) rescue []
+    JSON.dump(results.map { |r| r.to_hash.merge(
       presentation_format: r.presentation_format,
       humanized_format: r.humanized_format
     ) })
-  else
-    @page_section = "Search"
-    @page_section_link = "/search"
-    @page_title = "#{@query} | Search | GOV.UK Beta (Test)"
-
-    headers SlimmerHeaders.headers(settings.slimmer_headers.merge(result_count: @results.length))
-
-    if @results.any?
-      erb(:search)
-    else
-      erb(:no_search_results)
-    end
   end
-end
 
-get "/preload-autocomplete" do
-  # Eventually this is likely to be a list of commonly searched for terms
-  # so searching for those is really fast. For the beta, this is just a list
-  # of all terms.
-  expires 86400, :public
-  content_type :json
-  results = primary_search.autocomplete_cache rescue []
-  JSON.dump(results.map { |r| r.to_hash })
-end
-
-get "/autocomplete" do
-  content_type :json
-  query = params['q']
-
-  unless query
+  get "/sitemap.xml" do
     expires 86400, :public
-    return '[]'
-  end
-
-  expires 3600, :public if query.length < 5
-
-  results = primary_search.complete(query, params["format_filter"]) rescue []
-  JSON.dump(results.map { |r| r.to_hash.merge(
-    presentation_format: r.presentation_format,
-    humanized_format: r.humanized_format
-  ) })
-end
-
-get "/sitemap.xml" do
-  expires 86400, :public
-  # Site maps can have up to 50,000 links in them.
-  # We use one for / so we can have up to 49,999 others.
-  documents = primary_search.all_documents limit: 49_999
-  builder do |xml|
-    xml.instruct!
-    xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
-      xml.url do
-	xml.loc "#{base_url}#{"/"}"
-      end
-      documents.each do |document|
-	xml.url do
-	  url = document.link
-          url = "#{base_url}#{url}" if url =~ /^\//
-	  xml.loc url
-	end
+    # Site maps can have up to 50,000 links in them.
+    # We use one for / so we can have up to 49,999 others.
+    documents = primary_search.all_documents limit: 49_999
+    builder do |xml|
+      xml.instruct!
+      xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
+        xml.url do
+  	xml.loc "#{base_url}#{"/"}"
+        end
+        documents.each do |document|
+  	xml.url do
+  	  url = document.link
+            url = "#{base_url}#{url}" if url =~ /^\//
+  	  xml.loc url
+  	end
+        end
       end
     end
   end
-end
 
-post "/documents" do
-  request.body.rewind
-  documents = [JSON.parse(request.body.read)].flatten.map { |hash|
-    Document.from_hash(hash)
-  }
+  post "/documents" do
+    request.body.rewind
+    documents = [JSON.parse(request.body.read)].flatten.map { |hash|
+      Document.from_hash(hash)
+    }
 
-  boosts = {}
-  CSV.foreach(settings.boost_csv) { |row|
-    link, phrases = row
-    boosts[link] = phrases
-  }
+    boosts = {}
+    CSV.foreach(settings.boost_csv) { |row|
+      link, phrases = row
+      boosts[link] = phrases
+    }
 
-  better_documents = boost_documents(documents, boosts)
+    better_documents = boost_documents(documents, boosts)
 
-  simple_json_result(primary_search.add(better_documents))
-end
-
-post "/commit" do
-  simple_json_result(primary_search.commit)
-end
-
-get "/documents/*" do
-  document = primary_search.get(params["splat"].first)
-  halt 404 unless document
-  content_type :json
-  JSON.dump document.to_hash
-end
-
-delete "/documents/*" do
-  simple_json_result(primary_search.delete(params["splat"].first))
-end
-
-post "/documents/*" do
-  def text_error(content)
-    halt 403, {"Content-Type" => "text/plain"}, content
+    simple_json_result(primary_search.add(better_documents))
   end
 
-  unless request.form_data?
-    halt(
-      415,
-      {"Content-Type" => "text/plain"},
-      "Amendments require application/x-www-form-urlencoded data"
-    )
+  post "/commit" do
+    simple_json_result(primary_search.commit)
   end
-  document = primary_search.get(params["splat"].first)
-  halt 404 unless document
-  text_error "Cannot change document links" if request.POST.include? 'link'
 
-  # Note: this expects application/x-www-form-urlencoded data, not JSON
-  request.POST.each_pair do |key, value|
-    begin
-      document.set key, value
-    rescue NoMethodError
-      text_error "Unrecognised field '#{key}'"
+  get "/documents/*" do
+    document = primary_search.get(params["splat"].first)
+    halt 404 unless document
+    content_type :json
+    JSON.dump document.to_hash
+  end
+
+  delete "/documents/*" do
+    simple_json_result(primary_search.delete(params["splat"].first))
+  end
+
+  post "/documents/*" do
+    def text_error(content)
+      halt 403, {"Content-Type" => "text/plain"}, content
     end
-  end
-  simple_json_result(primary_search.add([document]))
-end
 
-delete "/documents" do
-  if params['delete_all']
-    action = primary_search.delete_all
-  else
-    action = primary_search.delete(params["link"])
+    unless request.form_data?
+      halt(
+        415,
+        {"Content-Type" => "text/plain"},
+        "Amendments require application/x-www-form-urlencoded data"
+      )
+    end
+    document = primary_search.get(params["splat"].first)
+    halt 404 unless document
+    text_error "Cannot change document links" if request.POST.include? 'link'
+
+    # Note: this expects application/x-www-form-urlencoded data, not JSON
+    request.POST.each_pair do |key, value|
+      begin
+        document.set key, value
+      rescue NoMethodError
+        text_error "Unrecognised field '#{key}'"
+      end
+    end
+    simple_json_result(primary_search.add([document]))
   end
-  simple_json_result(action)
-end
+
+  delete "/documents" do
+    if params['delete_all']
+      action = primary_search.delete_all
+    else
+      action = primary_search.delete(params["link"])
+    end
+    simple_json_result(action)
+  end
 end
 
 if settings.router[:path_prefix].empty?

--- a/backends-multiple-propositions-example.yml
+++ b/backends-multiple-propositions-example.yml
@@ -1,0 +1,31 @@
+# This is an example development config for running different backends for
+# government, specialist and mainstream content.
+#
+# Queries to theses indexes can be made calling GET /<index>/search?q=<query>
+# while documents can be added or removed with requests such as
+# POST /<index>/documents.  i.e. GET /mainstream/search?q=tax will return
+# as json all mainstream results about tax.
+
+# Setting primary and secondary to mainstream and specialist content affects
+# requests that don't target an index, such as GET /search?q=<query>
+
+development:
+  mainstream: &mainstream
+    type: elasticsearch
+    server: localhost
+    port: 9200
+    index_name: "mainstream"
+  specialist: &specialist
+    type: elasticsearch
+    server: localhost
+    port: 9200
+    index_name: "specialist"
+  government:
+    type: elasticsearch
+    server: localhost
+    port: 9200
+    index_name: "government"
+  primary:
+    *mainstream
+  secondary:
+    *specialist

--- a/backends.rb
+++ b/backends.rb
@@ -1,8 +1,12 @@
 require "solr_wrapper"
 require "elasticsearch_wrapper"
 require "null_backend"
+require "active_support/core_ext/module/delegation"
+
 
 class Backends
+  delegate :[], to: :backends
+
   def initialize(settings, logger = nil)
     @settings = settings
     @logger = logger || Logger.new("/dev/null")
@@ -14,14 +18,6 @@ class Backends
       backend_settings = @settings.backends[key] && @settings.backends[key].symbolize_keys
       hash[key] = backend_settings && build_backend(backend_settings)
     end
-  end
-
-  def primary_search
-    backends[:primary]
-  end
-
-  def secondary_search
-    backends[:secondary]
   end
 
 private

--- a/config.rb
+++ b/config.rb
@@ -6,16 +6,15 @@ def config_for(kind)
   YAML.load_file(File.expand_path("../#{kind}.yml", __FILE__))
 end
 
-def backend_config_for(backend)
+def backend_config
   # Note that we're not recursively symbolising keys, because the config for
   # each backend is currently flat. We may need to revisit this.
-  config_for(:backends)[ENV["RACK_ENV"]][backend].symbolize_keys
+  config_for(:backends)[ENV["RACK_ENV"]].symbolize_keys
 end
 
 set :router, config_for(:router)
 
-set :primary_search, backend_config_for("primary")
-set :secondary_search, backend_config_for("secondary")
+set :backends, backend_config
 set :elasticsearch_schema, config_for("elasticsearch_schema")
 
 set :slimmer_headers, config_for(:slimmer_headers)

--- a/test/functional/amendment_test.rb
+++ b/test/functional/amendment_test.rb
@@ -4,13 +4,13 @@ class AmendmentTest < IntegrationTest
 
   def setup
     super
-    stub_primary_and_secondary_searches
+    stub_backend
     disable_secondary_search
   end
 
   def test_should_amend_existing_document
-    @primary_search.expects(:get).returns(sample_document)
-    @primary_search.expects(:add).with() do |documents|
+    @backend_index.expects(:get).returns(sample_document)
+    @backend_index.expects(:add).with() do |documents|
       assert_equal 1, documents.length
       assert_equal "New exciting title", documents[0].title
       sample_document_attributes.each_pair do |key, value|
@@ -22,8 +22,8 @@ class AmendmentTest < IntegrationTest
   end
 
   def test_should_fail_on_invalid_field
-    @primary_search.expects(:get).returns(sample_document)
-    @primary_search.expects(:add).never
+    @backend_index.expects(:get).returns(sample_document)
+    @backend_index.expects(:add).never
 
     post "/documents/%2Ffoobang", {fish: "Trout"}
 
@@ -32,8 +32,8 @@ class AmendmentTest < IntegrationTest
   end
 
   def test_should_fail_on_json_post
-    @primary_search.expects(:get).never
-    @primary_search.expects(:add).never
+    @backend_index.expects(:get).never
+    @backend_index.expects(:add).never
 
     post(
       "/documents/%2Ffoobang",
@@ -45,8 +45,8 @@ class AmendmentTest < IntegrationTest
   end
 
   def test_should_refuse_to_update_link
-    @primary_search.expects(:get).returns(sample_document)
-    @primary_search.expects(:add).never
+    @backend_index.expects(:get).returns(sample_document)
+    @backend_index.expects(:add).never
 
     post "/documents/%2Ffoobang", {link: "/somewhere-else"}
 
@@ -54,8 +54,8 @@ class AmendmentTest < IntegrationTest
   end
 
   def test_should_fail_to_amend_missing_document
-    @primary_search.expects(:get).returns(nil)
-    @primary_search.expects(:add).never
+    @backend_index.expects(:get).returns(nil)
+    @backend_index.expects(:add).never
 
     post "/documents/%2Ffoobang", {title: "New exciting title"}
 

--- a/test/functional/document_view_test.rb
+++ b/test/functional/document_view_test.rb
@@ -4,12 +4,12 @@ class DocumentViewtest < IntegrationTest
 
   def setup
     super
-    stub_primary_and_secondary_searches
+    stub_backend
     disable_secondary_search
   end
 
   def test_should_view_existing_document
-    @primary_search.expects(:get).returns(sample_document)
+    @backend_index.expects(:get).returns(sample_document)
 
     get "/documents/%2Ffoobang"
 
@@ -19,7 +19,7 @@ class DocumentViewtest < IntegrationTest
   end
 
   def test_should_404_on_missing_document
-    @primary_search.expects(:get).returns(nil)
+    @backend_index.expects(:get).returns(nil)
 
     get "/documents/%2Ffoobang"
 

--- a/test/functional/multiple_backends_test.rb
+++ b/test/functional/multiple_backends_test.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+require "integration_test_helper"
+
+class MultipleBackendsTest < IntegrationTest
+  def test_passes_search_to_chosen_backend
+    chosen_backend = stub_everything("chosen backend")
+    app.any_instance.stubs(:available_backends).returns(chosen: chosen_backend)
+    chosen_backend.expects(:search).returns([])
+    get "/chosen/search?q=example"
+  end
+
+  def test_actions_other_than_search_use_primary_backend_as_default
+    primary_backend = stub_everything("primary backend")
+    app.any_instance.stubs(:available_backends).returns(primary: primary_backend)
+    primary_backend.expects(:get).returns({'example' => 'document'})
+    get "/documents/abc"
+  end
+
+  def test_responds_with_404_if_backend_not_found
+    app.any_instance.stubs(:available_backends).returns(chosen: nil)
+    get "/chosen/search?q=example"
+    assert_equal 404, last_response.status
+  end
+end

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -9,7 +9,8 @@ class SearchTest < IntegrationTest
   end
 
   def test_autocomplete_cache
-    @primary_search.stubs(:autocomplete_cache).returns([
+    stub_backend
+    @backend_index.stubs(:autocomplete_cache).returns([
       sample_document,
       sample_document
     ])
@@ -60,14 +61,16 @@ class SearchTest < IntegrationTest
   end
 
   def test_should_return_autocompletion_documents_as_json
-    @primary_search.stubs(:complete).returns([sample_document])
+    stub_backend
+    @backend_index.stubs(:complete).returns([sample_document])
     get "/autocomplete", {q: "bob"}
     assert last_response.ok?
     assert_equal [sample_document_attributes], JSON.parse(last_response.body)
   end
 
   def test_we_pass_the_optional_filter_parameter_to_autocomplete
-    @primary_search.expects(:complete).with("anything", "my-format").returns([])
+    stub_backend
+    @backend_index.expects(:complete).with("anything", "my-format").returns([])
     get "/autocomplete", {q: "anything", format_filter: "my-format"}
   end
 

--- a/test/integration/elasticsearch_admin_test.rb
+++ b/test/integration/elasticsearch_admin_test.rb
@@ -14,7 +14,7 @@ class ElasticsearchAdminTest < IntegrationTest
     delete_elasticsearch_index
 
     @wrapper = ElasticsearchAdminWrapper.new(
-      settings.primary_search,
+      settings.backends[:primary],
       settings.elasticsearch_schema
     )
   end

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -6,7 +6,7 @@ class ElasticsearchSearchTest < IntegrationTest
 
   def setup
     use_elasticsearch_for_primary_search
-    disable_secondary_search
+    app.any_instance.stubs(:secondary_search).returns(stub(search: []))
     WebMock.disable_net_connect!(allow: "localhost:9200")
     reset_elasticsearch_index
     add_sample_documents

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -61,8 +61,8 @@ class IntegrationTest < Test::Unit::TestCase
   end
 
   def use_solr_for_primary_search
-    settings.stubs(:primary_search).returns(
-      {
+    settings.stubs(:backends).returns(
+      primary: {
         type: "solr",
         server: "solr-test-server",
         port: 9999,
@@ -72,8 +72,8 @@ class IntegrationTest < Test::Unit::TestCase
   end
 
   def use_elasticsearch_for_primary_search
-    settings.stubs(:primary_search).returns(
-      {
+    settings.stubs(:backends).returns(
+      primary: {
         type: "elasticsearch",
         server: "localhost",
         port: 9200,
@@ -92,7 +92,7 @@ class IntegrationTest < Test::Unit::TestCase
 
   def reset_elasticsearch_index
     admin = ElasticsearchAdminWrapper.new(
-      settings.primary_search,
+      settings.backends[:primary],
       settings.elasticsearch_schema
     )
     admin.create_index!

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -103,6 +103,11 @@ class IntegrationTest < Test::Unit::TestCase
     assert_equal [], JSON.parse(last_response.body)
   end
 
+  def stub_backend
+    @backend_index = stub_everything("Chosen backend")
+    app.any_instance.stubs(:backend).returns(@backend_index)
+  end
+
   def stub_primary_and_secondary_searches
     @primary_search = stub_everything("Mainstream Solr wrapper")
     app.any_instance.stubs(:primary_search).returns(@primary_search)

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -105,9 +105,9 @@ class IntegrationTest < Test::Unit::TestCase
 
   def stub_primary_and_secondary_searches
     @primary_search = stub_everything("Mainstream Solr wrapper")
-    Backends.any_instance.stubs(:primary_search).returns(@primary_search)
+    app.any_instance.stubs(:primary_search).returns(@primary_search)
 
     @secondary_search = stub_everything("Whitehall Solr wrapper")
-    Backends.any_instance.stubs(:secondary_search).returns(@secondary_search)
+    app.any_instance.stubs(:secondary_search).returns(@secondary_search)
   end
 end


### PR DESCRIPTION
This defines routes of the form /<backend>/search and similar to perform requests against the given backend for all actions that use a single index.  Requests without a backend parameter (such as POST /documents) will be applied against the primary backend as before.

This will be needed to give whitehall access to two backends (specialist and government), and hopefully remove the need for whitehall to have a different rummager.

I've tried to be very conservative in how many changes I've made, and also attempted to keep almost all existing functionality working (everything other than the path prefix).  I'm afraid the tests are not great, but adding more was difficult, at least not without some disruptive refactoring.  I didn't find sinatra and testing went as well together as I'd expected.
