### PR TITLE
Report repeated submission failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'nokogiri', "1.5.5"
 gem 'whenever', require: false
 gem 'ffi-aspell', "0.0.3"
 gem "slop", "3.4.5"
-gem "sidekiq", "2.12.4"
+gem "sidekiq", "2.13.0"
 
 group :test do
   gem "shoulda-context"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     shotgun (0.9)
       rack (>= 1.0)
     shoulda-context (1.1.1)
-    sidekiq (2.12.4)
+    sidekiq (2.13.0)
       celluloid (>= 0.14.1)
       connection_pool (>= 1.0.0)
       json
@@ -121,7 +121,7 @@ DEPENDENCIES
   rest-client (= 1.6.7)
   shotgun
   shoulda-context
-  sidekiq (= 2.12.4)
+  sidekiq (= 2.13.0)
   simplecov
   simplecov-rcov
   sinatra (= 1.3.4)

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,15 @@
 require "rake/testtask"
 require "rest-client"
 require "logging"
-require_relative "config/logging"
 
 PROJECT_ROOT = File.dirname(__FILE__)
+LIBRARY_PATH = File.join(PROJECT_ROOT, "lib")
 
-File.join(PROJECT_ROOT, "lib").tap do |path|
+[PROJECT_ROOT, LIBRARY_PATH].each do |path|
   $LOAD_PATH.unshift path unless $LOAD_PATH.include? path
 end
 
-require "search_config"
+require "config"
 
 Dir[File.join(PROJECT_ROOT, 'lib/tasks/*.rake')].each { |file| load file }
 
@@ -48,7 +48,7 @@ def logger
 end
 
 def search_config
-  @search_config ||= SearchConfig.new
+  settings.search_config
 end
 
 def search_server

--- a/bootstrap_worker.rb
+++ b/bootstrap_worker.rb
@@ -7,5 +7,5 @@ library_path = File.join(project_root, "lib")
   $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
 end
 
-require "config/initializers/sidekiq"
+require "config"
 require "workers"

--- a/bootstrap_worker.rb
+++ b/bootstrap_worker.rb
@@ -8,4 +8,4 @@ library_path = File.join(project_root, "lib")
 end
 
 require "config/initializers/sidekiq"
-require "elasticsearch/bulk_index_worker"
+require "workers"

--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,4 @@
+require "sinatra"
 require_relative "env"
 require "active_support/core_ext/hash/keys"
 require "search_config"

--- a/config.rb
+++ b/config.rb
@@ -3,6 +3,7 @@ require_relative "env"
 require "active_support/core_ext/hash/keys"
 require "search_config"
 require_relative "exception_mailer"
+require "ses_mailer"  # For the exception_notification initialiser
 require "config/logging"
 
 set :search_config, SearchConfig.new

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -21,6 +21,7 @@ module Elasticsearch
     end
 
     sidekiq_retries_exhausted do |msg|
+      logger.warn "Job failed; forwarding to failure queue"
       FailedJobWorker.perform_async(msg)
     end
 

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -21,7 +21,7 @@ module Elasticsearch
     end
 
     sidekiq_retries_exhausted do |msg|
-      logger.warn "Job failed; forwarding to failure queue"
+      logger.warn "Job '#{msg["jid"]}' failed; forwarding to failure queue"
       FailedJobWorker.perform_async(msg)
     end
 

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -1,5 +1,5 @@
 require "sidekiq"
-require "search_config"
+require "config"
 require "failed_job_worker"
 
 module Elasticsearch
@@ -26,7 +26,7 @@ module Elasticsearch
 
   private
     def index(index_name)
-      SearchConfig.new.search_server.index(index_name)
+      settings.search_config.search_server.index(index_name)
     end
   end
 end

--- a/lib/failed_job_worker.rb
+++ b/lib/failed_job_worker.rb
@@ -1,0 +1,21 @@
+require "pp"
+require "sidekiq"
+
+class FailedJobWorker
+  include Sidekiq::Worker
+  sidekiq_options :retry => false
+
+  def logger
+    Logging.logger[self]
+  end
+
+  sidekiq_options :queue => :failed
+
+  def perform(job_info)
+    # `job_info` is the same format at Sidekiq's job format, as serialised to
+    # JSON and passed into Redis
+    puts "Job failed"
+    pp job_info
+    # TODO: send out an notification email
+  end
+end

--- a/lib/failed_job_worker.rb
+++ b/lib/failed_job_worker.rb
@@ -1,3 +1,4 @@
+require "stringio"
 require "pp"
 require "sidekiq"
 
@@ -14,8 +15,22 @@ class FailedJobWorker
   def perform(job_info)
     # `job_info` is the same format at Sidekiq's job format, as serialised to
     # JSON and passed into Redis
