### PR TITLE
Searches can specify a sort field and order

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -118,7 +118,7 @@ class Rummager < Sinatra::Application
   #   /search?q=pie&organisation_slug=home-office
   #
   # To get the results in date order, rather than relevancy:
-  #   /search?q=pie&order[public_timestamp]=desc
+  #   /search?q=pie&sort=public_timestamp&order=desc
   #
   # To get the results in a Hash:
   #   /search?q=pie&response_style=hash
@@ -146,6 +146,7 @@ class Rummager < Sinatra::Application
     organisation = params["organisation_slug"].blank? ? nil : params["organisation_slug"]
     result_set = current_index.search(query,
       organisation: organisation,
+      sort: params["sort"],
       order: params["order"],
       minimum_should_match: params["minimum_should_match"].to_s.size > 0)
     presenter_context = {

--- a/app.rb
+++ b/app.rb
@@ -117,6 +117,9 @@ class Rummager < Sinatra::Application
   # To scope a search to an organisation:
   #   /search?q=pie&organisation_slug=home-office
   #
+  # To get the results in date order, rather than relevancy:
+  #   /search?q=pie&order[public_timestamp]=desc
+  #
   # To get the results in a Hash:
   #   /search?q=pie&response_style=hash
   #
@@ -143,6 +146,7 @@ class Rummager < Sinatra::Application
     organisation = params["organisation_slug"].blank? ? nil : params["organisation_slug"]
     result_set = current_index.search(query,
       organisation: organisation,
+      order: params["order"],
       minimum_should_match: params["minimum_should_match"].to_s.size > 0)
     presenter_context = {
       organisation_registry: organisation_registry,

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -59,11 +59,22 @@ module Elasticsearch
             },
             filters: format_boosts + [time_boost]
           }
-        }
+        },
+        sort: sort
       }
     end
 
   private
+
+    def sort
+      if @options[:order]
+        [
+          @options[:order]
+        ]
+      else
+        []
+      end
+    end
 
     def core_query
       {

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -13,7 +13,8 @@ module Elasticsearch
 
     def default_options
       {
-        limit: 50
+        limit: 50,
+        order: "desc"
       }
     end
 
@@ -67,9 +68,9 @@ module Elasticsearch
   private
 
     def sort
-      if @options[:order]
+      if @options[:sort]
         [
-          @options[:order]
+          { @options[:sort] => { "order" => @options[:order] } }
         ]
       else
         []

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -14,7 +14,7 @@ module Elasticsearch
     def default_options
       {
         limit: 50,
-        order: "desc"
+        order: "desc" # Only used when a :sort option is given, but :order is not
       }
     end
 

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -164,7 +164,7 @@ class ElasticsearchSearchTest < IntegrationTest
   end
 
   def test_can_sort_results_by_date
-    get "/search.json?q=mali&order[public_timestamp]=asc"
+    get "/search.json?q=mali&sort=public_timestamp&order=desc"
     assert last_response.ok?
     # Results should come out oldest-first
     assert_result_links "/mali-3", "/mali-2", "/mali-1", order: true

--- a/test/unit/elasticsearch_search_query_builder_test.rb
+++ b/test/unit/elasticsearch_search_query_builder_test.rb
@@ -105,6 +105,14 @@ class SearchQueryBuilderTest < MiniTest::Unit::TestCase
     assert_equal expected, term_condition
   end
 
+  def test_can_order_by_any_value
+    builder = Elasticsearch::SearchQueryBuilder.new("pie", order: { "public_timestamp" => "desc" })
+    expected = [
+      { "public_timestamp" => "desc" }
+    ]
+    assert_equal expected, builder.query_hash[:sort]
+  end
+
   def test_escapes_the_query_for_lucene
     builder = Elasticsearch::SearchQueryBuilder.new("how?")
 

--- a/test/unit/elasticsearch_search_query_builder_test.rb
+++ b/test/unit/elasticsearch_search_query_builder_test.rb
@@ -105,10 +105,23 @@ class SearchQueryBuilderTest < MiniTest::Unit::TestCase
     assert_equal expected, term_condition
   end
 
-  def test_can_order_by_any_value
-    builder = Elasticsearch::SearchQueryBuilder.new("pie", order: { "public_timestamp" => "desc" })
+  def test_specifies_no_sort_if_none_provided
+    builder = Elasticsearch::SearchQueryBuilder.new("pie")
+    assert_equal [], builder.query_hash[:sort]
+  end
+
+  def test_can_order_by_any_field
+    builder = Elasticsearch::SearchQueryBuilder.new("pie", sort: "public_timestamp", order: "asc")
     expected = [
-      { "public_timestamp" => "desc" }
+      { "public_timestamp" => { "order" => "asc" } }
+    ]
+    assert_equal expected, builder.query_hash[:sort]
+  end
+
+  def test_defaults_to_desc_for_sort_order
+    builder = Elasticsearch::SearchQueryBuilder.new("pie", sort: "public_timestamp")
+    expected = [
+      { "public_timestamp" => { "order" => "desc" } }
     ]
     assert_equal expected, builder.query_hash[:sort]
   end


### PR DESCRIPTION
This will let us add a "sort by date" feature to (government) results on gov.uk/search

The API copies advanced_search, and relies on the Rack::Utils parse_nested_query behaviour, common in Rails apps: http://rdoc.info/gems/rack/Rack/Utils.parse_nested_query

As pointed out by @fatbusinessman, there are disadvantages to using this way of encoding parameters:
- whilst it is "standard" in Ruby, the standard seems to consist of "Rack does it this way", so for third-parties (via Content API), using the API won't be as easy
- the relevant specifications are not clear about whether square brackets are valid in URLs.

On the other hand, there are advantages:
- consistency with the `/advanced_search` API
- concise and scalable way of expressing one or more sort fields and their orders
