### PR TITLE
/search response is now always hash

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -120,8 +120,7 @@ class Rummager < Sinatra::Application
   # To get the results in date order, rather than relevancy:
   #   /search?q=pie&sort=public_timestamp&order=desc
   #
-  # To get the results in a Hash:
-  #   /search?q=pie&response_style=hash
+  # The response looks like this:
   #
   #   {
   #     "total": 1,
@@ -157,12 +156,7 @@ class Rummager < Sinatra::Application
       spelling_suggestions: suggester.suggestions(params["q"])
     }
     presenter = ResultSetPresenter.new(result_set, presenter_context)
-    if params["response_style"] == "hash"
-      presenter.present
-    else
-      results_array = MultiJson.decode(presenter.present)["results"]
-      MultiJson.encode(results_array)
-    end
+    presenter.present
   end
 
   # Perform an advanced search. Supports filters and pagination.

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -65,20 +65,20 @@ class SearchTest < IntegrationTest
   def test_returns_json_for_search_results
     stub_index.expects(:search).returns(stub(results: [sample_document], total: 1))
     get "/search", {q: "bob"}, "HTTP_ACCEPT" => "application/json"
-    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)
+    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)["results"]
     assert_match(/application\/json/, last_response.headers["Content-Type"])
   end
 
   def test_returns_json_when_requested_with_url_suffix
     stub_index.expects(:search).returns(stub(results: [sample_document], total: 1))
     get "/search.json", {q: "bob"}
-    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)
+    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)["results"]
     assert_match(/application\/json/, last_response.headers["Content-Type"])
   end
 
   def test_returns_spelling_suggestions_when_hash_requested
     stub_index.expects(:search).returns(stub(results: [], total: 0))
-    get "/search.json", {q: "speling", response_style: "hash"}
+    get "/search.json", {q: "speling"}
     assert_equal ["spelling"], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
@@ -86,7 +86,7 @@ class SearchTest < IntegrationTest
     stub_index.expects(:search).returns(stub(results: [], total: 0))
     OrganisationRegistry.any_instance.expects(:all)
       .returns([dft_organisation])
-    get "/search.json", {q: "DFT", response_style: "hash"} # DFT would get a suggestion
+    get "/search.json", {q: "DFT"} # DFT would get a suggestion
     assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
@@ -94,7 +94,7 @@ class SearchTest < IntegrationTest
     stub_index.expects(:search).returns(stub(results: [], total: 0))
     OrganisationRegistry.any_instance.expects(:all)
       .returns([dft_organisation])
-    get "/search.json", {q: "dft", response_style: "hash"} # DFT would get a suggestion
+    get "/search.json", {q: "dft"} # DFT would get a suggestion
     assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
@@ -110,25 +110,25 @@ class SearchTest < IntegrationTest
     stub_index.expects(:search).returns(stub(results: [], total: 0))
     OrganisationRegistry.any_instance.expects(:all)
       .returns([organisation_without_acronym])
-    get "/search.json", {q: "pies", response_style: "hash"}
+    get "/search.json", {q: "pies"}
     assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
   def test_does_not_suggest_corrections_for_words_in_ignore_file
     stub_index.expects(:search).returns(stub(results: [], total: 0))
-    get "/search.json", {q: "sorn", response_style: "hash"} # sorn would get a suggestion
+    get "/search.json", {q: "sorn"} # sorn would get a suggestion
     assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
   def test_does_not_suggest_corrections_for_numbers_or_words_containing_numbers
     stub_index.expects(:search).returns(stub(results: [], total: 0))
-    get "/search.json", {q: "v5c 2013", response_style: "hash"} # v5c would get a suggestion
+    get "/search.json", {q: "v5c 2013"} # v5c would get a suggestion
     assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
   def test_does_not_suggest_corrections_in_blacklist_file
     stub_index.expects(:search).returns(stub(results: [], total: 0))
-    get "/search.json", {q: "penison", response_style: "hash"} # penison would get an inappropriate suggestion
+    get "/search.json", {q: "penison"} # penison would get an inappropriate suggestion
     assert_equal ["pension"], MultiJson.decode(last_response.body)["spelling_suggestions"]
   end
 
