### PR TITLE
Index documents via a Redis-backed queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'nokogiri', "1.5.5"
 gem 'whenever', require: false
 gem 'ffi-aspell', "0.0.3"
 gem "slop", "3.4.5"
+gem "sidekiq", "2.12.4"
 
 group :test do
   gem "shoulda-context"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,9 +13,12 @@ GEM
       mime-types
       xml-simple
     builder (3.1.3)
+    celluloid (0.14.1)
+      timers (>= 1.0.0)
     chronic (0.9.1)
     ci_reporter (1.7.1)
       builder (>= 2.1.2)
+    connection_pool (1.1.0)
     crack (0.3.2)
     daemons (1.1.9)
     eventmachine (1.0.0)
@@ -48,11 +51,20 @@ GEM
       rack (>= 1.0)
     raindrops (0.10.0)
     rake (0.9.2)
+    redis (3.0.4)
+    redis-namespace (1.3.0)
+      redis (~> 3.0.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     shotgun (0.9)
       rack (>= 1.0)
     shoulda-context (1.1.1)
+    sidekiq (2.12.4)
+      celluloid (>= 0.14.1)
+      connection_pool (>= 1.0.0)
+      json
+      redis (>= 3.0)
+      redis-namespace
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -70,6 +82,7 @@ GEM
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
     tilt (1.3.3)
+    timers (1.1.0)
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
@@ -108,6 +121,7 @@ DEPENDENCIES
   rest-client (= 1.6.7)
   shotgun
   shoulda-context
+  sidekiq (= 2.12.4)
   simplecov
   simplecov-rcov
   sinatra (= 1.3.4)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ If you have indices from a Rummager instance before aliased indices, run:
 If you don't know which of these you need to run, try running the first one; it
 will fail safely with an error if you have an unmigrated index.
 
+Rummager has an asynchronous mode, disabled in development by default, that
+posts documents to a queue to be indexed later by a worker. To run this in
+development, you need to run both of these commands:
+
+    ENABLE_QUEUE=1 ./startup.sh
+    bundle exec rake jobs:work
+
 ## Indexing GOV.UK content
 
 Since search indexing happens through Panopticon's single registration API,

--- a/app.rb
+++ b/app.rb
@@ -187,7 +187,7 @@ class Rummager < Sinatra::Application
       current_index.document_from_hash(hash)
     }
 
-    simple_json_result(current_index.add(documents))
+    simple_json_result(current_index.add_queued(documents))
   end
 
   post "/?:index?/commit" do

--- a/app.rb
+++ b/app.rb
@@ -188,11 +188,11 @@ class Rummager < Sinatra::Application
     }
 
     if settings.enable_queue
-      result = current_index.add_queued(documents)
+      current_index.add_queued(documents)
+      json_result 202, "Queued"
     else
-      result = current_index.add(documents)
+      simple_json_result(current_index.add(documents))
     end
-    simple_json_result(result)
   end
 
   post "/?:index?/commit" do

--- a/app.rb
+++ b/app.rb
@@ -187,7 +187,12 @@ class Rummager < Sinatra::Application
       current_index.document_from_hash(hash)
     }
 
-    simple_json_result(current_index.add_queued(documents))
+    if settings.enable_queue
+      result = current_index.add_queued(documents)
+    else
+      result = current_index.add(documents)
+    end
+    simple_json_result(result)
   end
 
   post "/?:index?/commit" do

--- a/bootstrap_worker.rb
+++ b/bootstrap_worker.rb
@@ -1,0 +1,11 @@
+# Slightly hacky script to bootstrap the Sidekiq worker
+
+project_root = File.dirname(__FILE__)
+library_path = File.join(project_root, "lib")
+
+[project_root, library_path].each do |path|
+  $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
+end
+
+require "config/initializers/sidekiq"
+require "elasticsearch/bulk_index_worker"

--- a/config/initializers/async.rb
+++ b/config/initializers/async.rb
@@ -1,0 +1,3 @@
+# This file can be overwritten on deployment
+
+set :enable_queue, ! ENV["ENABLE_QUEUE"].nil?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,15 @@
+# This file will be overwritten on deployment
+require "sidekiq"
+
+redis_config = {
+  :url => "redis://localhost:6379/0",
+  :namespace => "rummager"
+}
+
+Sidekiq.configure_server do |config|
+  config.redis = redis_config
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = redis_config
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,15 @@
 # This file will be overwritten on deployment
 require "sidekiq"
 
