### PR TITLE
Migration locking

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -282,12 +282,15 @@ class Rummager < Sinatra::Application
     status["queues"] = {}
 
     retries = Sidekiq::RetrySet.new.group_by(&:queue)
+    scheduled = Sidekiq::ScheduledSet.new.group_by(&:queue)
 
     Sidekiq::Stats.new.queues.each do |queue_name, queue_size|
       retry_count = retries.fetch(queue_name, []).size
+      scheduled_count = scheduled.fetch(queue_name, []).size
       status["queues"][queue_name] = {
         "jobs" => queue_size,
-        "retries" => retry_count
+        "retries" => retry_count,
+        "scheduled" => scheduled_count
       }
     end
     MultiJson.encode(status)

--- a/lib/elasticsearch/amend_worker.rb
+++ b/lib/elasticsearch/amend_worker.rb
@@ -4,11 +4,18 @@ module Elasticsearch
   class AmendWorker < BaseWorker
     forward_to_failure_queue
 
+    LOCK_DELAY = 60  # seconds
+
     def perform(index_name, document_link, updates)
       logger.info "Amending document '#{document_link}' in '#{index_name}'"
       logger.info "Amending fields #{updates.keys.join(', ')}"
       logger.debug "Amendments: #{updates}"
-      index(index_name).amend(document_link, updates)
+      begin
+        index(index_name).amend(document_link, updates)
+      rescue Elasticsearch::IndexLocked
+        logger.info "Index #{index_name} is locked; rescheduling"
+        self.class.perform_in(LOCK_DELAY, index_name, document_link, updates)
+      end
     end
   end
 end

--- a/lib/elasticsearch/amend_worker.rb
+++ b/lib/elasticsearch/amend_worker.rb
@@ -4,8 +4,6 @@ module Elasticsearch
   class AmendWorker < BaseWorker
     forward_to_failure_queue
 
-    LOCK_DELAY = 60  # seconds
-
     def perform(index_name, document_link, updates)
       logger.info "Amending document '#{document_link}' in '#{index_name}'"
       logger.info "Amending fields #{updates.keys.join(', ')}"

--- a/lib/elasticsearch/base_worker.rb
+++ b/lib/elasticsearch/base_worker.rb
@@ -12,6 +12,9 @@ module Elasticsearch
   class BaseWorker
     include Sidekiq::Worker
 
+    # How long to wait, by default, if the index is currently locked
+    LOCK_DELAY = 60  # seconds
+
     # Default options: can be overridden with `sidekiq_options` in subclasses
     sidekiq_options :retry => 5, :backtrace => 12
 

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -4,8 +4,6 @@ module Elasticsearch
   class BulkIndexWorker < BaseWorker
     forward_to_failure_queue
 
-    LOCK_DELAY = 60  # seconds
-
     def perform(index_name, document_hashes)
       noun = document_hashes.size > 1 ? "documents" : "document"
       logger.info "Indexing #{document_hashes.size} queued #{noun} into #{index_name}"

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -4,11 +4,18 @@ module Elasticsearch
   class BulkIndexWorker < BaseWorker
     forward_to_failure_queue
 
+    LOCK_DELAY = 60  # seconds
+
     def perform(index_name, document_hashes)
       noun = document_hashes.size > 1 ? "documents" : "document"
       logger.info "Indexing #{document_hashes.size} queued #{noun} into #{index_name}"
 
-      index(index_name).bulk_index(document_hashes)
+      begin
+        index(index_name).bulk_index(document_hashes)
+      rescue Elasticsearch::IndexLocked
+        logger.info "Index #{index_name} is locked; rescheduling"
+        self.class.perform_in(LOCK_DELAY, index_name, document_hashes)
+      end
     end
   end
 end

--- a/lib/elasticsearch/delete_worker.rb
+++ b/lib/elasticsearch/delete_worker.rb
@@ -4,9 +4,16 @@ module Elasticsearch
   class DeleteWorker < BaseWorker
     forward_to_failure_queue
 
+    LOCK_DELAY = 60  # seconds
+
     def perform(index_name, document_link)
       logger.info "Deleting document '#{document_link}' from '#{index_name}'"
-      index(index_name).delete(document_link)
+      begin
+        index(index_name).delete(document_link)
+      rescue Elasticsearch::IndexLocked
+        logger.info "Index #{index_name} is locked; rescheduling"
+        self.class.perform_in(LOCK_DELAY, index_name, document_link)
+      end
     end
   end
 end

--- a/lib/elasticsearch/delete_worker.rb
+++ b/lib/elasticsearch/delete_worker.rb
@@ -4,8 +4,6 @@ module Elasticsearch
   class DeleteWorker < BaseWorker
     forward_to_failure_queue
 
-    LOCK_DELAY = 60  # seconds
-
     def perform(index_name, document_link)
       logger.info "Deleting document '#{document_link}' from '#{index_name}'"
       begin

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -107,6 +107,17 @@ module Elasticsearch
       @client.put("_settings", request_body, content_type: :json)
     end
 
+    def with_lock(&block)
+      logger.info "Locking #{@index_name}"
+      lock
+      begin
+        block.call
+      ensure
+        logger.info "Unlocking #{@index_name}"
+        unlock
+      end
+    end
+
     def add(documents)
       if documents.size == 1
         logger.info "Adding #{documents.size} document to #{index_name}"

