### PR TITLE
Install aspell and libaspell-dev for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - elasticsearch
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -qq aspell libaspell-dev
+- sudo apt-get install -qq aspell aspell-en libaspell-dev
 script:
   - bundle exec rake
 bundler_args: --without=development

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ env:
   - DB=mysql GOVUK_APP_DOMAIN=test.gov.uk RUBYOPT="-rpsych"
 services:
   - elasticsearch
+before_install:
+- sudo apt-get update -qq
+- sudo apt-get install -qq aspell libaspell-dev
 script:
   - bundle exec rake
 bundler_args: --without=development


### PR DESCRIPTION
Should fix failing Travis tests on the `spelling_suggestions` branch.

This will execute before the repo is cloned. `update` is required because
APT's cache may be pointing at stale mirror locations. `-qq` makes APT super
quiet, so that it doesn't clog up your normal test output. It should however
still give a meaningful message if it fails during the `apt-get`.
## 

I noticed your tests were failing. Based on what we talked about yesterday. HTH.
