### PR TITLE
Add 'acronym' to the government schema

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -594,6 +594,7 @@ mappings:
       _all: { enabled: true }
       properties:
         title:       { type: string, index: analyzed }
+        acronym:     { type: string, index: not_analyzed, include_in_all: false }
         description: { type: string, index: analyzed }
         indexable_content: { type: string, index: analyzed }
         format:      { type: string, index: not_analyzed, include_in_all: false }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -594,7 +594,7 @@ mappings:
       _all: { enabled: true }
       properties:
         title:       { type: string, index: analyzed }
-        acronym:     { type: string, index: not_analyzed, include_in_all: false }
+        acronym:     { type: string, index: analyzed }
         description: { type: string, index: analyzed }
         indexable_content: { type: string, index: analyzed }
         format:      { type: string, index: not_analyzed, include_in_all: false }

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -162,6 +162,7 @@ module Elasticsearch
     def match_fields
       {
         "title" => 5,
+        "acronym" => 5, # Ensure that organisations rank brilliantly for their acronym
         "description" => 2,
         "indexable_content" => 1,
       }


### PR DESCRIPTION
This lets us submit and use the 'acronym' for Organisations. AFAICT it wouldn't work otherwise.

Later on, when we are using the field from the index, we can remove the code in `OrganisationRegistry` that fills it in by processing the title.
