### PR TITLE
Add in raindrops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 source "https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/"
 
 gem "unicorn", "4.3.1"
+gem "raindrops", "~> 0.11.0"
 gem "sinatra", "1.3.4"
 gem "rake", "0.9.2", :require => false
 gem "json", "1.7.7"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 source "https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/"
 
 gem "unicorn", "4.3.1"
-gem "raindrops", "~> 0.11.0"
+gem "raindrops", "0.11.0"
 gem "sinatra", "1.3.4"
 gem "rake", "0.9.2", :require => false
 gem "json", "1.7.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ DEPENDENCIES
   nokogiri (= 1.5.5)
   rack (= 1.5.2)
   rack-test
-  raindrops (~> 0.11.0)
+  raindrops (= 0.11.0)
   rake (= 0.9.2)
   rest-client (= 1.6.7)
   shotgun

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
-    raindrops (0.10.0)
+    raindrops (0.11.0)
     rake (0.9.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -104,6 +104,7 @@ DEPENDENCIES
   nokogiri (= 1.5.5)
   rack (= 1.5.2)
   rack-test
+  raindrops (~> 0.11.0)
   rake (= 0.9.2)
   rest-client (= 1.6.7)
   shotgun

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,13 @@
 app_path = File.dirname(__FILE__)
 $:.unshift(app_path) unless $:.include?(app_path)
 
+# the app needs to be run with unicorn for this to work
+# if you want to see this running in dev use following instead of bowl:
+# bundle exec unicorn -l 3009
+if defined?(Raindrops)
+	use Raindrops::Middleware, :stats => $stats
+end
+
 require "env"
 
 require "bundler"

--- a/config.ru
+++ b/config.ru
@@ -1,9 +1,12 @@
 app_path = File.dirname(__FILE__)
 $:.unshift(app_path) unless $:.include?(app_path)
 
-# the app needs to be run with unicorn for this to work
-# if you want to see this running in dev use following instead of bowl:
-# bundle exec unicorn -l 3009
+# Raindrops is only loaded when running under Unicorn so we need the conditional
+# to prevent an undefined constant error.
+#
+# This middleware adds a /_raindrops path that exposes stats. To see this in
+# development, start the app like this instead of the usual running under thin:
+#    bundle exec unicorn -l 3009
 if defined?(Raindrops)
 	use Raindrops::Middleware, :stats => $stats
 end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,3 +1,6 @@
+require 'raindrops'
+$stats ||= Raindrops::Middleware::Stats.new
+
 def load_file_if_exists(config, file)
   config.instance_eval(File.read(file)) if File.exist?(file)
 end


### PR DESCRIPTION
Raindrops is a real-time stats toolkit to show statistics for Rack HTTP servers. It'll give us some visibility into the unicorn queue.

To view it in dev mode, rather than 'bowl rummager', do:

bundle exec unicorn -l 3009

Then you can view the stats at:

http://search.dev.gov.uk/_raindrops
