### PR TITLE
Explanations

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -155,10 +155,17 @@ class Rummager < Sinatra::Application
 
     expires 3600, :public if query.length < 20
     organisation = params["organisation_slug"].blank? ? nil : params["organisation_slug"]
-    result_set = current_index.search(query,
+
+    search_options = {
       organisation: organisation,
       sort: params["sort"],
-      order: params["order"])
+      order: params["order"]
+    }
+    if settings.enable_explain && params["explain"]
+      search_options[:explain] = true
+    end
+
+    result_set = current_index.search(query, search_options)
     presenter_context = {
       organisation_registry: organisation_registry,
       topic_registry: topic_registry,

--- a/config/initializers/explain.rb
+++ b/config/initializers/explain.rb
@@ -1,0 +1,3 @@
+# This file can be overwritten on deployment
+
+set :enable_explain, ENV["RACK_ENV"] == "development"

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -1,6 +1,6 @@
 class SearchIndexEntry
   def initialize(field_names, attributes = {})
-    @field_names = field_names.map(&:to_s) + ["es_score"]
+    @field_names = field_names.map(&:to_s) + ["es_score", "explanation"]
     @attributes = {}
     update_attributes!(attributes)
   end

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -280,12 +280,18 @@ module Elasticsearch
     end
 
     def search(keywords, options={})
+      if options.delete(:explain)
+        path = "_search?explain=1"
+      else
+        path = "_search"
+      end
+
       builder = SearchQueryBuilder.new(keywords, @mappings, options)
       raise InvalidQuery.new(builder.error) unless builder.valid?
 
       payload = MultiJson.dump(builder.query_hash)
       logger.debug "Request payload: #{payload}"
-      response = @client.get_with_payload("_search", payload)
+      response = @client.get_with_payload(path, payload)
       ResultSet.new(@mappings, MultiJson.decode(response))
     end
 

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -12,7 +12,10 @@ class ResultSet
 
 private
   def document_from_hit(hit)
-    hash = hit["_source"].merge("es_score" => hit["_score"])
+    hash = hit["_source"].merge(
+      "es_score" => hit["_score"],
+      "explanation" => hit["_explanation"]
+    )
     Document.from_hash(hash, @mappings)
   end
 end

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -12,10 +12,12 @@ class ResultSet
 
 private
   def document_from_hit(hit)
-    hash = hit["_source"].merge(
+    debug_fields = {
       "es_score" => hit["_score"],
       "explanation" => hit["_explanation"]
-    )
+    }.select { |key, value| value }
+
+    hash = hit["_source"].merge(debug_fields)
     Document.from_hash(hash, @mappings)
   end
 end

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -136,7 +136,7 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def test_returns_the_hits_converted_into_documents
-    Document.expects(:from_hash).with({"woo" => "hoo", "es_score" => nil}, default_mappings).returns :woo_hoo
+    Document.expects(:from_hash).with({"woo" => "hoo"}, default_mappings).returns :woo_hoo
     stub_request(:get, "http://example.com:9200/test-index/_search")
       .to_return(:status => 200, :body => "{\"hits\": {\"total\": 10, \"hits\": [{\"_source\": {\"woo\": \"hoo\"}}]}}", :headers => {})
     result_set = @wrapper.advanced_search(default_params)


### PR DESCRIPTION
Allow Rummager to return explanations for result scores in development, so we can figure out in more detail how our algorithms are working.
