### PR TITLE
Refactor result presentation

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -73,21 +73,15 @@ class Rummager < Sinatra::Application
 
     expires 3600, :public if query.length < 20
 
-    results = current_index.search(query)
-    ResultSetPresenter.new(results).present
+    result_set = current_index.search(query)
+    ResultSetPresenter.new(result_set).present
   end
 
   get "/:index/advanced_search.?:format?" do
     json_only
 
-    results = current_index.advanced_search(request.params)
-    MultiJson.encode({
-      total: results[:total],
-      results: results[:results].map { |r| r.to_hash.merge(
-        presentation_format: r.presentation_format,
-        humanized_format: r.humanized_format
-      )}
-    })
+    result_set = current_index.advanced_search(request.params)
+    ResultSetPresenter.new(result_set).present_with_total
   end
 
   post "/?:index?/documents" do

--- a/app.rb
+++ b/app.rb
@@ -9,6 +9,7 @@ require "csv"
 require "statsd"
 
 require "document"
+require "result_set_presenter"
 require "elasticsearch/index"
 require "elasticsearch/search_server"
 
@@ -73,11 +74,7 @@ class Rummager < Sinatra::Application
     expires 3600, :public if query.length < 20
 
     results = current_index.search(query)
-
-    MultiJson.encode(results.map { |r| r.to_hash.merge(
-      presentation_format: r.presentation_format,
-      humanized_format: r.humanized_format
-    )})
+    ResultSetPresenter.new(results).present
   end
 
   get "/:index/advanced_search.?:format?" do

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -124,35 +124,4 @@ class Document < SearchIndexEntry
     self.new(field_names, unflatten(hash))
   end
 
-  PRESENTATION_FORMAT_TRANSLATION = {
-    "planner" => "answer",
-    "smart_answer" => "answer",
-    "calculator" => "answer",
-    "licence_finder" => "answer",
-    "custom_application" => "answer",
-    "calendar" => "answer"
-  }
-
-  FORMAT_NAME_ALTERNATIVES = {
-    "programme" => "Benefits & credits",
-    "transaction" => "Services",
-    "local_transaction" => "Services",
-    "place" => "Services",
-    "answer" => "Quick answers",
-    "specialist_guidance" => "Specialist guidance"
-  }
-
-  def presentation_format
-    PRESENTATION_FORMAT_TRANSLATION.fetch(normalized_format, normalized_format)
-  end
-
-  def humanized_format
-    FORMAT_NAME_ALTERNATIVES[presentation_format] || presentation_format.humanize.pluralize
-  end
-
-  private
-
-  def normalized_format
-    self.format ? self.format.gsub("-", "_") : "unknown"
-  end
 end

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -1,0 +1,18 @@
+class ResultSet
+
+  attr_reader :total, :results
+
+  def initialize(mappings, elasticsearch_response)
+    @mappings = mappings
+    @total = elasticsearch_response["hits"]["total"]
+    @results = elasticsearch_response["hits"]["hits"].map { |hit|
+      document_from_hit(hit)
+    }.freeze
+  end
+
+private
+  def document_from_hit(hit)
+    hash = hit["_source"].merge("es_score" => hit["_score"])
+    Document.from_hash(hash, @mappings)
+  end
+end

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -15,11 +15,47 @@ class ResultSetPresenter
     )
   end
 
+  PRESENTATION_FORMAT_TRANSLATION = {
+    "planner" => "answer",
+    "smart_answer" => "answer",
+    "calculator" => "answer",
+    "licence_finder" => "answer",
+    "custom_application" => "answer",
+    "calendar" => "answer"
+  }
+
+  FORMAT_NAME_ALTERNATIVES = {
+    "programme" => "Benefits & credits",
+    "transaction" => "Services",
+    "local_transaction" => "Services",
+    "place" => "Services",
+    "answer" => "Quick answers",
+    "specialist_guidance" => "Specialist guidance"
+  }
+
 private
