### PR TITLE
Advanced search for whitehall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,20 @@
 source :rubygems
-source 'https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/'
+source "https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/"
 
 group :router do
-  gem 'router-client', '2.0.3', :require => 'router/client'
+  gem "router-client", "2.0.3", :require => "router/client"
 end
 
-gem 'unicorn', '4.3.1'
-gem 'sinatra', '1.3.4'
-gem 'rake', '0.9.2', :require => false
-gem 'json', '1.7.7'
-gem 'activesupport', '3.2.12'
-gem 'rack', '1.5.2'
-gem 'aws-ses', '0.4.4'
-gem 'rest-client', '1.6.7'
-gem 'statsd-ruby', '1.0.0'
+gem "unicorn", "4.3.1"
+gem "sinatra", "1.3.4"
+gem "rake", "0.9.2", :require => false
+gem "multi_json"
+gem "json", "1.7.7"
+gem "activesupport", "3.2.12"
+gem "rack", "1.5.2"
+gem "aws-ses", "0.4.4"
+gem "rest-client", "1.6.7"
+gem "statsd-ruby", "1.0.0"
 
 group :test do
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ DEPENDENCIES
   ci_reporter
   json (= 1.7.7)
   mocha
+  multi_json
   nokogiri
   rack (= 1.5.2)
   rack-test

--- a/app.rb
+++ b/app.rb
@@ -99,6 +99,14 @@ class Rummager < Sinatra::Application
     )})
   end
 
+  get "/:backend/advanced_search.?:format?" do
+    MultiJson.encode(backend.advanced_search(params).map { |r| r.to_hash.merge(
+      highlight: r.highlight,
+      presentation_format: r.presentation_format,
+      humanized_format: r.humanized_format
+    )})
+  end
+
   get "/?:backend?/preload-autocomplete" do
     # Eventually this is likely to be a list of commonly searched for terms
     # so searching for those is really fast. For the beta, this is just a list

--- a/app.rb
+++ b/app.rb
@@ -100,10 +100,10 @@ class Rummager < Sinatra::Application
   end
 
   get "/:backend/advanced_search.?:format?" do
