### PR TITLE
Explicitly require inflector in ResultSetPresenter.

### DIFF
--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -1,3 +1,5 @@
+require "active_support/inflector"
+
 class ResultSetPresenter
 
   def initialize(result_set, context = {})


### PR DESCRIPTION
Without this, the unit tests for this class fail when run in isolation.
