### PR TITLE
Combined search

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -68,6 +68,12 @@ class Rummager < Sinatra::Application
     end
   end
 
+  def govuk_indices
+    settings.search_config.govuk_index_names.map do |index_name|
+      search_server.index(index_name)
+    end
+  end
+
   def lines_from_a_file(filepath)
     path = File.expand_path(filepath, File.dirname(__FILE__))
     lines = File.open(path).map(&:chomp)
@@ -176,11 +182,7 @@ class Rummager < Sinatra::Application
 
     organisation = params["organisation_slug"].blank? ? nil : params["organisation_slug"]
 
-    mainstream_index = search_server.index("mainstream")
-    detailed_index = search_server.index("detailed")
-    government_index = search_server.index("government")
-
-    searcher = GovukSearcher.new(mainstream_index, detailed_index, government_index)
+    searcher = GovukSearcher.new(*govuk_indices)
     result_streams = searcher.search(@query, organisation, params["sort"])
 
     result_context = {

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -5,3 +5,5 @@ topic_registry_index: "government"
 document_series_registry_index: "government"
 document_collection_registry_index: "government"
 world_location_registry_index: "government"
+# These indices are passed in this order to GovukSearcher
+govuk_index_names: ["mainstream", "detailed", "government"]

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -34,6 +34,11 @@ class Document
     end
   end
 
+  def weighted(factor)
+    weighted_score = @es_score ? @es_score * factor : nil
+    Document.new(@field_names, @attributes, weighted_score)
+  end
+
   def elasticsearch_export
     Hash.new.tap do |doc|
       @field_names.each do |key|

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -285,7 +285,7 @@ module Elasticsearch
       payload = MultiJson.dump(builder.query_hash)
       logger.debug "Request payload: #{payload}"
       response = @client.get_with_payload("_search", payload)
-      ResultSet.new(@mappings, MultiJson.decode(response))
+      ResultSet.from_elasticsearch(@mappings, MultiJson.decode(response))
     end
 
     def advanced_search(params)
@@ -314,7 +314,7 @@ module Elasticsearch
       logger.info "Request payload: #{payload.to_json}"
 
       result = @client.get_with_payload("_search", payload.to_json)
-      ResultSet.new(@mappings, MultiJson.decode(result))
+      ResultSet.from_elasticsearch(@mappings, MultiJson.decode(result))
     end
 
     def delete(link)

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -19,7 +19,6 @@ class ResultSet
 
 private
   def self.document_from_hit(hit, mappings)
-    hash = hit["_source"].merge("es_score" => hit["_score"])
-    Document.from_hash(hash, mappings)
+    Document.from_hash(hit["_source"], mappings, hit["_score"])
   end
 end

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -21,6 +21,12 @@ class ResultSet
     ResultSet.new(@results.map { |r| r.weighted(factor) }, @total)
   end
 
+  def merge(other)
+    merged_results = (@results + other.results).sort_by(&:es_score).reverse
+    new_total = @total + other.total
+    ResultSet.new(merged_results, new_total)
+  end
+
 private
   def self.document_from_hit(hit, mappings)
     Document.from_hash(hit["_source"], mappings, hit["_score"])

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -17,6 +17,10 @@ class ResultSet
     ResultSet.new(results, total)
   end
 
+  def weighted(factor)
+    ResultSet.new(@results.map { |r| r.weighted(factor) }, @total)
+  end
+
 private
   def self.document_from_hit(hit, mappings)
     Document.from_hash(hit["_source"], mappings, hit["_score"])

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -27,6 +27,10 @@ class ResultSet
     ResultSet.new(merged_results, new_total)
   end
 
+  def take(count)
+    ResultSet.new(@results.take(count), @total)
+  end
+
 private
   def self.document_from_hit(hit, mappings)
     Document.from_hash(hit["_source"], mappings, hit["_score"])

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -31,6 +31,20 @@ class ResultSet
     ResultSet.new(@results.take(count), @total)
   end
 
+  # Return a ResultSet of all the items in this set that aren't in the other
+  # set. Equivalent in intent to Array#-.
+  def -(other)
+    # Using the link as the unique identifier; we can't simply test for
+    # equality, because we may be comparing weighted and unweighted results,
+    # which don't have the same attributes, so shouldn't be considered equal.
+    links = results.map(&:link)
+    other_links = other.results.map(&:link)
+    common_count = (links & other_links).count
+
+    ResultSet.new(results.reject { |r| other_links.include? r.link },
+                  total - common_count)
+  end
+
 private
   def self.document_from_hit(hit, mappings)
     Document.from_hash(hit["_source"], mappings, hit["_score"])

--- a/lib/elasticsearch/result_set.rb
+++ b/lib/elasticsearch/result_set.rb
@@ -2,17 +2,24 @@ class ResultSet
 
   attr_reader :total, :results
 
-  def initialize(mappings, elasticsearch_response)
-    @mappings = mappings
-    @total = elasticsearch_response["hits"]["total"]
-    @results = elasticsearch_response["hits"]["hits"].map { |hit|
-      document_from_hit(hit)
+  # Initialise from a list of Document objects.
+  def initialize(results, total = results.size)
+    @results = results.dup.freeze
+    @total = total
+  end
+
+  def self.from_elasticsearch(mappings, elasticsearch_response)
+    total = elasticsearch_response["hits"]["total"]
+    results = elasticsearch_response["hits"]["hits"].map { |hit|
+      document_from_hit(hit, mappings)
     }.freeze
+
+    ResultSet.new(results, total)
   end
 
 private
-  def document_from_hit(hit)
+  def self.document_from_hit(hit, mappings)
     hash = hit["_source"].merge("es_score" => hit["_score"])
-    Document.from_hash(hash, @mappings)
+    Document.from_hash(hash, mappings)
   end
 end

--- a/lib/govuk_search_presenter.rb
+++ b/lib/govuk_search_presenter.rb
@@ -1,0 +1,46 @@
+require "result_set_presenter"
+
+# Presents a combined set of results for a GOV.UK site search
+class GovukSearchPresenter
+
+  STREAM_TITLES = {
+    "top-results" => "Top results",
+    "services-information" => "Services and information",
+    "departments-policy" => "Departments and policy"
+  }
+
+  # The `result_sets` hash should be a map from stream names to ResultSet
+  # instances.
+  #
+  # `presenter_context` should be a map from registry names to registries,
+  # which gets passed to the ResultSetPresenter class. For example:
+  #
+  #     { organisation_registry: OrganisationRegistry.new(...) }
+  def initialize(result_sets, presenter_context = {})
+    unknown_keys = result_sets.keys - STREAM_TITLES.keys
+    if unknown_keys.any?
+      raise ArgumentError, "Unrecognised streams: #{unknown_keys.join(', ')}"
+    end
+
+    @result_sets = result_sets
+    @presenter_context = presenter_context
+  end
+
+  def present
+    output = {"streams" => {}}
+    presenters.each do |key, rs_presenter|
+      presented_stream = rs_presenter.present
+      output["streams"][key] = presented_stream.merge("title" => STREAM_TITLES[key])
+    end
+
+    output
+  end
+
+private
+
+  def presenters
+    Hash[@result_sets.map {|key, result_set|
+      [key, ResultSetPresenter.new(result_set, @presenter_context)]
+    }]
+  end
+end

--- a/lib/govuk_searcher.rb
+++ b/lib/govuk_searcher.rb
@@ -1,0 +1,36 @@
+# Combines search results across indices for the GOV.UK site search
+class GovukSearcher
+  def initialize(mainstream_index, detailed_index, government_index)
+    @mainstream_index = mainstream_index
+    @detailed_index = detailed_index
+    @government_index = government_index
+  end
+
+  # Search and combine the indices and return a hash of ResultSet objects
+  def search(query, organisation = nil, sort = nil)
+    mainstream_results = @mainstream_index.search(query)
+    detailed_results = @detailed_index.search(query)
+    government_results = @government_index.search(query,
+      organisation: organisation, sort: sort)
+
+    if organisation || sort
+      unfiltered_government_results = @government_index.search(query)
+    else
+      unfiltered_government_results = government_results
+    end
+
+    # si == services and information
+    si_results = mainstream_results.merge(detailed_results.weighted(0.8))
+
+    top_results = si_results.merge(unfiltered_government_results.weighted(0.6)).take(3)
+
+    remaining_si = si_results - top_results
+    remaining_government = government_results - top_results
+
+    {
+      "top-results" => top_results,
+      "services-information" => remaining_si,
+      "departments-policy" => remaining_government
+    }
+  end
+end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -43,6 +43,10 @@ class SearchConfig
     elasticsearch["world_location_registry_index"]
   end
 
+  def govuk_index_names
+    elasticsearch["govuk_index_names"]
+  end
+
 private
   def config_for(kind)
     YAML.load_file(File.expand_path("../#{kind}.yml", File.dirname(__FILE__)))

--- a/test/integration/combined_search_test.rb
+++ b/test/integration/combined_search_test.rb
@@ -1,0 +1,79 @@
+require "integration_test_helper"
+require "app"
+require "rest-client"
+
+class CombinedSearchTest < IntegrationTest
+
+  INDEX_NAMES = ["mainstream_test", "detailed_test", "government_test"]
+
+  def setup
+    stub_elasticsearch_settings(INDEX_NAMES)
+    app.settings.search_config.stubs(:govuk_index_names).returns(INDEX_NAMES)
+    enable_test_index_connections
+
+    INDEX_NAMES.each do |index_name|
+      try_remove_test_index(index_name)
+      create_test_index(index_name)
+      add_sample_documents(index_name, 2)
+      commit_index(index_name)
+    end
+  end
+
+  def teardown
+    INDEX_NAMES.each do |index_name|
+      clean_index_group(index_name)
+    end
+  end
+
+  def sample_document_attributes(index_name, count)
+    short_index_name = index_name.sub("_test", "")
+    (1..count).map do |i|
+      {
+        "title" => "Sample #{short_index_name} document #{i}",
+        "link" => "/#{short_index_name}-#{i}",
+        "indexable_content" => "Something something important content"
+      }
+    end
+  end
+
+  def add_sample_documents(index_name, count)
+    attributes = sample_document_attributes(index_name, count)
+    attributes.each do |sample_document|
+      post "/#{index_name}/documents", MultiJson.encode(sample_document)
+      assert last_response.ok?
+    end
+  end
+
+  def commit_index(index_name)
+    post "/#{index_name}/commit", nil
+  end
+
+  def parsed_response
+    MultiJson.decode(last_response.body)
+  end
+
+  def test_returns_success
+    get "/govuk/search?q=important"
+    assert last_response.ok?
+  end
+
+  def test_returns_streams
+    get "/govuk/search?q=important"
+    expected_streams = [
+      "top-results",
+      "services-information",
+      "departments-policy"
+    ].to_set
+    assert_equal expected_streams, parsed_response["streams"].keys.to_set
+  end
+
+  def test_returns_3_top_results
+    get "/govuk/search?q=important"
+    assert_equal 3, parsed_response["streams"]["top-results"]["results"].count
+  end
+
+  def test_returns_spelling_suggestions
+    get "/govuk/search?q=afgananistan"
+    assert parsed_response["spelling_suggestions"].include? "Afghanistan"
+  end
+end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -137,4 +137,23 @@ class DocumentTest < MiniTest::Unit::TestCase
 
     refute_includes Document.new(field_names, hash).to_hash, "es_score"
   end
+
+  def test_weighted_score
+    document_hash = {"link" => "/batman", "title" => "Batman"}
+    doc = Document.new(%w(link title), document_hash, 2.8)
+
+    weighted_doc = doc.weighted(0.5)
+    assert_equal "/batman", weighted_doc.link
+    assert_equal "Batman", weighted_doc.title
+    assert_equal 1.4, weighted_doc.es_score
+  end
+
+  def test_weighting_without_score
+    document_hash = {"link" => "/batman"}
+    doc = Document.new(%w(link), document_hash)
+
+    weighted_doc = doc.weighted(0.5)
+    assert_equal "/batman", weighted_doc.link
+    assert_nil weighted_doc.es_score
+  end
 end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -116,4 +116,25 @@ class DocumentTest < MiniTest::Unit::TestCase
 
     assert_equal hash.keys.sort, document.elasticsearch_export.keys.sort
   end
+
+  def test_should_include_result_score
+    hash = { "link" => "/batman" }
+    field_names = ["link"]
+
+    assert_equal 5.2, Document.new(field_names, hash, 5.2).es_score
+  end
+
+  def test_includes_elasticsearch_score_in_hash
+    hash = { "link" => "/batman" }
+    field_names = ["link"]
+
+    assert_equal 5.2, Document.new(field_names, hash, 5.2).to_hash["es_score"]
+  end
+
+  def test_leaves_out_blank_score
+    hash = { "link" => "/batman" }
+    field_names = ["link"]
+
+    refute_includes Document.new(field_names, hash).to_hash, "es_score"
+  end
 end

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -141,7 +141,7 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def test_returns_the_hits_converted_into_documents
-    Document.expects(:from_hash).with({"woo" => "hoo", "es_score" => nil}, default_mappings).returns :woo_hoo
+    Document.expects(:from_hash).with({"woo" => "hoo"}, default_mappings, nil).returns :woo_hoo
     stub_request(:get, "http://example.com:9200/test-index/_search")
       .to_return(:status => 200, :body => "{\"hits\": {\"total\": 10, \"hits\": [{\"_source\": {\"woo\": \"hoo\"}}]}}", :headers => {})
     result_set = @wrapper.advanced_search(default_params)

--- a/test/unit/govuk_search_presenter_test.rb
+++ b/test/unit/govuk_search_presenter_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+require "govuk_search_presenter"
+
+class GovukSearchPresenterTest < ShouldaUnitTestCase
+
+  context "no streams" do
+    setup do
+      @presenter = GovukSearchPresenter.new({})
+    end
+
+    should "present an empty set of streams" do
+      assert_equal({"streams" => {}}, @presenter.present)
+    end
+  end
+
+  context "unknown streams" do
+    should "reject unknown streams" do
+      assert_raises ArgumentError do
+        GovukSearchPresenter.new("cheese" => [])
+      end
+    end
+
+    should "report unknown streams in the exception" do
+      begin
+        GovukSearchPresenter.new("cheese" => []) and flunk
+      rescue ArgumentError => e
+        assert e.message.include? "cheese"
+      end
+    end
+  end
+
+  context "multiple streams" do
+    def stub_presenter
+      stub(present: {"results" => []})
+    end
+
+    setup do
+      @top_results = stub("top results")
+      @si_results = stub("S&I results")
+      @presenter = GovukSearchPresenter.new(
+        "top-results" => @top_results,
+        "services-information" => @si_results
+      )
+    end
+
+    should "instantiate a ResultSetPresenter per stream" do
+      ResultSetPresenter.expects(:new).with(@top_results, {}).returns(stub_presenter)
+      ResultSetPresenter.expects(:new).with(@si_results, {}).returns(stub_presenter)
+      @presenter.present
+    end
+
+    should "include results from each stream" do
+      ResultSetPresenter.stubs(:new).returns(stub_presenter)
+      output = @presenter.present
+      assert_equal(
+        ["top-results", "services-information"].to_set,
+        output["streams"].keys.to_set
+      )
+    end
+
+    should "insert titles" do
+      ResultSetPresenter.stubs(:new).returns(stub_presenter)
+      output = @presenter.present
+      streams = output["streams"]
+
+      assert_equal "Top results", streams["top-results"]["title"]
+      assert_equal "Services and information", streams["services-information"]["title"]
+    end
+  end
+
+  context "with ResultSetPresenter context" do
+    setup do
+      @top_results = stub("top results")
+      @si_results = stub("S&I results")
+      presenters = {
+        "top-results" => @top_results
+      }
+      @context = stub("presenter context")
+      @presenter = GovukSearchPresenter.new(
+        {"top-results" => @top_results},
+        @context
+      )
+    end
+
+    should "pass the presenter context on to child presenters" do
+      ResultSetPresenter.expects(:new)
+          .with(@top_results, @context)
+          .returns(stub_presenter)
+      @presenter.present
+    end
+  end
+end

--- a/test/unit/govuk_searcher_test.rb
+++ b/test/unit/govuk_searcher_test.rb
@@ -1,0 +1,156 @@
+require "test_helper"
+require "set"
+require "govuk_searcher"
+
+class GovukSearcherTest < ShouldaUnitTestCase
+
+  # results is a set of [score, link] pairs
+  class FakeResultSet < Struct.new(:results)
+    def merge(other)
+      merged_results = (results + other.results).sort.reverse
+      FakeResultSet.new(merged_results)
+    end
+
+    def weighted(factor)
+      weighted_results = results.map { |score, link| [score * factor, link] }
+      FakeResultSet.new(weighted_results)
+    end
+
+    def -(other)
+      new_results = results.reject { |r| other.links.include?(r[1]) }
+      FakeResultSet.new(new_results)
+    end
+
+    def take(count)
+      FakeResultSet.new(results.take(count))
+    end
+
+    def links
+      results.map { |r| r[1] }
+    end
+  end
+
+  context "unfiltered, unsorted search" do
+
+    setup do
+      @mainstream = stub("mainstream index")
+      @detailed = stub("detailed index")
+      @government = stub("government index")
+      @searcher = GovukSearcher.new(@mainstream, @detailed, @government)
+
+      no_parameters = { organisation: nil, sort: nil }
+      # No weighting
+      @mainstream.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[6, "/m1"], [5, "/m2"], [3, "/m3"]])
+      )
+      # Weighted: 5.6, 3.2
+      @detailed.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[7, "/d1"], [4, "/d2"]])
+      )
+      # Weighted: 4.8, 3.6
+      @government.expects(:search).with("cheese", no_parameters).returns(
+        FakeResultSet.new([[8, "/g1"], [6, "/g2"]])
+      )
+
+      @results = @searcher.search("cheese")
+    end
+
+    should "include the three result streams" do
+      assert_equal(
+        ["top-results", "services-information", "departments-policy"].to_set,
+        @results.keys.to_set
+      )
+    end
+
+    should "pull out the top three results" do
+      assert_equal(["/m1", "/d1", "/m2"], @results["top-results"].links)
+    end
+
+    should "display the remaining results in their respective streams" do
+      top_links = @results["top-results"].links
+
+      assert_equal ["/d2", "/m3"], @results["services-information"].links
+      assert_equal ["/g1", "/g2"], @results["departments-policy"].links
+    end
+  end
+
+  context "filtered search" do
+
+    setup do
+      @mainstream = stub("mainstream index")
+      @detailed = stub("detailed index")
+      @government = stub("government index")
+      @searcher = GovukSearcher.new(@mainstream, @detailed, @government)
+
+      no_parameters = { organisation: nil, sort: nil }
+      @mainstream.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[6, "/m1"]])
+      )
+      # Weighted: 4
+      @detailed.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[5, "/d1"]])
+      )
+      # Weighted: 4.8, 3.6
+      @government.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[8, "/g1"], [6, "/g2"]])
+      )
+      @government.expects(:search)
+                 .with("cheese", organisation: "org", sort: nil)
+                 .returns(FakeResultSet.new([[6, "/g1"]]))
+
+      @results = @searcher.search("cheese", "org")
+    end
+
+    should "pull out the top three results, including unfiltered" do
+      assert_equal(["/m1", "/g1", "/d1"], @results["top-results"].links)
+    end
+
+    should "display the remaining results in their respective streams" do
+      top_links = @results["top-results"].links
+
+      assert_equal [], @results["services-information"].links
+      # /g1 was in the top results; /g2 is not in the unfiltered results
+      assert_equal [], @results["departments-policy"].links
+    end
+  end
+
+  context "sorted search" do
+
+    setup do
+      @mainstream = stub("mainstream index")
+      @detailed = stub("detailed index")
+      @government = stub("government index")
+      @searcher = GovukSearcher.new(@mainstream, @detailed, @government)
+
+      no_parameters = { organisation: nil, sort: nil }
+      @mainstream.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[6, "/m1"]])
+      )
+      # Weighted: 4
+      @detailed.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[5, "/d1"]])
+      )
+      # Weighted: 4.8, 3.6
+      @government.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[8, "/g1"], [6, "/g2"]])
+      )
+      @government.expects(:search)
+                 .with("cheese", organisation: nil, sort: "public_timestamp")
+                 .returns(FakeResultSet.new([[6, "/g2"], [8, "/g1"]]))
+
+      @results = @searcher.search("cheese", nil, "public_timestamp")
+    end
+
+    should "pull out the top three results" do
+      assert_equal(["/m1", "/g1", "/d1"], @results["top-results"].links)
+    end
+
+    should "display the remaining results in their respective streams" do
+      top_links = @results["top-results"].links
+
+      assert_equal [], @results["services-information"].links
+      # /g1 was in the top results; /g2 is not in the unfiltered results
+      assert_equal ["/g2"], @results["departments-policy"].links
+    end
+  end
+end

