### PR TITLE
Non-JSON presenters

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -174,7 +174,7 @@ class Rummager < Sinatra::Application
       spelling_suggestions: suggester.suggestions(params["q"])
     }
     presenter = ResultSetPresenter.new(result_set, presenter_context)
-    presenter.present
+    MultiJson.encode presenter.present
   end
 
   # Perform an advanced search. Supports filters and pagination.
@@ -206,7 +206,7 @@ class Rummager < Sinatra::Application
     # Using request.params because it is just the params from the request
     # rather than things added by Sinatra (eg splat, captures, index and format)
     result_set = current_index.advanced_search(request.params)
-    ResultSetPresenter.new(result_set).present
+    MultiJson.encode ResultSetPresenter.new(result_set).present
   end
 
   get "/organisations.?:format?" do

--- a/app.rb
+++ b/app.rb
@@ -213,7 +213,7 @@ class Rummager < Sinatra::Application
     json_only
 
     organisations = organisation_registry.all
-    OrganisationSetPresenter.new(organisations).present
+    MultiJson.encode OrganisationSetPresenter.new(organisations).present
   end
 
   # Insert (or overwrite) a document

--- a/lib/organisation_set_presenter.rb
+++ b/lib/organisation_set_presenter.rb
@@ -5,15 +5,15 @@ class OrganisationSetPresenter
   end
 
   def present
-    MultiJson.encode({
-      total: @organisations.size,
-      results: @organisations.map { |organisation| build_result(organisation) }
-    })
+    {
+      "total" => @organisations.size,
+      "results" => @organisations.map { |organisation| build_result(organisation) }
+    }
   end
 
 private
   def build_result(organisation)
     slug = organisation.link.gsub(%r{^/government/organisations/}, "")
-    organisation.to_hash.merge(slug: slug)
+    organisation.to_hash.merge("slug" => slug)
   end
 end

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -9,13 +9,13 @@ class ResultSetPresenter
 
   def present
     presentable_hash = {
-      total: @result_set.total,
-      results: results
+      "total" => @result_set.total,
+      "results" => results
     }
     if spelling_suggestions
-      presentable_hash[:spelling_suggestions] = spelling_suggestions
+      presentable_hash["spelling_suggestions"] = spelling_suggestions
     end
