### PR TITLE
Fix sitemap timestamps

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,9 @@
 set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
 job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv search bundle exec rake :task'
 
-every 1.day, :at => '1.00am' do
+# Sitemap filenames are generated based on the current day and hour. Putting
+# this at 10 past gets around any problems that might arise from running just
+# before the hour.
+every 1.day, :at => '1.10am' do
   rake 'sitemap:generate_and_replace'
 end

--- a/lib/elasticsearch/sitemap.rb
+++ b/lib/elasticsearch/sitemap.rb
@@ -17,7 +17,7 @@ class Sitemap
   end
 
   def write_index(sitemap_filenames)
-    index_filename = "sitemap_#{@timestamp.strftime('%FT%H%M%S')}.xml"
+    index_filename = "sitemap_#{@timestamp.strftime('%FT%H')}.xml"
     index_full_path = File.join(@directory, index_filename)
     File.open(index_full_path, "w") do |sitemap_index_file|
       builder = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
@@ -68,7 +68,7 @@ class SitemapWriter
 private
   def next_filename
     @sitemap_file_count += 1
-    "sitemap_#{@sitemap_file_count}_#{@timestamp.strftime('%FT%H%M%S')}.xml"
+    "sitemap_#{@sitemap_file_count}_#{@timestamp.strftime('%FT%H')}.xml"
   end
 end
 

--- a/lib/elasticsearch/sitemap.rb
+++ b/lib/elasticsearch/sitemap.rb
@@ -58,7 +58,7 @@ class SitemapWriter
     # write our sitemap files and return an array of filenames
     sitemap_generator.sitemaps.map do |sitemap_xml|
       filename = next_filename
-      File.open(File.join(@directory, filename), "w") do |file| 
+      File.open(File.join(@directory, filename), "w") do |file|
         file.write(sitemap_xml)
       end
       filename


### PR DESCRIPTION
Different machines generating their own sitemaps are generating files with different timestamps, causing broken links in the sitemap index.