--- a/test/unit/result_set_test.rb
+++ b/test/unit/result_set_test.rb
@@ -140,4 +140,58 @@ class ResultSetTest < ShouldaUnitTestCase
       assert_equal [:foo, :bar, :baz], top_results.results
     end
   end
+
+  context "subtracting result sets" do
+    setup do
+      @documents = %w(/1 /2 /3 /4 /5).map { |link|
+        stub("Document #{link}", link: link)
+      }
+      @result_set = ResultSet.new(@documents[0,2], 10)
+    end
+
+    context "removing empty set" do
+      setup do
+        @other_result_set = ResultSet.new([], 2)
+        @remainder = @result_set - @other_result_set
+      end
+
+      should "keep the same results" do
+        assert_equal %w(/1 /2), @remainder.results.map(&:link)
+      end
+
+      should "keep the same total" do
+        assert_equal 10, @remainder.total
+      end
+    end
+
+    context "removing non-overlapping set" do
+      setup do
+        @other_result_set = ResultSet.new(@documents[3,2], 2)
+        @remainder = @result_set - @other_result_set
+      end
+
+      should "keep the same results" do
+        assert_equal %w(/1 /2), @remainder.results.map(&:link)
+      end
+
+      should "keep the same total" do
+        assert_equal 10, @remainder.total
+      end
+    end
+
+    context "removing overlapping set" do
+      setup do
+        @other_result_set = ResultSet.new(@documents[1,2], 2)
+        @remainder = @result_set - @other_result_set
+      end
+
+      should "remove the shared results" do
+        assert_equal %w(/1), @remainder.results.map(&:link)
+      end
+
+      should "subtract the shared count from the total" do
+        assert_equal 9, @remainder.total
+      end
+    end
+  end
 end

