### PR TITLE
Organisations

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -10,6 +10,7 @@ require "statsd"
 
 require "document"
 require "result_set_presenter"
+require "organisation_registry"
 require "elasticsearch/index"
 require "elasticsearch/search_server"
 
@@ -32,6 +33,11 @@ class Rummager < Sinatra::Application
     search_server.index(index_name)
   rescue Elasticsearch::NoSuchIndex
     halt(404)
+  end
+
+  def organisation_registry
+    index_name = settings.search_config.organisation_registry_index
+    OrganisationRegistry.new(search_server.index(index_name)) if index_name
   end
 
   def indices_for_sitemap
@@ -74,7 +80,7 @@ class Rummager < Sinatra::Application
     expires 3600, :public if query.length < 20
 
     result_set = current_index.search(query)
-    ResultSetPresenter.new(result_set).present
+    ResultSetPresenter.new(result_set, organisation_registry: organisation_registry).present
   end
 
   get "/:index/advanced_search.?:format?" do

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,2 +1,3 @@
 base_uri: "http://localhost:9200"
 index_names: ["mainstream", "detailed", "government", "service-manual"]
+organisation_registry_index: "government"

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -149,11 +149,18 @@ module Elasticsearch
       end
     end
 
-    def documents_by_format(format)
-      search_body = {query: {term: {format: format}}}
+    def documents_by_format(format, options = {})
       batch_size = 500
+      search_body = {query: {term: {format: format}}}
+      if options[:fields]
+        search_body.merge!(fields: options[:fields])
+        result_key = "fields"
+      else
+        result_key = "_source"
+      end
+
       ScrollEnumerator.new(@client, search_body, batch_size) do |hit|
-        document_from_hash(hit["_source"])
+        document_from_hash(hit[result_key])
       end
     end
 

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -149,6 +149,14 @@ module Elasticsearch
       end
     end
 
+    def documents_by_format(format)
+      search_body = {query: {term: {format: format}}}
+      batch_size = 500
+      ScrollEnumerator.new(@client, search_body, batch_size) do |hit|
+        document_from_hash(hit["_source"])
+      end
+    end
+
     def search(query)
       # Per-format boosting done as a filter, so the results get cached on the
       # server, as they are the same for each query

--- a/lib/organisation_registry.rb
+++ b/lib/organisation_registry.rb
@@ -16,10 +16,15 @@ class OrganisationRegistry
 private
   def organisations
     if refresh_needed?
-      @organisations = @index.documents_by_format("organisation").to_a
+      @organisations = fetch
       @cache_updated = @clock.now
     end
     @organisations
+  end
+
+  def fetch
+    fields = %w{link title}
+    @index.documents_by_format("organisation", fields: fields).to_a
   end
 
   def refresh_needed?

--- a/lib/organisation_registry.rb
+++ b/lib/organisation_registry.rb
@@ -1,7 +1,7 @@
 require "time"
 
 class OrganisationRegistry
-  CACHE_LIFETIME = 12 * 3600
+  CACHE_LIFETIME = 12 * 3600  # 12 hours
 
   def initialize(index, clock = DateTime)
     @index = index

--- a/lib/organisation_registry.rb
+++ b/lib/organisation_registry.rb
@@ -1,0 +1,32 @@
+require "time"
+
+class OrganisationRegistry
+  CACHE_LIFETIME = 12 * 3600
+
+  def initialize(index, clock = DateTime)
+    @index = index
+    @clock = clock
+    @cache_updated = nil
+  end
+
+  def [](slug)
+    organisations.find { |o| o.link == "/government/organisations/#{slug}" }
+  end
+
+private
+  def organisations
+    if refresh_needed?
+      @organisations = @index.documents_by_format("organisation").to_a
+      @cache_updated = @clock.now
+    end
+    @organisations
+  end
+
+  def refresh_needed?
+    @organisations.nil? || @cache_updated.nil? || cache_age >= CACHE_LIFETIME
+  end
+
+  def cache_age
+    @clock.now - @cache_updated
+  end
+end

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -62,12 +62,16 @@ private
       presentation_format: presentation_format(document),
       humanized_format: humanized_format(document)
     )
-    if result['organisations']
+    if result['organisations'] && should_expand_organisations?
       result['organisations'] = result['organisations'].map do |slug|
         organisation_by_slug(slug)
       end
     end
     result
+  end
+
+  def should_expand_organisations?
+    !! organisation_registry
   end
 
   def organisation_registry

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -1,7 +1,8 @@
 class ResultSetPresenter
 
-  def initialize(result_set)
+  def initialize(result_set, context = {})
     @result_set = result_set
+    @context = context
   end
 
   def present
@@ -53,9 +54,32 @@ private
   end
 
   def results
