### PR TITLE
Whitehall search improvements

### DIFF
--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -26,14 +26,7 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def test_keyword_param_is_converted_to_a_boosted_title_and_unboosted_general_query
-    stub_empty_search(:body => /#{Regexp.escape("\"query\":"+
-    "{\"bool\":{\"should\":["+
-      "{\"text\":{\"title\":"+
-        "{\"query\":\"happy fun time\",\"type\":\"phrase_prefix\",\"operator\":\"and\",\"analyzer\":\"query_default\",\"boost\":10,\"fuzziness\":0.5}"+
-      "}},"+
-      "{\"query_string\":"+
-        "{\"query\":\"happy fun time\",\"default_operator\":\"and\",\"analyzer\":\"query_default\"}"+
-      "}]}}")}/)
+    stub_empty_search(:body => "{\"from\":0,\"size\":1,\"query\":{\"custom_filters_score\":{\"query\":{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"happy fun time\",\"fields\":[\"title^3\"],\"default_operator\":\"and\",\"analyzer\":\"default\"}},{\"query_string\":{\"query\":\"happy fun time\",\"analyzer\":\"query_default\"}}]}},\"filters\":[{\"filter\":{\"term\":{\"search_format_types\":\"edition\"}},\"script\":\"((0.15 / ((3.1*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)\"}]}},\"filter\":{}}")
     @wrapper.advanced_search(default_params.merge('keywords' => 'happy fun time'))
   end
 


### PR DESCRIPTION
Dont use the `query_default` analyser by for the title match - this
causes issues where searches for 'passport' dont return anything but
'passpor' does

Implement the time decay from the main search and apply to all editions
for gain some form of date sorting, and change values (tails to
1 and starts at 3.5) see graph:

http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427e1tsm9rnveh

Also move to the non deplicated `query_string` query type, we loose the
fuzziness control.

https://www.pivotaltracker.com/story/show/48726201
