### PR TITLE
Time stamp boosting on documents with a field public_timestamp

### DIFF
--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -157,10 +157,10 @@ class ElasticsearchWrapper
       "smart-answer"  => 1.5,
       "transaction"   => 1.5,
       # Inside Gov formats
-      "topical_event" => 2,
-      "minister"      => 2,
-      "organisation"  => 2,
-      "topic"         => 2
+      "topical_event" => 1.5,
+      "minister"      => 1.5,
+      "organisation"  => 1.5,
+      "topic"         => 1.5
     }
 
     format_boosts = boosted_formats.map do |format, boost|
@@ -172,12 +172,12 @@ class ElasticsearchWrapper
 
     # An implementation of http://wiki.apache.org/solr/FunctionQuery#recip
     # y = a / (m * x + b); m=3.16E-11, a=0.08, and b=0.05
-    # Curve for half a year: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427ebb9h87j659
+    # Curve for 2 months: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427eejlvmofgm6
     #
-    # Behaves as a time decay penalty for older documents with a public_timestamp
+    # Behaves as a freshness boost for newer documents with a public_timestamp
     time_boost = {
       filter: { exists: { field: "public_timestamp" } },
-      script: "(0.08 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05))"
+      script: "(0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 1"
     }
 
     query_analyzer = "query_default"

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -172,7 +172,7 @@ class ElasticsearchWrapper
 
     # An implementation of http://wiki.apache.org/solr/FunctionQuery#recip
     # y = a / (m * x + b); m=3.16E-11, a=0.08, and b=0.05
-    # Curve for 2 months: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427eejlvmofgm6
+    # Curve for 2 months: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427enuc3gvsq73
     #
     # Behaves as a freshness boost for newer documents with a public_timestamp
     time_boost = {

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -173,6 +173,8 @@ class ElasticsearchWrapper
     # An implementation of http://wiki.apache.org/solr/FunctionQuery#recip
     # y = a / (m * x + b); m=3.16E-11, a=0.08, and b=0.05
     # Curve for half a year: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427ebb9h87j659
+    #
+    # Behaves as a time decay penalty for older documents with a public_timestamp
     time_boost = {
       filter: { exists: { field: "public_timestamp" } },
       script: "(0.08 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05))"

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -157,10 +157,10 @@ class ElasticsearchWrapper
       "smart-answer"  => 1.5,
       "transaction"   => 1.5,
       # Inside Gov formats
-      "topical_event" => 1.5,
-      "minister"      => 1.5,
-      "organisation"  => 1.5,
-      "topic"         => 1.5
+      "topical_event" => 2,
+      "minister"      => 2,
+      "organisation"  => 2,
+      "topic"         => 2
     }
 
     format_boosts = boosted_formats.map do |format, boost|
@@ -169,6 +169,11 @@ class ElasticsearchWrapper
         boost: boost
       }
     end
+
+    time_boost = {
+      filter: { exists: { field: "public_timestamp" } },
+      script: "(0.08 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05))"
+    }
 
     query_analyzer = "query_default"
 
@@ -218,7 +223,7 @@ class ElasticsearchWrapper
               should: query_boosts
             }
           },
-          filters: format_boosts
+          filters: format_boosts + [time_boost]
         }
       }
     }.to_json

--- a/lib/elasticsearch_wrapper.rb
+++ b/lib/elasticsearch_wrapper.rb
@@ -170,6 +170,9 @@ class ElasticsearchWrapper
       }
     end
 
+    # An implementation of http://wiki.apache.org/solr/FunctionQuery#recip
+    # y = a / (m * x + b); m=3.16E-11, a=0.08, and b=0.05
+    # Curve for half a year: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427ebb9h87j659
     time_boost = {
       filter: { exists: { field: "public_timestamp" } },
       script: "(0.08 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05))"

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -31,6 +31,33 @@ class ElasticsearchSearchTest < IntegrationTest
         "indexable_content" => "Tax, benefits, roads and stuff"
       },
       {
+        "title" => "Temporary closure of British Embassy in Mali",
+        "description" => "Temporary closure of British Embassy in Mali",
+        "format" => "news-article",
+        "link" => "/mali-3",
+        "section" => "",
+        "indexable_content" => "Temporary closure of British Embassy in Mali",
+        "public_timestamp" => Time.now
+      },
+      {
+        "title" => "Temporary closure of British Embassy in Mali",
+        "description" => "Temporary closure of British Embassy in Mali",
+        "format" => "news-article",
+        "link" => "/mali-2",
+        "section" => "",
+        "indexable_content" => "Temporary closure of British Embassy in Mali",
+        "public_timestamp" => Time.now - 10000
+      },
+      {
+        "title" => "Temporary closure of British Embassy in Mali",
+        "description" => "Temporary closure of British Embassy in Mali",
+        "format" => "news-article",
+        "link" => "/mali-1",
+        "section" => "",
+        "indexable_content" => "Temporary closure of British Embassy in Mali",
+        "public_timestamp" => Time.now - 1000000
+      },
+      {
         "title" => "Pork pies",
         "link" => "/pork-pies"
       }
@@ -51,6 +78,12 @@ class ElasticsearchSearchTest < IntegrationTest
   def assert_result_links(*links)
     parsed_response = MultiJson.decode(last_response.body)
     assert_equal links, parsed_response.map { |r| r["link"] }
+  end
+
+  def test_documents_with_public_timestamp_exhibit_a_decay_boost
+    get "/search.json?q=mali"
+    assert last_response.ok?
+    assert_result_links "/mali-3", "/mali-2", "/mali-1"
   end
 
   def test_should_search_by_content


### PR DESCRIPTION
Implemented using a custom score as in this blog post: http://jontai.me/blog/2013/01/advanced-scoring-in-elasticsearch/   

Changed `now` to `time()` as `now` was not defined.

Supersedes alphagov/rummager#54
