### PR TITLE
min should match always on for /search

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -149,8 +149,7 @@ class Rummager < Sinatra::Application
     result_set = current_index.search(query,
       organisation: organisation,
       sort: params["sort"],
-      order: params["order"],
-      minimum_should_match: params["minimum_should_match"].to_s.size > 0)
+      order: params["order"])
     presenter_context = {
       organisation_registry: organisation_registry,
       topic_registry: topic_registry,

--- a/bin/search
+++ b/bin/search
@@ -20,16 +20,8 @@ OptionParser.new do |opts|
     options[:index_name] = index
   end
 
-  opts.on("-m", "--minimum-should-match params", "enable minimum_should_match with given params") do |params|
-    options[:minimum_should_match] = params
-  end
-
   opts.on("-q", "--show-query", "Dump the query hash as JSON") do
     options[:show_query_hash] = true
-  end
-
-  opts.on("-c", "--compare minimum_should_match", "Compare a search with/without minimum_should_match") do |params|
-    options[:compare] = params
   end
 end.parse!
 
@@ -78,8 +70,7 @@ end
 index = SearchConfig.new.search_server.index(options[:index_name])
 query = ARGV.join(" ")
 search_options = {
-  limit: 1000,
-  minimum_should_match: options[:minimum_should_match]
+  limit: 1000
 }
 results = index.search(query, search_options)
 
@@ -89,10 +80,7 @@ if options[:show_query_hash]
 end
 
 if options[:compare]
-  search_options = {
-    minimum_should_match: options[:compare]
-  }
-  results2 = index.search(query, search_options)
+  results2 = index.search(query)
 
   puts "Search 1: #{results.total}"
   puts "Search 2: #{results2.total}"

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -26,36 +26,6 @@ module Elasticsearch
       @sort                 = options[:sort]
       @order                = options[:order] || "desc"
       @organisation         = options[:organisation]
-      @minimum_should_match = options[:minimum_should_match]
-    end
-
-    def default_minimum_should_match
-      # The following specification generates the following values for minimum_should_match
-      #
-      # Number of | Minimum
-      # optional  | should
-      # clauses   | match
-      # ----------+---------
-      # 1         | 1
-      # 2         | 2
-      # 3         | 2
-      # 4         | 3
-      # 5         | 3
-      # 6         | 3
-      # 7         | 3
-      # 8+        | 50%
-      #
-      # This table was worked out by using the comparison feature of
-      # bin/search with various example queries of different lengths (3, 4, 5,
-      # 7, 9 words) and inspecting the consequences on search results.
-      #
-      # Reference for the minimum_should_match syntax:
-      # http://lucene.apache.org/solr/api-3_6_2/org/apache/solr/util/doc-files/min-should-match.html
-      #
-      # In summary, a clause of the form "N<M" means when there are MORE than
-      # N clauses then M clauses should match. So, 2<2 means when there are
-      # MORE than 2 clauses then 2 should match.
-      "2<2 3<3 7<50%"
     end
 
     def query_hash
@@ -166,20 +136,39 @@ module Elasticsearch
           _all: {
             query: escape(@query),
             analyzer: QUERY_ANALYZER,
-          }.merge(minimum_should_match_clause)
+            minimum_should_match: minimum_should_match
+          }
         }
       }
     end
 
-    def minimum_should_match_clause
-      case @minimum_should_match
-      when String, Fixnum
-        {minimum_should_match: @minimum_should_match}
-      when true
-        {minimum_should_match: default_minimum_should_match}
-      else
-        {}
-      end
+    def minimum_should_match
+      # The following specification generates the following values for minimum_should_match
+      #
+      # Number of | Minimum
+      # optional  | should
+      # clauses   | match
+      # ----------+---------
+      # 1         | 1
+      # 2         | 2
+      # 3         | 2
+      # 4         | 3
+      # 5         | 3
+      # 6         | 3
+      # 7         | 3
+      # 8+        | 50%
+      #
+      # This table was worked out by using the comparison feature of
+      # bin/search with various example queries of different lengths (3, 4, 5,
+      # 7, 9 words) and inspecting the consequences on search results.
+      #
+      # Reference for the minimum_should_match syntax:
+      # http://lucene.apache.org/solr/api-3_6_2/org/apache/solr/util/doc-files/min-should-match.html
+      #
+      # In summary, a clause of the form "N<M" means when there are MORE than
+      # N clauses then M clauses should match. So, 2<2 means when there are
+      # MORE than 2 clauses then 2 should match.
+      "2<2 3<3 7<50%"
     end
 
     def organisation_query

--- a/test/unit/elasticsearch_search_query_builder_test.rb
+++ b/test/unit/elasticsearch_search_query_builder_test.rb
@@ -33,15 +33,8 @@ class SearchQueryBuilderTest < ShouldaUnitTestCase
     assert_equal expected, query_string_condition
   end
 
-  def test_minimum_should_match_disabled_by_default
+  def test_minimum_should_match_has_sensible_default
     builder = Elasticsearch::SearchQueryBuilder.new("one two three", mappings)
-
-    must_conditions = builder.query_hash[:query][:custom_filters_score][:query][:bool][:should][0][:bool][:must]
-    refute_includes must_conditions[0][:match][:_all], :minimum_should_match
-  end
-
-  def test_minimum_should_match_has_sensible_default_if_enabled
-    builder = Elasticsearch::SearchQueryBuilder.new("one two three", mappings, minimum_should_match: true)
 
     must_conditions = builder.query_hash[:query][:custom_filters_score][:query][:bool][:should][0][:bool][:must]
     assert_equal "2<2 3<3 7<50%", must_conditions[0][:match][:_all][:minimum_should_match]
@@ -141,13 +134,6 @@ class SearchQueryBuilderTest < ShouldaUnitTestCase
 
     query_string_condition = extract_condition_by_type(builder.query_hash, :match)
     assert_equal "how\\?", query_string_condition[:match][:_all][:query]
-  end
-
-  def test_can_pass_minimum_should_match
-    builder = Elasticsearch::SearchQueryBuilder.new("one two three", mappings, minimum_should_match: 2)
-
-    must_conditions = builder.query_hash[:query][:custom_filters_score][:query][:bool][:should][0][:bool][:must]
-    assert_equal 2, must_conditions[0][:match][:_all][:minimum_should_match]
   end
 
   def test_can_optionally_specify_limit


### PR DESCRIPTION
This will mean:
- service-manual will get the benefit of min should match (fewer, more
  relevant results)
- searches via Content API will get the benefit without end-users needing to
  specifically request it
- frontend doesn't need to specify it wants the feature

Arbitrary min should match rules were supported, but not used. I felt it wasn't worth keeping if it was unused, especially as it wasn't really documented and it was fairly complex.
