### PR TITLE
Fix JSON job encoding… again.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,6 @@
 end
 
 require "sinatra"
-require 'yajl/json_gem'
 require "multi_json"
 require "csv"
 

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -1,5 +1,6 @@
 require "sidekiq"
 require "config"
+require "sidekiq_json_encoding_patch"
 require "failed_job_worker"
 
 module Elasticsearch

--- a/lib/failed_job_worker.rb
+++ b/lib/failed_job_worker.rb
@@ -1,6 +1,7 @@
 require "stringio"
 require "pp"
 require "sidekiq"
+require "sidekiq_json_encoding_patch"
 
 class FailedJobWorker
   include Sidekiq::Worker

--- a/lib/sidekiq_json_encoding_patch.rb
+++ b/lib/sidekiq_json_encoding_patch.rb
@@ -1,0 +1,13 @@
+require "sidekiq"
+
+module Sidekiq
+  # Sidekiq, by default, lets the JSON library decide how to encode objects,
+  # including how to encode non-ASCII strings. This causes encoding problems
+  # if the client is dumping jobs as UTF-8 (which it will do with UTF-8 strings
+  # by default) and the worker is trying to load them as ASCII (which it does
+  # by default when reading from a socket). We can get around this problem
+  # entirely by forcing ASCII-only encoding (using "\uxxxx" escape sequences).
+  def self.dump_json(object)
+    JSON.generate(object, ascii_only: true)
+  end
+end

--- a/test/unit/sidekiq_patch_test.rb
+++ b/test/unit/sidekiq_patch_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+# Require a worker class, which will trigger the Sidekiq patching, just as
+# loading it from the app will
+require "elasticsearch/bulk_index_worker"
+
+# This previously required "yajl/json_gem", which overwrote the JSON.generate
+# method with one that didn't support the `ascii_only` flag.
+require "app"
+
+class SidekiqPatchTest < MiniTest::Unit::TestCase
+
+  def test_dumps_ascii_only
+    test_message = {message: "\u2018Get to da choppa!\u2019"}
+    assert_equal(
+      '{"message":"\u2018Get to da choppa!\u2019"}',
+      Sidekiq.dump_json(test_message)
+    )
+  end
+end


### PR DESCRIPTION
A new, more workinger version of #137.

The original didn’t work because YAJL was overwriting the `JSON` module with its own version. The new test should let us know if some other configuration of JSON gems breaks our serialisation.
