### PR TITLE
Raise ElasticSearch timeouts from 2.0s to 5.0s

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -40,10 +40,10 @@ module Elasticsearch
     SCROLL_TIMEOUT_MINUTES = 1
 
     # How long to wait between reads when streaming data from the elasticsearch server
-    TIMEOUT_SECONDS = 2.0
+    TIMEOUT_SECONDS = 5.0
 
     # How long to wait for a connection to the elasticsearch server
-    OPEN_TIMEOUT_SECONDS = 2.0
+    OPEN_TIMEOUT_SECONDS = 5.0
 
     attr_reader :mappings, :index_name
 


### PR DESCRIPTION
In [#83](https://github.com/alphagov/rummager/pull/83) a default timeout of 2.0s was introduced on requests to ElasticSearch. This resulted in a number of 5xx errors and as a result the timeout in production was raised to 5.0s - this PR is simply to document that fact.
- If we can resolve the root cause of why those requests took more than 2.0s, then this PR can be closed and the default will remain 2.0s
- If we cannot resolve the root cause of those requests taking too long, then this PR should be merged before Rummager is next deployed to Production.
