### PR TITLE
Supply slugs

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -603,6 +603,7 @@ mappings:
         subsection:  { type: string, index: not_analyzed, include_in_all: false }
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
         link:        { type: string, index: not_analyzed, include_in_all: false }
+        slug:        { type: string, index: not_analyzed, include_in_all: false }
         id:          { type: long, index: not_analyzed, include_in_all: false }
         organisations: { type: string, index: not_analyzed, include_in_all: false }
         document_series: { type: string, index: not_analyzed, include_in_all: false }

--- a/lib/document_series_registry.rb
+++ b/lib/document_series_registry.rb
@@ -9,12 +9,12 @@ class DocumentSeriesRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.link =~ %r{/series/#{slug}$} }
+    @cache.get.find { |o| o.slug == "#{slug}" }
   end
 
 private
   def fetch
-    fields = %w{link title}
+    fields = %w{slug link title}
     @index.documents_by_format("document_series", fields: fields).to_a
   end
 

--- a/lib/document_series_registry.rb
+++ b/lib/document_series_registry.rb
@@ -9,7 +9,7 @@ class DocumentSeriesRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.slug == "#{slug}" }
+    @cache.get.find { |o| o.slug == slug }
   end
 
 private

--- a/lib/organisation_registry.rb
+++ b/lib/organisation_registry.rb
@@ -24,7 +24,7 @@ class OrganisationRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.slug == "#{slug}" }
+    @cache.get.find { |o| o.slug == slug }
   end
 
 private

--- a/lib/organisation_registry.rb
+++ b/lib/organisation_registry.rb
@@ -24,12 +24,12 @@ class OrganisationRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.link == "/government/organisations/#{slug}" }
+    @cache.get.find { |o| o.slug == "#{slug}" }
   end
 
 private
   def fetch
-    fields = %w{link title acronym organisation_type}
+    fields = %w{slug link title acronym organisation_type}
     organisations = @index.documents_by_format("organisation", fields: fields)
     organisations.map do |o|
       fill_organisation_type(fix_acronym(o))

--- a/lib/topic_registry.rb
+++ b/lib/topic_registry.rb
@@ -9,12 +9,12 @@ class TopicRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.link == "/government/topics/#{slug}" }
+    @cache.get.find { |o| o.slug == "#{slug}" }
   end
 
 private
   def fetch
-    fields = %w(link title)
+    fields = %w(slug link title)
     @index.documents_by_format("topic", fields: fields).to_a
   end
 end

--- a/lib/topic_registry.rb
+++ b/lib/topic_registry.rb
@@ -9,7 +9,7 @@ class TopicRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.slug == "#{slug}" }
+    @cache.get.find { |o| o.slug == slug }
   end
 
 private

--- a/lib/world_location_registry.rb
+++ b/lib/world_location_registry.rb
@@ -9,7 +9,7 @@ class WorldLocationRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.slug == "#{slug}" }
+    @cache.get.find { |o| o.slug == slug }
   end
 
 private

--- a/lib/world_location_registry.rb
+++ b/lib/world_location_registry.rb
@@ -9,12 +9,12 @@ class WorldLocationRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.link == "/government/world/#{slug}" }
+    @cache.get.find { |o| o.slug == "#{slug}" }
   end
 
 private
   def fetch
-    fields = %w{link title}
+    fields = %w{slug link title}
     @index.documents_by_format("world_location", fields: fields).to_a
   end
 

