### PR TITLE
Add support for document collections

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -10,6 +10,7 @@ require "document"
 require "result_set_presenter"
 require "organisation_set_presenter"
 require "document_series_registry"
+require "document_collection_registry"
 require "organisation_registry"
 require "suggester"
 require "topic_registry"
@@ -37,6 +38,11 @@ class Rummager < Sinatra::Application
   def document_series_registry
     index_name = settings.search_config.document_series_registry_index
     @@document_series_registry ||= DocumentSeriesRegistry.new(search_server.index(index_name)) if index_name
+  end
+
+  def document_collection_registry
+    index_name = settings.search_config.document_collection_registry_index
+    @@document_collection_registry ||= DocumentCollectionRegistry.new(search_server.index(index_name)) if index_name
   end
 
   def organisation_registry
@@ -163,6 +169,7 @@ class Rummager < Sinatra::Application
       organisation_registry: organisation_registry,
       topic_registry: topic_registry,
       document_series_registry: document_series_registry,
+      document_collection_registry: document_collection_registry,
       world_location_registry: world_location_registry,
       spelling_suggestions: suggester.suggestions(params["q"])
     }

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -3,4 +3,5 @@ index_names: ["mainstream", "detailed", "government", "service-manual"]
 organisation_registry_index: "government"
 topic_registry_index: "government"
 document_series_registry_index: "government"
+document_collection_registry_index: "government"
 world_location_registry_index: "government"

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -622,6 +622,7 @@ mappings:
             hoc_paper_number: {type: string, index: not_analyzed}
         description: { type: string, index: analyzed }
         display_type: { type: string, index: not_analyzed, include_in_all: false }
+        document_collections: { type: string, index: not_analyzed, include_in_all: false }
         document_series: { type: string, index: not_analyzed, include_in_all: false }
         format:      { type: string, index: not_analyzed, include_in_all: false }
         indexable_content: { type: string, index: analyzed }

--- a/lib/document_collection_registry.rb
+++ b/lib/document_collection_registry.rb
@@ -1,0 +1,21 @@
+require "timed_cache"
+
+class DocumentCollectionRegistry
+  CACHE_LIFETIME = 12 * 3600  # 12 hours
+
+  def initialize(index, clock = Time)
+    @index = index
+    @cache = TimedCache.new(CACHE_LIFETIME, clock) { fetch }
+  end
+
+  def [](slug)
+    @cache.get.find { |o| o.slug == slug }
+  end
+
+private
+  def fetch
+    fields = %w{slug link title}
+    @index.documents_by_format("document_collection", fields: fields).to_a
+  end
+
+end

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -205,6 +205,7 @@ module Elasticsearch
         "organisation"      => 2.5,
         "topic"             => 1.5,
         "document_series"   => 1.3,
+        "document_collection" => 1.3,
         "operational_field" => 1.5,
       }
     end

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -67,6 +67,11 @@ private
         document_series_by_slug(slug)
       end
     end
+    if result['document_collections'] && should_expand_document_collections?
+      result['document_collections'] = result['document_collections'].map do |slug|
+        document_collection_by_slug(slug)
+      end
+    end
     if result['organisations'] && should_expand_organisations?
       result['organisations'] = result['organisations'].map do |slug|
         organisation_by_slug(slug)
@@ -89,6 +94,10 @@ private
     !! document_series_registry
   end
 
+  def should_expand_document_collections?
+    !! document_collection_registry
+  end
+
   def should_expand_organisations?
     !! organisation_registry
   end
@@ -103,6 +112,10 @@ private
 
   def document_series_registry
     @context[:document_series_registry]
+  end
+
+  def document_collection_registry
+    @context[:document_collection_registry]
   end
 
   def organisation_registry
@@ -125,6 +138,15 @@ private
     document_series = document_series_registry && document_series_registry[slug]
     if document_series
       document_series.to_hash.merge(slug: slug)
+    else
+      {slug: slug}
+    end
+  end
+
+  def document_collection_by_slug(slug)
+    document_collection = document_collection_registry && document_collection_registry[slug]
+    if document_collection
+      document_collection.to_hash.merge(slug: slug)
     else
       {slug: slug}
     end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -27,6 +27,10 @@ class SearchConfig
     elasticsearch["document_series_registry_index"]
   end
 
+  def document_collection_registry_index
+    elasticsearch["document_collection_registry_index"]
+  end
+
   def organisation_registry_index
     elasticsearch["organisation_registry_index"]
   end

--- a/test/unit/document_collection_registry_test.rb
+++ b/test/unit/document_collection_registry_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+require "document"
+require "document_collection_registry"
+
+class DocumentCollectionRegistryTest < MiniTest::Unit::TestCase
+  def setup
+    @index = stub("elasticsearch index")
+    @document_collection_registry = DocumentCollectionRegistry.new(@index)
+  end
+
+  def rail_statistics
+    Document.new(
+      %w(slug link title),
+      {
+        slug: "rail-statistics",
+        link: "/government/collections/rail-statistics",
+        title: "Rail statistics"
+      }
+    )
+  end
+
+  def test_can_fetch_document_collection_by_slug
+    @index.stubs(:documents_by_format)
+      .with("document_collection", anything)
+      .returns([rail_statistics])
+    document_collection = @document_collection_registry["rail-statistics"]
+    assert_equal rail_statistics.slug, document_collection.slug
+    assert_equal rail_statistics.link, document_collection.link
+    assert_equal rail_statistics.title, document_collection.title
+  end
+
+  def test_only_required_fields_are_requested_from_index
+    @index.expects(:documents_by_format)
+      .with("document_collection", fields: %w{slug link title})
+    document_collection = @document_collection_registry["rail-statistics"]
+  end
+
+  def test_returns_nil_if_document_collection_not_found
+    @index.stubs(:documents_by_format)
+      .with("document_collection", anything)
+      .returns([rail_statistics])
+    document_collection = @document_collection_registry["bus-statistics"]
+    assert_nil document_collection
+  end
+
+  def test_document_enumerator_is_traversed_only_once
+    document_enumerator = stub("enumerator")
+    document_enumerator.expects(:to_a).returns([rail_statistics]).once
+    @index.stubs(:documents_by_format)
+      .with("document_collection", anything)
+      .returns(document_enumerator)
+      .once
+    assert @document_collection_registry["rail-statistics"]
+    assert @document_collection_registry["rail-statistics"]
+  end
+
+  def test_uses_cache
+    # Make sure we're using TimedCache#get; TimedCache is tested elsewhere, so
+    # we don't need to worry about cache expiry tests here.
+    TimedCache.any_instance.expects(:get).with().returns([rail_statistics])
+    assert @document_collection_registry["rail-statistics"]
+  end
+end

--- a/test/unit/elasticsearch_search_query_builder_test.rb
+++ b/test/unit/elasticsearch_search_query_builder_test.rb
@@ -70,6 +70,7 @@ class SearchQueryBuilderTest < ShouldaUnitTestCase
       { filter: { term: { format: "organisation" } },      boost: 2.5 },
       { filter: { term: { format: "topic" } },             boost: 1.5 },
       { filter: { term: { format: "document_series" } },   boost: 1.3 },
+      { filter: { term: { format: "document_collection" } }, boost: 1.3 },
       { filter: { term: { format: "operational_field" } }, boost: 1.5 },
     ]
     assert_equal expected, filters[0..-2]


### PR DESCRIPTION
We're renaming document series -> document collections in Whitehall.
This change provides support for document collections. Support for
document series will be dropped in a future change.

https://www.pivotaltracker.com/story/show/58957338
