### PR TITLE
Change the advanced search date filters to use from/to

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -190,8 +190,8 @@ class Rummager < Sinatra::Application
   #   relevant_to_local_government - eg "1"
   #
   # If the field type is defined as "date", this is possible:
-  #   fieldname[before]     - eg public_timestamp[before]="2013-04-30"
-  #   fieldname[after]      - eg public_timestamp[after]="2013-04-30"
+  #   fieldname[from]     - eg public_timestamp[from]="2013-04-30"
+  #   fieldname[to]      - eg public_timestamp[to]="2013-04-30"
   #
   get "/:index/advanced_search.?:format?" do
     json_only

--- a/lib/elasticsearch/advanced_search_query_builder.rb
+++ b/lib/elasticsearch/advanced_search_query_builder.rb
@@ -55,7 +55,7 @@ module Elasticsearch
       # formatted.
       !(value.is_a?(Hash) &&
         value.keys.any? &&
-        (value.keys - ['from', 'to']).empty? &&
+        (value.keys - ['from', 'to', 'before', 'after']).empty? &&
         (value.values.reject { |date| date.to_s =~ /\A\d{4}-\d{2}-\d{2}\Z/}).empty?)
     end
 
@@ -155,6 +155,13 @@ module Elasticsearch
       end
       if filter_value.has_key?("to")
         filter["range"][property]["to"] = filter_value["to"]
+      end
+      # Deprecated date range options
+      if filter_value.has_key?("after")
+        filter["range"][property]["from"] = filter_value["after"]
+      end
+      if filter_value.has_key?("before")
+        filter["range"][property]["to"] = filter_value["before"]
       end
       filter
     end

--- a/lib/elasticsearch/advanced_search_query_builder.rb
+++ b/lib/elasticsearch/advanced_search_query_builder.rb
@@ -51,11 +51,11 @@ module Elasticsearch
 
     def invalid_date_property_value?(value)
       # invalid if it's not a hash, or is an empty hash, or has keys other
-      # than 'before' or 'after', or the values are not YYYY-MM-DD
+      # than 'from' or 'to', or the values are not YYYY-MM-DD
       # formatted.
       !(value.is_a?(Hash) &&
         value.keys.any? &&
-        (value.keys - ['before', 'after']).empty? &&
+        (value.keys - ['from', 'to']).empty? &&
         (value.values.reject { |date| date.to_s =~ /\A\d{4}-\d{2}-\d{2}\Z/}).empty?)
     end
 
@@ -150,11 +150,11 @@ module Elasticsearch
 
     def date_property_filter(property, filter_value)
       filter = {"range" => {property => {}}}
-      if filter_value.has_key?("after")
-        filter["range"][property]["from"] = filter_value["after"]
+      if filter_value.has_key?("from")
+        filter["range"][property]["from"] = filter_value["from"]
       end
-      if filter_value.has_key?("before")
-        filter["range"][property]["to"] = filter_value["before"]
+      if filter_value.has_key?("to")
+        filter["range"][property]["to"] = filter_value["to"]
       end
       filter
     end

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -89,6 +89,13 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
 
     stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"range\":{\"date_property\":{\"from\":\"2013-02-02\",\"to\":\"2013-02-03\"}}}")}/)
     @wrapper.advanced_search(default_params.merge('date_property' => {'from' => '2013-02-02', 'to' => '2013-02-03'}))
+
+    # Deprecated date range options
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"range\":{\"date_property\":{\"to\":\"2013-02-02\"}}}")}/)
+    @wrapper.advanced_search(default_params.merge('date_property' => {'before' => '2013-02-02'}))
+
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"range\":{\"date_property\":{\"from\":\"2013-02-02\"}}}")}/)
+    @wrapper.advanced_search(default_params.merge('date_property' => {'after' => '2013-02-02'}))
   end
 
   def test_filter_params_on_a_date_mapping_property_without_a_before_or_after_key_in_the_value_are_rejected

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -82,13 +82,13 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
     @wrapper.mappings['edition']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
 
     stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"range\":{\"date_property\":{\"to\":\"2013-02-02\"}}}")}/)
-    @wrapper.advanced_search(default_params.merge('date_property' => {'before' => '2013-02-02'}))
+    @wrapper.advanced_search(default_params.merge('date_property' => {'to' => '2013-02-02'}))
 
     stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"range\":{\"date_property\":{\"from\":\"2013-02-02\"}}}")}/)
-    @wrapper.advanced_search(default_params.merge('date_property' => {'after' => '2013-02-02'}))
+    @wrapper.advanced_search(default_params.merge('date_property' => {'from' => '2013-02-02'}))
 
     stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"range\":{\"date_property\":{\"from\":\"2013-02-02\",\"to\":\"2013-02-03\"}}}")}/)
-    @wrapper.advanced_search(default_params.merge('date_property' => {'after' => '2013-02-02', 'before' => '2013-02-03'}))
+    @wrapper.advanced_search(default_params.merge('date_property' => {'from' => '2013-02-02', 'to' => '2013-02-03'}))
   end
 
   def test_filter_params_on_a_date_mapping_property_without_a_before_or_after_key_in_the_value_are_rejected
@@ -96,9 +96,7 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
     stub_empty_search
 
     assert_rejected_search('Invalid value {} for date property "date_property"', default_params.merge('date_property' => {}))
-    assert_rejected_search('Invalid value {"from"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => {'from' => '2013-02-02'}))
     assert_rejected_search('Invalid value "2013-02-02" for date property "date_property"', default_params.merge('date_property' => '2013-02-02'))
-    assert_rejected_search('Invalid value {"to"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => {'to' => '2013-02-02'}))
     assert_rejected_search('Invalid value ["2013-02-02"] for date property "date_property"', default_params.merge('date_property' => ['2013-02-02']))
     assert_rejected_search('Invalid value {"between"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => {'between' => '2013-02-02'}))
     assert_rejected_search('Invalid value {"before"=>"2013-02-02", "up-to"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => {'before' => '2013-02-02', 'up-to' => '2013-02-02'}))


### PR DESCRIPTION
Whitehall used to use before and after date filters, but this has now changed to use from/to filters.

https://github.com/alphagov/whitehall/pull/906
