### PR TITLE
Extract acronyms

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -154,13 +154,17 @@ module Elasticsearch
       search_body = {query: {term: {format: format}}}
       if options[:fields]
         search_body.merge!(fields: options[:fields])
+        field_names = options[:fields]
         result_key = "fields"
       else
+        # Use all field names from the mappings
+        # TODO: remove duplication between this and Document.from_hash
+        field_names = @mappings["edition"]["properties"].keys.map(&:to_s)
         result_key = "_source"
       end
 
       ScrollEnumerator.new(@client, search_body, batch_size) do |hit|
-        document_from_hash(hit[result_key])
+        Document.new(field_names, hit[result_key])
       end
     end
 

--- a/lib/organisation_registry.rb
+++ b/lib/organisation_registry.rb
@@ -14,7 +14,29 @@ class OrganisationRegistry
 
 private
   def fetch
-    fields = %w{link title}
-    @index.documents_by_format("organisation", fields: fields).to_a
+    fields = %w{link title acronym}
+    organisations = @index.documents_by_format("organisation", fields: fields)
+    organisations.map { |o| fix_acronym(o) }
+  end
+
+  def fix_acronym(organisation)
+    # If an organisation doesn't have an acronym specified, and if there is one
+    # in the title, extract it.
+    #
+    # HACK: this is to get around the smushing together of title and acronym in
+    # the current index. Once they are separate, this code can be removed.
+
+    # e.g. "Ministry of Justice (MoJ)"
+
+    if organisation.has_field?(:acronym) && organisation.acronym.nil?
+      merged_pattern = %r{\A(?<title>.+) \((?<acronym>[^)]+)\)\Z}
+
+      pattern_match = merged_pattern.match(organisation.title)
+      if pattern_match
+        organisation.title = pattern_match["title"]
+        organisation.acronym = pattern_match["acronym"]
+      end
+    end
+    organisation
   end
 end


### PR DESCRIPTION
Support for showing acronyms in search result meta data. This is an intermediate step to use until we've added acronym to the search index.
