### PR TITLE
Escape conjunctions before passing them to search.

### DIFF
--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -204,13 +204,19 @@ class ElasticsearchWrapper
     + - && || ! ( ) { } [ ] ^ " ~ * ? : \\
   ].map { |s| Regexp.escape(s) }.join("|") + ")")
 
+  LUCENE_CONJUNCTIONS = /\b(AND|OR)\b/
+
   def escape(s)
     # 6 slashes =>
     #  ruby reads it as 3 backslashes =>
     #    the first 2 =>
     #      go into the regex engine which reads it as a single literal backslash
     #    the last one combined with the "1" to insert the first match group
-    s.gsub(LUCENE_SPECIAL_CHARACTERS, '\\\\\1')
+    special_chars_escaped = s.gsub(LUCENE_SPECIAL_CHARACTERS, '\\\\\1')
+
+    # Map something like 'fish AND chips' to 'fish "AND" chips', to avoid
+    # Lucene trying to parse it as a query conjunction
+    special_chars_escaped.gsub(LUCENE_CONJUNCTIONS, '"\1"')
   end
 
   def facet(field_name)

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -29,6 +29,10 @@ class ElasticsearchSearchTest < IntegrationTest
         "link" => "/another-example-answer",
         "section" => "Crime",
         "indexable_content" => "Tax, benefits, roads and stuff"
+      },
+      {
+        "title" => "Pork pies",
+        "link" => "/pork-pies"
       }
     ]
   end
@@ -109,5 +113,13 @@ class ElasticsearchSearchTest < IntegrationTest
       assert last_response.ok?
       assert_result_links "/an-example-answer"
     end
+  end
+
+  def test_should_not_parse_conjunctions_in_words
+    # Testing a SHOUTY QUERY because Lucene only treats capitalised
+    # conjunctions as special operators
+    get "/search.json?q=PORK+PIES"
+    assert last_response.ok?
+    assert_result_links "/pork-pies"
   end
 end

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -100,4 +100,14 @@ class ElasticsearchSearchTest < IntegrationTest
     assert last_response.ok?
     assert_no_results
   end
+
+  def test_should_not_fail_on_conjunctions
+    ["cheese AND ", "cheese OR ", " AND cheese", " OR cheese"].each do |term|
+      assert_nothing_raised "Request failed for '#{term}'" do
+        get "/search.json?q=#{CGI.escape term}"
+      end
+      assert last_response.ok?
+      assert_result_links "/an-example-answer"
+    end
+  end
 end


### PR DESCRIPTION
elasticsearch takes capitalised 'AND' and 'OR' and interprets them as Boolean query operators: if there isn't a word on either side, it will b0rk with an error.

Escaping queries still isn't an ideal fix -- preferably, I think we'd pass them in in a way that the engine wasn't trying to parse them as a Lucene query in the first place.
