### PR TITLE
Generate sitemap files under $docroot/sitemaps/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ production.log
 tmp/*
 .powrc
 /public/system/*.xml
+/public/system/sitemaps/*.xml
 /data

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "sidekiq", "2.13.0"
 # pin to version that includes security vulnerability fix
 gem "redis-namespace", "1.3.1"
 gem "newrelic_rpm", "3.6.7.152"
+gem "plek", "1.4.0"
 
 group :test do
   gem "shoulda-context"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     multi_json (1.3.6)
     newrelic_rpm (3.6.7.152)
     nokogiri (1.5.5)
+    plek (1.4.0)
     polyglot (0.3.3)
     rack (1.5.2)
     rack-protection (1.3.2)
@@ -122,6 +123,7 @@ DEPENDENCIES
   multi_json (= 1.3.6)
   newrelic_rpm (= 3.6.7.152)
   nokogiri (= 1.5.5)
+  plek (= 1.4.0)
   rack (= 1.5.2)
   rack-test
   raindrops (= 0.11.0)

--- a/lib/elasticsearch/sitemap.rb
+++ b/lib/elasticsearch/sitemap.rb
@@ -1,4 +1,5 @@
 require "nokogiri"
+require 'plek'
 
 EXCLUDED_FORMATS = ["recommended-link", "inside-government-link"]
 
@@ -40,8 +41,7 @@ class Sitemap
 
 private
   def base_url
-    return "https://www.gov.uk" if ENV["FACTER_govuk_platform"] == "production"
-    "https://www.#{ENV["FACTER_govuk_platform"]}.alphagov.co.uk"
+    Plek.current.website_root
   end
 end
 
@@ -116,9 +116,8 @@ class SitemapGenerator
     builder.to_xml
   end
 
-	private
-    def base_url
-      return "https://www.gov.uk" if ENV["FACTER_govuk_platform"] == "production"
-      "https://www.#{ENV["FACTER_govuk_platform"]}.alphagov.co.uk"
-    end
+private
+  def base_url
+    Plek.current.website_root
+  end
 end

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -8,9 +8,8 @@ namespace :sitemap do
 
     sitemap_directory = File.join(PROJECT_ROOT, "public", "system")
     sitemap = Sitemap.new(sitemap_directory)
-    sitemap_index_filename = sitemap.generate(search_server.all_indices)
+    sitemap_index_path = sitemap.generate(search_server.all_indices)
 
-    sitemap_index_path = File.join(sitemap_directory, sitemap_index_filename)
     sitemap_link_path = File.join(sitemap_directory, "sitemap.xml")
 
     `ln -sf #{sitemap_index_path} #{sitemap_link_path}`


### PR DESCRIPTION
This is needed to allow this to continue to work with the new router.  The routing currently relies on a fairly [gnarly regex](https://github.gds/gds/puppet/blob/76ef65a134a51ac9329eecd3f40382f79a396f20/modules/varnish/templates/default.vcl.erb#L50), which won't work with the path segment based scheme used by the router.

I've also updated the how the sitemap generator generates the website_base_url to use Plek (and therefore the `GOVUK_WEBSITE_ROOT` ENV variable).  This will have the advantage of actually working on preview.

**Note:** This depends on https://github.gds/gds/puppet/pull/1044.