+if ENV["RACK_ENV"]
+  namespace = "rummager-#{ENV['RACK_ENV']}"
+else
+  namespace = "rummager"
+end
+
 redis_config = {
   :url => "redis://localhost:6379/0",
-  :namespace => "rummager"
+  :namespace => namespace
 }
 
 Sidekiq.configure_server do |config|

--- a/helpers.rb
+++ b/helpers.rb
@@ -8,14 +8,17 @@ module Helpers
   end
 
   def simple_json_result(ok)
-    content_type :json
     if ok
-      result = "OK"
+      json_result 200, "OK"
     else
-      result = "error"
-      status 500
+      json_result 500, "error"
     end
-    MultiJson.encode("result" => result)
+  end
+
+  def json_result(status_code, message)
+    content_type :json
+    status status_code
+    MultiJson.encode("result" => message)
   end
 end
 

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -1,0 +1,26 @@
+require "sidekiq"
+require "search_config"
+
+module Elasticsearch
+  class BulkIndexWorker
+    include Sidekiq::Worker
+
+    def logger
+      Logging.logger[self]
+    end
+
+    sidekiq_options :queue => :bulk
+
+    def perform(index_name, document_hashes)
+      noun = document_hashes.size > 1 ? "documents" : "document"
+      logger.info "Indexing #{document_hashes.size} queued #{noun} into #{index_name}"
+
+      index(index_name).bulk_index(document_hashes)
+    end
+
+  private
+    def index(index_name)
+      SearchConfig.new.search_server.index(index_name)
+    end
+  end
+end

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -4,6 +4,7 @@ require "search_config"
 module Elasticsearch
   class BulkIndexWorker
     include Sidekiq::Worker
+    sidekiq_options :retry => 5
 
     def logger
       Logging.logger[self]

--- a/lib/elasticsearch/document_queue.rb
+++ b/lib/elasticsearch/document_queue.rb
@@ -1,0 +1,15 @@
+require "elasticsearch/bulk_index_worker"
+
+module Elasticsearch
+  # A queue of documents to be added to an index.
+  class DocumentQueue
+
+    def initialize(index_name)
+      @index_name = index_name
+    end
+
+    def queue_many(document_hashes)
+      BulkIndexWorker.perform_async(@index_name, document_hashes)
+    end
+  end
+end

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -1,0 +1,7 @@
+namespace :jobs do
+
+  task :work do
+    base_path = File.join(File.dirname(__FILE__), "../..")
+    exec("bundle exec sidekiq -q bulk -r #{base_path}/bootstrap_worker.rb")
+  end
+end

--- a/test/functional/indexing_test.rb
+++ b/test/functional/indexing_test.rb
@@ -12,6 +12,8 @@ class IndexingTest < IntegrationTest
   end
 
   def test_can_submit_documents
+    # The default is false, but let's be explicit about it
+    app.settings.expects(:enable_queue).returns(false)
     index = stub_index
 
     index.expects(:document_from_hash).with(document_hashes[0]).returns(:foo)

--- a/test/functional/indexing_test.rb
+++ b/test/functional/indexing_test.rb
@@ -1,0 +1,35 @@
+require "integration_test_helper"
+
+class IndexingTest < IntegrationTest
+
+  def document_hashes
+    [
+      {
+        "link" => "/foo",
+        "title" => "Foo"
+      }
+    ]
+  end
+
+  def test_can_submit_documents
+    index = stub_index
+
+    index.expects(:document_from_hash).with(document_hashes[0]).returns(:foo)
+    index.expects(:add).with([:foo]).returns(true)
+
+    post "/documents", MultiJson.encode(document_hashes), :content_type => :json
+
+    assert_equal 200, last_response.status
+  end
+
+  def test_can_submit_documents_asynchronously
+    app.settings.expects(:enable_queue).returns(true)
+    index = stub_index
+    index.expects(:document_from_hash).with(document_hashes[0]).returns(:foo)
+    index.expects(:add_queued).with([:foo]).returns(true)
+
+    post "/documents", MultiJson.encode(document_hashes), :content_type => :json
+
+    assert_equal 202, last_response.status
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -57,6 +57,7 @@ module ElasticsearchIntegration
       "index_names" => index_names
     })
     app.settings.stubs(:default_index_name).returns(@default_index_name)
