### PR TITLE
Replace builder with Nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "aws-ses", "0.4.4"
 gem "rest-client", "1.6.7"
 gem "statsd-ruby", "1.0.0"
 gem "logging", "1.8.1"
+gem 'nokogiri'
 
 group :test do
   gem 'simplecov'
@@ -21,7 +22,6 @@ group :test do
   gem 'rack-test'
   gem 'mocha', :require => false
   gem 'webmock', '1.9.3', :require => false
-  gem 'nokogiri', :require => false
 end
 
 group :development do

--- a/app.rb
+++ b/app.rb
@@ -103,23 +103,24 @@ class Rummager < Sinatra::Application
     documents = indices_for_sitemap.flat_map do |index|
       index.all_documents.take(49_999)
     end
-    builder do |xml|
-      xml.instruct!
+
+    builder = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
-        xml.url do
+        xml.url {
           xml.loc "#{base_url}#{"/"}"
-        end
+        }
         documents.each do |document|
           unless [settings.inside_government_link, settings.recommended_format].include?(document.format)
-            xml.url do
-              url = document.link
-              url = "#{base_url}#{url}" if url =~ /^\//
+            url = document.link
+            url = "#{base_url}#{url}" if url =~ /^\//
+            xml.url {
               xml.loc url
-            end
+            }
           end
         end
       end
     end
+    builder.to_xml
   end
 
   post "/?:index?/documents" do


### PR DESCRIPTION
Using Nokogiri to build the xml is supposed to be more efficient in terms of less objects created for the GC to clear up. This may aid, it does not solve, the memory leak issue.
