### PR TITLE
Close the old index after migration.

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -95,6 +95,10 @@ module Elasticsearch
       ! real_name.nil?
     end
 
+    def close
+      @client.post("_close", nil)
+    end
+
     # Apply a write lock to this index, making it read-only
     def lock
       request_body = {"index" => {"blocks" => {"write" => true}}}.to_json

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -46,6 +46,8 @@ namespace :rummager do
           # Switch aliases inside the lock so we avoid a race condition where a
           # new index exists, but the old index is available for writes
           index_group.switch_to new_index
+
+          old_index.close
         end
       else
         index_group.switch_to new_index

--- a/test/integration/elasticsearch_closing_test.rb
+++ b/test/integration/elasticsearch_closing_test.rb
@@ -1,0 +1,36 @@
+require "integration_test_helper"
+
+class ElasticsearchClosingTest < IntegrationTest
+
+  def setup
+    stub_elasticsearch_settings
+    enable_test_index_connections
+    try_remove_test_index
+  end
+
+  def teardown
+    clean_index_group
+  end
+
+  # When the index is closed, we don't particularly mind which exception gets
+  # raised, so long as it's a client error (4xx) of some kind
+  def restclient_4xx_errors
+    RestClient::Exceptions::EXCEPTIONS_MAP.select { |code, exception|
+      (400...500).include? code
+    }.values
+  end
+
+  def test_should_fail_to_insert_or_get_when_index_closed
+    create_test_index
+
+    index = search_server.index_group(@default_index_name).current
+    index.close
+    assert_raises *restclient_4xx_errors do
+      index.add([sample_document])
+    end
+
+    assert_raises *restclient_4xx_errors do
+      index.get("/foobang")
+    end
+  end
+end

--- a/test/integration/elasticsearch_closing_test.rb
+++ b/test/integration/elasticsearch_closing_test.rb
@@ -16,7 +16,7 @@ class ElasticsearchClosingTest < IntegrationTest
   # raised, so long as it's a client error (4xx) of some kind
   def restclient_4xx_errors
     RestClient::Exceptions::EXCEPTIONS_MAP.select { |code, exception|
-      (400...500).include? code
+      (400..499).include? code
     }.values
   end
 


### PR DESCRIPTION
There's no way to reach it from within the app, and rollbacks can only be done
manually, so there's no reason to keep the index open and taking up resources
on the elasticsearch server.