-    total, results = backend.advanced_search(params)
+    results = backend.advanced_search(params)
     MultiJson.encode({
-      total: total,
-      results: results.map { |r| r.to_hash.merge(
+      total: results[:total],
+      results: results[:results].map { |r| r.to_hash.merge(
         highlight: r.highlight,
         presentation_format: r.presentation_format,
         humanized_format: r.humanized_format

--- a/app.rb
+++ b/app.rb
@@ -100,7 +100,7 @@ class Rummager < Sinatra::Application
   end
 
   get "/:backend/advanced_search.?:format?" do
-    results = backend.advanced_search(params)
+    results = backend.advanced_search(request.params)
     MultiJson.encode({
       total: results[:total],
       results: results[:results].map { |r| r.to_hash.merge(

--- a/app.rb
+++ b/app.rb
@@ -100,11 +100,15 @@ class Rummager < Sinatra::Application
   end
 
   get "/:backend/advanced_search.?:format?" do
-    MultiJson.encode(backend.advanced_search(params).map { |r| r.to_hash.merge(
-      highlight: r.highlight,
-      presentation_format: r.presentation_format,
-      humanized_format: r.humanized_format
-    )})
+    total, results = backend.advanced_search(params)
+    MultiJson.encode({
+      total: total,
+      results: results.map { |r| r.to_hash.merge(
+        highlight: r.highlight,
+        presentation_format: r.presentation_format,
+        humanized_format: r.humanized_format
+      )}
+    })
   end
 
   get "/?:backend?/preload-autocomplete" do

--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,6 @@
 require_relative "env"
-require 'active_support/core_ext/hash/keys'
-require_relative 'exception_mailer'
+require "active_support/core_ext/hash/keys"
+require_relative "exception_mailer"
 
 def config_for(kind)
   YAML.load_file(File.expand_path("../#{kind}.yml", __FILE__))
@@ -33,12 +33,12 @@ set :max_recommended_results, 2
 set :recommended_format, "recommended-link"
 set :inside_government_link, "inside-government-link"
 
-set :format_order, ['transaction', 'answer', 'programme', 'guide']
+set :format_order, ["transaction", "answer", "programme", "guide"]
 
 configure :development do
   set :protection, false
 end
 
-initializers_path = File.expand_path('config/initializers/*.rb', File.dirname(__FILE__))
+initializers_path = File.expand_path("config/initializers/*.rb", File.dirname(__FILE__))
 
 Dir[initializers_path].each { |f| require f }

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -2,8 +2,8 @@ configure :production do
   if File.exist?("../aws_secrets.yml")
     disable :show_exceptions
     use ExceptionMailer, YAML.load_file("aws_secrets.yml"),
-        to: ['govuk-exceptions@digital.cabinet-office.gov.uk'],
+        to: ["govuk-exceptions@digital.cabinet-office.gov.uk"],
         from: '"Winston Smith-Churchill" <winston@alphagov.co.uk>',
-        subject: '[Rummager exception]'
+        subject: "[Rummager exception]"
   end
 end

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -476,19 +476,19 @@ mappings:
       properties:
         title:       { type: string, index: analyzed }
         description: { type: string, index: analyzed }
-        format:      { type: string, index: not_analyzed }
-        display_type: { type: string, index: not_analyzed }
+        indexable_content: { type: string, index: analyzed }
+        format:      { type: string, index: not_analyzed, include_in_all: false }
+        display_type: { type: string, index: not_analyzed, include_in_all: false }
         section:     { type: string, index: not_analyzed, include_in_all: false }
         subsection:  { type: string, index: not_analyzed, include_in_all: false }
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
         link:        { type: string, index: not_analyzed, include_in_all: false }
-        indexable_content: { type: string, index: analyzed }
-        id:          { type: long, index: not_analyzed }
-        organisations: { type: long, index: not_analyzed }
-        people: { type: long, index: not_analyzed }
-        speech_type: { type: long, index: not_analyzed }
-        news_article_type: { type: string, index: not_analyzed }
-        topics: { type: string, index: not_analyzed }
-        publication_type: { type: long, index: not_analyzed }
-        public_timestamp: { type: date, index: not_analyzed }
+        id:          { type: long, index: not_analyzed, include_in_all: false }
+        organisations: { type: long, index: not_analyzed, include_in_all: false }
+        people: { type: long, index: not_analyzed, include_in_all: false }
+        speech_type: { type: long, index: not_analyzed, include_in_all: false }
+        news_article_type: { type: string, index: not_analyzed, include_in_all: false }
+        topics: { type: string, index: not_analyzed, include_in_all: false }
+        publication_type: { type: long, index: not_analyzed, include_in_all: false }
+        public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -491,3 +491,4 @@ mappings:
         topics: { type: string, index: not_analyzed }
         publication_type: { type: long, index: not_analyzed }
         public_timestamp: { type: date, index: not_analyzed }
+        search_format_types: { type: string, index: not_analyzed, include_in_all: false }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -493,3 +493,4 @@ mappings:
         public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }
         relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }
+        world_locations: { type: string, index: not_analyzed, include_in_all: false }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -484,12 +484,9 @@ mappings:
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
         link:        { type: string, index: not_analyzed, include_in_all: false }
         id:          { type: long, index: not_analyzed, include_in_all: false }
-        organisations: { type: long, index: not_analyzed, include_in_all: false }
-        people: { type: long, index: not_analyzed, include_in_all: false }
-        speech_type: { type: long, index: not_analyzed, include_in_all: false }
-        news_article_type: { type: string, index: not_analyzed, include_in_all: false }
+        organisations: { type: string, index: not_analyzed, include_in_all: false }
+        people: { type: string, index: not_analyzed, include_in_all: false }
         topics: { type: string, index: not_analyzed, include_in_all: false }
-        publication_type: { type: long, index: not_analyzed, include_in_all: false }
         public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }
         relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -145,9 +145,9 @@ synonyms: &synonyms [
   "workplacepensions => workplace pensions",
   "yourmotcheck => mot check",
   "xmas => christmas",
-  
+
   # Additional terms
-  
+
   "book driving test => book driving test, book your practical driving test",
   "bursaries, bursary => bursaries, bursary, extra, university",
   "child care => child care, childcare",
@@ -161,7 +161,7 @@ synonyms: &synonyms [
   "firing => firing, dismiss, dismissing, dismissal",
   "getaway => getaway, gateway",
   "green deal => green deal, green deal energy saving, energy grants, heating",
-  "heating => heating, energy grants, energy saving, cold, warm, winter", 
+  "heating => heating, energy grants, energy saving, cold, warm, winter",
   "how much => how much, fees, rates",
   "ir35 => ir35, employment status",
   "job match => job match, jobmatch",
@@ -187,10 +187,10 @@ synonyms: &synonyms [
   "ukti => ukti, uk trade and investment, help for exporters, starting to export, uk welcomes",
   "utr, unique taxpayer reference => utr, unique taxpayer reference, register for self assessment",
   "wales => wales, cymru, cymraeg, gymraeg",
-  "weather, bad weather, winter weather => weather, cold weather, severe weather, winter weather, energy grants, heating", 
+  "weather, bad weather, winter weather => weather, cold weather, severe weather, winter weather, energy grants, heating",
   "welsh => welsh, cymraeg, gymraeg",
   "winter payment, winter payments => winter fuel payment, cold weather, warm home, energy saving, energy grants, heating",
-  
+
   # Forms and leaflets
 
   "br1, br 1 => state pension claim",
@@ -357,7 +357,7 @@ synonyms: &synonyms [
 
   # Temporary fix for Inside Government in general results
   "government gateway => gateway",
-  
+
   # Temporary fix for payroll terms
   "480 => 480, payroll",
   "ca38 => ca38, payroll",
@@ -382,7 +382,7 @@ synonyms: &synonyms [
   "ssp1 => ssp1, payroll",
   "tax calculator => tax calculator, payroll",
   "tax refund => tax refund, payroll",
-  
+
   # Temporary fix for career-specific job searches
   # TODO: Remove this once we have support for alternative keywords in Panopticon
   "admin => admin, find a job",
@@ -492,3 +492,4 @@ mappings:
         publication_type: { type: long, index: not_analyzed, include_in_all: false }
         public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }
+        relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }

--- a/exception_mailer.rb
+++ b/exception_mailer.rb
@@ -19,7 +19,7 @@ class ExceptionMailer
         send_notification boom, env
         raise
       end
-    send_notification env['mail.exception'], env if env['mail.exception']
+    send_notification env["mail.exception"], env if env["mail.exception"]
     [status, headers, body]
   end
 
@@ -38,7 +38,7 @@ class ExceptionMailer
     parts = []
     env_string = env.to_a.
       sort{|a,b| a.first <=> b.first}.
-      map{ |k,v| "%-25s%p" % [k+':', v] }.
+      map{ |k,v| "%-25s%p" % [k+":", v] }.
       join("\n  ")
 
     parts << <<-EOS
@@ -60,7 +60,7 @@ EOS
 Request Body:
 ===================================================================
 
-#{body.gsub(/^/, '  ')}
+#{body.gsub(/^/, "  ")}
 EOS
     end
 
@@ -78,7 +78,7 @@ EOS
   end
 
   def extract_body(env)
-    if io = env['rack.input']
+    if io = env["rack.input"]
       io.rewind if io.respond_to?(:rewind)
       io.read
     end

--- a/helpers.rb
+++ b/helpers.rb
@@ -4,8 +4,8 @@ module Helpers
   alias_method :h, :escape_html
 
   def base_url
-    return "https://www.gov.uk" if ENV['FACTER_govuk_platform'] == 'production'
-    "https://www.#{ENV['FACTER_govuk_platform']}.alphagov.co.uk"
+    return "https://www.gov.uk" if ENV["FACTER_govuk_platform"] == "production"
+    "https://www.#{ENV["FACTER_govuk_platform"]}.alphagov.co.uk"
   end
 
   def pluralize(singular, plural)

--- a/helpers.rb
+++ b/helpers.rb
@@ -20,7 +20,7 @@ module Helpers
       result = "error"
       status 500
     end
-    JSON.dump("result" => result)
+    MultiJson.encode("result" => result)
   end
 end
 

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -123,7 +123,7 @@ class Document < SearchIndexEntry
   attr_writer :highlight
 
   def self.from_hash(hash, mappings)
-    field_names = mappings['edition']['properties'].keys.map(&:to_s)
+    field_names = mappings["edition"]["properties"].keys.map(&:to_s)
     self.new(field_names, unflatten(hash))
   end
 
@@ -184,6 +184,6 @@ class Document < SearchIndexEntry
   private
 
   def normalized_format
-    self.format ? self.format.gsub("-", "_") : 'unknown'
+    self.format ? self.format.gsub("-", "_") : "unknown"
   end
 end

--- a/lib/elasticsearch_admin_wrapper.rb
+++ b/lib/elasticsearch_admin_wrapper.rb
@@ -11,7 +11,7 @@ class ElasticsearchAdminWrapper
   end
 
   def index_exists?
-    server_status = JSON.parse(@client.get("/_status"))
+    server_status = MultiJson.decode(@client.get("/_status"))
     server_status["indices"].keys.include? @client.index_name
   end
 
@@ -98,7 +98,7 @@ private
 
     health_params = { wait_for_status: "yellow", timeout: "#{timeout}s" }
     response = @client.get "/_cluster/health", params: health_params
-    health = JSON.parse(response)
+    health = MultiJson.decode(response)
     if health["timed_out"] || ! ["green", "yellow"].include?(health["status"])
       @logger.error "Failed to restore search. Response: #{response}"
       raise RuntimeError, "Failed to restore search"

--- a/lib/elasticsearch_admin_wrapper.rb
+++ b/lib/elasticsearch_admin_wrapper.rb
@@ -22,7 +22,7 @@ class ElasticsearchAdminWrapper
     index_payload = @schema["index"]
 
     if index_exists?
-      @logger.info "Index already exists: updating settings"
+      @logger.info "Index #{@client.index_name} already exists: updating settings"
 
       # For no readily discernible reason, a short delay here prevents the
       # tests (and potentially Rake tasks) causing some shards to fail when
@@ -41,7 +41,7 @@ class ElasticsearchAdminWrapper
       return :updated
     else
       @client.put("", index_payload.to_json)
-      @logger.info "Index created"
+      @logger.info "Index #{@client.index_name} created"
       return :created
     end
   end
@@ -53,11 +53,11 @@ class ElasticsearchAdminWrapper
 
   def delete_index
     begin
-      @logger.info "Deleting index"
+      @logger.info "Deleting index #{@client.index_name}"
       @client.delete ""
       return :deleted
     rescue RestClient::ResourceNotFound
-      @logger.info "Index didn't exist"
+      @logger.info "Index #{@client.index_name} didn't exist"
       return :absent
     end
   end

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -3,6 +3,7 @@ require "section"
 require "logger"
 require "cgi"
 require "rest-client"
+require "multi_json"
 require "json"
 
 class ElasticsearchWrapper
@@ -127,7 +128,7 @@ class ElasticsearchWrapper
       return nil
     end
 
-    document_from_hash(JSON.parse(response.body)["_source"])
+    document_from_hash(MultiJson.decode(response.body)["_source"])
   end
 
   def document_from_hash(hash)
@@ -138,7 +139,7 @@ class ElasticsearchWrapper
     limit = options.fetch(:limit, MASSIVE_NUMBER)
     search_body = {query: {match_all: {}}, size: limit}
     result = @client.request(:get, "_search", search_body.to_json)
-    result = JSON.parse(result)
+    result = MultiJson.decode(result)
     result['hits']['hits'].map { |hit|
       document_from_hash(hit['_source'])
     }
@@ -227,7 +228,7 @@ class ElasticsearchWrapper
     @logger.debug "Request payload: #{payload}"
 
     result = @client.request(:get, "_search", payload)
-    result = JSON.parse(result)
+    result = MultiJson.decode(result)
     result['hits']['hits'].map { |hit|
       document_from_hash(hit['_source'])
     }
@@ -273,7 +274,7 @@ class ElasticsearchWrapper
         }
     }.to_json
     result = @client.request(:get, "_search", payload)
-    result = JSON.parse(result)
+    result = MultiJson.decode(result)
     result['hits']['hits'].map { |hit|
       document_from_hash(hit['_source'])
     }
@@ -324,7 +325,7 @@ class ElasticsearchWrapper
         }
       }
     }.to_json
-    result = JSON.parse(@client.request(:get, "_search", payload))
+    result = MultiJson.decode(@client.request(:get, "_search", payload))
     result["facets"][facet_name]["terms"]
   end
 end

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -378,9 +378,9 @@ class ElasticsearchWrapper
     end
 
     def boolean_property_filter(property, filter_value)
-      if filter_value.to_s =~ /\A(true|yes|1|t|y)\Z/i
+      if filter_value.to_s =~ /\A(true|1)\Z/i
         {"term" => { property => true }}
-      elsif filter_value.to_s =~ /\A(false|no|0|f|n)\Z/i
+      elsif filter_value.to_s =~ /\A(false|0)\Z/i
         {"term" => { property => false }}
       end
     end

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -241,15 +241,13 @@ class ElasticsearchWrapper
     @logger.info "params:#{params.inspect}"
     raise "WTF WHERE ARE MY PARAMS!?" if params["per_page"].nil? || params["page"].nil?
 
-    order = params.delete("order")
-    format = params.delete("format")
-    backend = params.delete("backend")
-    backend = params.delete("backend")
-    keywords = params.delete("keywords")
-    per_page = params.delete("per_page").to_i
-    page = params.delete("page").to_i
-
-    payload = { "from" => page <= 1 ? 0 : (per_page * (page - 1)), "size" => per_page }
+    order     = params.delete("order")
+    format    = params.delete("format")
+    backend   = params.delete("backend")
+    keywords  = params.delete("keywords")
+    per_page  = params.delete("per_page").to_i
+    page      = params.delete("page").to_i
+    payload   = { "from" => page <= 1 ? 0 : (per_page * (page - 1)), "size" => per_page }
 
     if order
       payload.merge!({"sort" => [order]})
@@ -258,8 +256,22 @@ class ElasticsearchWrapper
     if keywords
       payload.merge!({"query" => {"bool" =>
           {"should" => [
-              {"text" => {"title" => {"query" => keywords,"type" => "phrase_prefix","operator" => "and", "analyzer" => "query_default", "boost" => 10, "fuzziness" =>0.5}}},
-              {"query_string" => {"query" => keywords, "default_operator" => "and","analyzer" => "query_default"}}
+              {"text" => {"title" => {
+                                      "query" => keywords,
+                                      "type" => "phrase_prefix",
+                                      "operator" => "and",
+                                      "analyzer" => "query_default",
+                                      "boost" => 10,
+                                      "fuzziness" =>0.5
+                                      }
+                          }
+              },
+              {"query_string" => {
+                                  "query" => keywords,
+                                  "default_operator" => "and",
+                                  "analyzer" => "query_default"
+                                  }
+              }
             ]
           }
         }

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -290,15 +290,50 @@ class ElasticsearchWrapper
       end
     end
 
+    def invalid_boolean_properties
+      @invalid_boolean_properties ||=
+        @filter_params
+          .select { |property, _| boolean_properties.include?(property) }
+          .select { |_, value| invalid_boolean_property_value?(value) }
+    end
+
+    BOOLEAN_TRUTHY = /\A(true|1)\Z/i
+    BOOLEAN_FALSEY = /\A(false|0)\Z/i
+    def invalid_boolean_property_value?(value)
+      (value.to_s !~ BOOLEAN_TRUTHY ) && (value.to_s !~ BOOLEAN_FALSEY)
+    end
+
+    def invalid_date_properties
+      @invalid_date_properties ||=
+        @filter_params
+          .select { |property, _| date_properties.include?(property) }
+          .select { |_, value| invalid_date_property_value?(value) }
+    end
+
+    def invalid_date_property_value?(value)
+      # invalid if it's not a hash, or is an empty hash, or has keys other
+      # than 'before' or 'after', or the values are not YYYY-MM-DD
+      # formatted.
+      !(value.is_a?(Hash) &&
+        value.keys.any? &&
+        (value.keys - ['before', 'after']).empty? &&
+        (value.values.reject { |date| date.to_s =~ /\A\d{4}-\d{2}-\d{2}\Z/}).empty?)
+    end
+
     def valid?
-      unknown_keys.empty? && unknown_sort_key.empty?
+      unknown_keys.empty? &&
+        unknown_sort_key.empty? &&
+        invalid_boolean_properties.empty? &&
+        invalid_date_properties.empty?
     end
 
     def error
       errors = []
       errors << "Querying unknown properties #{unknown_keys.inspect}" if unknown_keys.any?
       errors << "Sorting on unknown property #{unknown_sort_key.inspect}" if unknown_sort_key.any?
-      errors.join('. ')
+      errors << invalid_boolean_properties.map { |p, v| "Invalid value #{v.inspect} for boolean property \"#{p}\""} if invalid_boolean_properties.any?
+      errors << invalid_date_properties.map { |p, v| "Invalid value #{v.inspect} for date property \"#{p}\""} if invalid_date_properties.any?
+      errors.flatten.join('. ')
     end
 
     def query_hash
@@ -368,19 +403,20 @@ class ElasticsearchWrapper
     end
 
     def date_property_filter(property, filter_value)
-      #TODO validation?
-      return nil unless filter_value.is_a?(Hash)
-      if filter_value.has_key?("before")
-        {"range" => {property => {"to" => filter_value["before"]}}}
-      elsif filter_value.has_key?("after")
-        {"range" => {property => {"from" => filter_value["after"]}}}
+      filter = {"range" => {property => {}}}
+      if filter_value.has_key?("after")
+        filter["range"][property]["from"] = filter_value["after"]
       end
+      if filter_value.has_key?("before")
+        filter["range"][property]["to"] = filter_value["before"]
+      end
+      filter
     end
 
     def boolean_property_filter(property, filter_value)
-      if filter_value.to_s =~ /\A(true|1)\Z/i
+      if filter_value.to_s =~ BOOLEAN_TRUTHY
         {"term" => { property => true }}
-      elsif filter_value.to_s =~ /\A(false|0)\Z/i
+      elsif filter_value.to_s =~ BOOLEAN_FALSEY
         {"term" => { property => false }}
       end
     end

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -140,8 +140,8 @@ class ElasticsearchWrapper
     search_body = {query: {match_all: {}}, size: limit}
     result = @client.request(:get, "_search", search_body.to_json)
     result = MultiJson.decode(result)
-    result['hits']['hits'].map { |hit|
-      document_from_hash(hit['_source'])
+    result["hits"]["hits"].map { |hit|
+      document_from_hash(hit["_source"])
     }
   end
 
@@ -229,8 +229,8 @@ class ElasticsearchWrapper
 
     result = @client.request(:get, "_search", payload)
     result = MultiJson.decode(result)
-    result['hits']['hits'].map { |hit|
-      document_from_hash(hit['_source'])
+    result["hits"]["hits"].map { |hit|
+      document_from_hash(hit["_source"])
     }
   end
 
@@ -275,8 +275,8 @@ class ElasticsearchWrapper
     }.to_json
     result = @client.request(:get, "_search", payload)
     result = MultiJson.decode(result)
-    result['hits']['hits'].map { |hit|
-      document_from_hash(hit['_source'])
+    result["hits"]["hits"].map { |hit|
+      document_from_hash(hit["_source"])
     }
   end
 

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -262,9 +262,12 @@ class ElasticsearchWrapper
     # so we have to call @client.request directly.
     result = @client.request(:get, "_search", payload.to_json)
     result = MultiJson.decode(result)
-    [result["hits"]["total"], result["hits"]["hits"].map { |hit|
-      document_from_hash(hit["_source"])
-    }]
+    {
+      total: result["hits"]["total"],
+      results: result["hits"]["hits"].map { |hit|
+        document_from_hash(hit["_source"])
+      }
+    }
   end
 
   class AdvancedSearchQueryBuilder

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -234,6 +234,79 @@ class ElasticsearchWrapper
     }
   end
 
+
+
+# {"query":{"match_all":{}},"sort":[{"public_timestamp":"desc"}],"filter":{"and":[{"term":{"format":["fatality_notice"]}},{"term":{"topics":[46]}},{"term":{"organisations":[494]}},{"range":}]},"size":20,"from":0}
+  def advanced_search(params)
+    @logger.info "params:#{params.inspect}"
+    raise "WTF WHERE ARE MY PARAMS!?" if params["per_page"].nil? || params["page"].nil?
+
+    order = params.delete("order")
+    format = params.delete("format")
+    backend = params.delete("backend")
+    backend = params.delete("backend")
+    keywords = params.delete("keywords")
+    per_page = params.delete("per_page")
+    page = params.delete("page")
+
+    payload = { "from" => page, "size" => per_page }
+
+    if order
+      payload.merge!({"sort" => [order]})
+    end
+
+    if keywords
+      payload.merge!({"query" => {"bool" =>
+          {"should" => [
+              {"text" => {"title" => {"query" => keywords,"type" => "phrase_prefix","operator" => "and", "analyzer" => "query_default", "boost" => 10, "fuzziness" =>0.5}}},
+              {"query_string" => {"query" => keywords, "default_operator" => "and","analyzer" => "query_default", "fuzziness" => 0.2}}
+            ]
+          }
+        }
+      })
+    else
+      payload.merge!({"query" => {"match_all" => {}}})
+    end
+
+    unknown_keys = params.keys - @mappings["edition"]["properties"].keys
+
+    @logger.info unknown_keys.inspect
+    raise "WAT" unless (unknown_keys).empty?
+
+    date_properties= []
+    @mappings["edition"]["properties"].each do |p,h|
+      date_properties << p if h["type"] == "date"
+    end
+
+    filters = params.map do |k,v|
+      if date_properties.include?(k)
+        if v.has_key?("before") #TODO validation?
+          {"range" => {k => {"to" => v["before"]}}}
+        elsif v.has_key?("after")
+          {"range" => {k => {"from" => v["after"]}}}
+        end
+      else
+        if v.is_a?(Array) && v.size > 1
+          {"terms" => { k => v } }
+        else
+          {"term" => { k => v } }
+        end
+      end
+    end
+
+    payload.merge!({"filter" => {"and" => filters}})
+
+    # RestClient does not allow a payload with a GET request
+    # so we have to call @client.request directly.
+    @logger.info "Request payload: #{payload.to_json}"
+
+    result = @client.request(:get, "_search", payload.to_json)
+    result = MultiJson.decode(result)
+    result["hits"]["hits"].map { |hit|
+      document_from_hash(hit["_source"])
+    }
+  end
+
   LUCENE_SPECIAL_CHARACTERS = Regexp.new("(" + %w[
     + - && || ! ( ) { } [ ] ^ " ~ * ? : \\
   ].map { |s| Regexp.escape(s) }.join("|") + ")")

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -246,10 +246,10 @@ class ElasticsearchWrapper
     backend = params.delete("backend")
     backend = params.delete("backend")
     keywords = params.delete("keywords")
-    per_page = params.delete("per_page")
-    page = params.delete("page")
+    per_page = params.delete("per_page").to_i
+    page = params.delete("page").to_i
 
-    payload = { "from" => page, "size" => per_page }
+    payload = { "from" => page <= 1 ? 0 : (per_page * (page - 1)), "size" => per_page }
 
     if order
       payload.merge!({"sort" => [order]})

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -313,9 +313,9 @@ class ElasticsearchWrapper
 
     result = @client.request(:get, "_search", payload.to_json)
     result = MultiJson.decode(result)
-    result["hits"]["hits"].map { |hit|
+    [result["hits"]["total"], result["hits"]["hits"].map { |hit|
       document_from_hash(hit["_source"])
-    }
+    }]
   end
 
   LUCENE_SPECIAL_CHARACTERS = Regexp.new("(" + %w[

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -248,7 +248,11 @@ class ElasticsearchWrapper
     query_builder = AdvancedSearchQueryBuilder.new(keywords, params, order, @mappings)
     raise query_builder.error unless query_builder.valid?
 
-    payload = { "from" => page <= 1 ? 0 : (per_page * (page - 1)), "size" => per_page }
+    starting_index = page <= 1 ? 0 : (per_page * (page - 1))
+    payload = {
+      "from" => starting_index,
+      "size" => per_page
+    }
 
     payload.merge!(query_builder.query_hash)
 
@@ -313,7 +317,7 @@ class ElasticsearchWrapper
                      "operator" => "and",
                      "analyzer" => "query_default",
                      "boost" => 10,
-                     "fuzziness" =>0.5}
+                     "fuzziness" => 0.5}
                   }
                 },
                 {"query_string" => {
@@ -387,23 +391,11 @@ class ElasticsearchWrapper
     end
 
     def date_properties
-      if @date_properties.nil?
-        @date_properties= []
-        @mappings["edition"]["properties"].each do |p,h|
-          @date_properties << p if h["type"] == "date"
-        end
-      end
-      @date_properties
+      @date_properties ||= @mappings["edition"]["properties"].select { |p,h| h["type"] == "date" }.keys
     end
 
     def boolean_properties
-      if @boolean_properties.nil?
-        @boolean_properties = []
-        @mappings["edition"]["properties"].each do |p,h|
-          @boolean_properties << p if h["type"] == "boolean"
-        end
-      end
-      @boolean_properties
+      @boolean_properties ||= @mappings["edition"]["properties"].select { |p,h| h["type"] == "boolean" }.keys
     end
 
   end

--- a/test/functional/advanced_search_test.rb
+++ b/test/functional/advanced_search_test.rb
@@ -9,21 +9,21 @@ class AdvancedSearchTest < IntegrationTest
   end
 
   def test_returns_json_for_advanced_search_results
-    @backend_index.stubs(:advanced_search).returns([1, [sample_document]])
+    @backend_index.stubs(:advanced_search).returns({total: 1, results: [sample_document]})
     get "/meh/advanced_search", {per_page: '1', page: '1', keywords: 'meh'}, "HTTP_ACCEPT" => "application/json"
     assert_nothing_raised { MultiJson.decode(last_response.body) }
     assert_match /application\/json/, last_response.headers["Content-Type"]
   end
 
   def test_returns_json_when_requested_with_url_suffix
-    @backend_index.stubs(:advanced_search).returns([1, [sample_document]])
+    @backend_index.stubs(:advanced_search).returns({total: 1, results: [sample_document]})
     get "/meh/advanced_search.json", {per_page: '1', page: '1', keywords: 'meh'}
     assert_nothing_raised { MultiJson.decode(last_response.body) }
     assert_match /application\/json/, last_response.headers["Content-Type"]
   end
 
   def test_json_response_includes_total_and_results
-    @backend_index.stubs(:advanced_search).returns([1, [sample_document]])
+    @backend_index.stubs(:advanced_search).returns({total: 1, results: [sample_document]})
     get "/meh/advanced_search.json", {per_page: '1', page: '1', keywords: 'meh'}
     expected_result = {'total' => 1, 'results' => [sample_document_attributes.merge('highlight' => 'DESCRIPTION')]}
     assert_nothing_raised { MultiJson.decode(last_response.body) }

--- a/test/functional/advanced_search_test.rb
+++ b/test/functional/advanced_search_test.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+require "integration_test_helper"
+
+class SecondarySearchTest < IntegrationTest
+
+  def setup
+    super
+    stub_backend
+  end
+
+  def test_returns_json_for_advanced_search_results
+    @backend_index.stubs(:advanced_search).returns([1, [sample_document]])
+    get "/meh/advanced_search", {per_page: '1', page: '1', keywords: 'meh'}, "HTTP_ACCEPT" => "application/json"
+    assert_nothing_raised { MultiJson.decode(last_response.body) }
+    assert_match /application\/json/, last_response.headers["Content-Type"]
+  end
+
+  def test_returns_json_when_requested_with_url_suffix
+    @backend_index.stubs(:advanced_search).returns([1, [sample_document]])
+    get "/meh/advanced_search.json", {per_page: '1', page: '1', keywords: 'meh'}
+    assert_nothing_raised { MultiJson.decode(last_response.body) }
+    assert_match /application\/json/, last_response.headers["Content-Type"]
+  end
+
+  def test_json_response_includes_total_and_results
+    @backend_index.stubs(:advanced_search).returns([1, [sample_document]])
+    get "/meh/advanced_search.json", {per_page: '1', page: '1', keywords: 'meh'}
+    expected_result = {'total' => 1, 'results' => [sample_document_attributes.merge('highlight' => 'DESCRIPTION')]}
+    assert_nothing_raised { MultiJson.decode(last_response.body) }
+  end
+end

--- a/test/functional/advanced_search_test.rb
+++ b/test/functional/advanced_search_test.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "integration_test_helper"
 
-class SecondarySearchTest < IntegrationTest
+class AdvancedSearchTest < IntegrationTest
 
   def setup
     super

--- a/test/functional/document_view_test.rb
+++ b/test/functional/document_view_test.rb
@@ -15,7 +15,7 @@ class DocumentViewtest < IntegrationTest
 
     assert_equal 200, last_response.status
     assert last_response.content_type.start_with? "application/json"
-    assert_equal sample_document.to_hash, JSON.parse(last_response.body)
+    assert_equal sample_document.to_hash, MultiJson.decode(last_response.body)
   end
 
   def test_should_404_on_missing_document

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -17,7 +17,7 @@ class SearchTest < IntegrationTest
     get "/preload-autocomplete"
     assert last_response.ok?
 
-    results = JSON.parse last_response.body
+    results = MultiJson.decode last_response.body
     assert_equal 2, results.size
   end
 
@@ -26,7 +26,7 @@ class SearchTest < IntegrationTest
     @backend_index.stubs(:complete).returns([sample_document])
     get "/autocomplete", {q: "bob"}
     assert last_response.ok?
-    assert_equal [sample_document_attributes], JSON.parse(last_response.body)
+    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)
   end
 
   def test_we_pass_the_optional_filter_parameter_to_autocomplete
@@ -40,7 +40,7 @@ class SearchTest < IntegrationTest
       sample_document
     ])
     get "/search", {q: "bob"}, "HTTP_ACCEPT" => "application/json"
-    assert_equal [sample_document_attributes.merge("highlight"=>"DESCRIPTION")], JSON.parse(last_response.body)
+    assert_equal [sample_document_attributes.merge("highlight"=>"DESCRIPTION")], MultiJson.decode(last_response.body)
     assert_match /application\/json/, last_response.headers["Content-Type"]
   end
 
@@ -49,7 +49,7 @@ class SearchTest < IntegrationTest
       sample_document
     ])
     get "/search.json", {q: "bob"}
-    assert_equal [sample_document_attributes.merge("highlight"=>"DESCRIPTION")], JSON.parse(last_response.body)
+    assert_equal [sample_document_attributes.merge("highlight"=>"DESCRIPTION")], MultiJson.decode(last_response.body)
     assert_match /application\/json/, last_response.headers["Content-Type"]
   end
 

--- a/test/functional/secondary_search_test.rb
+++ b/test/functional/secondary_search_test.rb
@@ -19,7 +19,7 @@ class SecondarySearchTest < IntegrationTest
     assert last_response.ok?
     assert_equal(
       [sample_document.link, "/specialist-link"],
-      JSON.parse(last_response.body).map { |r| r["link"] }
+      MultiJson.decode(last_response.body).map { |r| r["link"] }
     )
   end
 end

--- a/test/integration/elasticsearch_admin_test.rb
+++ b/test/integration/elasticsearch_admin_test.rb
@@ -78,7 +78,7 @@ class ElasticsearchAdminTest < IntegrationTest
 private
 
   def index_status
-    JSON.parse(RestClient.get("http://localhost:9200/_status"))
+    MultiJson.decode(RestClient.get("http://localhost:9200/_status"))
   end
 
   def delete_elasticsearch_index
@@ -98,7 +98,7 @@ private
   end
 
   def get_mapping(index_name)
-    JSON.parse(RestClient.get "http://localhost:9200/#{index_name}/_mapping")[index_name]
+    MultiJson.decode(RestClient.get "http://localhost:9200/#{index_name}/_mapping")[index_name]
   rescue RestClient::ResourceNotFound
     nil
   end

--- a/test/integration/elasticsearch_advanced_search_test.rb
+++ b/test/integration/elasticsearch_advanced_search_test.rb
@@ -130,7 +130,7 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
         "date_property" => "2012-01-01"
       }
     ]
-    (more_documents).each do |sample_document|
+    more_documents.each do |sample_document|
       post "/documents", MultiJson.encode(sample_document)
       assert last_response.ok?
     end

--- a/test/integration/elasticsearch_advanced_search_test.rb
+++ b/test/integration/elasticsearch_advanced_search_test.rb
@@ -1,0 +1,152 @@
+require "integration_test_helper"
+require "app"
+require "rest-client"
+
+class ElasticsearchAdvancedSearchTest < IntegrationTest
+
+  def setup
+    use_elasticsearch_for_primary_search
+
+    schema = deep_copy(settings.elasticsearch_schema)
+    properties = schema["mappings"]["default"]["edition"]["properties"]
+    properties.merge!({"boolean_property" => { "type" => "boolean", "index" => "not_analyzed" },
+                       "date_property" => { "type" => "date", "index" => "not_analyzed" }})
+    app.settings.stubs(:elasticsearch_schema).returns(schema)
+
+    WebMock.disable_net_connect!(allow: "localhost:9200")
+    reset_elasticsearch_index
+    add_sample_documents
+    commit_index
+  end
+
+  def sample_document_attributes
+    [
+      {
+        "title" => "Cheese in my face",
+        "description" => "Hummus weevils",
+        "format" => "answer",
+        "link" => "/an-example-answer",
+        "indexable_content" => "I like my badger: he is tasty and delicious",
+        "boolean_property" => true,
+        "date_property" => "2012-01-01"
+      },
+      {
+        "title" => "Useful government information",
+        "description" => "Government, government, government. Developers.",
+        "format" => "answer",
+        "link" => "/another-example-answer",
+        "section" => "Crime",
+        "indexable_content" => "Tax, benefits, roads and stuff",
+        "boolean_property" => false,
+        "date_property" => "2012-01-03"
+      },
+      {
+        "title" => "Cheesey government information",
+        "description" => "Government, government, government. Developers.",
+        "format" => "answer",
+        "link" => "/yet-another-example-answer",
+        "section" => "Crime",
+        "indexable_content" => "Tax, benefits, roads and stuff, mostly about cheese",
+        "boolean_property" => true,
+        "date_property" => "2012-01-04"
+      },
+      {
+        "title" => "Pork pies",
+        "link" => "/pork-pies",
+        "boolean_property" => true,
+        "date_property" => "2012-01-02"
+      }
+    ]
+  end
+
+  def add_sample_documents
+    sample_document_attributes.each do |sample_document|
+      post "/documents", MultiJson.encode(sample_document)
+      assert last_response.ok?
+    end
+  end
+
+  def commit_index
+    post "/commit", nil
+  end
+
+  def assert_result_links(*links)
+    parsed_response = MultiJson.decode(last_response.body)
+    assert_equal links, parsed_response['results'].map { |r| r["link"] }
+  end
+
+  def assert_result_total(total)
+    parsed_response = MultiJson.decode(last_response.body)
+    assert_equal total, parsed_response['total']
+  end
+
+  def test_should_search_by_keywords
+    get "/primary/advanced_search.json?per_page=1&page=1&keywords=cheese"
+    assert last_response.ok?
+    assert_result_total 2
+    assert_result_links "/an-example-answer"
+  end
+
+  def test_should_allow_paging_through_keyword_search
+    get "/primary/advanced_search.json?per_page=1&page=2&keywords=cheese"
+    assert last_response.ok?
+    assert_result_total 2
+    assert_result_links "/yet-another-example-answer"
+  end
+
+  def test_should_filter_results_by_a_property
+    get "/primary/advanced_search.json?per_page=2&page=1&section=Crime"
+    assert last_response.ok?
+    assert_result_total 2
+    assert_result_links "/another-example-answer", "/yet-another-example-answer"
+  end
+
+  def test_should_allow_boolean_filtering
+    get "/primary/advanced_search.json?per_page=3&page=1&boolean_property=true"
+    assert last_response.ok?
+    assert_result_total 3
+    assert_result_links "/an-example-answer", "/yet-another-example-answer", "/pork-pies"
+  end
+
+  def test_should_allow_date_filtering
+    get "/primary/advanced_search.json?per_page=3&page=1&date_property[before]=2012-01-03"
+    assert last_response.ok?
+    assert_result_total 3
+    assert_result_links "/an-example-answer", "/another-example-answer", "/pork-pies"
+  end
+
+  def test_should_allow_combining_all_filters
+    # add another doc to make the filter combination need everything to pick
+    # the one we want
+    more_documents = [
+      {
+        "title" => "Government cheese",
+        "description" => "Government, government, government. cheese.",
+        "format" => "answer",
+        "link" => "/cheese-example-answer",
+        "section" => "Crime",
+        "indexable_content" => "Cheese tax.  Cheese recipies.  Cheese music.",
+        "boolean_property" => true,
+        "date_property" => "2012-01-01"
+      }
+    ]
+    (more_documents).each do |sample_document|
+      post "/documents", MultiJson.encode(sample_document)
+      assert last_response.ok?
+    end
+    commit_index
+
+
+    get "/primary/advanced_search.json?per_page=3&page=1&boolean_property=true&date_property[after]=2012-01-02&keywords=tax&section=Crime"
+    assert last_response.ok?
+    assert_result_total 1
+    assert_result_links "/yet-another-example-answer"
+  end
+
+  def test_should_allow_ordering_by_properties
+    get "/primary/advanced_search.json?per_page=4&page=1&order[date_property]=desc"
+    assert last_response.ok?
+    assert_result_total 4
+    assert_result_links "/yet-another-example-answer", "/another-example-answer", "/pork-pies", "/an-example-answer"
+  end
+end

--- a/test/integration/elasticsearch_amendment_test.rb
+++ b/test/integration/elasticsearch_amendment_test.rb
@@ -23,14 +23,14 @@ class ElasticsearchAmendmentTest < IntegrationTest
   end
 
   def add_sample_document
-    post "/documents", JSON.dump(sample_document_attributes)
+    post "/documents", MultiJson.encode(sample_document_attributes)
     assert last_response.ok?
   end
 
   def test_should_get_a_document_through_elasticsearch
     get "/documents/%2Fan-example-answer"
     assert last_response.ok?
-    parsed_response = JSON.parse(last_response.body)
+    parsed_response = MultiJson.decode(last_response.body)
 
     sample_document_attributes.each do |key, value|
       assert_equal value, parsed_response[key]
@@ -47,7 +47,7 @@ class ElasticsearchAmendmentTest < IntegrationTest
 
     get "/documents/%2Fan-example-answer"
     assert last_response.ok?
-    parsed_response = JSON.parse(last_response.body)
+    parsed_response = MultiJson.decode(last_response.body)
 
     updates = {"title" => "A new title"}
     sample_document_attributes.merge(updates).each do |key, value|

--- a/test/integration/elasticsearch_browsing_test.rb
+++ b/test/integration/elasticsearch_browsing_test.rb
@@ -36,7 +36,7 @@ class ElasticsearchBrowsingTest < IntegrationTest
 
   def add_sample_documents
     sample_document_attributes.each do |sample_document|
-      post "/documents", JSON.dump(sample_document)
+      post "/documents", MultiJson.encode(sample_document)
       assert last_response.ok?
     end
   end

--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -40,7 +40,7 @@ class ElasticsearchDeletionTest < IntegrationTest
 
   def add_sample_documents
     sample_document_attributes.each do |sample_document|
-      post "/documents", JSON.dump(sample_document)
+      post "/documents", MultiJson.encode(sample_document)
       assert last_response.ok?
     end
   end
@@ -50,7 +50,7 @@ class ElasticsearchDeletionTest < IntegrationTest
   end
 
   def assert_no_results
-    assert_equal [], JSON.parse(last_response.body)
+    assert_equal [], MultiJson.decode(last_response.body)
   end
 
   def test_should_404_on_deleted_content

--- a/test/integration/elasticsearch_indexing_test.rb
+++ b/test/integration/elasticsearch_indexing_test.rb
@@ -20,7 +20,7 @@ class ElasticsearchIndexingTest < IntegrationTest
 
   def retrieve_document_from_rummager(link)
     get "/documents/#{CGI::escape(link)}"
-    JSON.parse(last_response.body)
+    MultiJson.decode(last_response.body)
   end
 
   def assert_document_is_in_rummager(document)
@@ -36,14 +36,14 @@ class ElasticsearchIndexingTest < IntegrationTest
   def test_should_indicate_success_in_response_code_when_adding_a_new_document
     reset_elasticsearch_index
 
-    post "/documents", JSON.dump(@sample_document)
+    post "/documents", MultiJson.encode(@sample_document)
     assert last_response.ok?
   end
 
   def test_after_adding_a_document_to_index_should_be_able_to_retrieve_it_again
     reset_elasticsearch_index
 
-    post "/documents", JSON.dump(@sample_document)
+    post "/documents", MultiJson.encode(@sample_document)
 
     assert_document_is_in_rummager(@sample_document)
   end
@@ -54,7 +54,7 @@ class ElasticsearchIndexingTest < IntegrationTest
 
     test_data = @sample_document.merge("topics" => [1,2])
 
-    post "/documents", JSON.dump(test_data)
+    post "/documents", MultiJson.encode(test_data)
 
     assert_document_is_in_rummager(test_data)
   end

--- a/test/integration/elasticsearch_reindexing_test.rb
+++ b/test/integration/elasticsearch_reindexing_test.rb
@@ -43,7 +43,7 @@ class ElasticsearchReindexingTest < IntegrationTest
 
   def add_sample_documents
     sample_document_attributes.each do |sample_document|
-      post "/documents", JSON.dump(sample_document)
+      post "/documents", MultiJson.encode(sample_document)
       assert last_response.ok?
     end
   end
@@ -53,7 +53,7 @@ class ElasticsearchReindexingTest < IntegrationTest
   end
 
   def assert_result_links(*links)
-    parsed_response = JSON.parse(last_response.body)
+    parsed_response = MultiJson.decode(last_response.body)
     assert_equal links, parsed_response.map { |r| r["link"] }
   end
 
@@ -62,7 +62,7 @@ class ElasticsearchReindexingTest < IntegrationTest
     # stemming settings
 
     get "/search?q=directive"
-    assert_equal 2, JSON.parse(last_response.body).length
+    assert_equal 2, MultiJson.decode(last_response.body).length
 
     @stemmer["rules"] = ["directive => directive"]
     update_elasticsearch_index

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -39,7 +39,7 @@ class ElasticsearchSearchTest < IntegrationTest
 
   def add_sample_documents
     sample_document_attributes.each do |sample_document|
-      post "/documents", JSON.dump(sample_document)
+      post "/documents", MultiJson.encode(sample_document)
       assert last_response.ok?
     end
   end
@@ -49,7 +49,7 @@ class ElasticsearchSearchTest < IntegrationTest
   end
 
   def assert_result_links(*links)
-    parsed_response = JSON.parse(last_response.body)
+    parsed_response = MultiJson.decode(last_response.body)
     assert_equal links, parsed_response.map { |r| r["link"] }
   end
 

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -84,7 +84,7 @@ class SitemapTest < IntegrationTest
 
   def add_sample_documents
     sample_document_attributes.each do |sample_document|
-      post "/documents", JSON.dump(sample_document)
+      post "/documents", MultiJson.encode(sample_document)
       assert last_response.ok?
     end
   end
@@ -131,7 +131,7 @@ class SitemapTest < IntegrationTest
       "link" => "/a-specialist-guidance",
       "indexable_content" => "Always bring a towel."
     }
