### PR TITLE
Use longer HTTP timeouts during migrations.

### DIFF
--- a/lib/elasticsearch/client.rb
+++ b/lib/elasticsearch/client.rb
@@ -111,6 +111,7 @@ module Elasticsearch
         args[:headers] = headers if headers
         args[:timeout] = @timeout if @timeout
         args[:open_timeout] = @open_timeout if @open_timeout
+        logger.debug(args.reject { |k| k == :payload })
         RestClient::Request.execute(args)
       end
     end


### PR DESCRIPTION
Since we're not so bothered about a quick response during migrations, and more bothered about whether the migration completes successfully or not, it makes sense to go for a higher timeout on these requests.
