### PR TITLE
Validate sorting

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -108,6 +108,10 @@ class Rummager < Sinatra::Application
     halt(503, "Elasticsearch timed out")
   end
 
+  error Elasticsearch::InvalidQuery do
+    halt(400, env['sinatra.error'].message)
+  end
+
   # To search a named index:
   #   /index_name/search?q=pie
   #

--- a/app.rb
+++ b/app.rb
@@ -109,7 +109,7 @@ class Rummager < Sinatra::Application
   end
 
   error Elasticsearch::InvalidQuery do
-    halt(400, env['sinatra.error'].message)
+    halt(422, env['sinatra.error'].message)
   end
 
   # To search a named index:

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -189,7 +189,7 @@ module Elasticsearch
     end
 
     def search_query(query, options={})
-      SearchQueryBuilder.new(query, options).query_hash
+      SearchQueryBuilder.new(query, @mappings, options).query_hash
     end
 
     def search(query, options={})

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -202,7 +202,9 @@ module Elasticsearch
 
     def advanced_search(params)
       logger.info "params:#{params.inspect}"
-      raise "Pagination params are required." if params["per_page"].nil? || params["page"].nil?
+      if params["per_page"].nil? || params["page"].nil?
+        raise InvalidQuery.new("Pagination params are required.")
+      end
 
       # Delete params that we don't want to be passed as filter_params
       order     = params.delete("order")
@@ -211,7 +213,7 @@ module Elasticsearch
       page      = params.delete("page").to_i
 
       query_builder = AdvancedSearchQueryBuilder.new(keywords, params, order, @mappings)
-      raise query_builder.error unless query_builder.valid?
+      raise InvalidQuery.new(query_builder.error) unless query_builder.valid?
 
       starting_index = page <= 1 ? 0 : (per_page * (page - 1))
       payload = {

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -9,7 +9,15 @@ module Elasticsearch
     # `query`    - a string to search for
     # `mappings` - the field definitions for the index this query is going to
     #              used to validate parts of the query before sending to
-    #              Elasticsearch
+    #              Elasticsearch. The format is as follows:
+    #                {
+    #                  "edition" => {
+    #                    "_all" => { "enabled" => true },
+    #                    "properties" => {
+    #                       "fieldname" => { ...field definition... }
+    #                    }
+    #                  }
+    #                }
     # `options`  - a hash with symbol keys
     def initialize(query, mappings, options={})
       @query                = query

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -6,6 +6,8 @@ module Elasticsearch
 
     QUERY_ANALYZER = "query_default"
 
+    # `query`   - a string to search for
+    # `options` - a hash with symbol keys
     def initialize(query, options={})
       @query                = query
       @limit                = options[:limit] || 50

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -71,7 +71,7 @@ class SearchTest < IntegrationTest
 
   def test_returns_semantic_response_for_invalid_query
     get "/search", { q: "bob", sort: "not_in_schema" }
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
     assert_equal "Sorting on unknown property: not_in_schema", last_response.body
   end
 

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -69,6 +69,12 @@ class SearchTest < IntegrationTest
     assert_match(/application\/json/, last_response.headers["Content-Type"])
   end
 
+  def test_returns_semantic_response_for_invalid_query
+    get "/search", { q: "bob", sort: "not_in_schema" }
+    assert_equal 400, last_response.status
+    assert_equal "Sorting on unknown property: not_in_schema", last_response.body
+  end
+
   def test_returns_json_when_requested_with_url_suffix
     stub_index.expects(:search).returns(stub(results: [sample_document], total: 1))
     get "/search.json", {q: "bob"}

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -155,7 +155,7 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def assert_rejected_search(expected_error, search_args)
-    e = assert_raises(RuntimeError) do
+    e = assert_raises(Elasticsearch::InvalidQuery) do
       @wrapper.advanced_search(search_args)
     end
     assert_equal expected_error, e.message

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -149,6 +149,12 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     assert_requested(:get, "http://example.com:9200/test-index/_search")
   end
 
+  def test_raises_error_for_invalid_query
+    assert_raises Elasticsearch::InvalidQuery do
+      @wrapper.search("keyword search", sort: "not_a_field_in_mappings")
+    end
+  end
+
   def test_commit
     refresh_url = "http://example.com:9200/test-index/_refresh"
     stub_request(:post, refresh_url).to_return(


### PR DESCRIPTION
If a sort parameter for a field that's not in the index is supplied, Elasticsearch would return a 500 status, so Rummager would do too.

Also improved the behaviour of semantic search in the same kind of situation.