-    @result_set.results.map { |r| r.to_hash.merge(
-      presentation_format: presentation_format(r),
-      humanized_format: humanized_format(r)
-    )}
+    @result_set.results.map { |document| build_result(document) }
+  end
+
+  def build_result(document)
+    result = document.to_hash.merge(
+      presentation_format: presentation_format(document),
+      humanized_format: humanized_format(document)
+    )
+    if result['organisations']
+      result['organisations'] = result['organisations'].map do |slug|
+        organisation_by_slug(slug)
+      end
+    end
+    result
+  end
+
+  def organisation_registry
+    @context[:organisation_registry]
+  end
+
+  def organisation_by_slug(slug)
+    organisation = organisation_registry && organisation_registry[slug]
+    if organisation
+      organisation.to_hash.merge(slug: slug)
+    else
+      {slug: slug}
+    end
   end
 end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -23,6 +23,10 @@ class SearchConfig
     @elasticsearch ||= config_for("elasticsearch")
   end
 
+  def organisation_registry_index
+    elasticsearch["organisation_registry_index"]
+  end
+
 private
   def config_for(kind)
     YAML.load_file(File.expand_path("../#{kind}.yml", File.dirname(__FILE__)))

--- a/test/functional/multiple_backends_test.rb
+++ b/test/functional/multiple_backends_test.rb
@@ -3,8 +3,10 @@ require "integration_test_helper"
 
 class MultipleBackendsTest < IntegrationTest
   def test_passes_search_to_chosen_backend
-    chosen_index = mock("chosen index", search: stub(results: []))
-    Elasticsearch::SearchServer.any_instance.expects(:index).with("chosen").returns(chosen_index)
+    chosen_index = mock("chosen index")
+    chosen_index.expects(:search).returns(stub(results: []))
+    Elasticsearch::SearchServer.any_instance.stubs(:index).returns(stub("other index"))
+    Elasticsearch::SearchServer.any_instance.stubs(:index).with("chosen").returns(chosen_index)
     get "/chosen/search?q=example"
   end
 

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -1,7 +1,18 @@
 # encoding: utf-8
 require "integration_test_helper"
+require "organisation_registry"
 
 class SearchTest < IntegrationTest
+  def mod_organisation
+    Document.new(
+      %w(link title),
+      {
+        link: "/government/organisations/ministry-of-defence",
+        title: "Ministry of Defence (MoD)"
+      }
+    )
+  end
+
   def test_returns_json_for_search_results
     stub_index.expects(:search).returns(stub(results: [sample_document]))
     get "/search", {q: "bob"}, "HTTP_ACCEPT" => "application/json"
@@ -14,6 +25,24 @@ class SearchTest < IntegrationTest
     get "/search.json", {q: "bob"}
     assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)
     assert_match(/application\/json/, last_response.headers["Content-Type"])
+  end
+
+  def test_handles_results_with_organisations
+    mappings = default_mappings
+    mappings["edition"]["properties"]["organisations"] = {"type" => "string"}
+    document = Document.from_hash(
+      sample_document_attributes.merge(organisations: ["ministry-of-defence"]),
+      mappings
+    )
+
+    stub_index.expects(:search).returns(stub(results: [document]))
+    OrganisationRegistry.any_instance.stubs(:[])
+      .with("ministry-of-defence")
+      .returns(mod_organisation)
+    get "/search.json", {q: "bob"}
+    first_result = MultiJson.decode(last_response.body).first
+    assert_equal 1, first_result["organisations"].size
+    assert_equal mod_organisation.title, first_result["organisations"][0]["title"]
   end
 
   def test_returns_404_when_requested_with_non_json_url

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -140,6 +140,27 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     assert_requested :post, refresh_url
   end
 
+  def test_can_fetch_all_entries_by_format
+    search_pattern = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=500"
+    stub_request(:get, search_pattern).with(
+      body: MultiJson.encode({query: {term: {format: "organisation"}}})
+    ).to_return(
+      body: MultiJson.encode({_scroll_id: "abcdefgh", hits: {total: 10}})
+    )
+
+    hits = (1..10).map { |i|
+      { "_source" => { "link" => "/organisation-#{i}", "title" => "Organisation #{i}" } }
+    }
+    stub_request(:get, scroll_uri("abcdefgh")).to_return(
+      body: scroll_response_body("abcdefgh", 10, hits)
+    ).then.to_return(
+      body: scroll_response_body("abcdefgh", 10, [])
+    ).then.to_raise(RuntimeError)
+
+    result = @wrapper.documents_by_format("organisation")
+    assert_equal (1..10).map {|i| "Organisation #{i}" }, result.map(&:title)
+  end
+
   def test_all_documents_size
     # Test that we can count the documents without retrieving them all
     search_pattern = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=50"

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -155,7 +155,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       body: scroll_response_body("abcdefgh", 10, hits)
     ).then.to_return(
       body: scroll_response_body("abcdefgh", 10, [])
-    ).then.to_raise(RuntimeError)
+    ).then.to_raise("should never happen")
 
     result = @wrapper.documents_by_format("organisation")
     assert_equal (1..10).map {|i| "Organisation #{i}" }, result.map(&:title)
