### PR TITLE
Remove router registration code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source :rubygems
 source 'https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/'
 
-group :router do
-  gem 'router-client', '2.0.3', :require => 'router/client'
-end
-
 gem "unicorn"
 gem "sinatra"
 gem 'rake', '0.9.2', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,6 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.0.4)
     nokogiri (1.5.5)
-    null_logger (0.0.1)
     polyglot (0.3.3)
     rack (1.3.5)
     rack-protection (1.1.4)
@@ -38,9 +37,6 @@ GEM
     rake (0.9.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    router-client (2.0.3)
-      builder
-      null_logger
     shotgun (0.9)
       rack (>= 1.0)
     simplecov (0.5.4)
@@ -83,7 +79,6 @@ DEPENDENCIES
   rack-test
   rake (= 0.9.2)
   rest-client (= 1.6.7)
-  router-client (= 2.0.3)
   shotgun
   simplecov
   simplecov-rcov

--- a/Rakefile
+++ b/Rakefile
@@ -51,51 +51,6 @@ end
 
 task :default => :test
 
-namespace :router do
-  task :router_environment do
-    Bundler.require :router, :default
-
-    require 'logger'
-    @logger = Logger.new STDOUT
-    @logger.level = Logger::DEBUG
-
-    @router = Router::Client.new :logger => @logger
-  end
-
-  task :register_application => :router_environment do
-    platform = ENV['FACTER_govuk_platform']
-    app_id = "search"
-    url = "#{app_id}.#{platform}.alphagov.co.uk/"
-    @logger.info "Registering #{app_id} application against #{url}..."
-    @router.applications.update application_id: app_id, backend_url: url
-  end
-
-  task :register_routes => [ :router_environment ] do
-    app_id = "search"
-
-    begin
-      @logger.info "Registering full route /autocomplete"
-      @router.routes.update application_id: app_id, route_type: :full,
-        incoming_path: "/autocomplete"
-      @logger.info "Registering full route /preload-autocomplete"
-      @router.routes.update application_id: app_id, route_type: :full,
-        incoming_path: "/preload-autocomplete"
-      @logger.info "Registering full route /sitemap.xml"
-      @router.routes.update application_id: app_id, route_type: :full,
-        incoming_path: "/sitemap.xml"
-    rescue Router::Conflict => conflict_error
-      @logger.error "Route already exists: #{conflict_error.existing}"
-      raise conflict_error
-    end
-  end
-
-  desc "Register search application and routes with the router (run this task on server in cluster)"
-  task :register => :router_environment do
-    Rake::Task["router:register_application"].invoke
-    Rake::Task["router:register_routes"].invoke
-  end
-end
-
 namespace :rummager do
 
   # Set up the necessary backend and logging configuration for elasticsearch-


### PR DESCRIPTION
We're not using the router and rummager isn't public-facing anyway. It's clearer to just not have the dependency.
