### PR TITLE
Update HTML adapter to accommodate top results

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -39,6 +39,7 @@ class HealthCheckCLI
       on 'd', 'download', "Download search healthcheck data"
       on 'h', 'help', "Show help"
       on 'l', 'local', "Connect to local index directly (default)"
+      on 'limit=', "Limit to the first n tests", as: Integer
       on 'a', 'auth=', "Basic auth password (for html/json clients)"
       on 'H', 'html=', "Connect to a frontend at the the given url (eg. #{DEFAULT_HTML_URL})", default: DEFAULT_HTML_URL
       on 'j', 'json=', "Connect to a content api at the the given url (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
@@ -78,9 +79,16 @@ private
   end
 
   def run_one_test(index_name)
+    check_file_path = DATA_DIR + "#{index_name}-weighted-search-terms.csv"
+    check_file = open(check_file_path)
+    if opts["limit"]
+      # Take the first n + 1 lines (including header row) from the check file
+      check_file = StringIO.new(check_file.take(opts["limit"] + 1).join)
+    end
+
     HealthCheck::Checker.new(
       search_client: search_client_for(index_name),
-      test_data: DATA_DIR + "#{index_name}-weighted-search-terms.csv"
+      test_data: check_file
     ).run!
   end
 

--- a/bin/health_check
+++ b/bin/health_check
@@ -43,6 +43,7 @@ class HealthCheckCLI
       on 'a', 'auth=', "Basic auth password (for html/json clients)"
       on 'H', 'html=', "Connect to a frontend at the the given url (eg. #{DEFAULT_HTML_URL})", default: DEFAULT_HTML_URL
       on 'j', 'json=', "Connect to a content api at the the given url (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
+      on 'v', 'verbose', "Show verbose logging output"
       run(health_checker)
     end
   end
@@ -50,6 +51,12 @@ class HealthCheckCLI
   def call(opts, args)
     @opts = opts
     @args = args
+
+    if opts.verbose?
+      Logging.logger.root.level = :debug
+      Logging.logger.root.info "Debug logging enabled"
+    end
+
     if opts.download?
       FileUtils.mkdir_p(DATA_DIR)
       HealthCheck::Downloader.new(data_dir: DATA_DIR).download(*INDICES)

--- a/bin/health_check
+++ b/bin/health_check
@@ -17,10 +17,12 @@ require 'health_check/local_search_client'
 require 'health_check/html_search_client'
 require 'health_check/json_search_client'
 require 'health_check/downloader'
+require 'health_check/basic_auth_credentials'
 
 class HealthCheckCLI
 
   class Usage < StandardError; end
+
 
   attr_reader :opts, :args
 
@@ -40,7 +42,7 @@ class HealthCheckCLI
       on 'h', 'help', "Show help"
       on 'l', 'local', "Connect to local index directly (default)"
       on 'limit=', "Limit to the first n tests", as: Integer
-      on 'a', 'auth=', "Basic auth password (for html/json clients)"
+      on 'a', 'auth=', "Basic auth credentials (of the form 'user:pass'", as: HealthCheck::BasicAuthCredentials
       on 'H', 'html=', "Connect to a frontend at the the given url (eg. #{DEFAULT_HTML_URL})", default: DEFAULT_HTML_URL
       on 'j', 'json=', "Connect to a content api at the the given url (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
       on 'v', 'verbose', "Show verbose logging output"

--- a/lib/health_check/basic_auth_credentials.rb
+++ b/lib/health_check/basic_auth_credentials.rb
@@ -1,0 +1,19 @@
+module HealthCheck
+  # A value class for basic auth credentials, with a user name and a password.
+  # The `call` method is for compatibility with Slop's argument types.
+  #
+  # Because this is a Struct, the object can be passed into a Net::HTTP::Get
+  # request's #basic_auth method with the splat operator.
+  class BasicAuthCredentials < Struct.new(:user, :password)
+
+    # Since we've got to provide a `call` method for Slop, let's make that the
+    # only way to instantiate this class.
+    private_class_method :new
+
+    def self.call(value)
+      error = "Credentials must be of the form 'user:password'"
+      raise ArgumentError, error unless (value && value.include?(":"))
+      new(*value.split(":", 2)).freeze
+    end
+  end
+end

--- a/lib/health_check/checker.rb
+++ b/lib/health_check/checker.rb
@@ -27,7 +27,7 @@ module HealthCheck
 
     private
       def checks
-        CheckFileParser.new(File.open(@test_data)).checks.sort { |a,b| b.weight <=> a.weight }
+        CheckFileParser.new(@test_data).checks.sort { |a,b| b.weight <=> a.weight }
       end
 
       def calculator

