### PR TITLE
Better dev reloading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,5 +32,5 @@ end
 
 group :development do
   # (Intelligent) reloading server in development
-  gem "mr-sparkle", "0.1.0", git: "https://github.com/alphagov/mr-sparkle.git", branch: "optional_force_polling", ref: "8dfecf6"
+  gem "mr-sparkle", "0.2.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,4 @@ end
 group :development do
   # (Intelligent) reloading server in development
   gem "mr-sparkle", "0.1.0", git: "https://github.com/alphagov/mr-sparkle.git", branch: "optional_force_polling", ref: "8dfecf6"
-  # Use thin because WEBrick sometimes segfaults
-  gem "thin"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,8 @@ group :test do
 end
 
 group :development do
-  gem "shotgun"
+  # (Intelligent) reloading server in development
+  gem "mr-sparkle", "0.1.0", git: "git@github.com:alphagov/mr-sparkle.git", branch: "optional_force_polling", ref: "8dfecf6"
   # Use thin because WEBrick sometimes segfaults
   gem "thin"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 source "https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/"
 
-gem "unicorn", "4.3.1"
+gem "unicorn", "4.6.2"
 gem "raindrops", "0.11.0"
 gem "sinatra", "1.3.4"
 gem "rake", "0.9.2", :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 
 group :development do
   # (Intelligent) reloading server in development
-  gem "mr-sparkle", "0.1.0", git: "git@github.com:alphagov/mr-sparkle.git", branch: "optional_force_polling", ref: "8dfecf6"
+  gem "mr-sparkle", "0.1.0", git: "https://github.com/alphagov/mr-sparkle.git", branch: "optional_force_polling", ref: "8dfecf6"
   # Use thin because WEBrick sometimes segfaults
   gem "thin"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:alphagov/mr-sparkle.git
+  remote: https://github.com/alphagov/mr-sparkle.git
   revision: 8dfecf6034dfe6f751f6597b7feeb3d423e8503c
   ref: 8dfecf6
   branch: optional_force_polling

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,8 +32,6 @@ GEM
       builder (>= 2.1.2)
     connection_pool (1.1.0)
     crack (0.3.2)
-    daemons (1.1.9)
-    eventmachine (1.0.0)
     ffi (1.6.0)
     ffi-aspell (0.0.3)
       ffi (>= 1.0.11)
@@ -95,10 +93,6 @@ GEM
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     slop (3.4.5)
-    thin (1.5.0)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     tilt (1.3.3)
     timers (1.1.0)
     treetop (1.4.10)
@@ -144,7 +138,6 @@ DEPENDENCIES
   simplecov-rcov
   sinatra (= 1.3.4)
   slop (= 3.4.5)
