### PR TITLE
Fix bug in check for index existing.

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -87,20 +87,24 @@ module Elasticsearch
     end
 
     def real_name
-      alias_info = MultiJson.decode(@client.get("_aliases"))
       # If the index exists, it will return something of the form:
       # { real_name => { "aliases" => { alias => {} } } }
-      # If not, it'll return:
-      # {}
+      # If not, ES would return {} before version 0.90, but raises a 404 with version 0.90+
+      begin
+        alias_info = MultiJson.decode(@client.get("_aliases"))
+      rescue RestClient::ResourceNotFound => e
+        response_body = MultiJson.decode(e.http_body)
+        if response_body['error'].start_with?("IndexMissingException") then 
+          return nil
+        end
+        raise
+      end
+
       alias_info.keys.first
     end
 
     def exists?
-      begin
-        ! real_name.nil?
-      rescue RestClient::ResourceNotFound
-        false
-      end
+      ! real_name.nil?
     end
 
     def close

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -96,7 +96,11 @@ module Elasticsearch
     end
 
     def exists?
-      ! real_name.nil?
+      begin
+        ! real_name.nil?
+      rescue RestClient::ResourceNotFound
+        false
+      end
     end
 
     def close

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -21,6 +21,18 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_real_name_when_no_index
+    stub_request(:get, "http://example.com:9200/test-index/_aliases")
+      .to_return(
+        status: 404,
+        body: '{"error":"IndexMissingException[[text-index] missing]","status":404}',
+        headers: {"Content-Type" => "application/json; charset=UTF-8",
+                  "Content-Length" => 68}
+      )
+
+    assert_nil @wrapper.real_name
+  end
+
+  def test_real_name_when_no_index_es0_20
     # elasticsearch is weird: even though /index/_status 404s if the index
     # doesn't exist, /index/_aliases returns a 200.
     stub_request(:get, "http://example.com:9200/test-index/_aliases")


### PR DESCRIPTION
Elasticsearch 0.90+ raises a 404 instead of returning an empty response
on the _aliases endpoint when an alias doesn't exist; this change makes
index.exists? handle this response, and in turn allows
rummager:migrate_index work when there aren't existing indexes
