### PR TITLE
Allow the use of a "subsubsection" key.

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -13,6 +13,7 @@ mapping:
       format:      { type: string, index: not_analyzed, include_in_all: false }
       section:     { type: string, index: not_analyzed, include_in_all: false }
       subsection:  { type: string, index: not_analyzed, include_in_all: false }
+      subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
       link:        { type: string, index: not_analyzed, include_in_all: false }
       indexable_content: { type: string, index: analyzed }
 

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -107,7 +107,7 @@ class Document < Link
   # Rummager. In time, they are likely to disappear entirely, taking large
   # tracts of code with them.
 
-  auto_keys :title, :link, :description, :format, :section, :subsection,
+  auto_keys :title, :link, :description, :format, :section, :subsection, :subsubsection,
     :indexable_content, :additional_links, :boost_phrases
   attr_writer :highlight
 

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -9,6 +9,7 @@ class DocumentTest < Test::Unit::TestCase
       "format" => "answer",
       "section" => "Life in the UK",
       "subsection" => 'Queuing',
+      "subsubsection" => 'Barging to the front',
       "link" => "/an-example-answer",
       "indexable_content" => "HERE IS SOME CONTENT",
     }
@@ -20,6 +21,7 @@ class DocumentTest < Test::Unit::TestCase
     assert_equal "answer", document.format
     assert_equal "Life in the UK", document.section
     assert_equal "Queuing", document.subsection
+    assert_equal "Barging to the front", document.subsubsection
     assert_equal "/an-example-answer", document.link
     assert_equal "HERE IS SOME CONTENT", document.indexable_content
   end


### PR DESCRIPTION
This is needed for detailed guidance in order to e.g. show individual
breadcrumbs alongside search results.

While it would have been nicer and more "scalable" to combine the
"section", "subsection" & "subsubsection" keys into a single key with
e.g. an array of values, this would require significant changes in many
places. The solution in this commit seems like the most consistent and
least worst option for the moment.

See https://www.pivotaltracker.com/story/show/36615073.
