### PR TITLE
Show document series

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -10,6 +10,7 @@ require "statsd"
 
 require "document"
 require "result_set_presenter"
+require "document_series_registry"
 require "organisation_registry"
 require "topic_registry"
 require "elasticsearch/index"
@@ -34,6 +35,11 @@ class Rummager < Sinatra::Application
     search_server.index(index_name)
   rescue Elasticsearch::NoSuchIndex
     halt(404)
+  end
+
+  def document_series_registry
+    index_name = settings.search_config.document_series_registry_index
+    @@document_series_registry ||= DocumentSeriesRegistry.new(search_server.index(index_name)) if index_name
   end
 
   def organisation_registry
@@ -88,7 +94,8 @@ class Rummager < Sinatra::Application
     result_set = current_index.search(query)
     presenter_context = {
       organisation_registry: organisation_registry,
-      topic_registry: topic_registry
+      topic_registry: topic_registry,
+      document_series_registry: document_series_registry
     }
     ResultSetPresenter.new(result_set, presenter_context).present
   end

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -2,3 +2,4 @@ base_uri: "http://localhost:9200"
 index_names: ["mainstream", "detailed", "government", "service-manual"]
 organisation_registry_index: "government"
 topic_registry_index: "government"
+document_series_registry_index: "government"

--- a/lib/document_series_registry.rb
+++ b/lib/document_series_registry.rb
@@ -1,0 +1,21 @@
+require "timed_cache"
+
+class DocumentSeriesRegistry
+  CACHE_LIFETIME = 12 * 3600  # 12 hours
+
+  def initialize(index, clock = Time)
+    @index = index
+    @cache = TimedCache.new(CACHE_LIFETIME, clock) { fetch }
+  end
+
+  def [](slug)
+    @cache.get.find { |o| o.link =~ %r{/series/#{slug}$} }
+  end
+
+private
+  def fetch
+    fields = %w{link title}
+    @index.documents_by_format("document_series", fields: fields).to_a
+  end
+
+end

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -62,6 +62,11 @@ private
       presentation_format: presentation_format(document),
       humanized_format: humanized_format(document)
     )
+    if result['document_series'] && should_expand_document_series?
+      result['document_series'] = result['document_series'].map do |slug|
+        document_series_by_slug(slug)
+      end
+    end
     if result['organisations'] && should_expand_organisations?
       result['organisations'] = result['organisations'].map do |slug|
         organisation_by_slug(slug)
@@ -75,6 +80,10 @@ private
     result
   end
 
+  def should_expand_document_series?
+    !! document_series_registry
+  end
+
   def should_expand_organisations?
     !! organisation_registry
   end
@@ -83,12 +92,25 @@ private
     !! topic_registry
   end
 
+  def document_series_registry
+    @context[:document_series_registry]
+  end
+
   def organisation_registry
     @context[:organisation_registry]
   end
 
   def topic_registry
     @context[:topic_registry]
+  end
+
+  def document_series_by_slug(slug)
+    document_series = document_series_registry && document_series_registry[slug]
+    if document_series
+      document_series.to_hash.merge(slug: slug)
+    else
+      {slug: slug}
+    end
   end
 
   def organisation_by_slug(slug)

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -23,6 +23,10 @@ class SearchConfig
     @elasticsearch ||= config_for("elasticsearch")
   end
 
+  def document_series_registry_index
+    elasticsearch["document_series_registry_index"]
+  end
+
   def organisation_registry_index
     elasticsearch["organisation_registry_index"]
   end

--- a/test/unit/document_series_registry_test.rb
+++ b/test/unit/document_series_registry_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+require "document"
+require "document_series_registry"
+
+class DocumentSeriesRegistryTest < MiniTest::Unit::TestCase
+  def setup
+    @index = stub("elasticsearch index")
+    @document_series_registry = DocumentSeriesRegistry.new(@index)
+  end
+
+  def rail_statistics
+    Document.new(
+      %w(link title),
+      {
+        link: "/government/organisations/department-for-transport/series/rail-statistics",
+        title: "Rail statistics"
+      }
+    )
+  end
+
+  def test_can_fetch_document_series_by_slug
+    @index.stubs(:documents_by_format)
+      .with("document_series", anything)
+      .returns([rail_statistics])
+    document_series = @document_series_registry["rail-statistics"]
+    assert_equal rail_statistics.link, document_series.link
+    assert_equal rail_statistics.title, document_series.title
+  end
+
+  def test_only_required_fields_are_requested_from_index
+    @index.expects(:documents_by_format)
+      .with("document_series", fields: %w{link title})
+    document_series = @document_series_registry["rail-statistics"]
+  end
+
+  def test_returns_nil_if_document_series_not_found
+    @index.stubs(:documents_by_format)
+      .with("document_series", anything)
+      .returns([rail_statistics])
+    document_series = @document_series_registry["bus-statistics"]
+    assert_nil document_series
+  end
+
+  def test_document_enumerator_is_traversed_only_once
+    document_enumerator = stub("enumerator")
+    document_enumerator.expects(:to_a).returns([rail_statistics]).once
+    @index.stubs(:documents_by_format)
+      .with("document_series", anything)
+      .returns(document_enumerator)
+      .once
+    assert @document_series_registry["rail-statistics"]
+    assert @document_series_registry["rail-statistics"]
+  end
+
+  def test_uses_cache
+    # Make sure we're using TimedCache#get; TimedCache is tested elsewhere, so
+    # we don't need to worry about cache expiry tests here.
+    TimedCache.any_instance.expects(:get).with().returns([rail_statistics])
+    assert @document_series_registry["rail-statistics"]
+  end
+end


### PR DESCRIPTION
When a search result is part of a document series, return information about the document series, in the same manner as topics and organisations. Almost identical to: https://github.com/alphagov/rummager/pull/96