--- a/lib/elasticsearch/index_group.rb
+++ b/lib/elasticsearch/index_group.rb
@@ -87,6 +87,19 @@ module Elasticsearch
       Index.new(@base_uri, @name, @mappings, @promoted_results)
     end
 
+    # The unaliased version of the current index
+    #
+    # When we're migrating, we need access to this so we can still manipulate
+    # the index even after we have switched the alias
+    def current_real
+      current_index = current
+      if current_index.exists?
+        Index.new(@base_uri, current.real_name, @mappings, @promoted_results)
+      else
+        nil
+      end
+    end
+
     def index_names
       alias_map.keys
     end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -34,6 +34,11 @@ namespace :rummager do
       if old_index
         old_index.with_lock do
           new_index.populate_from old_index
+
+          # Now bulk inserts fail if any of their operations fail (de47247),
+          # and now we lock the old index to avoid any writes (87a7c60), the
+          # document counts should always match if we get to this point without
+          # throwing an exception, but it's a nice safeguard to have
           new_count = new_index.all_documents.size
           old_count = old_index.all_documents.size
           unless new_count == old_count
@@ -43,6 +48,7 @@ namespace :rummager do
             )
             raise RuntimeError, "Population count mismatch"
           end
+
           # Switch aliases inside the lock so we avoid a race condition where a
           # new index exists, but the old index is available for writes
           index_group.switch_to new_index

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -29,22 +29,27 @@ namespace :rummager do
       index_group = search_server.index_group(index_name)
 
       new_index = index_group.create_index
-      old_index = index_group.current
+      old_index = index_group.current_real
 
-      if old_index.exists?
-        new_index.populate_from old_index
-        new_count = new_index.all_documents.size
-        old_count = old_index.all_documents.size
-        unless new_count == old_count
-          logger.error(
-            "Population miscount: new index has #{new_count} documents, " +
-            "while old index has #{old_count}."
-          )
-          raise RuntimeError, "Population count mismatch"
+      if old_index
+        old_index.with_lock do
+          new_index.populate_from old_index
+          new_count = new_index.all_documents.size
+          old_count = old_index.all_documents.size
+          unless new_count == old_count
+            logger.error(
+              "Population miscount: new index has #{new_count} documents, " +
+              "while old index has #{old_count}."
+            )
+            raise RuntimeError, "Population count mismatch"
+          end
+          # Switch aliases inside the lock so we avoid a race condition where a
+          # new index exists, but the old index is available for writes
+          index_group.switch_to new_index
         end
+      else
+        index_group.switch_to new_index
       end
-
-      index_group.switch_to new_index
     end
   end
 

--- a/test/integration/elasticsearch_locking_test.rb
+++ b/test/integration/elasticsearch_locking_test.rb
@@ -1,0 +1,55 @@
+require "integration_test_helper"
+
+class ElasticsearchLockingTest < IntegrationTest
+
+  def setup
+    stub_elasticsearch_settings
+    enable_test_index_connections
+    try_remove_test_index
+  end
+
+  def teardown
+    clean_index_group
+  end
+
+  def test_should_fail_to_insert_when_index_locked
+    create_test_index
+
+    index = search_server.index_group(@default_index_name).current
+    index.lock
+    assert_raises Elasticsearch::IndexLocked do
+      index.add([sample_document])
+    end
+  end
+
+  def test_should_fail_to_amend_when_index_locked
+    create_test_index
+
+    index = search_server.index_group(@default_index_name).current
+    index.add([sample_document])
+    index.lock
+    assert_raises Elasticsearch::IndexLocked do
+      index.amend(sample_document.link, "title" => "New title")
+    end
+  end
+
+  def test_should_fail_to_delete_when_index_locked
+    create_test_index
+
+    index = search_server.index_group(@default_index_name).current
+    index.add([sample_document])
+    index.lock
+    assert_raises Elasticsearch::IndexLocked do
+      index.delete(sample_document.link)
+    end
+  end
+
+  def test_should_unlock_index
+    create_test_index
+
+    index = search_server.index_group(@default_index_name).current
+    index.lock
+    index.unlock
+    index.add([sample_document])
+  end
+end

--- a/test/unit/bulk_index_worker_test.rb
+++ b/test/unit/bulk_index_worker_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "elasticsearch/bulk_index_worker"
+require "elasticsearch/index"
 require "failed_job_worker"
 
 class BulkIndexWorkerTest < MiniTest::Unit::TestCase
@@ -15,6 +16,22 @@ class BulkIndexWorkerTest < MiniTest::Unit::TestCase
     Elasticsearch::SearchServer.any_instance.expects(:index)
       .with("test-index")
       .returns(mock_index)
+
+    worker = Elasticsearch::BulkIndexWorker.new
+    worker.perform("test-index", sample_document_hashes)
+  end
+
+  def test_retries_when_index_locked
+    lock_delay = Elasticsearch::BulkIndexWorker::LOCK_DELAY
+
+    mock_index = mock("index")
+    mock_index.expects(:bulk_index).raises(Elasticsearch::IndexLocked)
+    Elasticsearch::SearchServer.any_instance.expects(:index)
+      .with("test-index")
+      .returns(mock_index)
+
+    Elasticsearch::BulkIndexWorker.expects(:perform_in)
+      .with(lock_delay, "test-index", sample_document_hashes)
 
     worker = Elasticsearch::BulkIndexWorker.new
     worker.perform("test-index", sample_document_hashes)


### PR DESCRIPTION
Put a write lock onto the old index while we’re migrating to a new one, so any updates attempted during the migration can be applied once it’s finished (or aborted).