--- a/lib/health_check/html_search_client.rb
+++ b/lib/health_check/html_search_client.rb
@@ -36,9 +36,9 @@ module HealthCheck
         when Net::HTTPSuccess # 2xx
           response_page = Nokogiri::HTML.parse(response.body)
           extract_results(response_page)
-        when Net::HTTPBadGateway
+        when Net::HTTPServerError  # all 5xx errors
           if retries > 0
-            logger.info "HTTP 502 response: retrying..."
+            logger.info "HTTP #{response.code} response: retrying..."
             search(term, retries - 1)
           else
             raise "Too many failures: #{response}"

--- a/lib/health_check/html_search_client.rb
+++ b/lib/health_check/html_search_client.rb
@@ -49,7 +49,7 @@ module HealthCheck
     end
 
     def to_s
-      "HTML endpoint #{@base_url} [index=#{@index} auth=#{@auth.to_s.strip.size>0 ? "yes" : "no"}]"
+      "HTML endpoint #{@base_url} [index=#{@index} auth=#{@authentication ? "yes" : "no"}]"
     end
 
     private

--- a/lib/health_check/html_search_client.rb
+++ b/lib/health_check/html_search_client.rb
@@ -21,6 +21,9 @@ module HealthCheck
 
     def initialize(options={})
       @base_url       = options[:base_url] || URI.parse("https://www.gov.uk/search")
+      unless @base_url.path.include? "/search"
+        logger.warn "Base URL #{@base_url} does not look like a search page"
+      end
       @authentication = options[:authentication] || nil
       @index          = options[:index] || "mainstream"
     end

--- a/lib/health_check/json_search_client.rb
+++ b/lib/health_check/json_search_client.rb
@@ -25,7 +25,7 @@ module HealthCheck
     end
 
     def to_s
-      "JSON endpoint #{@base_url} [index=#{@index} auth=#{@auth.to_s.strip.size>0 ? "yes" : "no"}]"
+      "JSON endpoint #{@base_url} [index=#{@index} auth=#{@authentication ? "yes" : "no"}]"
     end
 
     private

--- a/test/unit/health_check/basic_auth_credentials_test.rb
+++ b/test/unit/health_check/basic_auth_credentials_test.rb
@@ -1,0 +1,32 @@
+require_relative "../../test_helper"
+require "health_check/basic_auth_credentials"
+
+module HealthCheck
+  class BasicAuthCredentialsTest < ShouldaUnitTestCase
+    should "be callable with a user:password string" do
+      creds = BasicAuthCredentials.call "bob:horseradish"
+      assert_equal "bob", creds.user
+      assert_equal "horseradish", creds.password
+    end
+
+    should "fail on a malformed string" do
+      assert_raises ArgumentError do
+        BasicAuthCredentials.call "spoons"
+      end
+    end
+
+    should "fail on a nil value" do
+      assert_raises ArgumentError do
+        BasicAuthCredentials.call nil
+      end
+    end
+
+    should "be splattable" do
+      stub_receiver = stub("receiver") do
+        expects(:call).with("bob", "horseradish")
+      end
+      creds = BasicAuthCredentials.call "bob:horseradish"
+      stub_receiver.call(*creds)
+    end
+  end
+end

--- a/test/unit/health_check/html_search_client_test.rb
+++ b/test/unit/health_check/html_search_client_test.rb
@@ -21,7 +21,7 @@ module HealthCheck
         <section id="content" role="main" class="group search ancillary">
           <div id="search-results-tabs">
             <div class="search-container group js-tab-content tab-content">
-              <div id="mainstream-results" class="js-tab-pane tab-pane ">
+              <div id="services-information-results" class="js-tab-pane tab-pane ">
                 <ul class="results-list internal-links">
                   <li class="section-driving type-guide">
                     <p class="search-result-title"><a href="/a">A result</a></p>
@@ -33,7 +33,7 @@ module HealthCheck
                   </li>
                 </ul>
               </div>
-              <div id="detailed-results" class="js-tab-pane tab-pane ">
+              <div id="department-results" class="js-tab-pane tab-pane ">
                 <ul class="results-list internal-links">
                   <li class="section-driving type-guide">
                     <p class="search-result-title"><a href="/b">A B result</a></p>
@@ -74,7 +74,7 @@ module HealthCheck
       stub_html("chalk")
       expected = ["/b"]
       base_url = URI.parse("http://www.dev.gov.uk/search")
-      client = HtmlSearchClient.new(base_url: base_url, index: "detailed")
+      client = HtmlSearchClient.new(base_url: base_url, index: "government")
       assert_equal expected, client.search("chalk")
     end
 


### PR DESCRIPTION
The HTML-parsing version of the health check wasn’t taking account of the top results list or the updated tab IDs in the markup.

Also add a few new configuration flags in the script which were helpful to me when developing and testing.
