### PR TITLE
Fix exception mailing when a job fails repeatedly

### DIFF
--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -8,8 +8,14 @@ module Elasticsearch
     include Sidekiq::Worker
     sidekiq_options :retry => 5
 
-    def logger
+    # Logger is defined on the class for use inthe `sidekiq_retries_exhausted`
+    # block, and as an instance method for use the rest of the time
+    def self.logger
       Logging.logger[self]
+    end
+
+    def logger
+      self.class.logger
     end
 
     sidekiq_options :queue => :bulk

--- a/lib/failed_job_worker.rb
+++ b/lib/failed_job_worker.rb
@@ -16,7 +16,12 @@ class FailedJobWorker
   def perform(job_info)
     # `job_info` is the same format at Sidekiq's job format, as serialised to
     # JSON and passed into Redis
-    mailer = settings.mailer
+    begin
+      mailer = settings.mailer
+    rescue NoMethodError  # If the initialiser isn't in place
+      mailer = nil
+    end
+
     unless mailer
       logger.warn "No mailer configured for failed job: discarding"
       logger.debug job_info

--- a/test/unit/bulk_index_worker_test.rb
+++ b/test/unit/bulk_index_worker_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "elasticsearch/bulk_index_worker"
+require "failed_job_worker"
 
 class BulkIndexWorkerTest < MiniTest::Unit::TestCase
   def sample_document_hashes
@@ -17,5 +18,12 @@ class BulkIndexWorkerTest < MiniTest::Unit::TestCase
 
     worker = Elasticsearch::BulkIndexWorker.new
     worker.perform("test-index", sample_document_hashes)
+  end
+
+  def test_forwards_to_failure_queue
+    stub_message = {}
+    FailedJobWorker.expects(:perform_async).with(stub_message)
+    fail_block = Elasticsearch::BulkIndexWorker.sidekiq_retries_exhausted_block
+    fail_block.call(stub_message)
   end
 end

--- a/test/unit/failed_job_worker_test.rb
+++ b/test/unit/failed_job_worker_test.rb
@@ -11,7 +11,16 @@ class FailedJobWorkerTest < MiniTest::Unit::TestCase
     FailedJobWorker.new.perform({"aardvark" => "horseradish"})
   end
 
+  # If the initialiser hasn't set up a mailer, the settings object won't
+  # respond to the `mailer` method at all.
   def test_should_warn_when_no_mailer_configured
+    Sinatra::Application.settings.expects(:mailer).raises(NoMethodError)
+    Logging.logger[FailedJobWorker].expects(:warn)
+    FailedJobWorker.new.perform({"aardvark" => "horseradish"})
+  end
+
+  # For if the mailer has been explicitly disabled, for some reason.
+  def test_should_warn_when_nil_mailer_configured
     Sinatra::Application.settings.expects(:mailer).returns(nil)
     Logging.logger[FailedJobWorker].expects(:warn)
     FailedJobWorker.new.perform({"aardvark" => "horseradish"})


### PR DESCRIPTION
There was a bug in the queue workers that was preventing failures being reported, and another that was causing errors in development (when no exception mailer is set up).
