### PR TITLE
Common logging configuration across Rake/Rack.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "rake/testtask"
 require "rest-client"
 require "logging"
+require_relative "config/logging"
 
 PROJECT_ROOT = File.dirname(__FILE__)
 
@@ -40,33 +41,11 @@ end
 
 require "ci/reporter/rake/minitest" if ENV["RACK_ENV"] == "test"
 
-class PushableLogger
-  # Because RestClient uses the '<<' method, rather than the levelled Logger
-  # methods, we have to put together a class that'll assign them a level
-
-  def initialize(logger, level)
-    @logger, @level = logger, level
-  end
-
-  def <<(message)
-    @logger.send @level, message
-  end
-end
-
 task :default => :test
 
 def logger
-  @_logger ||= begin
-    logger = Logging.logger.root
-    logger.add_appenders Logging.appenders.stdout
-    logger.level = verbose ? :debug : :info
-    logger
-  end
+  Logging.logger.root
 end
-
-# Log all RestClient output at debug level, so it doesn't show up unless rake
-# is invoked with the `--verbose` flag
-RestClient.log = PushableLogger.new(Logging.logger[RestClient], :debug)
 
 def search_config
   @search_config ||= SearchConfig.new

--- a/config.rb
+++ b/config.rb
@@ -2,6 +2,7 @@ require_relative "env"
 require "active_support/core_ext/hash/keys"
 require "search_config"
 require_relative "exception_mailer"
+require "config/logging"
 
 set :search_config, SearchConfig.new
 set :default_index_name, "mainstream"

--- a/config/logging.rb
+++ b/config/logging.rb
@@ -1,0 +1,26 @@
+require "logging"
+
+class PushableLogger
+  # Because RestClient uses the '<<' method, rather than the levelled Logger
+  # methods, we have to put together a class that'll assign them a level
+
+  def initialize(logger, level)
+    @logger, @level = logger, level
+  end
+
+  def <<(message)
+    @logger.send @level, message
+  end
+end
+
+Logging.logger.root.add_appenders Logging.appenders.stdout
+
+# If running within a Rakefile, we have the `verbose` option from the `-v`
+# command line flag; if running within a Rack app, we have the `$DEBUG` global.
+if (respond_to?(:verbose) && verbose) || $DEBUG
+  Logging.logger.root.level = :debug
+else
+  Logging.logger.root.level = :info
+end
+
+RestClient.log = PushableLogger.new(Logging.logger[RestClient], :debug)

--- a/config/logging.rb
+++ b/config/logging.rb
@@ -20,7 +20,7 @@ Logging.logger.root.add_appenders Logging.appenders.stdout
 if (respond_to?(:verbose) && verbose) || $DEBUG
   Logging.logger.root.level = :debug
 else
-  Logging.logger.root.level = :info
+  Logging.logger.root.level = :warn
 end
 
 RestClient.log = PushableLogger.new(Logging.logger[RestClient], :debug)


### PR DESCRIPTION
We can enable verbose logging using `rake -v` or `rackup -d -p <port>`.