@@ -168,7 +168,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       body: MultiJson.encode({query: {match_all: {}}})
     ).to_return(
       body: MultiJson.encode({_scroll_id: "abcdefgh", hits: {total: 100}})
-    ).then.to_raise(RuntimeError)
+    ).then.to_raise("should never happen")
     assert_equal @wrapper.all_documents.size, 100
   end
 
@@ -189,7 +189,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       body: scroll_response_body("abcdefgh", 100, hits[50, 50])
     ).then.to_return(
       body: scroll_response_body("abcdefgh", 100, [])
-    ).then.to_raise(RuntimeError)
+    ).then.to_raise("should never happen")
     all_documents = @wrapper.all_documents.to_a
     assert_equal 100, all_documents.size
     assert_equal "/foo-1", all_documents.first.link
@@ -213,15 +213,15 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
 
     stub_request(:get, scroll_uri("abcdefgh")).to_return(
       body: scroll_response_body("ijklmnop", total, hits[0, 2])
-    ).then.to_raise(RuntimeError)
+    ).then.to_raise("should never happen")
 
     stub_request(:get, scroll_uri("ijklmnop")).to_return(
       body: scroll_response_body("qrstuvwx", total, hits[2, 1])
-    ).then.to_raise(RuntimeError)
+    ).then.to_raise("should never happen")
 
     stub_request(:get, scroll_uri("qrstuvwx")).to_return(
       body: scroll_response_body("yz", total, [])
-    ).then.to_raise(RuntimeError)
+    ).then.to_raise("should never happen")
 
     all_documents = @wrapper.all_documents.to_a
     assert_equal ["/foo-1", "/foo-2", "/foo-3"], all_documents.map(&:link)

--- a/test/unit/organisation_registry_test.rb
+++ b/test/unit/organisation_registry_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+require "document"
+require "organisation_registry"
+
+class OrganisationRegistryTest < MiniTest::Unit::TestCase
+  def setup
+    @index = stub("elasticsearch index")
+    @organisation_registry = OrganisationRegistry.new(@index)
+  end
+
+  def mod_document
+    Document.new(
+      %w(link title),
+      {
+        link: "/government/organisations/ministry-of-defence",
+        title: "Ministry of Defence (MoD)"
+      }
+    )
+  end
+
+  def test_can_fetch_organisation_by_slug
+    @index.stubs(:documents_by_format).with("organisation").returns([mod_document])
+    organisation = @organisation_registry["ministry-of-defence"]
+    assert_equal "/government/organisations/ministry-of-defence", organisation.link
+    assert_equal "Ministry of Defence (MoD)", organisation.title
+  end
+
+  def test_returns_nil_if_organisation_not_found
+    @index.stubs(:documents_by_format).with("organisation").returns([mod_document])
+    organisation = @organisation_registry["ministry-of-silly-walks"]
+    assert_nil organisation
+  end
+
+  def test_organisations_are_cached
+    @index.stubs(:documents_by_format)
+      .with("organisation")
+      .returns([mod_document])
+      .once
+    assert @organisation_registry["ministry-of-defence"]
+    assert @organisation_registry["ministry-of-defence"]
+  end
+
+  def test_document_enumerator_is_traversed_only_once
+    document_enumerator = stub("enumerator")
+    document_enumerator.expects(:to_a).returns([mod_document]).once
+    @index.stubs(:documents_by_format)
+      .with("organisation")
+      .returns(document_enumerator)
+      .once
+    assert @organisation_registry["ministry-of-defence"]
+    assert @organisation_registry["ministry-of-defence"]
+  end
+
+  def test_organisation_cache_expires
+    initial_time = DateTime.now
+
+    clock = stub("clock", now: initial_time)
+    @organisation_registry = OrganisationRegistry.new(@index, clock)
+    @index.expects(:documents_by_format).with("organisation").returns([mod_document]).twice
+
+    @organisation_registry["ministry-of-defence"]
+    clock.stubs(:now).returns(initial_time + OrganisationRegistry::CACHE_LIFETIME)
+    @organisation_registry["ministry-of-defence"]
+  end
+
+  def test_organisation_cache_does_not_expire_within_cache_lifetime
+    initial_time = DateTime.now
+
+    clock = stub("clock", now: initial_time)
+    @organisation_registry = OrganisationRegistry.new(@index, clock)
+    @index.expects(:documents_by_format).with("organisation").returns([mod_document]).once
+
+    @organisation_registry["ministry-of-defence"]
+    clock.stubs(:now).returns(initial_time + OrganisationRegistry::CACHE_LIFETIME - 1)
+    @organisation_registry["ministry-of-defence"]
+  end
+end

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -145,7 +145,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     assert_equal "ministry-of-silly-walks", output[0]["organisations"][0]["slug"]
   end
 
