### PR TITLE
Remove old highlight functionality.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -75,7 +75,6 @@ class Rummager < Sinatra::Application
     results = current_index.search(query)
 
     MultiJson.encode(results.map { |r| r.to_hash.merge(
-      highlight: r.highlight,
       presentation_format: r.presentation_format,
       humanized_format: r.humanized_format
     )})
@@ -88,7 +87,6 @@ class Rummager < Sinatra::Application
     MultiJson.encode({
       total: results[:total],
       results: results[:results].map { |r| r.to_hash.merge(
-        highlight: r.highlight,
         presentation_format: r.presentation_format,
         humanized_format: r.humanized_format
       )}

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -119,8 +119,6 @@ end
 
 class Document < SearchIndexEntry
 
-  attr_writer :highlight
-
   def self.from_hash(hash, mappings)
     field_names = mappings["edition"]["properties"].keys.map(&:to_s)
     self.new(field_names, unflatten(hash))
@@ -150,10 +148,6 @@ class Document < SearchIndexEntry
 
   def humanized_format
     FORMAT_NAME_ALTERNATIVES[presentation_format] || presentation_format.humanize.pluralize
-  end
-
-  def highlight
-    @highlight || description
   end
 
   private

--- a/test/functional/advanced_search_test.rb
+++ b/test/functional/advanced_search_test.rb
@@ -21,7 +21,7 @@ class AdvancedSearchTest < IntegrationTest
     Elasticsearch::Index.any_instance.stubs(:advanced_search)
       .returns({total: 1, results: [sample_document]})
     get "/rummager_test/advanced_search.json", {per_page: '1', page: '1', keywords: 'meh'}
-    expected_result = {'total' => 1, 'results' => [sample_document_attributes.merge('highlight' => 'DESCRIPTION')]}
+    expected_result = {'total' => 1, 'results' => [sample_document_attributes]}
     assert last_response.ok?, "Bad status: #{last_response.status}"
     assert_match /application\/json/, last_response.headers["Content-Type"]
     result = MultiJson.decode(last_response.body)

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -5,14 +5,14 @@ class SearchTest < IntegrationTest
   def test_returns_json_for_search_results
     stub_index.expects(:search).returns([sample_document])
     get "/search", {q: "bob"}, "HTTP_ACCEPT" => "application/json"
-    assert_equal [sample_document_attributes.merge("highlight"=>"DESCRIPTION")], MultiJson.decode(last_response.body)
+    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)
     assert_match(/application\/json/, last_response.headers["Content-Type"])
   end
 
   def test_returns_json_when_requested_with_url_suffix
     stub_index.expects(:search).returns([sample_document])
     get "/search.json", {q: "bob"}
-    assert_equal [sample_document_attributes.merge("highlight"=>"DESCRIPTION")], MultiJson.decode(last_response.body)
+    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)
     assert_match(/application\/json/, last_response.headers["Content-Type"])
   end
 

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -154,25 +154,6 @@ class DocumentTest < MiniTest::Unit::TestCase
     assert_equal hash.keys.sort, document.to_hash.keys.sort
   end
 
-  def test_should_use_description_for_highlight_if_no_highlight_is_set
-    hash = {
-      "description" => "DESCRIPTION",
-    }
-
-    document = Document.from_hash(hash, @mappings)
-    assert_equal "DESCRIPTION", document.highlight
-  end
-
-  def test_should_prefer_highlight_if_set
-    hash = {
-      "description" => "DESCRIPTION",
-    }
-
-    document = Document.from_hash(hash, @mappings)
-    document.highlight = "HIGHLIGHT"
-    assert_equal "HIGHLIGHT", document.highlight
-  end
-
   def test_should_skip_missing_fields_in_elasticsearch_export
     hash = {
         "_type" => "edition",


### PR DESCRIPTION
It's not used by the front end any more, and wasn't being set by any of the code since we switched to elasticsearch.
