### PR TITLE
Force Sidekiq to encode all jobs as ASCII-only

### DIFF
--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -1,5 +1,6 @@
 require "sidekiq"
 require "config"
+require "sidekiq_json_encoding_patch"
 require "failed_job_worker"
 
 module Elasticsearch

--- a/lib/failed_job_worker.rb
+++ b/lib/failed_job_worker.rb
@@ -1,6 +1,7 @@
 require "stringio"
 require "pp"
 require "sidekiq"
+require "sidekiq_json_encoding_patch"
 
 class FailedJobWorker
   include Sidekiq::Worker

--- a/lib/sidekiq_json_encoding_patch.rb
+++ b/lib/sidekiq_json_encoding_patch.rb
@@ -1,0 +1,17 @@
+require "sidekiq"
+
+module Sidekiq
+  # Sidekiq, by default, lets the JSON library decide how to encode objects,
+  # including how to encode non-ASCII strings. This causes encoding problems
+  # if the client is dumping jobs as UTF-8 (which it will do with UTF-8 strings
+  # by default) and the worker is trying to load them as ASCII (which it does
+  # by default when reading from a socket). We can get around this problem
+  # entirely by forcing ASCII-only encoding (using "\uxxxx" escape sequences).
+  #
+  # This didn't happen before we removed the activesupport gem, because that
+  # delves into the JSON library and forces everything to encode and decode
+  # UTF-8.
+  def self.dump_json(object)
+    JSON.generate(object, ascii_only: true)
+  end
+end


### PR DESCRIPTION
This gets around the problem of making sure the app and the worker are both using the same (or at least compatible) encoding settings, by forcing all the JSON to be ASCII-compatible.
