### PR TITLE
Revert "Add fallback for registry entries without slugs."

### DIFF
--- a/lib/document_series_registry.rb
+++ b/lib/document_series_registry.rb
@@ -9,8 +9,7 @@ class DocumentSeriesRegistry
   end
 
   def [](slug)
-    # TODO: remove the link fallback once slugs are migrated
-    @cache.get.find { |o| o.slug == slug || o.link =~ %r{/series/#{slug}$} }
+    @cache.get.find { |o| o.slug == slug }
   end
 
 private

--- a/lib/organisation_registry.rb
+++ b/lib/organisation_registry.rb
@@ -24,8 +24,7 @@ class OrganisationRegistry
   end
 
   def [](slug)
-    # TODO: remove the link fallback once slugs are migrated
-    @cache.get.find { |o| o.slug == slug || o.link == "/government/organisations/#{slug}"}
+    @cache.get.find { |o| o.slug == slug }
   end
 
 private

--- a/lib/topic_registry.rb
+++ b/lib/topic_registry.rb
@@ -9,8 +9,7 @@ class TopicRegistry
   end
 
   def [](slug)
-    # TODO: remove the link fallback once all slugs are migrated
-    @cache.get.find { |o| o.slug == slug || o.link == "/government/topics/#{slug}" }
+    @cache.get.find { |o| o.slug == slug }
   end
 
 private

--- a/lib/world_location_registry.rb
+++ b/lib/world_location_registry.rb
@@ -9,8 +9,7 @@ class WorldLocationRegistry
   end
 
   def [](slug)
-    # TODO: remove the link fallback once we have slugs everywhere
-    @cache.get.find { |o| o.slug == slug || o.link == "/government/world/#{slug}"}
+    @cache.get.find { |o| o.slug == slug }
   end
 
 private

--- a/test/unit/document_series_registry_test.rb
+++ b/test/unit/document_series_registry_test.rb
@@ -29,23 +29,6 @@ class DocumentSeriesRegistryTest < MiniTest::Unit::TestCase
     assert_equal rail_statistics.title, document_series.title
   end
 
-  def test_can_fall_back_on_link_munging
-    # TODO: remove this once slugs are all migrated
-    rail_statistics_without_slug = Document.new(
-      %w(slug link title),
-      {
-        link: "/government/organisations/department-for-transport/series/rail-statistics",
-        title: "Rail statistics"
-      }
-    )
-    @index.stubs(:documents_by_format)
-      .with("document_series", anything)
-      .returns([rail_statistics_without_slug])
-    document_series = @document_series_registry["rail-statistics"]
-    assert_equal rail_statistics.link, document_series.link
-    assert_equal rail_statistics.title, document_series.title
-  end
-
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
       .with("document_series", fields: %w{slug link title})

--- a/test/unit/organisation_registry_test.rb
+++ b/test/unit/organisation_registry_test.rb
@@ -43,23 +43,6 @@ class OrganisationRegistryTest < MiniTest::Unit::TestCase
     assert_equal "Ministry of Defence", organisation.title
   end
 
-  def test_can_fall_back_on_link_munging
-    # TODO: remove this once all the slugs are migrated
-    mod_document_without_slug = Document.new(
-      %w(slug link title acronym organisation_type),
-      {
-        link: "/government/organisations/ministry-of-defence",
-        title: "Ministry of Defence"
-      }
-    )
-    @index.stubs(:documents_by_format)
-      .with("organisation", anything)
-      .returns([mod_document_without_slug])
-    organisation = @organisation_registry["ministry-of-defence"]
-    assert_equal "/government/organisations/ministry-of-defence", organisation.link
-    assert_equal "Ministry of Defence", organisation.title
-  end
-
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
       .with("organisation", fields: %w{slug link title acronym organisation_type})

--- a/test/unit/topic_registry_test.rb
+++ b/test/unit/topic_registry_test.rb
@@ -36,23 +36,6 @@ class TopicRegistryTest < MiniTest::Unit::TestCase
     assert_equal "Housing", topic.title
   end
 
-  def test_can_fall_back_on_link_munging
-    # TODO: remove this once all the slugs are migrated
-    housing_document_without_slug = Document.new(
-      %w(slug link title),
-      {
-        link: "/government/topics/housing",
-        title: "Housing"
-      }
-    )
-    @index.stubs(:documents_by_format)
-      .with("topic", anything)
-      .returns([housing_document_without_slug])
-    topic = @topic_registry["housing"]
-    assert_equal "/government/topics/housing", topic.link
-    assert_equal "Housing", topic.title
-  end
-
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
       .with("topic", fields: %w{slug link title})

--- a/test/unit/world_location_registry_test.rb
+++ b/test/unit/world_location_registry_test.rb
@@ -29,24 +29,6 @@ class WorldLocationRegistryTest < MiniTest::Unit::TestCase
     assert_equal angola.title, world_location.title
   end
 
-  def test_can_fall_back_to_link_munging
-    # TODO: remove this functionality once we have everything migrated
-    angola_without_slug = Document.new(
-      # The document is still aware of slugs
-      %w(slug link title),
-      {
-        link: "/government/world/angola",
-        title: "Angola"
-      }
-    )
-    @index.stubs(:documents_by_format)
-      .with("world_location", anything)
-      .returns([angola_without_slug])
-    world_location = @world_location_registry["angola"]
-    assert_equal angola.link, world_location.link
-    assert_equal angola.title, world_location.title
-  end
-
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
       .with("world_location", fields: %w{slug link title})


### PR DESCRIPTION
Since the slugs are now migrated, we don't need this fallback any more.

This reverts commit ca08b45af9bfeac7e89d13e14b70c056a109afd3.
