### PR TITLE
Avoid reading boost file for every indexing call

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -39,6 +39,15 @@ def secondary_search
   available_backends[:secondary]
 end
 
+def boosts
+  # Build a map of links to a string of comma-separated phrases
+  @boosts ||= CSV.read(settings.boost_csv).inject({}) { |previous_boosts, row|
+    link, phrases = row
+    previous_boosts[link] = phrases
+    previous_boosts
+  }
+end
+
 helpers do
   include Helpers
 end
@@ -142,12 +151,6 @@ post "/?:backend?/documents" do
   request.body.rewind
   documents = [JSON.parse(request.body.read)].flatten.map { |hash|
     Document.from_hash(hash)
-  }
-
-  boosts = {}
-  CSV.foreach(settings.boost_csv) { |row|
-    link, phrases = row
-    boosts[link] = phrases
   }
 
   better_documents = boost_documents(documents, boosts)

--- a/app.rb
+++ b/app.rb
@@ -41,11 +41,10 @@ end
 
 def boosts
   # Build a map of links to a string of comma-separated phrases
-  @boosts ||= CSV.read(settings.boost_csv).inject({}) { |previous_boosts, row|
+  @boosts ||= CSV.read(settings.boost_csv).each_with_object({}) do |row, boosts|
     link, phrases = row
-    previous_boosts[link] = phrases
-    previous_boosts
-  }
+    boosts[link] = phrases
+  end
 end
 
 helpers do

--- a/test/unit/boosts_test.rb
+++ b/test/unit/boosts_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+require "app"
+
+CSV_BOOSTS = <<eos
+"/joker","clown prince of crime"
+"/batman","dark knight, caped crusader"
+eos
+
+class BoostTest < Test::Unit::TestCase
+
+  def test_should_parse_boosts_from_csv
+    CSV.stubs(:read).returns(CSV.parse(CSV_BOOSTS))
+    expected_boosts = {
+      "/joker" => "clown prince of crime",
+      "/batman" => "dark knight, caped crusader"
+    }
+    assert_equal expected_boosts, boosts
+  end
+end


### PR DESCRIPTION
This was what was giving us terrible performance (~1 document/sec) through single registration, as the documents were being submitted individually and triggering a full CSV file read each time. The file is
only going to change on deployment, as it's currently implemented, so there's no obvious risk to reading it all in on first use.

We're likely to revisit document boosting soon, so this may be removed in its current form, but this was the simplest change that would give us the performance we want.