--- a/test/unit/result_set_test.rb
+++ b/test/unit/result_set_test.rb
@@ -68,4 +68,28 @@ class ResultSetTest < ShouldaUnitTestCase
       assert_equal [:doc], result_set.results
     end
   end
+
+  context "weighted results" do
+    setup do
+      weighted_1 = stub(es_score: 0.6)
+      document_1 = mock("Document 1") do
+        expects(:weighted).with(0.5).returns(weighted_1)
+      end
+      weighted_2 = stub(es_score: 0.4)
+      document_2 = mock("Document 2") do
+        expects(:weighted).with(0.5).returns(weighted_2)
+      end
+      @result_set = ResultSet.new([document_1, document_2], 12)
+    end
+
+    should "weight each result" do
+      weighted_result_set = @result_set.weighted(0.5)
+      assert_equal [0.6, 0.4], weighted_result_set.results.map(&:es_score)
+    end
+
+    should "keep the same total" do
+      weighted_result_set = @result_set.weighted(0.5)
+      assert_equal 12, weighted_result_set.total
+    end
+  end
 end

--- a/test/unit/result_set_test.rb
+++ b/test/unit/result_set_test.rb
@@ -55,15 +55,14 @@ class ResultSetTest < ShouldaUnitTestCase
 
     should "pass the fields to Document.from_hash" do
       expected_hash = has_entry("foo", "bar")