--- a/test/unit/document_series_registry_test.rb
+++ b/test/unit/document_series_registry_test.rb
@@ -10,8 +10,9 @@ class DocumentSeriesRegistryTest < MiniTest::Unit::TestCase
 
   def rail_statistics
     Document.new(
-      %w(link title),
+      %w(slug link title),
       {
+        slug: "rail-statistics",
         link: "/government/organisations/department-for-transport/series/rail-statistics",
         title: "Rail statistics"
       }
@@ -23,13 +24,14 @@ class DocumentSeriesRegistryTest < MiniTest::Unit::TestCase
       .with("document_series", anything)
       .returns([rail_statistics])
     document_series = @document_series_registry["rail-statistics"]
+    assert_equal rail_statistics.slug, document_series.slug
     assert_equal rail_statistics.link, document_series.link
     assert_equal rail_statistics.title, document_series.title
   end
 
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
-      .with("document_series", fields: %w{link title})
+      .with("document_series", fields: %w{slug link title})
     document_series = @document_series_registry["rail-statistics"]
   end
 

--- a/test/unit/organisation_registry_test.rb
+++ b/test/unit/organisation_registry_test.rb
@@ -10,9 +10,10 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
 
   def mod_document
     Document.new(
-      %w(link title acronym organisation_type),
+      %w(slug link title acronym organisation_type),
       {
         link: "/government/organisations/ministry-of-defence",
+        slug: "ministry-of-defence",
         title: "Ministry of Defence"
       }
     )
@@ -38,12 +39,13 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
       .returns([mod_document])
     organisation = @organisation_registry["ministry-of-defence"]
     assert_equal "/government/organisations/ministry-of-defence", organisation.link
+    assert_equal "ministry-of-defence", organisation.slug
     assert_equal "Ministry of Defence", organisation.title
   end
 
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
-      .with("organisation", fields: %w{link title acronym organisation_type})
+      .with("organisation", fields: %w{slug link title acronym organisation_type})
       .returns([])
     organisation = @organisation_registry["ministry-of-defence"]
   end
@@ -66,8 +68,9 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
 
   def test_indicates_organisation_type_from_index
     fully_labelled_document = Document.new(
-      %w(link title acronym organisation_type),
+      %w(slug link title acronym organisation_type),
       {
+        slug: "office-of-the-fonz",
         link: "/government/organisations/office-of-the-fonz",
         title: "Office of The Fonz",
         organisation_type: "Gang"
@@ -82,8 +85,9 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
 
   def test_organisation_type_from_index_takes_precedence
     fully_labelled_document = Document.new(
-      %w(link title acronym organisation_type),
+      %w(slug link title acronym organisation_type),
       {
+        slug: "ministry-of-defence",
         link: "/government/organisations/ministry-of-defence",
         title: "Ministry of Defence",
         organisation_type: "Stuff and things"
@@ -98,8 +102,9 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
 
   def test_extracts_acronym_from_title_if_missing
     document = Document.new(
-      %w(link title acronym),
+      %w(slug link title acronym),
       {
+        slug: "ministry-of-defence",
         link: "/government/organisations/ministry-of-defence",
         title: "Ministry of Defence (MoD)"
       }
@@ -114,8 +119,9 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
 
   def test_leaves_title_unchanged_if_acronym_present
     document = Document.new(
-      %w(link title acronym),
+      %w(slug link title acronym),
       {
+        slug: "ministry-of-defence",
         link: "/government/organisations/ministry-of-defence",
         title: "Ministry of Defence",
         acronym: "MoD"
@@ -131,8 +137,9 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
 
   def test_leaves_extra_brackets_when_extracting_acronym
     document = Document.new(
-      %w(link title acronym),
+      %w(slug link title acronym),
       {
+        slug: "forest-enterprise-england",
         link: "/government/organisations/forest-enterprise-england",
         title: "Forest Enterprise (England) (FEE)",
       }
@@ -147,8 +154,9 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
 
   def test_leaves_extra_brackets_when_acronym_present
     document = Document.new(
-      %w(link title acronym),
+      %w(slug link title acronym),
       {
+        slug: "forest-enterprise-england",
         link: "/government/organisations/forest-enterprise-england",
         title: "Forest Enterprise (England)",
         acronym: "FEE"
@@ -178,8 +186,9 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
     # know about the field and will raise an error on #acronym calls.
 
     document = Document.new(
-      %w(link title),
+      %w(slug link title),
       {
+        slug: "ministry-of-justice",
         link: "/government/organisations/ministry-of-justice",
         title: "Ministry of Justice (MoJ)",
       }

--- a/test/unit/topic_registry_test.rb
+++ b/test/unit/topic_registry_test.rb
@@ -10,8 +10,9 @@ class TopicRegistryTest < MiniTest::Unit::TestCase
 
   def housing_document
     Document.new(
-      %w(link title),
+      %w(slug link title),
       {
+        slug: "housing",
         link: "/government/topics/housing",
         title: "Housing"
       }
@@ -30,13 +31,14 @@ class TopicRegistryTest < MiniTest::Unit::TestCase
       .with("topic", anything)
       .returns([housing_document])
     topic = @topic_registry["housing"]
+    assert_equal "housing", topic.slug
     assert_equal "/government/topics/housing", topic.link
     assert_equal "Housing", topic.title
   end
 
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
-      .with("topic", fields: %w{link title})
+      .with("topic", fields: %w{slug link title})
     topic = @topic_registry["housing"]
   end
 

--- a/test/unit/world_location_registry_test.rb
+++ b/test/unit/world_location_registry_test.rb
@@ -10,8 +10,9 @@ class WorldLocationRegistryTest < MiniTest::Unit::TestCase
 
   def angola
     Document.new(
-      %w(link title),
+      %w(slug link title),
       {
+        slug: "angola",
         link: "/government/world/angola",
         title: "Angola"
       }
@@ -23,13 +24,14 @@ class WorldLocationRegistryTest < MiniTest::Unit::TestCase
       .with("world_location", anything)
       .returns([angola])
     world_location = @world_location_registry["angola"]
+    assert_equal angola.slug, world_location.slug
     assert_equal angola.link, world_location.link
     assert_equal angola.title, world_location.title
   end
 
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
-      .with("world_location", fields: %w{link title})
+      .with("world_location", fields: %w{slug link title})
     world_location = @world_location_registry["angola"]
   end
 


### PR DESCRIPTION
Now that whitehall is including slugs as part of the search data being posted into the index, we can look things up in the registries via slug rather than the workaround of assumed knowledge about the structure of links.
