### PR TITLE
elasticsearch browse

### DIFF
--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -139,6 +139,22 @@ class ElasticsearchWrapper
     }
   end
 
+  def section(section_slug)
+    # RestClient does not allow a payload with a GET request
+    # so we have to call @client.request directly.
+    payload = {
+        from: 0, size: 50,
+        query: {
+          term: { section: section_slug }
+        }
+    }.to_json
+    result = @client.request(:get, "_search", payload)
+    result = JSON.parse(result)
+    result['hits']['hits'].map { |hit|
+      Document.from_hash(hit['_source'])
+    }
+  end
+
   def delete(link)
     begin
       # Can't use a simple delete, because we don't know the type

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -117,6 +117,28 @@ class ElasticsearchWrapper
     }
   end
 
+  def facet(field_name)
+    # Return a list of Section objects for each section with content
+    unless field_name == "section"
+      raise ArgumentError, "Faceting is only available on sections"
+    end
+
+    payload = {
+      query: {match_all: {}},
+      size: 0,  # We only need facet information: no point returning results
+      facets: {
+        section: {
+          terms: {field: "section", size: 100, order: "term"},
+          global: true
+        }
+      }
+    }.to_json
+    result = JSON.parse(@client.request(:get, "_search", payload))
+    result["facets"]["section"]["terms"].map { |term_info|
+      Section.new(term_info["term"])
+    }
+  end
+
   def delete(link)
     begin
       # Can't use a simple delete, because we don't know the type

--- a/test/integration/elasticsearch_browsing_test.rb
+++ b/test/integration/elasticsearch_browsing_test.rb
@@ -1,0 +1,54 @@
+require "integration_test_helper"
+require "app"
+require "rest-client"
+
+class ElasticsearchBrowsingTest < IntegrationTest
+
+  def setup
+    use_elasticsearch_for_primary_search
+    disable_secondary_search
+    WebMock.disable_net_connect!(allow: "localhost:9200")
+    reset_elasticsearch_index
+    add_sample_documents
+    commit_index
+  end
+
+  def sample_document_attributes
+    [
+      {
+        "title" => "Cheese in my face",
+        "description" => "Hummus weevils",
+        "format" => "answer",
+        "link" => "/an-example-answer",
+        "section" => "crime-and-justice",
+        "indexable_content" => "I like my badger: he is tasty and delicious"
+      },
+      {
+        "title" => "Useful government information",
+        "description" => "Government, government, government. Developers.",
+        "format" => "answer",
+        "link" => "/another-example-answer",
+        "section" => "work",
+        "indexable_content" => "Tax, benefits, roads and stuff"
+      }
+    ]
+  end
+
+  def add_sample_documents
+    sample_document_attributes.each do |sample_document|
+      post "/documents", JSON.dump(sample_document)
+      assert last_response.ok?
+    end
+  end
+
+  def commit_index
+    post "/commit", nil
+  end
+
+  def test_should_list_sections
+    get "/browse"
+    assert_links "Crime and justice" => "/browse/crime-and-justice",
+                 "Work" => "/browse/work"
+  end
+
+end

--- a/test/integration/elasticsearch_browsing_test.rb
+++ b/test/integration/elasticsearch_browsing_test.rb
@@ -51,4 +51,16 @@ class ElasticsearchBrowsingTest < IntegrationTest
                  "Work" => "/browse/work"
   end
 
+  def test_should_list_documents_in_section
+    # This is an old and crufty way of hacking around Slimmer, but we're about
+    # to kill off all front-end functionality from Rummager, so there's little
+    # point in doing things nicely
+    stub_request(:get, "https://panopticon.test.alphagov.co.uk/curated_lists.json").
+      to_return(body: "{}")
+
+    get "/browse/work"
+    assert_links "Useful government information" => "/another-example-answer"
+    refute_links "Cheese in my face" => "/an-example-answer"
+  end
+
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require 'slimmer/test'
 require "app"
+require "nokogiri"
 
 require "htmlentities"
 
@@ -9,6 +10,15 @@ module ResponseAssertions
     haystack = HTMLEntities.new.decode(last_response.body.gsub(/<[^>]+>/, " ").gsub(/\s+/, " "))
     message = "Expected to find #{needle.inspect} in\n#{haystack}"
     assert haystack.include?(needle), message
+  end
+
+  def assert_links(link_map)
+    doc = Nokogiri::HTML.parse(last_response.body)
+    link_map.each do |text, href|
+      assert doc.xpath("//a[text()='#{text.gsub("'", "\\'")}']").any? { |link|
+        link["href"] == href
+      }
+    end
   end
 end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -20,6 +20,16 @@ module ResponseAssertions
       }
     end
   end
+
+  def refute_links(link_map)
+    doc = Nokogiri::HTML.parse(last_response.body)
+    link_map.each do |text, href|
+      assert_false doc.xpath("//a[text()='#{text.gsub("'", "\\'")}']").any? { |link|
+        link["href"] == href
+      }
+    end
+  end
+
 end
 
 module IntegrationFixtures


### PR DESCRIPTION
Add section browsing capability from elasticsearch so we can migrate our search index over before the new API-driven browse pages are finished.

There's a few simple tests, but nothing too thorough, since we'll be replacing this functionality imminently anyway.
