### PR TITLE
Drop the concurrency to 2 for sidekiq

### DIFF
--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -2,6 +2,6 @@ namespace :jobs do
 
   task :work do
     base_path = File.join(File.dirname(__FILE__), "../..")
-    exec("bundle exec sidekiq -q bulk -q failed -r #{base_path}/bootstrap_worker.rb")
+    exec("bundle exec sidekiq -c 2 -q bulk -q failed -r #{base_path}/bootstrap_worker.rb")
   end
 end


### PR DESCRIPTION
The current default of 25 causes an issue due to memory usage where we cannot create new threads, when doing a whitehall rebuild of the index see this issue for more information:

https://github.com/mperham/sidekiq/issues/54
