### PR TITLE
Hacky fix for settings update

### DIFF
--- a/lib/elasticsearch_admin_wrapper.rb
+++ b/lib/elasticsearch_admin_wrapper.rb
@@ -23,6 +23,16 @@ class ElasticsearchAdminWrapper
 
     if index_exists?
       @logger.info "Index already exists: updating settings"
+
+      # For no readily discernible reason, a short delay here prevents the
+      # tests (and potentially Rake tasks) causing some shards to fail when
+      # reopening the index in some configurations (occasionally in Jenkins;
+      # reliably on dev machines configured to use 20 shards per index).
+      # Neither a `flush` nor a `refresh` gets around this problem, otherwise I
+      # would much prefer those. I would love to find a more sensible way to
+      # achieve this.
+      sleep 1
+
       @logger.debug @client.post("_close", nil)
       @logger.debug @client.put("_settings", index_payload["settings"].to_json)
       @logger.debug @client.post("_open", nil)

--- a/lib/elasticsearch_admin_wrapper.rb
+++ b/lib/elasticsearch_admin_wrapper.rb
@@ -23,9 +23,9 @@ class ElasticsearchAdminWrapper
 
     if index_exists?
       @logger.info "Index already exists: updating settings"
-      @client.post("_close", nil)
-      @client.put("_settings", index_payload["settings"].to_json)
-      @client.post("_open", nil)
+      @logger.debug @client.post("_close", nil)
+      @logger.debug @client.put("_settings", index_payload["settings"].to_json)
+      @logger.debug @client.post("_open", nil)
       wait_until_ready
       @logger.info "Settings updated"
       return :updated


### PR DESCRIPTION
@fatbusinessman had been working on this code before he went on holiday. He was finding problems with Elasticsearch indexes when rebuilding that is fixed by adding a sleep into the rebuild process.

This is not a long term fix and we need to revisit it, but in David's absence I'm going to go ahead and merge it pending a deeper investigation.
