### PR TITLE
Don't make suggestions for numbers

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -86,6 +86,8 @@ class Rummager < Sinatra::Application
     if organisation_registry
       ignore = ignore + organisation_registry.all.map(&:acronym).reject(&:nil?)
     end
+    digit_or_word_containing_a_digit = /\d/
+    ignore = ignore + [digit_or_word_containing_a_digit]
     Suggester.new(ignore: MatcherSet.new(ignore),
                   blacklist: MatcherSet.new(blacklist_from_file))
   end

--- a/app.rb
+++ b/app.rb
@@ -18,6 +18,7 @@ require "topic_registry"
 require "world_location_registry"
 require "elasticsearch/index"
 require "elasticsearch/search_server"
+require "matcher_set"
 
 require_relative "config"
 require_relative "helpers"
@@ -85,7 +86,8 @@ class Rummager < Sinatra::Application
     if organisation_registry
       ignore = ignore + organisation_registry.all.map(&:acronym).reject(&:nil?)
     end
-    Suggester.new(ignore: ignore, blacklist: blacklist_from_file)
+    Suggester.new(ignore: MatcherSet.new(ignore),
+                  blacklist: MatcherSet.new(blacklist_from_file))
   end
 
   def text_error(content)

--- a/lib/matcher_set.rb
+++ b/lib/matcher_set.rb
@@ -1,0 +1,25 @@
+class MatcherSet
+  attr_reader :matchers
+
+  # matchers - an array of strings and/or regexes.
+  #            Strings are matched ignoring case.
+  def initialize(matchers)
+    @matchers = matchers.dup
+  end
+
+  # Does this MatcherSet match the supplied string?
+  def include?(candidate)
+    @matchers.any? do |matcher|
+      case matcher
+        when String
+          # casecmp returns 0 when the strings are equivalent, ignoring case
+          candidate.casecmp(matcher) == 0
+        when Regexp
+          # match returns nil if no match, or a MatchData if any matches
+          !! candidate.match(matcher)
+        else
+          raise "Unexpected matcher type: #{matcher}"
+      end
+    end
+  end
+end

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -120,6 +120,12 @@ class SearchTest < IntegrationTest
     assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
+  def test_does_not_suggest_corrections_for_numbers_or_words_containing_numbers
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    get "/search.json", {q: "v5c 2013", response_style: "hash"} # sorn would get a suggestion
+    assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
   def test_does_not_suggest_corrections_in_blacklist_file
     stub_index.expects(:search).returns(stub(results: [], total: 0))
     get "/search.json", {q: "penison", response_style: "hash"} # penison would get an inappropriate suggestion

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -122,7 +122,7 @@ class SearchTest < IntegrationTest
 
   def test_does_not_suggest_corrections_for_numbers_or_words_containing_numbers
     stub_index.expects(:search).returns(stub(results: [], total: 0))
-    get "/search.json", {q: "v5c 2013", response_style: "hash"} # sorn would get a suggestion
+    get "/search.json", {q: "v5c 2013", response_style: "hash"} # v5c would get a suggestion
     assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 

--- a/test/unit/matcher_set_test.rb
+++ b/test/unit/matcher_set_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+require "matcher_set"
+
+class MatcherSetTest < MiniTest::Unit::TestCase
+
+  def test_should_match_strings
+    matcher_set = MatcherSet.new(["foo", "bang"])
+    assert matcher_set.include?("foo")
+    refute matcher_set.include?("baz")
+  end
+
+  def test_should_match_strings_case_insensitively
+    matcher_set = MatcherSet.new(["foo"])
+    assert matcher_set.include?("Foo")
+  end
+
+  def test_should_match_regexes
+    matcher_set = MatcherSet.new([/oo/])
+    assert matcher_set.include?("Foo")
+    refute matcher_set.include?("Fopo")
+  end
+
+  def test_matchers_should_be_immutable
+    members = ["foo"]
+    matcher_set = MatcherSet.new(members)
+    members.pop
+    assert matcher_set.include?("foo")
+  end
+end


### PR DESCRIPTION
Until now it has made unhelpful suggestions for numbers or words containing numbers, for example:
- v5c => Vic
- 2013 => W
- g8 => G
