### PR TITLE
Boost Ministers, Organisations, and Topical Events

### DIFF
--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -152,7 +152,8 @@ class ElasticsearchWrapper
       # Inside Gov formats
       "topical_event" => 1.5,
       "minister"      => 1.5,
-      "organisation"  => 1.5
+      "organisation"  => 1.5,
+      "topic"         => 1.5
     }
 
     format_boosts = boosted_formats.map do |format, boost|

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -144,7 +144,17 @@ class ElasticsearchWrapper
 
     # Per-format boosting done as a filter, so the results get cached on the
     # server, as they are the same for each query
-    boosted_formats = { "smart-answer" => 1.5, "transaction" => 1.5 }
+
+    boosted_formats = {
+      # Mainstream formats
+      "smart-answer"  => 1.5,
+      "transaction"   => 1.5,
+      # Inside Gov formats
+      "topical_event" => 1.5,
+      "minister"      => 1.5,
+      "organisation"  => 1.5
+    }
+
     format_boosts = boosted_formats.map do |format, boost|
       {
         filter: { term: { format: format } },


### PR DESCRIPTION
These things are more important than news stories, speeches, etc. within the Inside Government data model. This boosting gives them a relatively higher weight versus other things that match, because users should always be able to find:
- The G8 itself, versus a news article about the G8
- David Cameron versus an article about David Cameron visiting a hospital
- The Ministry of Defense versus an publication about HR within the MOD

In the future we should do some work to offer per-index boosting instead of doing it blanketly (given that the format names are quite generic, and there's no cross-platform data model).
