### PR TITLE
"wales office" wasn't returning the Wales Office org page

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -230,12 +230,11 @@ synonyms: &synonyms [
   "ukti => ukti, uk trade and investment, help for exporters, starting to export, uk welcomes",
   "under-occupancy, under occupancy, underoccupancy  => under-occupancy, under occupancy, underoccupancy, bedroom, housing benefit",
   "utr, unique taxpayer reference => utr, unique taxpayer reference, register for self assessment",
-  "wales => wales, cymru, cymraeg, gymraeg",
+  "wales => wales, cymru",
   "weather, bad weather, winter weather => weather, cold weather, severe weather, winter weather, energy grants, heating",
   "welsh => welsh, cymraeg, gymraeg",
   "winter payment, winter payments => winter fuel payment, cold weather, warm home, energy saving, energy grants, heating",
   "work trial => work trial, work experience, recruiters",
-
   # Forms and leaflets
 
   "adif => birth or adoption certificate form, student finance forms",


### PR DESCRIPTION
The Wales Office organisation page[0] should be returned for "wales office".

Because of the synonyms, the query "wales office" was expanded to "wales cymru cymraeg gymraeg office".
With this number of terms, the minimum should match filter requires at least 3
terms to be in the document, but the org page only has "wales" and "office", so was
excluded from the results.
- 0 - https://www.gov.uk/government/organisations/wales-office