-  def test_organisations_just_have_slug_if_no_registry_available
+  def test_organisations_not_modified_if_no_registry_available
     presenter = ResultSetPresenter.new(
       single_result_with_organisations("ministry-of-silly-walks"),
       organisation_registry: nil
@@ -153,6 +153,6 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
     output = output_for(presenter)
     assert_equal 1, output[0]["organisations"].size
-    assert_equal "ministry-of-silly-walks", output[0]["organisations"][0]["slug"]
+    assert_equal "ministry-of-silly-walks", output[0]["organisations"][0]
   end
 end

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -5,7 +5,7 @@ require "multi_json"
 
 class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
-  FIELDS = %w(link title description format)
+  FIELDS = %w(link title description format organisations)
 
   def result_set
     documents = [
@@ -24,6 +24,18 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     stub(results: [Document.new(FIELDS, :format => format)])
   end
 
+  def single_result_with_organisations(*organisation_slugs)
+    document_hash = {
+        "link" => "/foo",
+        "title" => "Foo",
+        "description" => "Full of foo.",
+        "format" => "edition",
+        "organisations" => organisation_slugs
+      }
+
+    stub(results: [Document.new(FIELDS, document_hash)])
+  end
+
   def output_for(presenter)
     MultiJson.decode(presenter.present)
   end
@@ -32,7 +44,8 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     presenter = ResultSetPresenter.new(result_set)
     output = output_for(presenter)
     assert_equal 1, output.length
-    assert_equal [], FIELDS - output[0].keys
+    # Check all the fields from the document are present
+    assert_equal [], %w(link title description format) - output[0].keys
   end
 
   def test_presented_json_includes_presentation_format
@@ -88,5 +101,58 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     result_set = single_result_with_format "ocean_map"
     output = output_for(ResultSetPresenter.new(result_set))
     assert_equal "Ocean maps", output[0]["humanized_format"]
+  end
+
+  def test_expands_organisations
+    mod_document = Document.new(
+      %w(link title),
+      link: "/government/organisations/ministry-of-defence",
+      title: "Ministry of Defence (MoD)"
+    )
+    organisation_registry = stub("organisation registry")
+    organisation_registry.expects(:[])
+      .with("ministry-of-defence")
+      .returns(mod_document)
+
+    presenter = ResultSetPresenter.new(
+      single_result_with_organisations("ministry-of-defence"),
+      organisation_registry: organisation_registry
+    )
+
+    output = output_for(presenter)
+    assert_equal 1, output[0]["organisations"].size
+    assert_instance_of Hash, output[0]["organisations"][0]
+    assert_equal "Ministry of Defence (MoD)", output[0]["organisations"][0]["title"]
+    assert_equal "/government/organisations/ministry-of-defence", output[0]["organisations"][0]["link"]
+    assert_equal "ministry-of-defence", output[0]["organisations"][0]["slug"]
+  end
+
+  def test_unknown_organisations_just_have_slug
+    organisation_registry = stub("organisation registry")
+    organisation_registry.expects(:[])
+      .returns(nil)
+
+    presenter = ResultSetPresenter.new(
+      single_result_with_organisations("ministry-of-silly-walks"),
+      organisation_registry: organisation_registry
+    )
+
+    output = output_for(presenter)
+    assert_equal 1, output[0]["organisations"].size
+    assert_instance_of Hash, output[0]["organisations"][0]
+    refute_includes output[0]["organisations"][0], "title"
+    refute_includes output[0]["organisations"][0], "link"
+    assert_equal "ministry-of-silly-walks", output[0]["organisations"][0]["slug"]
+  end
+
+  def test_organisations_just_have_slug_if_no_registry_available
+    presenter = ResultSetPresenter.new(
+      single_result_with_organisations("ministry-of-silly-walks"),
+      organisation_registry: nil
+    )
+
+    output = output_for(presenter)
+    assert_equal 1, output[0]["organisations"].size
+    assert_equal "ministry-of-silly-walks", output[0]["organisations"][0]["slug"]
   end
 end


### PR DESCRIPTION
When presenting results, convert the `organisations` field from a list of strings to a list of hashes containing organisation links and titles, based on the organisations in the search index.

If this isn’t enabled in the configuration with the `organisation_registry_index` key, this will leave the results as they are.
