### PR TITLE
Add a flag to the startup script to skip bundling.

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,36 @@
 #!/bin/bash
 
-bundle install
+usage()
+{
+cat << EOF
+Usage: $0 [options]
+
+Run a development server.
+
+OPTIONS:
+   -h       Show this message
+   -n       Skip bundle installation
+
+
+EOF
+}
+
+while getopts "hn" OPTION
+do
+  case $OPTION in
+    h )
+      usage
+      exit 1
+      ;;
+    n )
+      # Load a custom SSH config file if given
+      NO_INSTALL=1
+      ;;
+  esac
+done
+shift $(($OPTIND-1))
+
+if [[ -z $NO_INSTALL ]]; then
+  bundle install
+fi
 bundle exec mr-sparkle --force-polling -- -p 3009


### PR DESCRIPTION
This means we can use the same script for development servers run directly, and those run from the development Procfile, so the Procfile needn't be aware of which server we use in development.
