### PR TITLE
Raise errors when indexing fails

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -111,6 +111,10 @@ class Rummager < Sinatra::Application
     halt(422, env['sinatra.error'].message)
   end
 
+  error Elasticsearch::BulkIndexFailure do
+    halt(500, env['sinatra.error'].message)
+  end
+
   # To search a named index:
   #   /index_name/search?q=pie
   #

--- a/test/functional/indexing_test.rb
+++ b/test/functional/indexing_test.rb
@@ -34,4 +34,15 @@ class IndexingTest < IntegrationTest
 
     assert_equal 202, last_response.status
   end
+
+  def test_handles_bulk_index_failure
+    app.settings.expects(:enable_queue).returns(false)
+    index = stub_index
+    index.expects(:document_from_hash).with(document_hashes[0]).returns(:foo)
+    index.expects(:add).raises(Elasticsearch::BulkIndexFailure.new([]))
+
+    post "/documents", MultiJson.encode(document_hashes), :content_type => :json
+
+    assert_equal 500, last_response.status
+  end
 end


### PR DESCRIPTION
Currently we ignore some classes of indexing failure. This change inspects the response body and looks for any failures and raises an error. Things like Timeouts, Elasticsearch being unavailable and so on are already be reported.

In development, this change would mean you get a semantic 500 error for failed indexing requests, rather than 200.
In production-like environments, because indexing is done in the background, the error will be raised in the worker and then retried by Sidekiq's retry mechanism as normal.
