### PR TITLE
Remove the exception notifier initialiser.

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,9 +1,0 @@
-configure :production do
-  if File.exist?("../aws_secrets.yml")
-    disable :show_exceptions
-    use ExceptionMailer, YAML.load_file("aws_secrets.yml"),
-        to: ["govuk-exceptions@digital.cabinet-office.gov.uk"],
-        from: '"Winston Smith-Churchill" <winston@alphagov.co.uk>',
-        subject: "[Rummager exception]"
-  end
-end


### PR DESCRIPTION
We configure exception notification on deployment whenever we're going to use it, so there's no need to have this initialiser in the project itself.