-    post "/detailed/documents", JSON.dump(document_in_another_index)
+    post "/detailed/documents", MultiJson.encode(document_in_another_index)
     assert last_response.ok?
     post "/detailed/commit", nil
     assert last_response.ok?

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -88,7 +88,7 @@ class IntegrationTest < Test::Unit::TestCase
   end
 
   def assert_no_results
-    assert_equal [], JSON.parse(last_response.body)
+    assert_equal [], MultiJson.decode(last_response.body)
   end
 
   def stub_backend

--- a/test/unit/elasticsearch_wrapper_advanced_search_test.rb
+++ b/test/unit/elasticsearch_wrapper_advanced_search_test.rb
@@ -1,0 +1,150 @@
+require "test_helper"
+require "elasticsearch_wrapper"
+require "webmock"
+
+class ElasticsearchWrapperTest < Test::Unit::TestCase
+  include Fixtures::DefaultMappings
+
+  def setup
+    @settings = {
+      server: "example.com",
+      port: 9200,
+      index_name: "test-index"
+    }
+    @wrapper = ElasticsearchWrapper.new(@settings, default_mappings)
+  end
+
+  def test_pagingation_params_are_required
+    stub_empty_search
+    e = assert_raises(RuntimeError) do
+      @wrapper.advanced_search({})
+    end
+    assert_equal 'Pagination params are required.', e.message
+    assert_nothing_raised(RuntimeError) do
+      @wrapper.advanced_search({'page' => '1', 'per_page' => '1'})
+    end
+  end
+
+  def test_pagination_params_are_converted_to_from_and_to_correctly
+    stub_empty_search(:body => /\"from\":0,\"size\":10/)
+    @wrapper.advanced_search({'page' => '1', 'per_page' => '10'})
+
+    stub_empty_search(:body => /\"from\":6,\"size\":3/)
+    @wrapper.advanced_search({'page' => '3', 'per_page' => '3'})
+  end
+
+  def test_keyword_param_is_converted_to_a_boosted_title_and_unboosted_general_query
+    stub_empty_search(:body => /#{Regexp.escape("\"query\":"+
+    "{\"bool\":{\"should\":["+
+      "{\"text\":{\"title\":"+
+        "{\"query\":\"happy fun time\",\"type\":\"phrase_prefix\",\"operator\":\"and\",\"analyzer\":\"query_default\",\"boost\":10,\"fuzziness\":0.5}"+
+      "}},"+
+      "{\"query_string\":"+
+        "{\"query\":\"happy fun time\",\"default_operator\":\"and\",\"analyzer\":\"query_default\"}"+
+      "}]}}")}/)
+    @wrapper.advanced_search(default_params.merge('keywords' => 'happy fun time'))
+  end
+
+  def test_missing_keyword_param_means_a_match_all_query
+    stub_empty_search(:body => /#{Regexp.escape("\"query\":{\"match_all\":{}}")}/)
+    @wrapper.advanced_search(default_params)
+  end
+
+  def test_single_value_filter_param_is_turned_into_a_term_filter
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"section\":\"jones\"}}")}/)
+    @wrapper.advanced_search(default_params.merge('section' => 'jones'))
+
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"section\":\"jones\"}}")}/)
+    @wrapper.advanced_search(default_params.merge('section' => ['jones']))
+  end
+
+  def test_multiple_value_filter_param_is_turned_into_a_terms_filter
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"terms\":{\"section\":[\"jones\",\"richards\"]}}")}/)
+    @wrapper.advanced_search(default_params.merge('section' => ['jones', 'richards']))
+  end
+
+  def test_filter_params_are_turned_into_anded_term_filters_on_that_property
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"and\":[{\"term\":{\"section\":\"jones\"}},{\"term\":{\"link\":\"richards\"}}]}")}/)
+    @wrapper.advanced_search(default_params.merge('section' => ['jones'], 'link' => ['richards']))
+  end
+
+  def test_filter_params_on_a_boolean_mapping_property_are_convered_to_true_based_on_something_that_looks_truthy
+    @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"boolean_property\":true}}")}/)
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'true'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 't'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'yes'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'y'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => '1'))
+  end
+
+  def test_filter_params_on_a_boolean_mapping_property_are_convered_to_false_based_on_something_that_looks_falsey
+    @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"boolean_property\":false}}")}/)
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'false'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'f'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'no'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'n'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => '0'))
+  end
+
+  def test_filter_params_on_a_boolean_mapping_property_are_ignored_if_they_dont_look_truthy_or_falsey
+    @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{}")}/)
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'falsey'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'flob'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'true facts'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'cheese'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => '101'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'yar'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'ok'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'nope'))
+  end
+
+  def test_filter_params_on_a_date_mapping_property_are_turned_into_a_range_filter_with_order_based_on_the_key_in_the_value
+    @wrapper.mappings['edition']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"range\":{\"date_property\":{\"to\":\"2013-02-02\"}}}")}/)
+    @wrapper.advanced_search(default_params.merge('date_property' => {'before' => '2013-02-02'}))
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"range\":{\"date_property\":{\"from\":\"2013-02-02\"}}}")}/)
+    @wrapper.advanced_search(default_params.merge('date_property' => {'after' => '2013-02-02'}))
+  end
+
+  def test_filter_params_on_a_date_mapping_property_without_a_before_or_after_key_in_the_value_are_ignored
+    @wrapper.mappings['edition']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{}")}/)
+    @wrapper.advanced_search(default_params.merge('date_property' => {'from' => '2013-02-02'}))
+    @wrapper.advanced_search(default_params.merge('date_property' => '2013-02-02'))
+    @wrapper.advanced_search(default_params.merge('date_property' => {'to' => '2013-02-02'}))
+    @wrapper.advanced_search(default_params.merge('date_property' => ['2013-02-02']))
+    @wrapper.advanced_search(default_params.merge('date_property' => {'between' => '2013-02-02'}))
+  end
+
+  def test_filter_params_that_are_not_index_properties_are_not_allowed
+    e = assert_raises(RuntimeError) do
+      @wrapper.advanced_search(default_params.merge('brian' => 'jones', 'keith' => 'richards'))
+    end
+    assert_equal 'Querying unknown properties ["brian", "keith"]', e.message
+  end
+
+  def test_order_params_are_turned_into_a_sort_query
+    stub_empty_search(:body => /#{Regexp.escape("\"sort\":[{\"title\":\"asc\"}]")}/)
+    @wrapper.advanced_search(default_params.merge('order' => {'title' => 'asc'}))
+  end
+
+  def test_order_params_on_properties_not_in_the_mappings_are_not_allowed
+    e = assert_raises(RuntimeError) do
+      @wrapper.advanced_search(default_params.merge('order' => {'brian' => 'asc'}))
+    end
+    assert_equal 'Sorting on unknown property ["brian"]', e.message
+  end
+
+  def default_params
+    {'page' => '1', 'per_page' => '1'}
+  end
+
+  def stub_empty_search(with_args = {})
+    r = stub_request(:get, "http://example.com:9200/test-index/_search")
+    r.with(with_args) unless with_args.empty?
+    r.to_return(:status => 200, :body => "{\"hits\": {\"total\": 0, \"hits\": []}}", :headers => {})
+  end
+end

--- a/test/unit/elasticsearch_wrapper_advanced_search_test.rb
+++ b/test/unit/elasticsearch_wrapper_advanced_search_test.rb
@@ -14,7 +14,7 @@ class ElasticsearchWrapperAdvancedSearchTest < Test::Unit::TestCase
     @wrapper = ElasticsearchWrapper.new(@settings, default_mappings)
   end
 
-  def test_pagingation_params_are_required
+  def test_pagination_params_are_required
     stub_empty_search
 
     assert_rejected_search('Pagination params are required.', {})

--- a/test/unit/elasticsearch_wrapper_advanced_search_test.rb
+++ b/test/unit/elasticsearch_wrapper_advanced_search_test.rb
@@ -140,14 +140,16 @@ class ElasticsearchWrapperAdvancedSearchTest < Test::Unit::TestCase
 
   def test_returns_the_total_and_the_hits
     stub_empty_search()
-    assert_equal [0, []], @wrapper.advanced_search(default_params)
+    expected_result = {total: 0, results: []}
+    assert_equal expected_result, @wrapper.advanced_search(default_params)
   end
 
   def test_returns_the_hits_converted_into_documents
     Document.expects(:from_hash).with({"woo" => "hoo"}, default_mappings).returns :woo_hoo
     stub_request(:get, "http://example.com:9200/test-index/_search")
       .to_return(:status => 200, :body => "{\"hits\": {\"total\": 10, \"hits\": [{\"_source\": {\"woo\": \"hoo\"}}]}}", :headers => {})
-    assert_equal [10, [:woo_hoo]], @wrapper.advanced_search(default_params)
+    expected_result = {total: 10, results: [:woo_hoo]}
+    assert_equal expected_result, @wrapper.advanced_search(default_params)
   end
 
   def default_params

--- a/test/unit/elasticsearch_wrapper_advanced_search_test.rb
+++ b/test/unit/elasticsearch_wrapper_advanced_search_test.rb
@@ -72,9 +72,6 @@ class ElasticsearchWrapperAdvancedSearchTest < Test::Unit::TestCase
     @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
     stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"boolean_property\":true}}")}/)
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'true'))
-    @wrapper.advanced_search(default_params.merge('boolean_property' => 't'))
-    @wrapper.advanced_search(default_params.merge('boolean_property' => 'yes'))
-    @wrapper.advanced_search(default_params.merge('boolean_property' => 'y'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => '1'))
   end
 
