### PR TITLE
Clean up a variable that just acts as an alias

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -209,8 +209,6 @@ module Elasticsearch
         end
       end
 
-      query_boosts = shingle_boosts
-
       payload = {
         from: 0, size: 50,
         query: {
@@ -226,7 +224,7 @@ module Elasticsearch
                     analyzer: query_analyzer
                   }
                 },
-                should: query_boosts
+                should: shingle_boosts
               }
             },
             filters: format_boosts + [time_boost]


### PR DESCRIPTION
Originally it was appended to, but no longer.
See: 7fe0d23638d48bc44a008a23cb3b3ed359f3c66e
