### PR TITLE
Remove our one instance of statsd logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "activesupport", "3.2.12"
 gem "rack", "1.5.2"
 gem "aws-ses", "0.4.4"
 gem "rest-client", "1.6.7"
-gem "statsd-ruby", "1.0.0"
 gem "logging", "1.8.1"
 gem 'nokogiri', "1.5.5"
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,6 @@ GEM
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     slop (3.4.5)
-    statsd-ruby (1.0.0)
     thin (1.5.0)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -127,7 +126,6 @@ DEPENDENCIES
   simplecov-rcov
   sinatra (= 1.3.4)
   slop (= 3.4.5)
-  statsd-ruby (= 1.0.0)
   thin
   turn
   unicorn (= 4.3.1)

--- a/app.rb
+++ b/app.rb
@@ -6,7 +6,6 @@ require "sinatra"
 require 'yajl/json_gem'
 require "multi_json"
 require "csv"
-require "statsd"
 
 require "document"
 require "result_set_presenter"
@@ -24,12 +23,6 @@ require_relative "config"
 require_relative "helpers"
 
 class Rummager < Sinatra::Application
-  def self.statsd
-    @@statsd ||= Statsd.new("localhost").tap do |c|
-      c.namespace = ENV["GOVUK_STATSD_PREFIX"].to_s
-    end
-  end
-
   def search_server
     settings.search_config.search_server
   end

--- a/lib/elasticsearch/client.rb
+++ b/lib/elasticsearch/client.rb
@@ -86,13 +86,6 @@ module Elasticsearch
       (@base_uri + sub_path).to_s
     end
 
-    def recording_elastic_error(&block)
-      yield
-    rescue Errno::ECONNREFUSED, Timeout::Error, SocketError
-      Rummager.statsd.increment("elasticsearcherror")
-      raise
-    end
-
     def logging_exception_body(&block)
       yield
     rescue RestClient::InternalServerError => error
@@ -109,18 +102,16 @@ module Elasticsearch
         headers[:content_type] = "application/json"
       end
 
-      recording_elastic_error do
-        logging_exception_body do
-          args = {
-            method: method,
-            url: url_for(path),
-          }
-          args[:payload] = payload if payload
-          args[:headers] = headers if headers
-          args[:timeout] = @timeout if @timeout
-          args[:open_timeout] = @open_timeout if @open_timeout
-          RestClient::Request.execute(args)
-        end
+      logging_exception_body do
+        args = {
+          method: method,
+          url: url_for(path),
+        }
+        args[:payload] = payload if payload
+        args[:headers] = headers if headers
+        args[:timeout] = @timeout if @timeout
+        args[:open_timeout] = @open_timeout if @open_timeout
+        RestClient::Request.execute(args)
       end
     end
   end


### PR DESCRIPTION
We're not using this to inform any decisions, and it's causing problems in worker processes where `Rummager` isn't defined.