@@ -82,9 +79,6 @@ class ElasticsearchWrapperAdvancedSearchTest < Test::Unit::TestCase
     @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
     stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"boolean_property\":false}}")}/)
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'false'))
-    @wrapper.advanced_search(default_params.merge('boolean_property' => 'f'))
-    @wrapper.advanced_search(default_params.merge('boolean_property' => 'no'))
-    @wrapper.advanced_search(default_params.merge('boolean_property' => 'n'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => '0'))
   end
 
@@ -92,12 +86,12 @@ class ElasticsearchWrapperAdvancedSearchTest < Test::Unit::TestCase
     @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
     stub_empty_search(:body => /#{Regexp.escape("\"filter\":{}")}/)
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'falsey'))
+    @wrapper.advanced_search(default_params.merge('boolean_property' => 'truey'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'flob'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'true facts'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'cheese'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => '101'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'yar'))
-    @wrapper.advanced_search(default_params.merge('boolean_property' => 'ok'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'nope'))
   end
 

--- a/test/unit/elasticsearch_wrapper_advanced_search_test.rb
+++ b/test/unit/elasticsearch_wrapper_advanced_search_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "elasticsearch_wrapper"
 require "webmock"
 
-class ElasticsearchWrapperTest < Test::Unit::TestCase
+class ElasticsearchWrapperAdvancedSearchTest < Test::Unit::TestCase
   include Fixtures::DefaultMappings
 
   def setup

