### PR TITLE
Evaluate `all_documents` lazily

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -101,7 +101,7 @@ class Rummager < Sinatra::Application
     # Site maps can have up to 50,000 links in them.
     # We use one for / so we can have up to 49,999 others.
     documents = indices_for_sitemap.flat_map do |index|
-      index.all_documents(limit: 49_999)
+      index.all_documents.take(49_999)
     end
     builder do |xml|
       xml.instruct!

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -33,12 +33,6 @@ module Elasticsearch
     # We should be able to keep this low, since these are only for internal use
     SCROLL_TIMEOUT_MINUTES = 1
 
-    # We need to provide a limit to queries: if we want everything, just use this
-    # This number is big enough that it vastly exceeds the number of items we're
-    # indexing, but not so big as to trigger strange behaviour (internal errors)
-    # in elasticsearch
-    MASSIVE_NUMBER = 200_000
-
     attr_reader :mappings, :index_name
 
     def initialize(base_uri, index_name, mappings, logger = nil)

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -72,7 +72,7 @@ module ElasticsearchIntegration
   end
 
   def enable_test_index_connections
-    WebMock.disable_net_connect!(allow: %r{http://localhost:9200/(_aliases|[a-z]+_test.*)})
+    WebMock.disable_net_connect!(allow: %r{http://localhost:9200/(_search/scroll|_aliases|[a-z]+_test.*)})
   end
 
   def search_server


### PR DESCRIPTION
Instead of loading all the documents into memory at once, we can load them up in batches as they are needed. This should reduce memory use, but more importantly avoids the problem of timeouts as elasticsearch tries to form a response with several thousand documents in it.

**Note**: pulling this into the `index_aliases` branch instead of `master`, because this work builds on the index aliasing and is required to make it work with the `government` index, but I don’t want it to get lost in the rest of the pull request.