-  thin
   turn
   unicorn (= 4.6.2)
   webmock (= 1.9.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: git@github.com:alphagov/mr-sparkle.git
+  revision: 8dfecf6034dfe6f751f6597b7feeb3d423e8503c
+  ref: 8dfecf6
+  branch: optional_force_polling
+  specs:
+    mr-sparkle (0.1.0)
+      listen (~> 1.0)
+      rb-fsevent (>= 0.9)
+      rb-inotify (>= 0.8)
+      unicorn (>= 4.5)
+
 GEM
   remote: https://rubygems.org/
   remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
@@ -28,6 +40,10 @@ GEM
     i18n (0.6.0)
     json (1.7.7)
     kgio (2.8.0)
+    listen (1.2.2)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      rb-kqueue (>= 0.2)
     little-plugger (1.1.3)
     logging (1.8.1)
       little-plugger (>= 1.1.3)
@@ -51,13 +67,16 @@ GEM
       rack (>= 1.0)
     raindrops (0.11.0)
     rake (0.9.2)
+    rb-fsevent (0.9.3)
+    rb-inotify (0.9.0)
+      ffi (>= 0.5.0)
+    rb-kqueue (0.2.0)
+      ffi (>= 0.5.0)
     redis (3.0.4)
     redis-namespace (1.3.0)
       redis (~> 3.0.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    shotgun (0.9)
-      rack (>= 1.0)
     shoulda-context (1.1.1)
     sidekiq (2.13.0)
       celluloid (>= 0.14.1)
@@ -111,6 +130,7 @@ DEPENDENCIES
   logging (= 1.8.1)
   minitest (= 4.6.1)
   mocha
+  mr-sparkle (= 0.1.0)!
   multi_json (= 1.3.6)
   nokogiri (= 1.5.5)
   rack (= 1.5.2)
@@ -118,7 +138,6 @@ DEPENDENCIES
   raindrops (= 0.11.0)
   rake (= 0.9.2)
   rest-client (= 1.6.7)
-  shotgun
   shoulda-context
   sidekiq (= 2.13.0)
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       ffi (>= 1.0.11)
     i18n (0.6.0)
     json (1.7.7)
-    kgio (2.7.4)
+    kgio (2.8.0)
     little-plugger (1.1.3)
     logging (1.8.1)
       little-plugger (>= 1.1.3)
@@ -87,7 +87,7 @@ GEM
       polyglot (>= 0.3.1)
     turn (0.9.6)
       ansi
-    unicorn (4.3.1)
+    unicorn (4.6.2)
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
@@ -127,7 +127,7 @@ DEPENDENCIES
   slop (= 3.4.5)
   thin
   turn
-  unicorn (= 4.3.1)
+  unicorn (= 4.6.2)
   webmock (= 1.9.3)
   whenever
   yajl-ruby (= 1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/mr-sparkle.git
-  revision: 8dfecf6034dfe6f751f6597b7feeb3d423e8503c
-  ref: 8dfecf6
-  branch: optional_force_polling
-  specs:
-    mr-sparkle (0.1.0)
-      listen (~> 1.0)
-      rb-fsevent (>= 0.9)
-      rb-inotify (>= 0.8)
-      unicorn (>= 4.5)
-
 GEM
   remote: https://rubygems.org/
   remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
@@ -32,7 +20,7 @@ GEM
       builder (>= 2.1.2)
     connection_pool (1.1.0)
     crack (0.3.2)
-    ffi (1.6.0)
+    ffi (1.9.0)
     ffi-aspell (0.0.3)
       ffi (>= 1.0.11)
     i18n (0.6.0)
@@ -55,6 +43,11 @@ GEM
     minitest (4.6.1)
     mocha (0.13.2)
       metaclass (~> 0.0.1)
+    mr-sparkle (0.2.0)
+      listen (~> 1.0)
+      rb-fsevent (>= 0.9)
+      rb-inotify (>= 0.8)
+      unicorn (>= 4.5)
     multi_json (1.3.6)
     nokogiri (1.5.5)
     polyglot (0.3.3)
@@ -124,7 +117,7 @@ DEPENDENCIES
   logging (= 1.8.1)
   minitest (= 4.6.1)
   mocha
-  mr-sparkle (= 0.1.0)!
+  mr-sparkle (= 0.2.0)
   multi_json (= 1.3.6)
   nokogiri (= 1.5.5)
   rack (= 1.5.2)

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec shotgun -o '0.0.0.0' -p 3009
+bundle exec mr-sparkle --force-polling -- -p 3009


### PR DESCRIPTION
In development, we currently use shotgun if we want code reloading and thin if we want speed.

There are some problems with shotgun though:
- it's slow - it boots the entire app for every request
- it has a bug where doesn't log in development

mr-sparkles on the other hand, only reloads when files change, so is much faster.

Also this means using unicorn in development, which should be good for dev-prod parity.

I intend to make the same change in Content API if this PR is successful.

You can try it out with:

``` bash
bundle exec mr-sparkle --force-polling -- -p 3009
```

Hat tip to @gma for suggesting mr-sparkle. :shipit: 