--- a/test/unit/elasticsearch_wrapper_advanced_search_test.rb
+++ b/test/unit/elasticsearch_wrapper_advanced_search_test.rb
@@ -138,6 +138,18 @@ class ElasticsearchWrapperTest < Test::Unit::TestCase
     assert_equal 'Sorting on unknown property ["brian"]', e.message
   end
 
+  def test_returns_the_total_and_the_hits
+    stub_empty_search()
+    assert_equal [0, []], @wrapper.advanced_search(default_params)
+  end
+
+  def test_returns_the_hits_converted_into_documents
+    Document.expects(:from_hash).with({"woo" => "hoo"}, default_mappings).returns :woo_hoo
+    stub_request(:get, "http://example.com:9200/test-index/_search")
+      .to_return(:status => 200, :body => "{\"hits\": {\"total\": 10, \"hits\": [{\"_source\": {\"woo\": \"hoo\"}}]}}", :headers => {})
+    assert_equal [10, [:woo_hoo]], @wrapper.advanced_search(default_params)
+  end
+
   def default_params
     {'page' => '1', 'per_page' => '1'}
   end

--- a/test/unit/elasticsearch_wrapper_advanced_search_test.rb
+++ b/test/unit/elasticsearch_wrapper_advanced_search_test.rb
@@ -17,7 +17,7 @@ class ElasticsearchWrapperAdvancedSearchTest < Test::Unit::TestCase
   def test_pagination_params_are_required
     stub_empty_search
 
-    assert_rejected_search('Pagination params are required.', {})
+    assert_rejected_search("Pagination params are required.", {})
     assert_nothing_raised(RuntimeError) do
       @wrapper.advanced_search({'page' => '1', 'per_page' => '1'})
     end


### PR DESCRIPTION
Provide an advanced_search endpoint that can do querying as well as filtering and pagination.  The main use-case for this is to provide a better search experience for the whitehall search page which allows filtering the results by department, topic, world location, and document type, as well as reordering the results by date.

Takes: per_page, page, order, keywords params as instructions for pagination, query and sorting the result set.  All other params (ignoring app specific ones like format and backend) are assumed to be filter queries.  The request is rejected if these filter queries do not match properties in the mappings file for the index.

This pull request is supported by a corresponding pull-request to alphagov/gds-api-adapters#44 that provides the api client.