+    app.settings.stubs(:enable_queue).returns(false)
   end
 
   def stub_modified_schema

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "app"
 require "elasticsearch/search_server"
+require "sidekiq/testing/inline"  # Make all queued jobs run immediately
 
 module IntegrationFixtures
   include Fixtures::DefaultMappings
@@ -51,7 +52,7 @@ module ElasticsearchIntegration
 
     @default_index_name = default || index_names.first
 
-    app.settings.search_config.stubs(:elasticsearch).returns({
+    SearchConfig.any_instance.stubs(:elasticsearch).returns({
       "base_uri" => "http://localhost:9200",
       "index_names" => index_names
     })

--- a/test/unit/bulk_index_worker_test.rb
+++ b/test/unit/bulk_index_worker_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+require "elasticsearch/bulk_index_worker"
+
+class BulkIndexWorkerTest < MiniTest::Unit::TestCase
+  def sample_document_hashes
+    %w(foo bar baz).map do |slug|
+      {:link => "/#{slug}", :title => slug.capitalize}
+    end
+  end
+
+  def test_indexes_documents
+    mock_index = mock("index")
+    mock_index.expects(:bulk_index).with(sample_document_hashes)
+    Elasticsearch::SearchServer.any_instance.expects(:index)
+      .with("test-index")
+      .returns(mock_index)
+
+    worker = Elasticsearch::BulkIndexWorker.new
+    worker.perform("test-index", sample_document_hashes)
+  end
+end

--- a/test/unit/document_queue_test.rb
+++ b/test/unit/document_queue_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+require "elasticsearch/document_queue"
+require "elasticsearch/bulk_index_worker"
+
+class DocumentQueueTest < MiniTest::Unit::TestCase
+  def sample_document_hashes
+    %w(foo bar baz).map do |slug|
+      {:link => "/#{slug}", :title => slug.capitalize}
+    end
+  end
+
+  def test_can_queue_documents_in_bulk
+    Elasticsearch::BulkIndexWorker.expects(:perform_async)
+      .with("test-index", sample_document_hashes)
+    queue = Elasticsearch::DocumentQueue.new("test-index")
+    queue.queue_many(sample_document_hashes)
+  end
+end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -103,6 +103,24 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     assert_requested :get, document_url
   end
 
+  def test_add_queued_documents
+    json_document = {
+        "_type" => "edition",
+        "link" => "/foo/bar",
+        "title" => "TITLE ONE",
+    }
+    document = stub("document", elasticsearch_export: json_document)
+
+    mock_queue = mock("document queue") do
+      expects(:queue_many).with([json_document])
+    end
+    Elasticsearch::DocumentQueue.expects(:new)
+      .with("test-index")
+      .returns(mock_queue)
+
+    @wrapper.add_queued([document])
+  end
+
   def test_get_document_not_found
     document_url = "http://example.com:9200/test-index/_all/%2Fa-bad-link"
 

--- a/test/unit/helpers_test.rb
+++ b/test/unit/helpers_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+require "helpers"
+
+class HelpersTest < MiniTest::Unit::TestCase
+  include Helpers
+
+  def test_simple_json_result_ok
+    expects(:content_type).with(:json)
+    # 200 is the default status: whether it gets called or not, we don't mind
+    expects(:status).with(200).at_most_once
+    assert_equal '{"result":"OK"}', simple_json_result(true)
+  end
+
+  def test_simple_json_result_error
+    expects(:content_type).with(:json)
+    expects(:status).with(500)
+    assert_equal '{"result":"error"}', simple_json_result(false)
+  end
+end


### PR DESCRIPTION
To help avoid some of the timeout problems (particularly when reindexing on Preview and Staging), send submitted documents to a queue and have a worker add them when elasticsearch is ready. In case of timeouts, the worker retries the submission automatically.

This is disabled by default, and can be enabled with an environment variable or on deployment with an initialiser; the intention is to turn it on in all non-development environments.
