### PR TITLE
Don't include recommended links in sitemap

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -126,10 +126,12 @@ class Rummager < Sinatra::Application
           xml.loc "#{base_url}#{"/"}"
         end
         documents.each do |document|
-          xml.url do
-            url = document.link
-            url = "#{base_url}#{url}" if url =~ /^\//
-            xml.loc url
+          unless document.format == settings.recommended_format
+            xml.url do
+              url = document.link
+              url = "#{base_url}#{url}" if url =~ /^\//
+              xml.loc url
+            end
           end
         end
       end

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -34,6 +34,14 @@ class SitemapTest < IntegrationTest
         "link" => "/another-example-answer",
         "section" => "Crime",
         "indexable_content" => "Tax, benefits, roads and stuff"
+      },
+      {
+        "title" => "External government information",
+        "description" => "Government, government, government. Developers.",
+        "format" => "recommended-link",
+        "link" => "/external-example-answer",
+        "section" => "Crime",
+        "indexable_content" => "Tax, benefits, roads and stuff"
       }
     ]
   end
@@ -52,10 +60,24 @@ class SitemapTest < IntegrationTest
     assert_equal links, paths
   end
 
+  def assert_no_link(link)
+    doc = Nokogiri::XML(last_response.body)
+    paths = doc.css('loc').collect(&:text).map { |l| URI.parse(l).path }
+
+    assert ! paths.include?(link), "Found #{link} in sitemap"
+  end
+
   def test_should_return_a_sitemap
     get "/sitemap.xml"
     assert last_response.headers["Content-Type"].include?("application/xml")
     assert last_response.ok?
     assert_result_links "/", "/an-example-answer", "/another-example-answer"
+  end
+
+  def test_should_not_include_recommended_links
+    get "/sitemap.xml"
+    assert last_response.headers["Content-Type"].include?("application/xml")
+    assert last_response.ok?
+    assert_no_link "/external-example-answer"
   end
 end

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -39,7 +39,7 @@ class SitemapTest < IntegrationTest
         "title" => "External government information",
         "description" => "Government, government, government. Developers.",
         "format" => "recommended-link",
-        "link" => "/external-example-answer",
+        "link" => "http://www.example.com/external-example-answer",
         "section" => "Crime",
         "indexable_content" => "Tax, benefits, roads and stuff"
       }


### PR DESCRIPTION
By definition they're not part of our site. Thanks to @beng for spotting this one.
