### PR TITLE
Add operational_field and sort properties

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -624,6 +624,7 @@ mappings:
         format:      { type: string, index: not_analyzed, include_in_all: false }
         indexable_content: { type: string, index: analyzed }
         link:        { type: string, index: not_analyzed, include_in_all: false }
+        operational_field: { type: string, index: not_analyzed, include_in_all: false }
         organisations: { type: string, index: not_analyzed, include_in_all: false }
         people: { type: string, index: not_analyzed, include_in_all: false }
         promoted_for: { type: string, index: analyzed, include_in_all: false }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -608,10 +608,8 @@ mappings:
     edition:
       _all: { enabled: true }
       properties:
-        title:       { type: string, index: analyzed }
+        id:          { type: long, index: not_analyzed, include_in_all: false }
         acronym:     { type: string, index: analyzed }
-        description: { type: string, index: analyzed }
-        indexable_content: { type: string, index: analyzed }
         attachments:
           properties:
             content: {type: string, index: analyzed}
@@ -620,20 +618,22 @@ mappings:
             unique_reference: {type: string, index: not_analyzed}
             command_paper_number: {type: string, index: not_analyzed}
             hoc_paper_number: {type: string, index: not_analyzed}
-        format:      { type: string, index: not_analyzed, include_in_all: false }
+        description: { type: string, index: analyzed }
         display_type: { type: string, index: not_analyzed, include_in_all: false }
+        document_series: { type: string, index: not_analyzed, include_in_all: false }
+        format:      { type: string, index: not_analyzed, include_in_all: false }
+        indexable_content: { type: string, index: analyzed }
+        link:        { type: string, index: not_analyzed, include_in_all: false }
+        organisations: { type: string, index: not_analyzed, include_in_all: false }
+        people: { type: string, index: not_analyzed, include_in_all: false }
+        promoted_for: { type: string, index: analyzed, include_in_all: false }
+        public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
+        relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }
+        search_format_types: { type: string, index: not_analyzed, include_in_all: false }
         section:     { type: string, index: not_analyzed, include_in_all: false }
+        slug:        { type: string, index: not_analyzed, include_in_all: false }
         subsection:  { type: string, index: not_analyzed, include_in_all: false }
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
-        link:        { type: string, index: not_analyzed, include_in_all: false }
-        slug:        { type: string, index: not_analyzed, include_in_all: false }
-        id:          { type: long, index: not_analyzed, include_in_all: false }
-        organisations: { type: string, index: not_analyzed, include_in_all: false }
-        document_series: { type: string, index: not_analyzed, include_in_all: false }
-        people: { type: string, index: not_analyzed, include_in_all: false }
+        title:       { type: string, index: analyzed }
         topics: { type: string, index: not_analyzed, include_in_all: false }
-        public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
-        search_format_types: { type: string, index: not_analyzed, include_in_all: false }
-        relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }
         world_locations: { type: string, index: not_analyzed, include_in_all: false }
-        promoted_for: { type: string, index: analyzed, include_in_all: false }


### PR DESCRIPTION
Sorting the properties to make it easier to scan, adding the property `operational_field` which is needed to display the results from rummager
