### PR TITLE
Force news article about Syria to be at the top

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -559,6 +559,8 @@ stems: &stems [
 promoted_results:
 - terms: job
   link: /jobsearch
+- terms: syria
+  link: /government/news/syria-chemical-weapons-attack
 
 index:
   settings:


### PR DESCRIPTION
This is to respond to a request from No 10 that this item be right at the top given the sensitive nature of the Syria situation, it'll be a landing page for Government announcements about it.
