### PR TITLE
Treat non appearance as pass for 'should not' checks

### DIFF
--- a/lib/health_check/check.rb
+++ b/lib/health_check/check.rb
@@ -37,16 +37,16 @@ module HealthCheck
       success = !!(positive_check? ? found_in_limit : ! found_in_limit)
 
       marker = "[#{weight}-POINT]"
+      expectation = positive_check? ? "<= #{minimum_rank}" : "> #{minimum_rank}"
       if found_index
-        expectation = positive_check? ? "<= #{minimum_rank}" : "> #{minimum_rank}"
         message = "#{marker} Found '#{path}' for '#{search_term}' in position #{found_index + 1} (expected #{expectation})"
-        if success
-          logger.pass(message)
-        else
-          logger.fail(message)
-        end
       else
-        logger.fail("#{marker} Didn't find '#{path}' in results for '#{search_term}'")
+        message = "#{marker} Didn't find '#{path}' for '#{search_term}' in any position (expected #{expectation})"
+      end
+      if success
+        logger.pass(message)
+      else
+        logger.fail(message)
       end
 
       score = success ? weight : 0

--- a/test/unit/health_check/check_test.rb
+++ b/test/unit/health_check/check_test.rb
@@ -6,40 +6,77 @@ Logging.logger.root.appenders = nil
 module HealthCheck
   class CheckTest < ShouldaUnitTestCase
     context "result" do
-      should "return a Result" do
-        check = Check.new("carmen", "should", "/a", 1, 200)
-        search_results = ["https://www.gov.uk/a"]
-
-        result = check.result(search_results)
-
-        assert_equal true, result.success
-        assert_equal 200, result.score
-        assert_equal 200, result.possible_score
-      end
-
-      context "desired result is outside of the desired ranking" do
-        should "return a failure Result" do
+      context "'should' checks" do
+        should "return a Result" do
           check = Check.new("carmen", "should", "/a", 1, 200)
-          search_results = ["https://www.gov.uk/b", "https://www.gov.uk/a"]
+          search_results = ["https://www.gov.uk/a"]
+
+          result = check.result(search_results)
+
+          assert_equal true, result.success
+          assert_equal 200, result.score
+          assert_equal 200, result.possible_score
+        end
+
+        context "desired result is outside of the desired ranking" do
+          should "return a failure Result" do
+            check = Check.new("carmen", "should", "/a", 1, 200)
+            search_results = ["https://www.gov.uk/b", "https://www.gov.uk/a"]
+
+            result = check.result(search_results)
+
+            assert_equal false, result.success
+            assert_equal 0, result.score
+            assert_equal 200, result.possible_score
+          end
+        end
+
+        context "desired result isn't in the results" do
+          should "return a failure Result" do
+            check = Check.new("carmen", "should", "/a", 1, 200)
+            search_results = ["https://www.gov.uk/b", "https://www.gov.uk/a"]
+
+            result = check.result(search_results)
+
+            assert_equal false, result.success
+            assert_equal 0, result.score
+            assert_equal 200, result.possible_score
+          end
+        end
+      end
+    end
+
+    context "'should not' checks" do
+      context "an undesirable result is in the top N" do
+        should "fail" do
+          check = Check.new("carmen", "should not", "/a", 1, 200)
+          search_results = ["https://www.gov.uk/a", "https://www.gov.uk/b"]
 
           result = check.result(search_results)
 
           assert_equal false, result.success
-          assert_equal 0, result.score
-          assert_equal 200, result.possible_score
         end
       end
 
-      context "desired result isn't in the results" do
-        should "return a failure Result" do
-          check = Check.new("carmen", "should", "/a", 1, 200)
+      context "an undesirable result is after the top N" do
+        should "pass" do
+          check = Check.new("carmen", "should not", "/a", 1, 200)
           search_results = ["https://www.gov.uk/b", "https://www.gov.uk/a"]
 
           result = check.result(search_results)
 
-          assert_equal false, result.success
-          assert_equal 0, result.score
-          assert_equal 200, result.possible_score
+          assert_equal true, result.success
+        end
+      end
+
+      context "an undesirable result doesn't appear" do
+        should "pass" do
+          check = Check.new("carmen", "should not", "/x", 1, 200)
+          search_results = ["https://www.gov.uk/a", "https://www.gov.uk/b"]
+
+          result = check.result(search_results)
+
+          assert_equal true, result.success
         end
       end
     end

--- a/test/unit/health_check/check_test.rb
+++ b/test/unit/health_check/check_test.rb
@@ -52,7 +52,9 @@ module HealthCheck
           check = Check.new("carmen", "should not", "/a", 1, 200)
           search_results = ["https://www.gov.uk/a", "https://www.gov.uk/b"]
 
-          check.stubs(:logger).returns(mock("foo", fail: nil))
+          logger = mock("logger")
+          logger.expects(:fail)
+          check.stubs(:logger).returns(logger)
 
           result = check.result(search_results)
 
@@ -65,7 +67,9 @@ module HealthCheck
           check = Check.new("carmen", "should not", "/a", 1, 200)
           search_results = ["https://www.gov.uk/b", "https://www.gov.uk/a"]
 
-          check.stubs(:logger).returns(mock("foo", pass: nil))
+          logger = mock("logger")
+          logger.expects(:pass)
+          check.stubs(:logger).returns(logger)
 
           result = check.result(search_results)
 
@@ -78,7 +82,9 @@ module HealthCheck
           check = Check.new("carmen", "should not", "/x", 1, 200)
           search_results = ["https://www.gov.uk/a", "https://www.gov.uk/b"]
 
-          check.stubs(:logger).returns(mock("foo", pass: nil))
+          logger = mock("logger")
+          logger.expects(:pass)
+          check.stubs(:logger).returns(logger)
 
           result = check.result(search_results)
 

--- a/test/unit/health_check/check_test.rb
+++ b/test/unit/health_check/check_test.rb
@@ -52,6 +52,8 @@ module HealthCheck
           check = Check.new("carmen", "should not", "/a", 1, 200)
           search_results = ["https://www.gov.uk/a", "https://www.gov.uk/b"]
 
+          check.stubs(:logger).returns(mock("foo", fail: nil))
+
           result = check.result(search_results)
 
           assert_equal false, result.success
@@ -63,6 +65,8 @@ module HealthCheck
           check = Check.new("carmen", "should not", "/a", 1, 200)
           search_results = ["https://www.gov.uk/b", "https://www.gov.uk/a"]
 
+          check.stubs(:logger).returns(mock("foo", pass: nil))
+
           result = check.result(search_results)
 
           assert_equal true, result.success
@@ -73,6 +77,8 @@ module HealthCheck
         should "pass" do
           check = Check.new("carmen", "should not", "/x", 1, 200)
           search_results = ["https://www.gov.uk/a", "https://www.gov.uk/b"]
+
+          check.stubs(:logger).returns(mock("foo", pass: nil))
 
           result = check.result(search_results)
 


### PR DESCRIPTION
For 'should not' checks, where the result did not appear at all, we were correctly recording that it passed, and adding it to the score, but we logged a message that said it failed.

This is because the logging of failures was disconnected from the "success" to some extent.
