### PR TITLE
Fix rake tasks that try to reference logger

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,9 +55,14 @@ end
 
 task :default => :test
 
-logger = Logging.logger.root
-logger.add_appenders Logging.appenders.stdout
-logger.level = verbose ? :debug : :info
+def logger
+  @_logger ||= begin
+    logger = Logging.logger.root
+    logger.add_appenders Logging.appenders.stdout
+    logger.level = verbose ? :debug : :info
+    logger
+  end
+end
 
 # Log all RestClient output at debug level, so it doesn't show up unless rake
 # is invoked with the `--verbose` flag


### PR DESCRIPTION
Tasks defined outside of the Rakefile did not have access to the `logger`
local variable defined in the Rakefile, so would error when they tried to use it.

For reasons I don't understand, methods defined in the Rakefile are accessible to tasks defined in other files.

Supersedes https://github.com/alphagov/rummager/pull/93
