### PR TITLE
Fix the migrate_index and migrate_from_unaliased_index rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,4 @@
 require "rake/testtask"
-require "rest-client"
-require "logging"
 
 PROJECT_ROOT = File.dirname(__FILE__)
 
@@ -40,50 +38,4 @@ end
 
 require "ci/reporter/rake/minitest" if ENV["RACK_ENV"] == "test"
 
-class PushableLogger
-  # Because RestClient uses the '<<' method, rather than the levelled Logger
-  # methods, we have to put together a class that'll assign them a level
-
-  def initialize(logger, level)
-    @logger, @level = logger, level
-  end
-
-  def <<(message)
-    @logger.send @level, message
-  end
-end
-
 task :default => :test
-
-logger = Logging.logger.root
-logger.add_appenders Logging.appenders.stdout
-logger.level = verbose ? :debug : :info
-
-# Log all RestClient output at debug level, so it doesn't show up unless rake
-# is invoked with the `--verbose` flag
-RestClient.log = PushableLogger.new(Logging.logger[RestClient], :debug)
-
-def search_config
-  @search_config ||= SearchConfig.new
-end
-
-def search_server
-  search_config.search_server
-end
-
-def index_names
-  case ENV["RUMMAGER_INDEX"]
-  when "all"
-    all_index_names
-  when String
-    [ENV["RUMMAGER_INDEX"]]
-  else
-    raise "You must specify an index name in RUMMAGER_INDEX, or 'all'"
-  end
-end
-
-def all_index_names
-  search_config.index_names
-end
-
-


### PR DESCRIPTION
These were broken because the local variable `logger` was being set in the
Rakefile, so weren't accessible to these tasks which were moved to a separate
file.

Example of the error:

```
    rake aborted!
    undefined local variable or method `logger' for main:Object
```
