### PR TITLE
Minimum should match

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -114,7 +114,7 @@ class Rummager < Sinatra::Application
 
     expires 3600, :public if query.length < 20
     organisation = params["organisation_slug"].blank? ? nil : params["organisation_slug"]
-    result_set = current_index.search(query, organisation)
+    result_set = current_index.search(query, organisation: organisation)
     presenter_context = {
       organisation_registry: organisation_registry,
       topic_registry: topic_registry,

--- a/app.rb
+++ b/app.rb
@@ -114,7 +114,9 @@ class Rummager < Sinatra::Application
 
     expires 3600, :public if query.length < 20
     organisation = params["organisation_slug"].blank? ? nil : params["organisation_slug"]
-    result_set = current_index.search(query, organisation: organisation)
+    result_set = current_index.search(query,
+      organisation: organisation,
+      minimum_should_match: params["minimum_should_match"].to_s.size > 0)
     presenter_context = {
       organisation_registry: organisation_registry,
       topic_registry: topic_registry,

--- a/bin/search
+++ b/bin/search
@@ -19,6 +19,10 @@ OptionParser.new do |opts|
   opts.on("-i", "--index INDEX", "Specify index (default: #{options[:index_name]})") do |index|
     options[:index_name] = index
   end
+
+  opts.on("-m", "--minimum-should-match params", "enable minimum_should_match with given params") do |params|
+    options[:minimum_should_match] = params
+  end
 end.parse!
 
 def show_result(i, r)
@@ -49,7 +53,10 @@ end
 
 index = SearchConfig.new.search_server.index(options[:index_name])
 query = ARGV.join(" ")
-results = index.search(query)
+search_options = {
+  minimum_should_match: options[:minimum_should_match]
+}
+results = index.search(query, search_options)
 
 puts "Index: #{options[:index_name]}"
 puts "Query: #{query}"

--- a/bin/search
+++ b/bin/search
@@ -38,7 +38,7 @@ def show_result(i, r)
   puts tabulate([3, 3, 10, 50, 50], [i, r.es_score, relevancy_bar,  r.title, r.link])
 end
 
-def show_result_comparison(i, r1, new_index)
+def show_result_comparison(i, original_result, new_index)
   message = if new_index
     change = i - new_index
     if change == 0
@@ -51,7 +51,7 @@ def show_result_comparison(i, r1, new_index)
   else
     "X"
   end
-  puts tabulate([3, 3, 80, 10], [i, r1.es_score, r1.title, message])
+  puts tabulate([3, 3, 80, 10], [i, original_result.es_score, original_result.title, message])
 end
 
 def truncate(data, max_length)

--- a/bin/search
+++ b/bin/search
@@ -23,6 +23,10 @@ OptionParser.new do |opts|
   opts.on("-m", "--minimum-should-match params", "enable minimum_should_match with given params") do |params|
     options[:minimum_should_match] = params
   end
+
+  opts.on("-q", "--show-query", "Dump the query hash as JSON") do
+    options[:show_query_hash] = true
+  end
 end.parse!
 
 def show_result(i, r)
@@ -58,6 +62,10 @@ search_options = {
 }
 results = index.search(query, search_options)
 
+if options[:show_query_hash]
+  puts "QUERY:"
+  puts MultiJson.dump(index.search_query(query, search_options), pretty: true)
+end
 puts "Index: #{options[:index_name]}"
 puts "Query: #{query}"
 puts "Total results: #{results.total}"

--- a/bin/search
+++ b/bin/search
@@ -27,11 +27,31 @@ OptionParser.new do |opts|
   opts.on("-q", "--show-query", "Dump the query hash as JSON") do
     options[:show_query_hash] = true
   end
+
+  opts.on("-c", "--compare minimum_should_match", "Compare a search with/without minimum_should_match") do |params|
+    options[:compare] = params
+  end
 end.parse!
 
 def show_result(i, r)
   relevancy_bar = '#' * r.es_score.floor
   puts tabulate([3, 3, 10, 50, 50], [i, r.es_score, relevancy_bar,  r.title, r.link])
+end
+
+def show_result_comparison(i, r1, new_index)
+  message = if new_index
+    change = i - new_index
+    if change == 0
+      "="
+    elsif change > 0
+      "+#{change} (#{new_index})"
+    else
+      "-#{-change} (#{new_index})"
+    end
+  else
+    "X"
+  end
+  puts tabulate([3, 3, 80, 10], [i, r1.es_score, r1.title, message])
 end
 
 def truncate(data, max_length)
@@ -58,6 +78,7 @@ end
 index = SearchConfig.new.search_server.index(options[:index_name])
 query = ARGV.join(" ")
 search_options = {
+  limit: 1000,
   minimum_should_match: options[:minimum_should_match]
 }
 results = index.search(query, search_options)
@@ -66,13 +87,37 @@ if options[:show_query_hash]
   puts "QUERY:"
   puts MultiJson.dump(index.search_query(query, search_options), pretty: true)
 end
-puts "Index: #{options[:index_name]}"
-puts "Query: #{query}"
-puts "Total results: #{results.total}"
-puts
 
-puts tabulate([3, 3, 10, 50, 50], ["i", "sc", "score", "title", "link"])
-puts tabulate([3, 3, 10, 50, 50], ["===", "===", "=====", "=====", "===="])
-results.results.each.with_index do |r, i|
-  show_result(i + 1, r)
+if options[:compare]
+  search_options = {
+    minimum_should_match: options[:compare]
+  }
+  results2 = index.search(query, search_options)
+
+  puts "Search 1: #{results.total}"
+  puts "Search 2: #{results2.total}"
+  if options[:show_query_hash]
+    puts "QUERY2:"
+    puts MultiJson.dump(index.search_query(query, search_options), pretty: true)
+  end
+
+  puts tabulate([3, 50, 3, 50], ["sc", "title", "sc", "title"])
+  puts tabulate([3, 50, 3, 50], ["===", "=====", "===", "====="])
+  results.results[0..50].each.with_index do |r1, i|
+    new_index = results2.results.find_index {|r| r1.link == r.link}
+    show_result_comparison(i, r1, new_index)
+  end
+
+else
+
+  puts "Index: #{options[:index_name]}"
+  puts "Query: #{query}"
+  puts "Total results: #{results.total}"
+  puts
+
+  puts tabulate([3, 3, 10, 50, 50], ["i", "sc", "score", "title", "link"])
+  puts tabulate([3, 3, 10, 50, 50], ["===", "===", "=====", "=====", "===="])
+  results.results.each.with_index do |r, i|
+    show_result(i + 1, r)
+  end
 end

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -512,6 +512,19 @@ stems: &stems [
   "universal => universal"
 ]
 
+# Promoted results
+#
+# When indexing a promoted item, the promoted_for field is set with the given
+# terms. At search time an extra query checks for matches between the users
+# search phrase and the promoted item. The promoted item search does not have
+# a minimum_should_match so even a single word in common will trigger the
+# boosting. Any matches are boosted by 100x effectively forcing them to the
+# top.
+#
+# NOTE: if you add items to this section, the index will need to be re-built
+promoted_results:
+- terms: job
+  link: /jobsearch
 
 index:
   settings:

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -558,6 +558,7 @@ mappings:
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
         link:        { type: string, index: not_analyzed, include_in_all: false }
         indexable_content: { type: string, index: analyzed }
+        promoted_for: { type: string, index: analyzed, include_in_all: false }
   government:
     edition:
       _all: { enabled: true }
@@ -580,3 +581,4 @@ mappings:
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }
         relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }
         world_locations: { type: string, index: not_analyzed, include_in_all: false }