-      Document.expects(:from_hash).with(expected_hash, mappings).returns(:doc)
+      Document.expects(:from_hash).with(expected_hash, mappings, anything).returns(:doc)
 
       result_set = ResultSet.from_elasticsearch(mappings, @response)
       assert_equal [:doc], result_set.results
     end
 
     should "pass the result score to Document.from_hash" do
-      expected_hash = has_entry("es_score", 12)
-      Document.expects(:from_hash).with(expected_hash, mappings).returns(:doc)
+      Document.expects(:from_hash).with(is_a(Hash), mappings, 12).returns(:doc)
 
       result_set = ResultSet.from_elasticsearch(mappings, @response)
       assert_equal [:doc], result_set.results

--- a/test/unit/result_set_test.rb
+++ b/test/unit/result_set_test.rb
@@ -92,4 +92,30 @@ class ResultSetTest < ShouldaUnitTestCase
       assert_equal 12, weighted_result_set.total
     end
   end
+
+  context "merged result sets" do
+    setup do
+      docs_1 = [
+        stub(link: "/a", es_score: 4),
+        stub(link: "/b", es_score: 2)
+      ]
+      @result_set = ResultSet.new(docs_1)
+
+      docs_2 = [
+        stub(link: "/c", es_score: 3),
+        stub(link: "/d", es_score: 1)
+      ]
+      @other = ResultSet.new(docs_2, 5)
+    end
+
+    should "merge and sort the results" do
+      merged = @result_set.merge(@other)
+      assert_equal %w(/a /c /b /d), merged.results.map(&:link)
+    end
+
+    should "sum the totals" do
+      merged = @result_set.merge(@other)
+      assert_equal 7, merged.total
+    end
+  end
 end

