### PR TITLE
Ensure backends loads correct mappings

### DIFF
--- a/backends.rb
+++ b/backends.rb
@@ -41,6 +41,6 @@ private
 
   def mappings_for(backend_name)
     all_mappings = @settings.elasticsearch_schema["mappings"]
-    all_mappings[backend_name] || all_mappings["default"]
+    all_mappings[backend_name.to_s] || all_mappings["default"]
   end
 end

--- a/test/fixtures/backends.fixture.yml
+++ b/test/fixtures/backends.fixture.yml
@@ -1,0 +1,25 @@
+development:
+  mainstream: &mainstream
+    type: elasticsearch
+    server: localhost
+    port: 9200
+    index_name: "mainstream"
+  detailed: &detailed
+    type: elasticsearch
+    server: localhost
+    port: 9200
+    index_name: "detailed"
+  government: &government
+    type: elasticsearch
+    server: localhost
+    port: 9200
+    index_name: "government"
+  primary:
+    *mainstream
+  secondary:
+    type: none
+test:
+  primary:
+    type: none
+  secondary:
+    type: none

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -104,10 +104,6 @@ class IntegrationTest < Test::Unit::TestCase
     app.any_instance.stubs(:secondary_search).returns(@secondary_search)
   end
 
-  def load_yaml_fixture(filename)
-    YAML.load_file(File.expand_path("fixtures/#{filename}", File.dirname(__FILE__)))
-  end
-
   def wrapper_for(index_name, mappings_fixture_file = "elasticsearch_schema.fixture.yml")
     ElasticsearchAdminWrapper.new(
       {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,3 +19,13 @@ if ENV["USE_SIMPLECOV"]
   SimpleCov.start
   SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 end
+
+module TestHelpers
+  def load_yaml_fixture(filename)
+    YAML.load_file(File.expand_path("fixtures/#{filename}", File.dirname(__FILE__)))
+  end
+end
+
+class Test::Unit::TestCase
+  include TestHelpers
+end

--- a/test/unit/backends_test.rb
+++ b/test/unit/backends_test.rb
@@ -1,15 +1,15 @@
 require "test_helper"
 require "backends"
-require 'active_support/core_ext/hash/keys'
+require "active_support/core_ext/hash/keys"
 
 class BackendsTest < Test::Unit::TestCase
   include Fixtures::DefaultMappings
 
   def test_should_use_custom_mappings_defined_in_elasticsearch_schema
     settings = stub("settings")
-    settings.stubs(:backends).returns(load_yaml_fixture('backends.fixture.yml')["development"].symbolize_keys)
-    settings.stubs(:elasticsearch_schema).returns(load_yaml_fixture('elasticsearch_schema.fixture.yml'))
+    settings.stubs(:backends).returns(load_yaml_fixture("backends.fixture.yml")["development"].symbolize_keys)
+    settings.stubs(:elasticsearch_schema).returns(load_yaml_fixture("elasticsearch_schema.fixture.yml"))
     backends = Backends.new(settings)
-    assert_equal %w{title topics}, backends[:government].mappings['edition']['properties'].keys
+    assert_equal %w{title topics}, backends[:government].mappings["edition"]["properties"].keys
   end
 end

--- a/test/unit/backends_test.rb
+++ b/test/unit/backends_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "backends"
+require 'active_support/core_ext/hash/keys'
+
+class BackendsTest < Test::Unit::TestCase
+  include Fixtures::DefaultMappings
+
+  def test_should_use_custom_mappings_defined_in_elasticsearch_schema
+    settings = stub("settings")
+    settings.stubs(:backends).returns(load_yaml_fixture('backends.fixture.yml')["development"].symbolize_keys)
+    settings.stubs(:elasticsearch_schema).returns(load_yaml_fixture('elasticsearch_schema.fixture.yml'))
+    backends = Backends.new(settings)
+    assert_equal %w{title topics}, backends[:government].mappings['edition']['properties'].keys
+  end
+end


### PR DESCRIPTION
The `backend_name` variable is a symbol, not a string. So it was not
finding the mappings when looking them up. Unfortunately there's a
default fallback so this was silently failing.

Fixed the implementation and added a unit test for the Backends class.
