### PR TITLE
Don't suggest changes to punctuation

### DIFF
--- a/lib/suggester.rb
+++ b/lib/suggester.rb
@@ -24,10 +24,6 @@ class Suggester
       end
     end.join("")
 
-    # suggested_string = query_string.split("\s").map do |word|
-    #   suggestion_for_a_word(word) || word
-    # end.join(" ")
-
     if suggested_string.downcase == query_string.downcase
       # don't suggest the input, even if the case has changed
       []

--- a/lib/suggester.rb
+++ b/lib/suggester.rb
@@ -15,11 +15,20 @@ class Suggester
   #  * is retained if in the dictionary, otherwise
   #  * is replaced by it's most likely correction
   def suggestions(query_string)
-    suggested_string = query_string.split("\s").map do |word|
-      suggestion_for_a_word(word) || word
-    end.join(" ")
+    suggested_string = query_string.split(/\b/).map do |token|
+      # token might be punctuation, whitespace or a word
+      if token.match(/\w/) # \w - Any word character (letter, number, underscore)
+        suggestion_for_a_word(token) || token
+      else
+        token
+      end
+    end.join("")
 
-    if suggested_string.downcase == query_string.split("\s").join(" ").downcase
+    # suggested_string = query_string.split("\s").map do |word|
+    #   suggestion_for_a_word(word) || word
+    # end.join(" ")
+
+    if suggested_string.downcase == query_string.downcase
       # don't suggest the input, even if the case has changed
       []
     else

--- a/test/unit/suggester_test.rb
+++ b/test/unit/suggester_test.rb
@@ -38,6 +38,17 @@ class SuggesterTest < MiniTest::Unit::TestCase
     assert_equal [], suggester.suggestions("  jobs")
   end
 
+  def test_does_not_suggest_changes_just_to_punctuation
+    suggester = Suggester.new
+    assert_equal [], suggester.suggestions("why?")
+  end
+
+  def test_does_not_suggest_changes_to_punctuation
+    suggester = Suggester.new
+    assert_equal ["bad, spelling"], suggester.suggestions("bad, speling")
+    assert_equal ["self-employed"], suggester.suggestions("smelf-employed")
+  end
+
   def test_should_not_remove_a_word_with_no_suggestions
     # if ffi-aspell has no suggestions, it returns an empty array
     suggester = Suggester.new


### PR DESCRIPTION
It's unhelpful to make suggestions that are the same but without punctuation.
We currently do this, for example:
- how? => how
- comma, word => comma word

It's also nice to retain the user's punctuation where possible.
