### PR TITLE
Add in attachments on the government index

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -528,8 +528,8 @@ stems: &stems [
   "international => international",
   "paye => paye",
   "permitted => permitted",
-  "practical => practical", 
-  "practice => practice", 
+  "practical => practical",
+  "practice => practice",
   "probate => probate",
   "publication => publication",
   "publications => publication",
@@ -607,6 +607,14 @@ mappings:
         acronym:     { type: string, index: analyzed }
         description: { type: string, index: analyzed }
         indexable_content: { type: string, index: analyzed }
+        attachments:
+          properties:
+            content: {type: string, index: analyzed}
+            title: {type: string, index: analyzed}
+            isbn: {type: string, index: not_analyzed}
+            unique_reference: {type: string, index: not_analyzed}
+            command_paper_number: {type: string, index: not_analyzed}
+            hoc_paper_number: {type: string, index: not_analyzed}
         format:      { type: string, index: not_analyzed, include_in_all: false }
         display_type: { type: string, index: not_analyzed, include_in_all: false }
         section:     { type: string, index: not_analyzed, include_in_all: false }

--- a/lib/elasticsearch/advanced_search_query_builder.rb
+++ b/lib/elasticsearch/advanced_search_query_builder.rb
@@ -12,7 +12,8 @@ module Elasticsearch
     end
 
     def unknown_keys
-      @unknown_keys ||= @filter_params.keys - @mappings["edition"]["properties"].keys
+      @unknown_keys ||= @filter_params.keys - (@mappings["edition"]["properties"].keys +
+        @mappings["edition"]["properties"]["attachments"]["properties"].keys.map{|k| "attachments.#{k}"})
     end
 
     def unknown_sort_key


### PR DESCRIPTION
Using Tika to preprocess the attachments you can store an array of the
attachment text to be included in the search index.

We are not using the attachments-mapper plugin because this stores the
base64 encoded version on the file (twice) and IG has 40GB of files
