### PR TITLE
Fast bulk loading

### DIFF
--- a/bin/bulk_load
+++ b/bin/bulk_load
@@ -22,7 +22,7 @@ switched over.
 }
   run do |opts, args|
     raise("Please specify exactly one index") unless args.size == 1
-    BulkLoader.new(args.first).load_from($stdin)
+    BulkLoader.new(SearchConfig.new, args.first, logger: Logger.new(STDERR)).load_from($stdin)
   end
 end
 

--- a/bin/bulk_load
+++ b/bin/bulk_load
@@ -3,7 +3,7 @@
 PROJECT_ROOT = File.dirname(__FILE__) + "/../"
 LIBRARY_PATH = PROJECT_ROOT + "lib/"
 
-$: << LIBRARY_PATH unless $:.include?(LIBRARY_PATH)
+$LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
 
 INDICES = %w{mainstream detailed government}
 

--- a/bin/bulk_load
+++ b/bin/bulk_load
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+PROJECT_ROOT = File.dirname(__FILE__) + "/../"
+LIBRARY_PATH = PROJECT_ROOT + "lib/"
+
+$: << LIBRARY_PATH unless $:.include?(LIBRARY_PATH)
+
+INDICES = %w{mainstream detailed government}
+
+require "logging"
+require "search_config"
+require "slop"
+require "bulk_loader"
+
+Slop.parse(help: true) do
+  banner %Q{Usage: #{File.basename(__FILE__)} {#{INDICES.join("|")}}
+
+Bulk loads data from stdin to the specified index. Loading is done in an
+unconnected index alias and on completion of the index load the alias is
+switched over.
+
+}
+  run do |opts, args|
+    raise("Please specify exactly one index") unless args.size == 1
+    BulkLoader.new(args.first).load_from($stdin)
+  end
+end
+

--- a/bin/bulk_load
+++ b/bin/bulk_load
@@ -13,16 +13,23 @@ require "slop"
 require "bulk_loader"
 
 Slop.parse(help: true) do