-    puts "Job failed"
-    pp job_info
-    # TODO: send out an notification email
+    mailer = settings.mailer
+    unless mailer
+      logger.warn "No mailer configured for failed job: discarding"
+      logger.debug job_info
+      return
+    end
+
+    message_body = StringIO.new
+    message_body << introduction
+    message_body << "\n\n"
+    PP.pp(job_info, message_body)
+    mailer.send_email("Job failure", message_body.string)
+  end
+
+private
+  def introduction
+    "The following job failed submission to elasticsearch:"
   end
 end

--- a/lib/ses_mailer.rb
+++ b/lib/ses_mailer.rb
@@ -1,0 +1,20 @@
+require "aws/ses"
+
+class SESMailer
+  def initialize(aws_config, options)
+    @ses = AWS::SES::Base.new(aws_config)
+
+    @to = options[:to]
+    @from = options[:from]
+    @subject_prefix = options[:subject] || "[Exception]"
+  end
+
+  def send_email(subject, body)
+    @ses.send_email(
+      to: @to,
+      from: @from,
+      subject: "#{@subject_prefix} #{subject}",
+      text_body: body
+    )
+  end
+end

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -2,6 +2,6 @@ namespace :jobs do
 
   task :work do
     base_path = File.join(File.dirname(__FILE__), "../..")
-    exec("bundle exec sidekiq -q bulk -r #{base_path}/bootstrap_worker.rb")
+    exec("bundle exec sidekiq -q bulk -q failed -r #{base_path}/bootstrap_worker.rb")
   end
 end

--- a/lib/workers.rb
+++ b/lib/workers.rb
@@ -1,0 +1,2 @@
+require "elasticsearch/bulk_index_worker"
+require "failed_job_worker"

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -52,7 +52,7 @@ module ElasticsearchIntegration
 
     @default_index_name = default || index_names.first
 
-    SearchConfig.any_instance.stubs(:elasticsearch).returns({
+    app.settings.search_config.stubs(:elasticsearch).returns({
       "base_uri" => "http://localhost:9200",
       "index_names" => index_names
     })

--- a/test/unit/failed_job_worker_test.rb
+++ b/test/unit/failed_job_worker_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+require "failed_job_worker"
+require "config"
+require "logging"
+
+class FailedJobWorkerTest < MiniTest::Unit::TestCase
+  def test_should_send_to_mailer
+    mock_mailer = mock("Mailer")
+    mock_mailer.expects(:send_email).with('Job failure', includes("aardvark"))
+    Sinatra::Application.settings.expects(:mailer).returns(mock_mailer)
+    FailedJobWorker.new.perform({"aardvark" => "horseradish"})
+  end
+
+  def test_should_warn_when_no_mailer_configured
+    Sinatra::Application.settings.expects(:mailer).returns(nil)
+    Logging.logger[FailedJobWorker].expects(:warn)
+    FailedJobWorker.new.perform({"aardvark" => "horseradish"})
+  end
+end

--- a/test/unit/ses_mailer_test.rb
+++ b/test/unit/ses_mailer_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+require "ses_mailer"
+
+class SESMailerTest < MiniTest::Unit::TestCase
+  def test_should_have_recipient_and_sender
+    mock_ses = mock("SES")
+    AWS::SES::Base.expects(:new).with(:aws_config).returns(mock_ses)
+    mailer = SESMailer.new(
+      :aws_config,
+      to: "foo@example.com",
+      from: "bar@example.com"
+    )
+
+    mock_ses.expects(:send_email).with(has_entries(
+      to: "foo@example.com",
+      from: "bar@example.com"
+    ))
+
+    mailer.send_email(:subject, :body)
+  end
+
+  def test_should_prepend_subject
+    mock_ses = mock("SES")
+    AWS::SES::Base.expects(:new).with(:aws_config).returns(mock_ses)
+    mailer = SESMailer.new(
+      :aws_config,
+      subject: "[Stuff and things]"
+    )
+
+    mock_ses.expects(:send_email).with(has_entry(
+      :subject, "[Stuff and things] Something happened"
+    ))
+
+    mailer.send_email("Something happened", :body)
+  end
+
+  def test_should_send_body
+    mock_ses = mock("SES")
+    AWS::SES::Base.expects(:new).with(:aws_config).returns(mock_ses)
+    mailer = SESMailer.new(:aws_config, {})
+
+    mock_ses.expects(:send_email).with(has_entry(
+      :text_body, "BODY BODY BODY"
+    ))
+
+    mailer.send_email(:subject, "BODY BODY BODY")
+  end
+end


### PR DESCRIPTION
Now we have a queue in place, we don’t know at submission time whether a document gets indexed correctly. The simplest way to gauge how much of a problem this is is to email out in a similar way to our exception emails.