--- a/test/unit/result_set_test.rb
+++ b/test/unit/result_set_test.rb
@@ -118,4 +118,26 @@ class ResultSetTest < ShouldaUnitTestCase
       assert_equal 7, merged.total
     end
   end
+
+  context "taking results" do
+    setup do
+      results = [:foo, :bar, :baz]
+      @result_set = ResultSet.new(results, 10)
+    end
+
+    should "take the first n results" do
+      top_results = @result_set.take(2)
+      assert_equal [:foo, :bar], top_results.results
+    end
+
+    should "leave the total count unchanged" do
+      top_results = @result_set.take(2)
+      assert_equal 10, top_results.total
+    end
+
+    should "take up to n results" do
+      top_results = @result_set.take(5)
+      assert_equal [:foo, :bar, :baz], top_results.results
+    end
+  end
 end

--- a/test/unit/result_set_test.rb
+++ b/test/unit/result_set_test.rb
@@ -25,11 +25,12 @@ class ResultSetTest < ShouldaUnitTestCase
     end
 
     should "report zero results" do
-      assert_equal 0, ResultSet.new(mappings, @response).total
+      assert_equal 0, ResultSet.from_elasticsearch(mappings, @response).total
     end
 
     should "have an empty result set" do
-      assert_equal 0, ResultSet.new(mappings, @response).results.size
+      result_set = ResultSet.from_elasticsearch(mappings, @response)
+      assert_equal 0, result_set.results.size
     end
   end
 
