### PR TITLE
/search can return results in a hash

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -85,6 +85,13 @@ class Rummager < Sinatra::Application
 
   # /index_name/search?q=pie to search a named index
   # /search?q=pie to search the primary index
+  # /search?q=pie&response_style=hash to get the results in a Hash, eg:
+  # {
+  #   "total": 1,
+  #   "results": [
+  #     ...
+  #   ]
+  # }
   get "/?:index?/search.?:format?" do
     json_only
 
@@ -104,7 +111,12 @@ class Rummager < Sinatra::Application
       document_series_registry: document_series_registry,
       world_location_registry: world_location_registry
     }
-    ResultSetPresenter.new(result_set, presenter_context).present
+    presenter = ResultSetPresenter.new(result_set, presenter_context)
+    if params["response_style"] == "hash"
+      presenter.present_with_total
+    else
+      presenter.present
+    end
   end
 
   get "/:index/advanced_search.?:format?" do

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -91,9 +91,17 @@ class ElasticsearchSearchTest < IntegrationTest
     post "/commit", nil
   end
 
-  def assert_result_links(*links)
+  def assert_result_links(*expected_links)
     parsed_response = MultiJson.decode(last_response.body)
-    assert_equal links, parsed_response.map { |r| r["link"] }
+    case parsed_response
+      when Hash
+        result_links = parsed_response["results"].map { |r| r["link"] }
+      when Array
+        result_links = parsed_response.map { |r| r["link"] }
+      else
+        raise "I don't know how to parse #{parsed_response.class}"
+    end
+    assert_equal expected_links, result_links
   end
 
   def test_documents_with_public_timestamp_exhibit_a_decay_boost
@@ -173,5 +181,14 @@ class ElasticsearchSearchTest < IntegrationTest
     get "/search.json?q=PORK+PIES"
     assert last_response.ok?
     assert_result_links "/pork-pies"
+  end
+
+  def test_can_specify_hash_response_style
+    get "/search.json?q=badger&response_style=hash"
+    assert last_response.ok?
+    parsed_response = MultiJson.decode(last_response.body)
+    assert parsed_response.is_a?(Hash)
+    assert_equal ["total", "results"], parsed_response.keys
+    assert_result_links "/an-example-answer"
   end
 end


### PR DESCRIPTION
This lets clients request a hash, which lets us do two things:
1. It's extensible. We can add more data to the response (eg totals, facet data...)
2. we can selectively migrate clients to use the hash format

Eventually, hash will be the only response style. It's worth pointing out that the `/advanced_search` already returns a hash.