@@ -145,7 +145,7 @@ class SearchTest < IntegrationTest
       .with("bus-timetables")
       .returns(bus_timetables_document_series)
     get "/search.json", {q: "bob"}
-    first_result = MultiJson.decode(last_response.body).first
+    first_result = MultiJson.decode(last_response.body)["results"].first
     assert_equal 1, first_result["document_series"].size
     assert_equal bus_timetables_document_series.title, first_result["document_series"][0]["title"]
   end
@@ -163,7 +163,7 @@ class SearchTest < IntegrationTest
       .with("ministry-of-defence")
       .returns(mod_organisation)
     get "/search.json", {q: "bob"}
-    first_result = MultiJson.decode(last_response.body).first
+    first_result = MultiJson.decode(last_response.body)["results"].first
     assert_equal 1, first_result["organisations"].size
     assert_equal mod_organisation.title, first_result["organisations"][0]["title"]
   end
@@ -181,7 +181,7 @@ class SearchTest < IntegrationTest
       .with("housing")
       .returns(housing_topic)
     get "/search.json", {q: "bob"}
-    first_result = MultiJson.decode(last_response.body).first
+    first_result = MultiJson.decode(last_response.body)["results"].first
     assert_equal 1, first_result["topics"].size
     assert_equal housing_topic.title, first_result["topics"][0]["title"]
   end
@@ -199,7 +199,7 @@ class SearchTest < IntegrationTest
       .with("angola")
       .returns(angola_world_location)
     get "/search.json", {q: "bob"}
-    first_result = MultiJson.decode(last_response.body).first
+    first_result = MultiJson.decode(last_response.body)["results"].first
     assert_equal 1, first_result["world_locations"].size
     assert_equal angola_world_location.title, first_result["world_locations"][0]["title"]
   end

--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -55,7 +55,7 @@ class ElasticsearchDeletionTest < IntegrationTest
   end
 
   def assert_no_results
-    assert_equal [], MultiJson.decode(last_response.body)
+    assert_equal [], MultiJson.decode(last_response.body)["results"]
   end
 
   def test_should_404_on_deleted_content

--- a/test/integration/elasticsearch_migration_test.rb
+++ b/test/integration/elasticsearch_migration_test.rb
@@ -50,7 +50,7 @@ class ElasticsearchMigrationTest < IntegrationTest
 
   def assert_result_links(*links)
     parsed_response = MultiJson.decode(last_response.body)
-    assert_equal links, parsed_response.map { |r| r["link"] }
+    assert_equal links, parsed_response["results"].map { |r| r["link"] }
   end
 
   def test_full_reindex
@@ -58,7 +58,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     # stemming settings
 
     get "/search?q=directive"
-    assert_equal 2, MultiJson.decode(last_response.body).length
+    assert_equal 2, MultiJson.decode(last_response.body)["results"].length
 
     @stemmer["rules"] = ["directive => directive"]
 

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -237,15 +237,6 @@ class ElasticsearchSearchTest < IntegrationTest
     assert_result_links "/pork-pies"
   end
 
-  def test_can_specify_hash_response_style
-    get "/search.json?q=badger&response_style=hash"
-    assert last_response.ok?
-    parsed_response = MultiJson.decode(last_response.body)
-    assert parsed_response.is_a?(Hash)
-    assert_equal ["total", "results", "spelling_suggestions"], parsed_response.keys
-    assert_result_links "/an-example-answer"
-  end
-
   def test_promoted_items_float_to_top_if_query_contains_a_promoted_keyword
     get "/search.json?q=promoted+jobs+in+birmingham"
     assert last_response.ok?

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -121,7 +121,7 @@ class IntegrationTest < MiniTest::Unit::TestCase
   end
 
   def assert_no_results
-    assert_equal [], MultiJson.decode(last_response.body)
+    assert_equal [], MultiJson.decode(last_response.body)["results"]
   end
 
   def stub_index


### PR DESCRIPTION
Please DO NOT MERGE until https://github.com/alphagov/govuk_content_api/commit/d18c39697c90a41ad20be82a6a23d15b643a309b has been deployed, at which point all clients are compatible.

Hash is much more flexible. This change is safe to make once all clients are requesting/expecting a hash.

Turns out there were quite a few tests using the previous default behaviour.