-  banner %Q{Usage: #{File.basename(__FILE__)} {#{INDICES.join("|")}}
+  search_config = SearchConfig.new
+  banner %Q{Usage: #{File.basename(__FILE__)} {#{search_config.index_names.join("|")}}
 
-Bulk loads data from stdin to the specified index. Loading is done in an
-unconnected index alias and on completion of the index load the alias is
-switched over.
+Bulk loads data from stdin to the specified index. The data should be in the
+format accepted by the elastic search bulk command[1].
 
+Loading is done in an unconnected index alias and on completion of the index
+load the alias is switched over.
+
+[1] http://www.elasticsearch.org/guide/reference/api/bulk/
 }
   run do |opts, args|
-    raise("Please specify exactly one index") unless args.size == 1
-    BulkLoader.new(SearchConfig.new, args.first, logger: Logger.new(STDERR)).load_from($stdin)
+    if args.size == 1
+      BulkLoader.new(search_config, args.first, logger: Logger.new(STDERR)).load_from($stdin)
+    else
+      puts self
+    end
   end
 end
 

--- a/lib/bulk_loader.rb
+++ b/lib/bulk_loader.rb
@@ -1,0 +1,42 @@
+class BulkLoader
+  def initialize(search_config, index_name, options = {})
+    @search_config = search_config
+    @index_name = index_name
+    @batch_size = options[:batch_size] || 1024
+  end
+
+  def load_from(iostream)
+    new_index = index_group.create_index
+    old_index = index_group.current_real
+
+    if old_index
+      old_index.with_lock do
+        do_indexing(new_index, iostream)
+
+        # Switch aliases inside the lock so we avoid a race condition where a
+        # new index exists, but the old index is available for writes
+        index_group.switch_to new_index
+
+        old_index.close
+      end
+    else
+      index_group.switch_to new_index
+      do_indexing(new_index, iostream)
+    end
+  end
+
+private
+  def do_indexing(index, iostream)
+    iostream.each_line.each_slice(@batch_size) do |lines|
+      index.bulk_index(lines.join(""))
+    end
+  end
+
+  def search_server
+    @search_server ||= @search_config.search_server
+  end
+
+  def index_group
+    @index_group ||= search_server.index_group(@index_name)
+  end
+end

--- a/lib/bulk_loader.rb
+++ b/lib/bulk_loader.rb
@@ -1,13 +1,18 @@
+require 'time'
+
 class BulkLoader
   def initialize(search_config, index_name, options = {})
     @search_config = search_config
     @index_name = index_name
     @batch_size = options[:batch_size] || 1024
+    @logger = options[:logger] || Logger.new(nil)
   end
 
   def load_from(iostream)
     new_index = index_group.create_index
+    @logger.info "Created index #{new_index.real_name}"
     old_index = index_group.current_real
+    @logger.info "Old index #{old_index.real_name}"
 
     if old_index
       old_index.with_lock do
@@ -27,9 +32,33 @@ class BulkLoader
 
 private
   def do_indexing(index, iostream)
-    iostream.each_line.each_slice(@batch_size) do |lines|
+    @logger.info "Indexing to #{index.real_name}"
+    total_lines = 0
+    start_time = Time.now
+    in_even_sized_batches(iostream) do |lines|
       index.bulk_index(lines.join(""))
+      @logger.info "Sent #{lines.size} lines (#{byte_size(lines)} bytes)"
+      total_lines += lines.size
     end
+    elapsed_time = Time.now - start_time
+    @logger.info "Indexed %s lines in %.2f seconds (%.2f lines/sec)" % [total_lines, elapsed_time, total_lines / elapsed_time]
+  end
+
+  def byte_size(lines)
+    lines.inject(0) {|memo, l| memo + l.size}
+  end
+
+  def in_even_sized_batches(iostream, target_chunk_size = 1024*1024, &block)
+    chunk = []
+    iostream.each_line.each_slice(2) do |command, document|
+      chunk << command
+      chunk << document
+      if byte_size(chunk) > target_chunk_size
+        yield chunk
+        chunk = []
+      end
+    end
+    yield chunk if chunk.any?
   end
 
   def search_server

--- a/test/integration/bulk_loader_test.rb
+++ b/test/integration/bulk_loader_test.rb
@@ -1,0 +1,80 @@
+require "integration_test_helper"
+require "rest-client"
+require "bulk_loader"
+require "cgi"
+
+class BulkLoaderTest < IntegrationTest
+
+  def setup
+    stub_elasticsearch_settings
+    enable_test_index_connections
+    try_remove_test_index
+    @sample_document = {
+      "title" => "TITLE",
+      "description" => "DESCRIPTION",
+      "format" => "answer",
+      "link" => "/an-example-answer",
+      "indexable_content" => "HERE IS SOME CONTENT"
+    }
+  end
+
+  def teardown
+    clean_index_group
+  end
+
+  def retrieve_document_from_rummager(link)
+    get "/documents/#{CGI::escape(link)}"
+    MultiJson.decode(last_response.body)
+  end
+
+  def assert_document_is_in_rummager(document)
+    retrieved = retrieve_document_from_rummager(document['link'])
+
+    assert_equal document.keys.sort, retrieved.keys.sort
+
+    document.each do |key, value|
+      assert_equal value, retrieved[key], "Field #{key} should be '#{value}' but was '#{retrieved[key]}'"
+    end
+  end
+
+  def index_payload(document)
+    index_action = {
+      "index" => {
+        "_id" => document['link'],
+        "_type" => "edition"
+      }
+    }
+
+    payload = [
+      index_action.to_json,
+      document.to_json
+    ].join("\n") + "\n"
+  end
+
+  def test_indexes_documents
+    create_test_index
+
+    bulk_loader = BulkLoader.new(app.settings.search_config, @default_index_name)
+    bulk_loader.load_from(StringIO.new(index_payload(@sample_document)))
+
+    assert_document_is_in_rummager(@sample_document)
+  end
+
+  def test_updates_an_existing_document
+    create_test_index
+    index_group = search_server.index_group(@default_index_name)
+    old_index = index_group.current_real
+
+    doc_v1 = @sample_document.merge({"title" => "Original Title"})
+    doc_v2 = @sample_document.merge({"title" => "New Title"})
+
+    post "/documents", MultiJson.encode(doc_v1)
+    old_index.commit
+    assert_document_is_in_rummager(doc_v1)
+
+    bulk_loader = BulkLoader.new(app.settings.search_config, @default_index_name)
+    bulk_loader.load_from(StringIO.new(index_payload(doc_v2)))
+
+    assert_document_is_in_rummager(doc_v2)
+  end
+end

--- a/test/unit/bulk_loader_test.rb
+++ b/test/unit/bulk_loader_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+require "bulk_loader"
+require "stringio"
+require "logger"
+
+class BulkLoaderTest < MiniTest::Unit::TestCase
+  def test_can_break_iostream_into_batches_of_lines_of_specified_byte_size
+    input = StringIO.new(%w{a b c d}.join("\n") + "\n")
+    loader = BulkLoader.new(stub("search config"), stub("index name"))
+    batches = []
+    loader.send(:in_even_sized_batches, input, 4) do |batch|
+      batches << batch
+    end
+
+    assert_equal [["a\n", "b\n"], ["c\n", "d\n"]], batches
+  end
+
+  def test_line_pairs_are_not_split_if_batch_size_too_small_to_fit_first_pair_of_lines
+    input = StringIO.new(%w{a b c d}.join("\n") + "\n")
+    loader = BulkLoader.new(stub("search config"), stub("index name"))
+    batches = []
+    loader.send(:in_even_sized_batches, input, 3) do |batch|
+      batches << batch
+    end
+
+    assert_equal [["a\n", "b\n"], ["c\n", "d\n"]], batches
+  end
+
+  def test_line_pairs_are_not_split_if_batch_boundary_falls_in_second_pair_of_lines
+    input = StringIO.new(%w{a b c d e f}.join("\n") + "\n")
+    loader = BulkLoader.new(stub("search config"), stub("index name"))
+    batches = []
+    loader.send(:in_even_sized_batches, input, 5) do |batch|
+      batches << batch
+    end
+
+    assert_equal [["a\n", "b\n", "c\n", "d\n"], ["e\n", "f\n"]], batches
+  end
+end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -82,6 +82,20 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     assert_requested(:post, "http://example.com:9200/test-index/_bulk")
   end
 
+  def test_should_bulk_update_documents_with_raw_command_stream
+    # Note that this comes with a trailing newline, which elasticsearch needs
+    payload = <<-eos
+{"index":{"_type":"edition","_id":"/foo/bar"}}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE"}
+    eos
+    stub_request(:post, "http://example.com:9200/test-index/_bulk").with(
+        body: payload,
+        headers: {"Content-Type" => "application/json"}
+    ).to_return(body: '{"items":[]}')
+    @wrapper.bulk_index payload
+    assert_requested(:post, "http://example.com:9200/test-index/_bulk")
+  end
+
   def test_should_raise_error_for_failures_in_bulk_update
     json_documents = [
       { "_type" => "edition", "link" => "/foo/bar", "title" => "TITLE ONE" },


### PR DESCRIPTION
Support bulk loading by reading a stream of indexing commands and data via standard input.

Indexing operations are split into packets of about 1MB in size and sent to elastic search directly.

The indexing process supports a seamless re-indexing by loading new data in a disconnected index before switching over.

Loading a complete government index takes approx 25 seconds on my local machine.

This is a preliminary pull request for discussion. I think it's pretty much complete but haven't shown the code to anyone else yet so would appreciate feedback.