-    MultiJson.encode(presentable_hash)
+    presentable_hash
   end
 
   PRESENTATION_FORMAT_TRANSLATION = {
@@ -61,8 +61,8 @@ private
 
   def build_result(document)
     result = document.to_hash.merge(
-      presentation_format: presentation_format(document),
-      humanized_format: humanized_format(document)
+      "presentation_format" => presentation_format(document),
+      "humanized_format" => humanized_format(document)
     )
     if result['document_series'] && should_expand_document_series?
       result['document_series'] = result['document_series'].map do |slug|
@@ -139,45 +139,45 @@ private
   def document_series_by_slug(slug)
     document_series = document_series_registry && document_series_registry[slug]
     if document_series
-      document_series.to_hash.merge(slug: slug)
+      document_series.to_hash.merge("slug" => slug)
     else
-      {slug: slug}
+      {"slug" => slug}
     end
   end
 
   def document_collection_by_slug(slug)
     document_collection = document_collection_registry && document_collection_registry[slug]
     if document_collection
-      document_collection.to_hash.merge(slug: slug)
+      document_collection.to_hash.merge("slug" => slug)
     else
-      {slug: slug}
+      {"slug" => slug}
     end
   end
 
   def organisation_by_slug(slug)
     organisation = organisation_registry && organisation_registry[slug]
     if organisation
-      organisation.to_hash.merge(slug: slug)
+      organisation.to_hash.merge("slug" => slug)
     else
-      {slug: slug}
+      {"slug" => slug}
     end
   end
 
   def topic_by_slug(slug)
     topic = topic_registry && topic_registry[slug]
     if topic
-      topic.to_hash.merge(slug: slug)
+      topic.to_hash.merge("slug" => slug)
     else
-      {slug: slug}
+      {"slug" => slug}
     end
   end
 
   def world_location_by_slug(slug)
     world_location = world_location_registry && world_location_registry[slug]
     if world_location
-      world_location.to_hash.merge(slug: slug)
+      world_location.to_hash.merge("slug" => slug)
     else
-      {slug: slug}
+      {"slug" => slug}
     end
   end
 end

--- a/test/unit/organisation_set_presenter_test.rb
+++ b/test/unit/organisation_set_presenter_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "organisation_set_presenter"
+
+class OrganisationSetPresenterTest < ShouldaUnitTestCase
+
+  context "presenting organisations" do
+    setup do
+      @organisations = [
+        stub("Org 1",
+             link: "/government/organisations/foo",
+             to_hash: {"title" => "Foo"}),
+        stub("Org 2",
+             link: "/government/organisations/bar",
+             to_hash: {"title" => "Bar"})
+      ]
+      @presenter = OrganisationSetPresenter.new(@organisations)
+    end
+
+    should "include organisation fields" do
+      results = @presenter.present["results"]
+      assert_equal ["Foo", "Bar"], results.map { |r| r["title"] }
+    end
+
+    should "calculate the slug from the organisation's link" do
+      results = @presenter.present["results"]
+      assert_equal ["foo", "bar"], results.map { |r| r["slug"] }
+    end
+  end
+
+end

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -82,13 +82,9 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     stub(results: [Document.new(FIELDS, document_hash)], total: 1)
   end
 
-  def output_for(presenter)
-    MultiJson.decode(presenter.present)
-  end
-
   def test_generates_json_from_documents
     presenter = ResultSetPresenter.new(result_set)
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal 1, output["results"].length
     # Check all the fields from the document are present
     assert_equal [], %w(link title description format) - output["results"][0].keys
@@ -96,43 +92,43 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
   def test_presented_json_includes_presentation_format
     presenter = ResultSetPresenter.new(result_set)
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal "edition", output["results"][0]["presentation_format"]
   end
 
   def test_presented_json_includes_humanized_format
     presenter = ResultSetPresenter.new(result_set)
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal "Editions", output["results"][0]["humanized_format"]
   end
 
   def test_should_use_answer_as_presentation_format_for_planner
     result_set = single_result_with_format "planner"
-    output = output_for(ResultSetPresenter.new(result_set))
+    output = ResultSetPresenter.new(result_set).present
     assert_equal "answer", output["results"][0]["presentation_format"]
   end
 
   def test_should_use_answer_as_presentation_format_for_smart_answer
     result_set = single_result_with_format "smart_answer"
-    output = output_for(ResultSetPresenter.new(result_set))
+    output = ResultSetPresenter.new(result_set).present
     assert_equal "answer", output["results"][0]["presentation_format"]
   end
 
   def test_should_use_answer_as_presentation_format_for_licence_finder
     result_set = single_result_with_format "licence_finder"
-    output = output_for(ResultSetPresenter.new(result_set))
+    output = ResultSetPresenter.new(result_set).present
     assert_equal "answer", output["results"][0]["presentation_format"]
   end
 
   def test_should_use_guide_as_presentation_format_for_guide
     result_set = single_result_with_format "guide"
-    output = output_for(ResultSetPresenter.new(result_set))
+    output = ResultSetPresenter.new(result_set).present
     assert_equal "guide", output["results"][0]["presentation_format"]
   end
 
   def test_should_use_humanized_format
     result_set = single_result_with_format "place"
-    output = output_for(ResultSetPresenter.new(result_set))
+    output = ResultSetPresenter.new(result_set).present
     assert_equal "Services", output["results"][0]["humanized_format"]
   end
 
@@ -140,12 +136,12 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     presenter = ResultSetPresenter.new(single_result_with_format("foo"))
     presenter.stubs(:presentation_format).returns("place")
 
-    assert_equal "Services", output_for(presenter)["results"][0]["humanized_format"]
+    assert_equal "Services", presenter.present["results"][0]["humanized_format"]
   end
 
   def test_generates_humanized_format_if_not_present
     result_set = single_result_with_format "ocean_map"
-    output = output_for(ResultSetPresenter.new(result_set))
+    output = ResultSetPresenter.new(result_set).present
     assert_equal "Ocean maps", output["results"][0]["humanized_format"]
   end
 
@@ -165,7 +161,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       document_series_registry: document_series_registry
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal 1, output["results"][0]["document_series"].size
     assert_instance_of Hash, output["results"][0]["document_series"][0]
     assert_equal "Rail statistics", output["results"][0]["document_series"][0]["title"]
@@ -190,7 +186,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       document_collection_registry: document_collection_registry
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal 1, output["results"][0]["document_collections"].size
     assert_instance_of Hash, output["results"][0]["document_collections"][0]
     assert_equal "Rail statistics", output["results"][0]["document_collections"][0]["title"]
@@ -215,7 +211,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       organisation_registry: organisation_registry
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal 1, output["results"][0]["organisations"].size
     assert_instance_of Hash, output["results"][0]["organisations"][0]
     assert_equal "Ministry of Defence (MoD)", output["results"][0]["organisations"][0]["title"]
@@ -239,7 +235,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       topic_registry: topic_registry
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal 1, output["results"][0]["topics"].size
     assert_instance_of Hash, output["results"][0]["topics"][0]
     assert_equal "Housing", output["results"][0]["topics"][0]["title"]
@@ -263,7 +259,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       world_location_registry: world_location_registry
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal 1, output["results"][0]["world_locations"].size
     assert_instance_of Hash, output["results"][0]["world_locations"][0]
     assert_equal "Angola", output["results"][0]["world_locations"][0]["title"]
@@ -281,7 +277,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       organisation_registry: organisation_registry
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal 1, output["results"][0]["organisations"].size
     assert_instance_of Hash, output["results"][0]["organisations"][0]
     refute_includes output["results"][0]["organisations"][0], "title"
@@ -295,7 +291,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       organisation_registry: nil
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal 1, output["results"][0]["organisations"].size
     assert_equal "ministry-of-silly-walks", output["results"][0]["organisations"][0]
   end
@@ -306,7 +302,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       spelling_suggestions: ["spelling can be improved"]
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     expected = [
       "spelling can be improved"
     ]
@@ -319,7 +315,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
       spelling_suggestions: nil # nil, not empty array
     )
 
-    output = output_for(presenter)
+    output = presenter.present
     assert_equal ["total", "results"], output.keys
   end
 end


### PR DESCRIPTION
We have a couple of presenter classes in Rummager present serialised JSON, rather than a serialisable data structure, which makes them tricky to test and a pain to compose.