+        promoted_for: { type: string, index: analyzed, include_in_all: false }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -521,7 +521,9 @@ stems: &stems [
 # boosting. Any matches are boosted by 100x effectively forcing them to the
 # top.
 #
-# NOTE: if you add items to this section, the index will need to be re-built
+# NOTES:
+#  - if you add items to this section, the index will need to be re-built
+#  - the terms are stemmed so there's no need to enter both 'job' and 'jobs'
 promoted_results:
 - terms: job
   link: /jobsearch

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -49,9 +49,9 @@ module Elasticsearch
     # How long to wait for a connection to the elasticsearch server
     OPEN_TIMEOUT_SECONDS = 5.0
 
-    attr_reader :mappings, :index_name
+    attr_reader :mappings, :index_name, :promoted_results
 
-    def initialize(base_uri, index_name, mappings)
+    def initialize(base_uri, index_name, mappings, promoted_results = [])
       @client = Client.new(
         base_uri + "#{CGI.escape(index_name)}/",
         timeout: TIMEOUT_SECONDS,
@@ -60,6 +60,7 @@ module Elasticsearch
       @index_name = index_name
       raise ArgumentError, "Missing index_name parameter" unless @index_name
       @mappings = mappings
+      @promoted_results = promoted_results
     end
 
     def field_names

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -174,8 +174,8 @@ module Elasticsearch
       end
     end
 
-    def search(query, organisation=nil)
-      builder = SearchQueryBuilder.new(query, organisation)
+    def search(query, options={})
+      builder = SearchQueryBuilder.new(query, options)
       payload = builder.query_hash.to_json
 
       logger.debug "Request payload: #{payload}"

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -174,10 +174,12 @@ module Elasticsearch
       end
     end
 
-    def search(query, options={})
-      builder = SearchQueryBuilder.new(query, options)
-      payload = builder.query_hash.to_json
+    def search_query(query, options={})
+      SearchQueryBuilder.new(query, options).query_hash
+    end
 
+    def search(query, options={})
+      payload = search_query(query, options).to_json
       logger.debug "Request payload: #{payload}"
       response = @client.get_with_payload("_search", payload)
       ResultSet.new(@mappings, MultiJson.decode(response))

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -182,7 +182,7 @@ module Elasticsearch
     end
 
     def search(query, options={})
-      payload = search_query(query, options).to_json
+      payload = MultiJson.dump(search_query(query, options), pretty: true)
       logger.debug "Request payload: #{payload}"
       response = @client.get_with_payload("_search", payload)
       ResultSet.new(@mappings, MultiJson.decode(response))

--- a/lib/elasticsearch/index_group.rb
+++ b/lib/elasticsearch/index_group.rb
@@ -3,6 +3,7 @@ require "securerandom"
 require "rest-client"
 require "cgi"
 require "elasticsearch/index"
+require "promoted_result"
 
 module Elasticsearch
 
@@ -15,12 +16,15 @@ module Elasticsearch
   #
   # One of these indexes is aliased to the group name itself.
   class IndexGroup
-    def initialize(base_uri, name, index_settings, mappings)
+    attr_reader :promoted_results
+
+    def initialize(base_uri, name, index_settings, mappings, promoted_results = [])
       @base_uri = base_uri
       @client = Client.new(base_uri)
       @name = name
       @index_settings = index_settings
       @mappings = mappings
+      @promoted_results = promoted_results
     end
 
     def create_index
@@ -80,7 +84,7 @@ module Elasticsearch
     end
 
     def current
-      Index.new(@base_uri, @name, @mappings)
+      Index.new(@base_uri, @name, @mappings, @promoted_results)
     end
 
     def index_names

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -13,8 +13,38 @@ module Elasticsearch
 
     def default_options
       {
-        limit: 50
+        limit: 50,
+        minimum_should_match: default_minimum_should_match
       }
+    end
+
+    def default_minimum_should_match
+      # The following specification generates the following values for minimum_should_match
+      #
+      # Number of | Minimum
+      # optional  | should
+      # clauses   | match
+      # ----------+---------
+      # 1         | 1
+      # 2         | 2
+      # 3         | 2
+      # 4         | 3
+      # 5         | 3
+      # 6         | 3
+      # 7         | 3
+      # 8+        | 50%
+      #
+      # This table was worked out by using the comparison feature of
+      # bin/search with various example queries of different lengths (3, 4, 5,
+      # 7, 9 words) and inspecting the consequences on search results.
+      #
+      # Reference for the minimum_should_match syntax:
+      # http://lucene.apache.org/solr/api-3_6_2/org/apache/solr/util/doc-files/min-should-match.html
+      #
+      # In summary, a clause of the form "N<M" means when there are MORE than
+      # N clauses then M clauses should match. So, 2<2 means when there are
+      # MORE than 2 clauses then 2 should match.
+      "2<2 3<3 7<50%"
     end
 
     def query_hash

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -8,7 +8,13 @@ module Elasticsearch
 
     def initialize(query, options={})
       @query = query
-      @options = options
+      @options = default_options.merge(options)
+    end
+
+    def default_options
+      {
+        limit: 50
+      }
     end
 
     def query_hash
@@ -34,7 +40,7 @@ module Elasticsearch
         }
       end
       {
-        from: 0, size: 50,
+        from: 0, size: @options[:limit],
         query: {
           custom_filters_score: {
             query: {

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -6,9 +6,9 @@ module Elasticsearch
 
     QUERY_ANALYZER = "query_default"
 
-    def initialize(query, organisation=nil)
+    def initialize(query, options={})
       @query = query
-      @organisation = organisation
+      @options = options
     end
 
     def query_hash
@@ -23,10 +23,13 @@ module Elasticsearch
           }
         }
       ]
-      if @organisation
+      if @options[:minimum_should_match]
+        must_conditions[0][:query_string][:minimum_should_match] = @options[:minimum_should_match]
+      end
+      if @options[:organisation]
         must_conditions << {
           term: {
-            organisations: @organisation
+            organisations: @options[:organisation]
           }
         }
       end

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -13,8 +13,7 @@ module Elasticsearch
 
     def default_options
       {
-        limit: 50,
-        minimum_should_match: default_minimum_should_match
+        limit: 50
       }
     end
 
@@ -86,20 +85,26 @@ module Elasticsearch
     end
 
     def query_string_query
-      query_string_query = {
+      {
         query_string: {
           fields: match_fields.map { |name, boost|
             boost == 1 ? name : "#{name}^#{boost}"
           },
           query: escape(@query),
           analyzer: QUERY_ANALYZER
-        }
+        }.merge(minimum_should_match_clause)
       }
+    end
 
-      if @options[:minimum_should_match]
-        query_string_query[:query_string][:minimum_should_match] = @options[:minimum_should_match]
+    def minimum_should_match_clause
+      case @options[:minimum_should_match]
+      when String, Fixnum
+        {minimum_should_match: @options[:minimum_should_match]}
+      when true
+        {minimum_should_match: default_minimum_should_match}
+      else
+        {}
       end
-      query_string_query
     end
 
     def organisation_query

--- a/lib/elasticsearch/search_server.rb
+++ b/lib/elasticsearch/search_server.rb
@@ -1,5 +1,6 @@
 require "uri"
 require "elasticsearch/index_group"
+require "promoted_result"
 
 module Elasticsearch
   class NoSuchIndex < ArgumentError; end
@@ -14,7 +15,7 @@ module Elasticsearch
     end
 
     def index_group(prefix)
-      IndexGroup.new(@base_uri, prefix, index_settings(prefix), mappings(prefix))
+      IndexGroup.new(@base_uri, prefix, index_settings(prefix), mappings(prefix), promoted_results)
     end
 
     def index(prefix)
@@ -22,6 +23,12 @@ module Elasticsearch
         index_group(prefix).current
       else
         raise NoSuchIndex, prefix
+      end
+    end
+
+    def promoted_results
+      @promoted_results ||= (@schema["promoted_results"] || []).map do |pr|
+        PromotedResult.new(pr["link"], pr["terms"])
       end
     end
 

--- a/lib/promoted_result.rb
+++ b/lib/promoted_result.rb
@@ -1,0 +1,17 @@
+class PromotedResult
+  attr_reader :link, :terms
+
+  def initialize(link, terms)
+    @link = link
+    @terms = terms.is_a?(Array) ? terms : split_terms(terms)
+  end
+
+  def promoted_for?(term)
+    terms.include?(term)
+  end
+
+private
+  def split_terms(terms)
+    (terms || "").split(/ +/).reject {|t| t.size == 0}
+  end
+end

--- a/lib/result_promoter.rb
+++ b/lib/result_promoter.rb
@@ -1,16 +1,12 @@
-class ResultPromoter
-  class PromotedResult < Struct.new(:id, :terms)
-    def promoted_for?(term)
-      terms.include?(term)
-    end
-  end
+require 'promoted_result'
 
+class ResultPromoter
   def initialize
     @promoted_results = []
   end
 
-  def add(id, terms)
-    @promoted_results << PromotedResult.new(id, terms)
+  def add(link, terms)
+    @promoted_results << PromotedResult.new(link, terms)
   end
 
   def promoted_terms_in(query)

--- a/lib/result_promoter.rb
+++ b/lib/result_promoter.rb
@@ -5,15 +5,6 @@ class ResultPromoter
     @promoted_results = promoted_results
   end
 
-  def promoted_terms_in(query)
-    terms = query.downcase.gsub(/[^a-z]/, " ").split(/ +/).uniq
-    terms.select do |term|
-      @promoted_results.any? do |promoted_result|
-        promoted_result.promoted_for?(term)
-      end
-    end
-  end
-
   def with_promotion(document_hash)
     promoted_terms = @promoted_results.select do |promoted_result|
       document_hash["link"] == promoted_result.link

--- a/lib/result_promoter.rb
+++ b/lib/result_promoter.rb
@@ -1,0 +1,24 @@
+class ResultPromoter
+  class PromotedResult < Struct.new(:id, :terms)
+    def promoted_for?(term)
+      terms.include?(term)
+    end
+  end
+
+  def initialize
+    @promoted_results = []
+  end
+
+  def add(id, terms)
+    @promoted_results << PromotedResult.new(id, terms)
+  end
+
+  def promoted_terms_in(query)
+    terms = query.downcase.gsub(/[^a-z]/, " ").split(/ +/).uniq
+    terms.select do |term|
+      @promoted_results.any? do |promoted_result|
+        promoted_result.promoted_for?(term)
+      end
+    end
+  end
+end

--- a/lib/result_promoter.rb
+++ b/lib/result_promoter.rb
@@ -1,12 +1,8 @@
 require 'promoted_result'
 
 class ResultPromoter
-  def initialize
-    @promoted_results = []
-  end
-
-  def add(link, terms)
-    @promoted_results << PromotedResult.new(link, terms)
+  def initialize(promoted_results)
+    @promoted_results = promoted_results
   end
 
   def promoted_terms_in(query)
@@ -14,6 +10,21 @@ class ResultPromoter
     terms.select do |term|
       @promoted_results.any? do |promoted_result|
         promoted_result.promoted_for?(term)
+      end
+    end
+  end
+
+  def with_promotion(document_hash)
+    promoted_terms = @promoted_results.select do |promoted_result|
+      document_hash["link"] == promoted_result.link
+    end.map do |promoted_result|
+      promoted_result.terms
+    end.flatten
+    document_hash.dup.tap do |new_hash|
+      if promoted_terms.any?
+        new_hash["promoted_for"] = promoted_terms.join(" ")
+      else
+        new_hash.delete("promoted_for")
       end
     end
   end

--- a/test/functional/index_group_test.rb
+++ b/test/functional/index_group_test.rb
@@ -336,4 +336,15 @@ class IndexGroupTest < MiniTest::Unit::TestCase
 
     assert_requested delete_stub
   end
+
+  def test_promoted_results_passed_to_index
+    promoted_results = stub("promoted results")
+    base_uri = "http://localhost"
+    name = "my_index"
+    index_settings = {"settings" => {}}
+    mappings = {"default" => {}}
+    index_group = Elasticsearch::IndexGroup.new(base_uri, name, index_settings, mappings, promoted_results)
+
+    assert_equal promoted_results, index_group.current.promoted_results
+  end
 end

--- a/test/unit/elasticsearch_search_query_builder_test.rb
+++ b/test/unit/elasticsearch_search_query_builder_test.rb
@@ -26,8 +26,15 @@ class SearchQueryBuilderTest < MiniTest::Unit::TestCase
     assert_equal expected, query_string_condition
   end
 
-  def test_minimum_should_match_has_sensible_default
+  def test_minimum_should_match_disabled_by_default
     builder = Elasticsearch::SearchQueryBuilder.new("one two three")
+
+    must_conditions = builder.query_hash[:query][:custom_filters_score][:query][:bool][:should][0][:bool][:must]
+    refute_includes must_conditions[0][:query_string], :minimum_should_match
+  end
+
+  def test_minimum_should_match_has_sensible_default_if_enabled
+    builder = Elasticsearch::SearchQueryBuilder.new("one two three", minimum_should_match: true)
 
     must_conditions = builder.query_hash[:query][:custom_filters_score][:query][:bool][:should][0][:bool][:must]
     assert_equal "2<2 3<3 7<50%", must_conditions[0][:query_string][:minimum_should_match]

--- a/test/unit/result_promoter_test.rb
+++ b/test/unit/result_promoter_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+require "result_promoter"
+
+class ResultPromoterTest < MiniTest::Unit::TestCase
+  def test_can_identify_whether_a_query_contains_a_promoted_term
+    result_promoter = ResultPromoter.new
+    result_promoter.add("/jobsearch", ["job", "jobs"])
+    assert_equal ["jobs"], result_promoter.promoted_terms_in("jobs in birmingham")
+    assert_equal [], result_promoter.promoted_terms_in("plumbing in birmingham")
+    assert_equal ["job"], result_promoter.promoted_terms_in("job search")
+    assert_equal ["job"], result_promoter.promoted_terms_in("job job")
+    assert_equal [], result_promoter.promoted_terms_in("jobbing")
+  end
+end

--- a/test/unit/result_promoter_test.rb
+++ b/test/unit/result_promoter_test.rb
@@ -3,12 +3,42 @@ require "result_promoter"
 
 class ResultPromoterTest < MiniTest::Unit::TestCase
   def test_can_identify_whether_a_query_contains_a_promoted_term
-    result_promoter = ResultPromoter.new
-    result_promoter.add("/jobsearch", ["job", "jobs"])
+    result_promoter = ResultPromoter.new([
+      PromotedResult.new("/jobsearch", ["job", "jobs"])
+    ])
+
     assert_equal ["jobs"], result_promoter.promoted_terms_in("jobs in birmingham")
     assert_equal [], result_promoter.promoted_terms_in("plumbing in birmingham")
     assert_equal ["job"], result_promoter.promoted_terms_in("job search")
     assert_equal ["job"], result_promoter.promoted_terms_in("job job")
     assert_equal [], result_promoter.promoted_terms_in("jobbing")
   end
+
+  def test_with_promotion_sets_promoted_for_for_promoted_documents
+    result_promoter = ResultPromoter.new([
+      PromotedResult.new("/jobsearch", ["job", "jobs"])
+    ])
+
+    promoted = result_promoter.with_promotion({"link" => "/jobsearch"})
+    assert_equal "job jobs", promoted["promoted_for"]
+  end
+
+  def test_with_promotion_does_not_set_promoted_for_for_other_documents
+    result_promoter = ResultPromoter.new([
+      PromotedResult.new("/jobsearch", ["job", "jobs"])
+    ])
+
+    promoted = result_promoter.with_promotion({"link" => "/tax-disc"})
+    refute_includes promoted, "promoted_for"
+  end
+
+  def test_with_promotion_clears_promoted_for_if_a_document_has_it_set_already
+    result_promoter = ResultPromoter.new([
+      PromotedResult.new("/jobsearch", ["job", "jobs"])
+    ])
+
+    promoted = result_promoter.with_promotion({"link" => "/tax-disc", "promoted_for" => "jobs"})
+    refute_includes promoted, "promoted_for"
+  end
+
 end

--- a/test/unit/result_promoter_test.rb
+++ b/test/unit/result_promoter_test.rb
@@ -2,18 +2,6 @@ require "test_helper"
 require "result_promoter"
 
 class ResultPromoterTest < MiniTest::Unit::TestCase
-  def test_can_identify_whether_a_query_contains_a_promoted_term
-    result_promoter = ResultPromoter.new([
-      PromotedResult.new("/jobsearch", ["job", "jobs"])
-    ])
-
-    assert_equal ["jobs"], result_promoter.promoted_terms_in("jobs in birmingham")
-    assert_equal [], result_promoter.promoted_terms_in("plumbing in birmingham")
-    assert_equal ["job"], result_promoter.promoted_terms_in("job search")
-    assert_equal ["job"], result_promoter.promoted_terms_in("job job")
-    assert_equal [], result_promoter.promoted_terms_in("jobbing")
-  end
-
   def test_with_promotion_sets_promoted_for_for_promoted_documents
     result_promoter = ResultPromoter.new([
       PromotedResult.new("/jobsearch", ["job", "jobs"])


### PR DESCRIPTION
The aim of this pull request is to reduce the number of irrelevant results returned for multi-word searches. At present we frequently observe multi-word searches returning many irrelevant results because results will be returned if they match even just one word of the multi-word query. 

Thankfully elasticsearch offers a feature called minimum_should_match designed to address this. This pull request activates minimum_shoud_match according to the following table:

```
Number of | Minimum
optional  | should
clauses   | match
----------+---------
1         | 1
2         | 2
3         | 2
4         | 3
5         | 3
6         | 3
7         | 3
8+        | 50%
```

The table was devised by myself and @tarastockford using the comparison feature of bin/search with various example queries of different lengths (3, 4, 5, 7, 9 words) and inspecting the consequences on search results. We think that this table should give a good improvement to search performance.

There is one problem with this which is that searches such as 'jobs in birmingham' will only return results which mention both 'jobs' and 'birmingham'. These types of queries are very common and we want the jobsearch to be the top result for such searches. To address this, this PR also includes a 'promoted_results' facility. This is configured in the elasticsearch_schema.yml. It works by adding an additional field called 'promoted_for'. An extra query clause will check if any of the search words match a promoted term and if so that document will be boosted to the top of the results. The only promoted item at present is /jobsearch promoted for the term 'job' (stemmed)

I also did a few refactorings to allow more flexible options to be passed down to the search query builder, and added  features in the bin/search script which allow comparison of different minimum_should_match settings.

UPDATE: I've now added a feature flag to disable this by default in production but allow it to be evaluated in preview.