+  def presentation_format(document)
+    normalized = normalized_format(document)
+    PRESENTATION_FORMAT_TRANSLATION.fetch(normalized, normalized)
+  end
+
+  def humanized_format(document)
+    presentation = presentation_format(document)
+    FORMAT_NAME_ALTERNATIVES[presentation] || presentation.humanize.pluralize
+  end
+
+  def normalized_format(document)
+    if document.format
+      document.format.gsub("-", "_")
+    else
+      "unknown"
+    end
+  end
+
   def results
     @result_set.results.map { |r| r.to_hash.merge(
-      presentation_format: r.presentation_format,
-      humanized_format: r.humanized_format
+      presentation_format: presentation_format(r),
+      humanized_format: humanized_format(r)
     )}
   end
 end

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -1,13 +1,25 @@
 class ResultSetPresenter
 
-  def initialize(results)
-    @results = results
+  def initialize(result_set)
+    @result_set = result_set
   end
 
   def present
-    MultiJson.encode(@results.map { |r| r.to_hash.merge(
+    MultiJson.encode(results)
+  end
+
+  def present_with_total
+    MultiJson.encode(
+      total: @result_set.total,
+      results: results
+    )
+  end
+
+private
+  def results
+    @result_set.results.map { |r| r.to_hash.merge(
       presentation_format: r.presentation_format,
       humanized_format: r.humanized_format
-    )})
+    )}
   end
 end

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -1,0 +1,13 @@
+class ResultSetPresenter
+
+  def initialize(results)
+    @results = results
+  end
+
+  def present
+    MultiJson.encode(@results.map { |r| r.to_hash.merge(
+      presentation_format: r.presentation_format,
+      humanized_format: r.humanized_format
+    )})
+  end
+end

--- a/test/functional/advanced_search_test.rb
+++ b/test/functional/advanced_search_test.rb
@@ -9,7 +9,7 @@ class AdvancedSearchTest < IntegrationTest
 
   def test_returns_json_for_advanced_search_results
     Elasticsearch::Index.any_instance.stubs(:advanced_search)
-      .returns({total: 1, results: [sample_document]})
+      .returns(stub(total: 1, results: [sample_document]))
     get "/rummager_test/advanced_search", {per_page: '1', page: '1', keywords: 'meh'}, "HTTP_ACCEPT" => "application/json"
     assert last_response.ok?, "Bad status: #{last_response.status}"
     result = MultiJson.decode(last_response.body)
@@ -19,7 +19,7 @@ class AdvancedSearchTest < IntegrationTest
 
   def test_json_response_includes_total_and_results
     Elasticsearch::Index.any_instance.stubs(:advanced_search)
-      .returns({total: 1, results: [sample_document]})
+      .returns(stub(total: 1, results: [sample_document]))
     get "/rummager_test/advanced_search.json", {per_page: '1', page: '1', keywords: 'meh'}
     expected_result = {'total' => 1, 'results' => [sample_document_attributes]}
     assert last_response.ok?, "Bad status: #{last_response.status}"

--- a/test/functional/multiple_backends_test.rb
+++ b/test/functional/multiple_backends_test.rb
@@ -3,7 +3,7 @@ require "integration_test_helper"
 
 class MultipleBackendsTest < IntegrationTest
   def test_passes_search_to_chosen_backend
-    chosen_index = mock("chosen index", search: [])
+    chosen_index = mock("chosen index", search: stub(results: []))
     Elasticsearch::SearchServer.any_instance.expects(:index).with("chosen").returns(chosen_index)
     get "/chosen/search?q=example"
   end

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -3,14 +3,14 @@ require "integration_test_helper"
 
 class SearchTest < IntegrationTest
   def test_returns_json_for_search_results
-    stub_index.expects(:search).returns([sample_document])
+    stub_index.expects(:search).returns(stub(results: [sample_document]))
     get "/search", {q: "bob"}, "HTTP_ACCEPT" => "application/json"
     assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)
     assert_match(/application\/json/, last_response.headers["Content-Type"])
   end
 
   def test_returns_json_when_requested_with_url_suffix
-    stub_index.expects(:search).returns([sample_document])
+    stub_index.expects(:search).returns(stub(results: [sample_document]))
     get "/search.json", {q: "bob"}
     assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)
     assert_match(/application\/json/, last_response.headers["Content-Type"])

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -79,56 +79,6 @@ class DocumentTest < MiniTest::Unit::TestCase
     assert_equal "TITLE", document.title
   end
 
