### PR TITLE
Gracefully respond after an ES timeout

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -111,6 +111,10 @@ class Rummager < Sinatra::Application
     content_type :json
   end
 
+  error RestClient::RequestTimeout do
+    halt(503, "Elasticsearch timed out")
+  end
+
   # To search a named index:
   #   /index_name/search?q=pie
   #

--- a/config.rb
+++ b/config.rb
@@ -14,6 +14,10 @@ configure :development do
   set :protection, false
 end
 
+# Enable custom error handling (eg ``error Exception do;...end``)
+# Disable fancy exception pages (but still get good ones).
+disable :show_exceptions
+
 initializers_path = File.expand_path("config/initializers/*.rb", File.dirname(__FILE__))
 
 Dir[initializers_path].each { |f| require f }

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -221,4 +221,10 @@ class SearchTest < IntegrationTest
     get "/search"
     assert last_response.not_found?
   end
+
+  def test_returns_503_when_elasticsearch_timesout
+    stub_index.expects(:search).raises(RestClient::RequestTimeout)
+    get "/search.json", { q: "search term" }
+    assert_equal 503, last_response.status
+  end
 end


### PR DESCRIPTION
Return a 503. This lets clients understand what happened and respond accordingly (eg retry).
