### PR TITLE
Update scroll ID when using scan queries

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -333,7 +333,7 @@ module Elasticsearch
     end
 
     def scroll_page_uri(scroll_id)
-      result_page_uri = URI::Generic.build(
+      URI::Generic.build(
         # Scrolling is accessed from the server root, not an index
         path: "/_search/scroll",
         query: URI.encode_www_form(

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -125,31 +125,17 @@ module Elasticsearch
 
       total_hits = scroll_result["hits"]["total"]
 
-      result_page_uri = URI::Generic.build(
-        # Scrolling is accessed from the server root, not an index
-        path: "/_search/scroll",
-        query: URI.encode_www_form(
-          scroll: "#{SCROLL_TIMEOUT_MINUTES}m",
-          scroll_id: scroll_id
-        )
-      )
-
       # Pull out the results as they are needed
       SizedEnumerator.new(total_hits) do |yielder|
+        scroll_id = scroll_result["_scroll_id"]
+
         loop do
-          begin
-            response = @client.with_error_log_level(:warn) do
-              @client.get(result_page_uri)
-            end
-          rescue RestClient::InternalServerError => e
-            # elasticsearch returns a 500 status code if any of the shards
-            # encountered an error (for example, running off the end of the
-            # scroll), but this doesn't necessarily mean there aren't any more
-            # results.
-            response = e.response
-          end
+          result_page_uri = scroll_page_uri(scroll_id)
+          response = @client.get(result_page_uri)
 
           page = MultiJson.decode(response)
+          scroll_id = page.fetch("_scroll_id")  # Error if scroll ID absent
+
           # The way we tell we've got through all the results is when
           # elasticsearch gives us an empty array of hits. This means all the
           # shards have run out of results.
@@ -344,6 +330,17 @@ module Elasticsearch
 
     def index_action(doc)
       {"index" => {"_type" => doc["_type"], "_id" => doc["link"]}}
+    end
+
+    def scroll_page_uri(scroll_id)
+      result_page_uri = URI::Generic.build(
+        # Scrolling is accessed from the server root, not an index
+        path: "/_search/scroll",
+        query: URI.encode_www_form(
+          scroll: "#{SCROLL_TIMEOUT_MINUTES}m",
+          scroll_id: scroll_id
+        )
+      )
     end
   end
 end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -164,12 +164,11 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       { "_source" => { "link" => "/foo-#{i}" } }
     }
     stub_request(:get, scroll_uri).to_return(
-      body: MultiJson.encode({hits: {total: 100, hits: hits[0, 50]}})
+      body: scroll_response_body("abcdefgh", 100, hits[0, 50])
     ).then.to_return(
-      body: MultiJson.encode({hits: {total: 100, hits: hits[50, 50]}})
+      body: scroll_response_body("abcdefgh", 100, hits[50, 50])
     ).then.to_return(
-      status: 500,
-      body: MultiJson.encode({hits: {total: 100, hits: []}})
+      body: scroll_response_body("abcdefgh", 100, [])
     ).then.to_raise(RuntimeError)
     all_documents = @wrapper.all_documents.to_a
     assert_equal 100, all_documents.size
@@ -177,37 +176,47 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     assert_equal "/foo-100", all_documents.last.link
   end
 
-  def test_all_documents_with_multiple_shards
-    # Test that the scrolling search works when one of multiple shards runs out
-    # of results
-
+  def test_changing_scroll_id
     search_uri = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=2"
-    scroll_uri = "http://example.com:9200/_search/scroll?scroll=1m&scroll_id=abcdefgh"
+
+    def scroll_uri(scroll_id)
+       "http://example.com:9200/_search/scroll?scroll=1m&scroll_id=#{scroll_id}"
+    end
 
     Elasticsearch::Index.stubs(:scroll_batch_size).returns(2)
 
     stub_request(:get, search_uri).with(
       body: MultiJson.encode({query: {match_all: {}}})
     ).to_return(
-      body: MultiJson.encode({_scroll_id: "abcdefgh", hits: {total: 5}})
+      body: MultiJson.encode({_scroll_id: "abcdefgh", hits: {total: 3}})
     )
-    hits = (1..5).map { |i|
+    hits = (1..3).map { |i|
       { "_source" => { "link" => "/foo-#{i}" } }
     }
-    stub_request(:get, scroll_uri).to_return(
-      # The first 4 results: two per shard
-      body: MultiJson.encode({hits: {total: 4, hits: hits[0...4]}})
-    ).then.to_return(
-      # elasticsearch returns a 500 if any of the shards have run out of
-      # results
-      status: 500,
-      # The fifth result
-      body: MultiJson.encode({hits: {total: 100, hits: hits[4..-1]}})
-    ).then.to_return(
-      status: 500,
-      body: MultiJson.encode({hits: {total: 100, hits: []}})
+    total = hits.size
+
+    stub_request(:get, scroll_uri("abcdefgh")).to_return(
+      body: scroll_response_body("ijklmnop", total, hits[0, 2])
     ).then.to_raise(RuntimeError)
 
-    assert_equal 5, @wrapper.all_documents.count
+    stub_request(:get, scroll_uri("ijklmnop")).to_return(
+      body: scroll_response_body("qrstuvwx", total, hits[2, 1])
+    ).then.to_raise(RuntimeError)
+
+    stub_request(:get, scroll_uri("qrstuvwx")).to_return(
+      body: scroll_response_body("yz", total, [])
+    ).then.to_raise(RuntimeError)
+
+    all_documents = @wrapper.all_documents.to_a
+    assert_equal ["/foo-1", "/foo-2", "/foo-3"], all_documents.map(&:link)
+  end
+
+  def scroll_response_body(scroll_id, total_results, results)
+      MultiJson.encode(
+        {
+          _scroll_id: scroll_id,
+          hits: {total: total_results, hits: results}
+        }
+      )
   end
 end


### PR DESCRIPTION
This ID appears to change for the last request in a series, causing strange behaviour (HTTP error responses with results) if the request URI doesn't change.
