### PR TITLE
Bug fix: delete external links

### DIFF
--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -254,7 +254,7 @@ class ElasticsearchWrapper
   def delete(link)
     begin
       # Can't use a simple delete, because we don't know the type
-      @client.delete "_query?q=link:#{CGI.escape(link)}"
+      @client.delete "_query", params: {q: "link:#{escape(link)}"}
     rescue RestClient::ResourceNotFound
     end
     return true  # For consistency with the Solr API and simple_json_response

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -66,7 +66,7 @@ class ElasticsearchWrapper
         end
         recording_elastic_error do
           RestClient.send(method_name, url_for(sub_path), *args)
-        end        
+        end
       end
     end
 

--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -29,6 +29,11 @@ class ElasticsearchDeletionTest < IntegrationTest
         "link" => "/another-example-answer",
         "section" => "Crime",
         "indexable_content" => "Tax, benefits, roads and stuff"
+      },
+      {
+          "title" => "Some other site",
+          "format" => "answer",
+          "link" => "http://example.com/",
       }
     ]
   end
@@ -64,6 +69,17 @@ class ElasticsearchDeletionTest < IntegrationTest
 
     get "/search.json?q=cheese"
     assert_no_results
+  end
+
+  def test_should_delete_an_item_with_a_full_url
+    get "/documents/http:%2F%2Fexample.com%2F"
+    assert last_response.ok?
+
+    delete "/documents/http:%2F%2Fexample.com%2F"
+    assert last_response.ok?
+
+    get "/documents/http:%2F%2Fexample.com%2F"
+    assert last_response.not_found?
   end
 
   def test_should_delete_all_the_things


### PR DESCRIPTION
Fix a bug where recommended links couldn’t be deleted, as their `link` fields have absolute URLs in them, and the colons in the absolute URLs were confusing Lucene’s query parser.
