### PR TITLE
Switch docroot to be public directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ production.log
 /.bundle
 tmp/*
 .powrc
-/public/system/*.xml
-/public/system/sitemaps/*.xml
+/public/sitemap.xml
+/public/sitemaps/
 /data
 /log

--- a/config.rb
+++ b/config.rb
@@ -8,10 +8,6 @@ require "config/logging"
 set :search_config, SearchConfig.new
 set :default_index_name, "mainstream"
 
-set :static, true
-set :static_cache_control, [:public, :max_age => 86400]
-set :public_folder, File.join(File.dirname(__FILE__), 'public', 'system')
-
 configure :development do
   set :protection, false
 end

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -6,11 +6,11 @@ namespace :sitemap do
     # Individual site maps can have a maximum of 50,000 links in them.
     # Generate site maps and then an index site map to point to them
 
-    sitemap_directory = File.join(PROJECT_ROOT, "public", "system")
-    sitemap = Sitemap.new(sitemap_directory)
+    output_directory = File.join(PROJECT_ROOT, "public")
+    sitemap = Sitemap.new(output_directory)
     sitemap_index_path = sitemap.generate(search_server.all_indices)
 
-    sitemap_link_path = File.join(sitemap_directory, "sitemap.xml")
+    sitemap_link_path = File.join(output_directory, "sitemap.xml")
 
     `ln -sf #{sitemap_index_path} #{sitemap_link_path}`
     fail("Symlinking failed") unless $?.success?


### PR DESCRIPTION
Previously, public/system was configured as the docroot for sinatra (but not for nginx).  This brings it back in line with all the other apps.

This depends on https://github.gds/gds/alphagov-deployment/pull/401
