### PR TITLE
Fix scan queries with multiple shards

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -113,9 +113,19 @@ namespace :rummager do
       index_group = search_server.index_group(index_name)
 
       new_index = index_group.create_index
+      old_index = index_group.current
 
-      if index_group.current.exists?
-        new_index.populate_from index_group.current
+      if old_index.exists?
+        new_index.populate_from old_index
+        new_count = new_index.all_documents.size
+        old_count = old_index.all_documents.size
+        unless new_count == old_count
+          logger.error(
+            "Population miscount: new index has #{new_count} documents, " +
+            "while old index has #{old_count}."
+          )
+          raise RuntimeError, "Population count mismatch"
+        end
       end
 
       index_group.switch_to new_index

--- a/lib/elasticsearch/client.rb
+++ b/lib/elasticsearch/client.rb
@@ -44,9 +44,9 @@ module Elasticsearch
     # of results.
     def with_error_log_level(level, &block)
       previous_level, @error_log_level = @error_log_level, level
-      result = yield
+      return yield
+    ensure
       @error_log_level = previous_level
-      result
     end
 
   private

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -142,7 +142,9 @@ module Elasticsearch
       SizedEnumerator.new(total_hits) do |yielder|
         loop do
           begin
-            response = @client.get(result_page_uri)
+            response = @client.with_error_log_level(:warn) do
+              @client.get(result_page_uri)
+            end
           rescue RestClient::InternalServerError => e
             # elasticsearch returns a 500 status code if any of the shards
             # encountered an error (for example, running off the end of the

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -158,6 +158,10 @@ module Elasticsearch
           # elasticsearch gives us an empty array of hits. This means all the
           # shards have run out of results.
           if page["hits"]["hits"].any?
+            logger.debug do
+              hits_on_page = page["hits"]["hits"].size
+              "Retrieved #{hits_on_page} of all documents from #{index_name}"
+            end
             page["hits"]["hits"].each do |hit|
               yielder << document_from_hash(hit["_source"])
             end

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -79,10 +79,6 @@ module Elasticsearch
 
     def populate_from(source_index)
       total_indexed = 0
-      # This will load the entire content of the search index into memory at
-      # once, which isn't yet a big deal but may become a problem as the search
-      # index grows. One alternative could be to use elasticsearch scan queries
-      # <http://www.elasticsearch.org/guide/reference/api/search/search-type.html>
       all_docs = source_index.all_documents
       all_docs.each_slice(self.class.populate_batch_size) do |documents|
         add documents

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+require "elasticsearch/client"
+require "rest-client"
+require "logging"
+
+class ClientTest < MiniTest::Unit::TestCase
+
+  def internal_server_error(body = "STUFF AND THINGS BROKE")
+    RestClient::InternalServerError.new(
+      # Can't use stub() here, because RestClient does weird inspection
+      Struct.new(:code, :body).new("500", body)
+    )
+  end
+
+  def test_logs_error_body
+    RestClient.expects(:get).raises(internal_server_error)
+    Logging.logger[Elasticsearch::Client].expects(:error)
+      .with(regexp_matches(/STUFF AND THINGS BROKE/))
+
+    assert_raises RestClient::InternalServerError do
+      Elasticsearch::Client.new("http://localhost/").get("")
+    end
+  end
+
+  def test_changes_error_log_level
+    # Test we can change the log level for the duration of a block
+
+    RestClient.expects(:get).raises(internal_server_error)
+    Logging.logger[Elasticsearch::Client].expects(:warn)
+      .with(regexp_matches(/STUFF AND THINGS BROKE/))
+
+    client = Elasticsearch::Client.new("http://localhost/")
+    assert_raises RestClient::InternalServerError do
+      client.with_error_log_level(:warn) do
+        client.get("")
+      end
+    end
+  end
+
+  def test_resets_error_log_level
+    # Test that the error log level goes back to normal outside the block
+
+    RestClient.expects(:get).raises(internal_server_error)
+    RestClient.expects(:head).raises(internal_server_error("More breakage"))
+
+    Logging.logger[Elasticsearch::Client].expects(:warn)
+      .with(regexp_matches(/STUFF AND THINGS BROKE/))
+    Logging.logger[Elasticsearch::Client].expects(:error)
+      .with(regexp_matches(/More breakage/))
+
+    client = Elasticsearch::Client.new("http://localhost/")
+    assert_raises RestClient::InternalServerError do
+      client.with_error_log_level(:warn) do
+        client.get("")
+      end
+    end
+    assert_raises RestClient::InternalServerError do
+      client.head("")
+    end
+  end
+end


### PR DESCRIPTION
As it turns out, elasticsearch is weird in two ways:
- The `size` parameter on scan queries refers to the number of hits to return per shard, not in total.
- If any of the shards have run out of results, the entire response has a 500 status code but can still contain results.

(Rebased and improved version of alphagov/rummager#73.)