@@ -49,21 +50,23 @@ class ResultSetTest < ShouldaUnitTestCase
     end
 
     should "report one result" do
-      assert_equal 1, ResultSet.new(mappings, @response).total
+      assert_equal 1, ResultSet.from_elasticsearch(mappings, @response).total
     end
 
     should "pass the fields to Document.from_hash" do
       expected_hash = has_entry("foo", "bar")
       Document.expects(:from_hash).with(expected_hash, mappings).returns(:doc)
 
-      assert_equal [:doc], ResultSet.new(mappings, @response).results
+      result_set = ResultSet.from_elasticsearch(mappings, @response)
+      assert_equal [:doc], result_set.results
     end
 
     should "pass the result score to Document.from_hash" do
       expected_hash = has_entry("es_score", 12)
       Document.expects(:from_hash).with(expected_hash, mappings).returns(:doc)
 
-      assert_equal [:doc], ResultSet.new(mappings, @response).results
+      result_set = ResultSet.from_elasticsearch(mappings, @response)
+      assert_equal [:doc], result_set.results
     end
   end
 end


### PR DESCRIPTION
Combine all the results needed for the GOV.UK site search into a single request.

This will let us pull out the hairy result-merging (and the multiple Rummager requests that go along with it) from [the controller in frontend](https://github.com/alphagov/frontend/blob/master/app/controllers/search_controller.rb#L11-105). It’ll also let us make the search work in a less hairy way without frontend needing to know about it.
