### PR TITLE
Timeout if elasticsearch is misbehaving

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -38,10 +38,20 @@ module Elasticsearch
     # We should be able to keep this low, since these are only for internal use
     SCROLL_TIMEOUT_MINUTES = 1
 
+    # How long to wait between reads when streaming data from the elasticsearch server
+    TIMEOUT_SECONDS = 2.0
+
+    # How long to wait for a connection to the elasticsearch server
+    OPEN_TIMEOUT_SECONDS = 2.0
+
     attr_reader :mappings, :index_name
 
     def initialize(base_uri, index_name, mappings)
-      @client = Client.new(base_uri + "#{CGI.escape(index_name)}/")
+      @client = Client.new(
+        base_uri + "#{CGI.escape(index_name)}/",
+        timeout: TIMEOUT_SECONDS,
+        open_timeout: OPEN_TIMEOUT_SECONDS
+      )
       @index_name = index_name
       raise ArgumentError, "Missing index_name parameter" unless @index_name
       @mappings = mappings

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -13,7 +13,9 @@ class ClientTest < MiniTest::Unit::TestCase
   end
 
   def test_logs_error_body
-    RestClient.expects(:get).raises(internal_server_error)
+    RestClient::Request.expects(:execute).with(has_entry(method: :get))
+      .raises(internal_server_error)
+
     Logging.logger[Elasticsearch::Client].expects(:error)
       .with(regexp_matches(/STUFF AND THINGS BROKE/))
 
@@ -25,7 +27,9 @@ class ClientTest < MiniTest::Unit::TestCase
   def test_changes_error_log_level
     # Test we can change the log level for the duration of a block
 
-    RestClient.expects(:get).raises(internal_server_error)
+    RestClient::Request.expects(:execute).with(has_entry(method: :get))
+      .raises(internal_server_error)
+
     Logging.logger[Elasticsearch::Client].expects(:warn)
       .with(regexp_matches(/STUFF AND THINGS BROKE/))
 
@@ -40,8 +44,10 @@ class ClientTest < MiniTest::Unit::TestCase
   def test_resets_error_log_level
     # Test that the error log level goes back to normal outside the block
 
-    RestClient.expects(:get).raises(internal_server_error)
-    RestClient.expects(:head).raises(internal_server_error("More breakage"))
+    RestClient::Request.expects(:execute).with(has_entry(method: :get))
+      .raises(internal_server_error)
+    RestClient::Request.expects(:execute).with(has_entry(method: :head))
+      .raises(internal_server_error("More breakage"))
 
     Logging.logger[Elasticsearch::Client].expects(:warn)
       .with(regexp_matches(/STUFF AND THINGS BROKE/))
@@ -57,5 +63,19 @@ class ClientTest < MiniTest::Unit::TestCase
     assert_raises RestClient::InternalServerError do
       client.head("")
     end
+  end
+
+  def test_timeout
+    # Test that Elasticsearch::Client accepts a timeout option and passes it on
+    # to RestClient
+    RestClient::Request.expects(:execute).with(has_entries(timeout: 10))
+    Elasticsearch::Client.new("http://localhost/", timeout: 10).get("")
+  end
+
+  def test_open_timeout
+    # Test that Elasticsearch::Client accepts an open_timeout option and passes
+    # it on to RestClient
+    RestClient::Request.expects(:execute).with(has_entries(open_timeout: 10))
+    Elasticsearch::Client.new("http://localhost/", open_timeout: 10).get("")
   end
 end


### PR DESCRIPTION
This PR adds support to `Elasticsearch::Client` for specifying timeouts which
are passed through to the underlying `RestClient` instance.

Also add a couple of default timeouts (2s connection, 2s between-reads) in
`Elasticsearch::Index`.