-  def test_should_use_answer_as_presentation_format_for_planner
-    hash = {:format => "planner"}
-
-    document = Document.from_hash(hash, @mappings)
-    assert_equal "answer", document.presentation_format
-  end
-
-  def test_should_use_answer_as_presentation_format_for_smart_answer
-    hash = {:format => "smart_answer"}
-
-    document = Document.from_hash(hash, @mappings)
-    assert_equal "answer", document.presentation_format
-  end
-
-  def test_should_use_answer_as_presentation_format_for_licence_finder
-    hash = {:format => "licence_finder"}
-
-    document = Document.from_hash(hash, @mappings)
-    assert_equal "answer", document.presentation_format
-  end
-
-  def test_should_use_guide_as_presentation_format_for_guide
-    hash = {:format => "guide"}
-
-    document = Document.from_hash(hash, @mappings)
-    assert_equal "guide", document.presentation_format
-  end
-
-  def test_takes_humanized_format_if_present
-    hash = {:format => "place"}
-
-    document = Document.from_hash(hash, @mappings)
-    assert_equal "Services", document.humanized_format
-  end
-
-  def test_uses_presentation_format_to_find_alternative_format_name
-    hash = {:format => "map"}
-
-    document = Document.from_hash(hash, @mappings)
-    document.stubs(:presentation_format).returns("place")
-    assert_equal "Services", document.humanized_format
-  end
-
-  def test_generates_humanized_format_if_not_present
-    hash = {:format => "ocean_map"}
-
-    document = Document.from_hash(hash, @mappings)
-    assert_equal "Ocean maps", document.humanized_format
-  end
-
   def test_should_round_trip_document_from_hash_and_back_into_hash
     hash = {
       "title" => "TITLE",

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -130,15 +130,18 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   def test_returns_the_total_and_the_hits
     stub_empty_search()
     expected_result = {total: 0, results: []}
-    assert_equal expected_result, @wrapper.advanced_search(default_params)
+    result_set = @wrapper.advanced_search(default_params)
+    assert_equal 0, result_set.total
+    assert_equal [], result_set.results
   end
 
   def test_returns_the_hits_converted_into_documents
     Document.expects(:from_hash).with({"woo" => "hoo", "es_score" => nil}, default_mappings).returns :woo_hoo
     stub_request(:get, "http://example.com:9200/test-index/_search")
       .to_return(:status => 200, :body => "{\"hits\": {\"total\": 10, \"hits\": [{\"_source\": {\"woo\": \"hoo\"}}]}}", :headers => {})
-    expected_result = {total: 10, results: [:woo_hoo]}
-    assert_equal expected_result, @wrapper.advanced_search(default_params)
+    result_set = @wrapper.advanced_search(default_params)
+    assert_equal 10, result_set.total
+    assert_equal [:woo_hoo], result_set.results
   end
 
   def default_params

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -6,8 +6,8 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
   FIELDS = %w(link title description format)
 
-  def documents
-    [
+  def result_set
+    documents = [
       {
         "link" => "/foo",
         "title" => "Foo",
@@ -15,10 +15,12 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
         "format" => "edition"
       }
     ].map { |h| Document.new(FIELDS, h) }
+
+    stub("result set", results: documents, total: 1)
   end
 
   def test_generates_json_from_documents
-    presenter = ResultSetPresenter.new(documents)
+    presenter = ResultSetPresenter.new(result_set)
     json = presenter.present
     output = MultiJson.decode(json)
     assert_equal 1, output.length
@@ -26,14 +28,14 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
   end
 
   def test_presented_json_includes_presentation_format
-    presenter = ResultSetPresenter.new(documents)
+    presenter = ResultSetPresenter.new(result_set)
     json = presenter.present
     output = MultiJson.decode(json)
     assert_equal "edition", output[0]["presentation_format"]
   end
 
   def test_presented_json_includes_humanized_format
-    presenter = ResultSetPresenter.new(documents)
+    presenter = ResultSetPresenter.new(result_set)
     json = presenter.present
     output = MultiJson.decode(json)
     assert_equal "Editions", output[0]["humanized_format"]

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "document"
 require "result_set_presenter"
+require "multi_json"
 
 class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
@@ -19,25 +20,73 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     stub("result set", results: documents, total: 1)
   end
 
+  def single_result_with_format(format)
+    stub(results: [Document.new(FIELDS, :format => format)])
+  end
+
+  def output_for(presenter)
+    MultiJson.decode(presenter.present)
+  end
+
   def test_generates_json_from_documents
     presenter = ResultSetPresenter.new(result_set)
-    json = presenter.present
-    output = MultiJson.decode(json)
+    output = output_for(presenter)
     assert_equal 1, output.length
     assert_equal [], FIELDS - output[0].keys
   end
 
   def test_presented_json_includes_presentation_format
     presenter = ResultSetPresenter.new(result_set)
-    json = presenter.present
-    output = MultiJson.decode(json)
+    output = output_for(presenter)
     assert_equal "edition", output[0]["presentation_format"]
   end
 
   def test_presented_json_includes_humanized_format
     presenter = ResultSetPresenter.new(result_set)
-    json = presenter.present
-    output = MultiJson.decode(json)
+    output = output_for(presenter)
     assert_equal "Editions", output[0]["humanized_format"]
+  end
+
+  def test_should_use_answer_as_presentation_format_for_planner
+    result_set = single_result_with_format "planner"
+    output = output_for(ResultSetPresenter.new(result_set))
+    assert_equal "answer", output[0]["presentation_format"]
+  end
+
+  def test_should_use_answer_as_presentation_format_for_smart_answer
+    result_set = single_result_with_format "smart_answer"
+    output = output_for(ResultSetPresenter.new(result_set))
+    assert_equal "answer", output[0]["presentation_format"]
+  end
+
+  def test_should_use_answer_as_presentation_format_for_licence_finder
+    result_set = single_result_with_format "licence_finder"
+    output = output_for(ResultSetPresenter.new(result_set))
+    assert_equal "answer", output[0]["presentation_format"]
+  end
+
+  def test_should_use_guide_as_presentation_format_for_guide
+    result_set = single_result_with_format "guide"
+    output = output_for(ResultSetPresenter.new(result_set))
+    assert_equal "guide", output[0]["presentation_format"]
+  end
+
+  def test_should_use_humanized_format
+    result_set = single_result_with_format "place"
+    output = output_for(ResultSetPresenter.new(result_set))
+    assert_equal "Services", output[0]["humanized_format"]
+  end
+
+  def test_uses_presentation_format_to_find_alternative_format_name
+    presenter = ResultSetPresenter.new(single_result_with_format("foo"))
+    presenter.stubs(:presentation_format).returns("place")
+
+    assert_equal "Services", output_for(presenter)[0]["humanized_format"]
+  end
+
+  def test_generates_humanized_format_if_not_present
+    result_set = single_result_with_format "ocean_map"
+    output = output_for(ResultSetPresenter.new(result_set))
+    assert_equal "Ocean maps", output[0]["humanized_format"]
   end
 end

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+require "document"
+require "result_set_presenter"
+
+class ResultSetPresenterTest < MiniTest::Unit::TestCase
+
+  FIELDS = %w(link title description format)
+
+  def documents
+    [
+      {
+        "link" => "/foo",
+        "title" => "Foo",
+        "description" => "Full of foo.",
+        "format" => "edition"
+      }
+    ].map { |h| Document.new(FIELDS, h) }
+  end
+
+  def test_generates_json_from_documents
+    presenter = ResultSetPresenter.new(documents)
+    json = presenter.present
+    output = MultiJson.decode(json)
+    assert_equal 1, output.length
+    assert_equal [], FIELDS - output[0].keys
+  end
+
+  def test_presented_json_includes_presentation_format
+    presenter = ResultSetPresenter.new(documents)
+    json = presenter.present
+    output = MultiJson.decode(json)
+    assert_equal "edition", output[0]["presentation_format"]
+  end
+
+  def test_presented_json_includes_humanized_format
+    presenter = ResultSetPresenter.new(documents)
+    json = presenter.present
+    output = MultiJson.decode(json)
+    assert_equal "Editions", output[0]["humanized_format"]
+  end
+end


### PR DESCRIPTION
Create a `ResultSetPresenter` class to handle presentation logic around results and format translations. Also unify return types across the `search` and `advanced_search` endpoints.
