### PR TITLE
Remove obsolete format fields

### DIFF
--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -37,33 +37,13 @@ class ResultSetPresenter
   }
 
 private
-  def presentation_format(document)
-    normalized = normalized_format(document)
-    PRESENTATION_FORMAT_TRANSLATION.fetch(normalized, normalized)
-  end
-
-  def humanized_format(document)
-    presentation = presentation_format(document)
-    FORMAT_NAME_ALTERNATIVES[presentation] || presentation.humanize.pluralize
-  end
-
-  def normalized_format(document)
-    if document.format
-      document.format.gsub("-", "_")
-    else
-      "unknown"
-    end
-  end
-
   def results
     @result_set.results.map { |document| build_result(document) }
   end
 
   def build_result(document)
-    result = document.to_hash.merge(
-      "presentation_format" => presentation_format(document),
-      "humanized_format" => humanized_format(document)
-    )
+    result = document.to_hash
+
     if result['document_series'] && should_expand_document_series?
       result['document_series'] = result['document_series'].map do |slug|
         document_series_by_slug(slug)

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -11,8 +11,6 @@ module IntegrationFixtures
       "title" => "TITLE1",
       "description" => "DESCRIPTION",
       "format" => "local_transaction",
-      "humanized_format" => "Services",
-      "presentation_format" => "local_transaction",
       "section" => "life-in-the-uk",
       "link" => "/URL"
     }

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -89,61 +89,6 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     assert_equal [], %w(link title description format) - output["results"][0].keys
   end
 
-  def test_presented_json_includes_presentation_format
-    presenter = ResultSetPresenter.new(result_set)
-    output = presenter.present
-    assert_equal "edition", output["results"][0]["presentation_format"]
-  end
-
-  def test_presented_json_includes_humanized_format
-    presenter = ResultSetPresenter.new(result_set)
-    output = presenter.present
-    assert_equal "Editions", output["results"][0]["humanized_format"]
-  end
-
-  def test_should_use_answer_as_presentation_format_for_planner
-    result_set = single_result_with_format "planner"
-    output = ResultSetPresenter.new(result_set).present
-    assert_equal "answer", output["results"][0]["presentation_format"]
-  end
-
-  def test_should_use_answer_as_presentation_format_for_smart_answer
-    result_set = single_result_with_format "smart_answer"
-    output = ResultSetPresenter.new(result_set).present
-    assert_equal "answer", output["results"][0]["presentation_format"]
-  end
-
-  def test_should_use_answer_as_presentation_format_for_licence_finder
-    result_set = single_result_with_format "licence_finder"
-    output = ResultSetPresenter.new(result_set).present
-    assert_equal "answer", output["results"][0]["presentation_format"]
-  end
-
-  def test_should_use_guide_as_presentation_format_for_guide
-    result_set = single_result_with_format "guide"
-    output = ResultSetPresenter.new(result_set).present
-    assert_equal "guide", output["results"][0]["presentation_format"]
-  end
-
-  def test_should_use_humanized_format
-    result_set = single_result_with_format "place"
-    output = ResultSetPresenter.new(result_set).present
-    assert_equal "Services", output["results"][0]["humanized_format"]
-  end
-
-  def test_uses_presentation_format_to_find_alternative_format_name
-    presenter = ResultSetPresenter.new(single_result_with_format("foo"))
-    presenter.stubs(:presentation_format).returns("place")
-
-    assert_equal "Services", presenter.present["results"][0]["humanized_format"]
-  end
-
-  def test_generates_humanized_format_if_not_present
-    result_set = single_result_with_format "ocean_map"
-    output = ResultSetPresenter.new(result_set).present
-    assert_equal "Ocean maps", output["results"][0]["humanized_format"]
-  end
-
   def test_expands_document_series
     rail_statistics_document = Document.new(
       %w(link title),


### PR DESCRIPTION
The `presentation_format` and `humanized_format` fields used to be used in the frontend to display results, but we don't use them any more.
