### PR TITLE
Dont suggest words in a blacklist

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -74,12 +74,20 @@ class Rummager < Sinatra::Application
     end
   end
 
+  def blacklist_from_file
+    @@_blacklist_from_file ||= begin
+      path = File.expand_path("config/suggest/blacklist.txt", File.dirname(__FILE__))
+      lines = File.open(path).map(&:chomp)
+      lines.reject { |line| line.start_with?('#') || line.empty? }
+    end
+  end
+
   def suggester
     ignore = ignores_from_file
     if organisation_registry
       ignore = ignore + organisation_registry.all.map(&:acronym).reject(&:nil?)
     end
-    Suggester.new(ignore: ignore)
+    Suggester.new(ignore: ignore, blacklist: blacklist_from_file)
   end
 
   def text_error(content)

--- a/app.rb
+++ b/app.rb
@@ -66,20 +66,18 @@ class Rummager < Sinatra::Application
     end
   end
 
+  def lines_from_a_file(filepath)
+    path = File.expand_path(filepath, File.dirname(__FILE__))
+    lines = File.open(path).map(&:chomp)
+    lines.reject { |line| line.start_with?('#') || line.empty? }
+  end
+
   def ignores_from_file
-    @@_ignores_from_file ||= begin
-      path = File.expand_path("config/suggest/ignore.txt", File.dirname(__FILE__))
-      lines = File.open(path).map(&:chomp)
-      lines.reject { |line| line.start_with?('#') || line.empty? }
-    end
+    @@_ignores_from_file ||= lines_from_a_file("config/suggest/ignore.txt")
   end
 
   def blacklist_from_file
-    @@_blacklist_from_file ||= begin
-      path = File.expand_path("config/suggest/blacklist.txt", File.dirname(__FILE__))
-      lines = File.open(path).map(&:chomp)
-      lines.reject { |line| line.start_with?('#') || line.empty? }
-    end
+    @@_blacklist_from_file ||= lines_from_a_file("config/suggest/blacklist.txt")
   end
 
   def suggester

--- a/config/suggest/blacklist.txt
+++ b/config/suggest/blacklist.txt
@@ -1,0 +1,4 @@
+# Words not to be used as suggestions.
+fuck
+fucks
+penis

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -120,6 +120,12 @@ class SearchTest < IntegrationTest
     assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
+  def test_does_not_suggest_corrections_in_blacklist_file
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    get "/search.json", {q: "penison", response_style: "hash"} # penison would get an inappropriate suggestion
+    assert_equal ["pension"], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
   def test_handles_results_with_document_series
     mappings = default_mappings
     mappings["edition"]["properties"]["document_series"] = {"type" => "string"}

--- a/test/unit/suggester_test.rb
+++ b/test/unit/suggester_test.rb
@@ -58,4 +58,19 @@ class SuggesterTest < MiniTest::Unit::TestCase
     suggester = Suggester.new(ignore: ["DFT"])
     assert_equal ["DFT badger"], suggester.suggestions("DFT bagder")
   end
+
+  def test_should_not_suggest_words_in_blacklist
+    suggester = Suggester.new(blacklist: ["fuck", "fucks"])
+    assert_equal ["funk"], suggester.suggestions("fcuk") # funk is the third suggestion
+  end
+
+  def test_should_not_suggest_words_in_blacklist_even_when_split
+    suggester = Suggester.new(blacklist: ["penis"])
+    assert_equal ["pension"], suggester.suggestions("penison") # generates "penis on"
+  end
+
+  def test_should_not_suggest_words_in_blacklist_even_when_hyphenated
+    suggester = Suggester.new(blacklist: ["penis"])
+    assert_equal ["pension"], suggester.suggestions("penison") # generates "penis-on"
+  end
 end

--- a/test/unit/suggester_test.rb
+++ b/test/unit/suggester_test.rb
@@ -73,4 +73,9 @@ class SuggesterTest < MiniTest::Unit::TestCase
     suggester = Suggester.new(blacklist: ["penis"])
     assert_equal ["pension"], suggester.suggestions("penison") # generates "penis-on"
   end
+
+  def test_blacklist_is_applied_to_whole_words_only
+    suggester = Suggester.new(blacklist: ["ass"])
+    assert_equal ["class"], suggester.suggestions("cluss") # top suggestion is "class"
+  end
 end


### PR DESCRIPTION
It isn't appropriate for GOV.UK to suggest "penis on" for "penison", and it is more helpful for it to actually suggest "pension", so let's do that.

Blacklist to be fleshed out later.
