### PR TITLE
Self-indexing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -227,8 +227,18 @@ namespace :rummager do
     puts "sure this worked as you expected."
   end
 
-  desc "Reindex all indexed content"
+  desc "Reindex all content in the index"
   task :reindex => :rummager_environment do
     Reindexer.new(@search_wrapper, @logger).reindex_all
   end
+
+  desc "Reindex all content in all indexes"
+  task :reindex_all => :rummager_environment do
+    @search_wrappers.each do |name, wrapper|
+      puts "Reindexing '#{name}' index..."
+      Reindexer.new(wrapper, @logger).reindex_all
+      puts "...done!"
+    end
+  end
+
 end

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ File.join(File.dirname(__FILE__), "lib").tap do |path|
 end
 
 require "elasticsearch_admin_wrapper"
+require "reindexer"
 
 desc "Run all the tests"
 task "test" => ["test:units", "test:functionals", "test:integration"]
@@ -215,5 +216,10 @@ namespace :rummager do
     puts "...done!"
     puts "You probably want to run the rummager:list_formats task now, to make"
     puts "sure this worked as you expected."
+  end
+
+  desc "Reindex all indexed content"
+  task :reindex => :rummager_environment do
+    Reindexer.new(@search_wrapper, @logger).reindex_all
   end
 end

--- a/lib/reindexer.rb
+++ b/lib/reindexer.rb
@@ -1,0 +1,19 @@
+class Reindexer
+
+  BATCH_SIZE = 50
+
+  def initialize(backend, logger = nil)
+    @backend = backend
+    @logger = logger || Logger.new("/dev/null")
+  end
+
+  def reindex_all
+    total_indexed = 0
+    all_docs = @backend.all_documents(limit: 500000)
+    all_docs.each_slice(BATCH_SIZE) do |documents|
+      @backend.add documents
+      total_indexed += documents.length
+      @logger.info "Reindexed #{total_indexed} of #{all_docs.size}"
+    end
+  end
+end

--- a/lib/reindexer.rb
+++ b/lib/reindexer.rb
@@ -9,7 +9,11 @@ class Reindexer
 
   def reindex_all
     total_indexed = 0
-    all_docs = @backend.all_documents(limit: 500000)
+    # This will load the entire content of the search index into memory at
+    # once, which isn't yet a big deal but may become a problem as the search
+    # index grows. One alternative could be to use elasticsearch scan queries
+    # <http://www.elasticsearch.org/guide/reference/api/search/search-type.html>
+    all_docs = @backend.all_documents
     all_docs.each_slice(BATCH_SIZE) do |documents|
       @backend.add documents
       total_indexed += documents.length

--- a/test/integration/elasticsearch_reindexing_test.rb
+++ b/test/integration/elasticsearch_reindexing_test.rb
@@ -1,0 +1,79 @@
+require "integration_test_helper"
+require "app"
+require "rest-client"
+require "reindexer"
+require "rack/logger"
+
+class ElasticsearchReindexingTest < IntegrationTest
+
+  def setup
+    use_elasticsearch_for_primary_search
+    app.any_instance.stubs(:secondary_search).returns(stub(search: []))
+    WebMock.disable_net_connect!(allow: "localhost:9200")
+
+    es_settings = settings.elasticsearch_schema["index"]["settings"]
+    @stemmer = es_settings["analysis"]["filter"]["stemmer_override"]
+    # Save for restore on teardown
+    @original_rules = @stemmer["rules"]
+    @stemmer["rules"] = ["fish => fish"]  # elasticsearch needs at least 1 rule
+
+    reset_elasticsearch_index
+    add_sample_documents
+    commit_index
+  end
+
+  def teardown
+    @stemmer["rules"] = @original_rules
+  end
+
+  def sample_document_attributes
+    [
+      {
+        "title" => "Important government directive",
+        "format" => "answer",
+        "link" => "/important",
+      },
+      {
+        "title" => "Direct contact with aliens",
+        "format" => "answer",
+        "link" => "/aliens",
+      }
+    ]
+  end
+
+  def add_sample_documents
+    sample_document_attributes.each do |sample_document|
+      post "/documents", JSON.dump(sample_document)
+      assert last_response.ok?
+    end
+  end
+
+  def commit_index
+    post "/commit", nil
+  end
+
+  def assert_result_links(*links)
+    parsed_response = JSON.parse(last_response.body)
+    assert_equal links, parsed_response.map { |r| r["link"] }
+  end
+
+  def test_full_reindex
+    # Test that a reindex re-adds all the documents with new
+    # stemming settings
+
+    get "/search?q=directive"
+    assert_equal 2, JSON.parse(last_response.body).length
+
+    @stemmer["rules"] = ["directive => directive"]
+    update_elasticsearch_index
+
+    backends = Backends.new(settings)
+    Reindexer.new(backends[:primary]).reindex_all
+
+    get "/search?q=directive"
+    assert_result_links "/important"
+
+    get "/search?q=direct"
+    assert_result_links "/aliens"
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -89,12 +89,17 @@ class IntegrationTest < Test::Unit::TestCase
   end
 
   def reset_elasticsearch_index(index_name=:primary)
-    admin = ElasticsearchAdminWrapper.new(
-      settings.backends[index_name],
-      settings.elasticsearch_schema
-    )
-    admin.ensure_index!
-    admin.put_mappings
+    admin_wrapper(index_name).tap do |admin|
+      admin.ensure_index!
+      admin.put_mappings
+    end
+  end
+
+  def update_elasticsearch_index(index_name=:primary)
+    admin_wrapper(index_name).tap do |admin|
+      admin.ensure_index
+      admin.put_mappings
+    end
   end
 
   def assert_no_results
@@ -112,5 +117,13 @@ class IntegrationTest < Test::Unit::TestCase
 
     @secondary_search = stub_everything("Whitehall Solr wrapper")
     app.any_instance.stubs(:secondary_search).returns(@secondary_search)
+  end
+
+private
+  def admin_wrapper(index_name)
+    ElasticsearchAdminWrapper.new(
+      settings.backends[index_name],
+      settings.elasticsearch_schema
+    )
   end
 end


### PR DESCRIPTION
Up until now, when we change the elasticsearch indexer (usually with new stemming overrides) we have had to reindex all documents from the apps themselves, which is slow and error-prone. This lets us tell Rummager to reindex everything it already knows about with a Rake task.
