### PR TITLE
Report on the size of the document queue

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -241,4 +241,14 @@ class Rummager < Sinatra::Application
     end
     simple_json_result(action)
   end
+
+  get "/_status" do
+    status = {}
+    status["queues"] = {}
+
+    Sidekiq::Stats.new.queues.each do |queue_name, queue_size|
+      status["queues"][queue_name] = {"jobs" => queue_size}
+    end
+    MultiJson.encode(status)
+  end
 end

--- a/test/functional/status_test.rb
+++ b/test/functional/status_test.rb
@@ -1,0 +1,17 @@
+require "integration_test_helper"  # Because it tests the Sinatra app
+
+class StatusTest < IntegrationTest
+  def test_shows_queue_job_count
+    Sidekiq::Stats.any_instance.expects(:queues).returns(
+      {"bulk" => 12}
+    )
+    get "/_status"
+    assert last_response.ok?
+    # Don't mind whether the response type has a charset
+    assert_equal "application/json", last_response.content_type.split(";")[0]
+
+    parsed_response = MultiJson.decode(last_response.body)
+    assert_equal ["bulk"], parsed_response["queues"].keys
+    assert_equal 12, parsed_response["queues"]["bulk"]["jobs"]
+  end
+end


### PR DESCRIPTION
If and when we add in more queues, this will report on the number of jobs in them as well.

Note that this shows the number of jobs (i.e. batches) in the queue, rather than the number of documents enqueued.
