### PR TITLE
Increase scroll timeout.

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -54,10 +54,6 @@ module Elasticsearch
       50
     end
 
-    # How long to hold a scroll cursor open between requests
-    # We should be able to keep this low, since these are only for internal use
-    SCROLL_TIMEOUT_MINUTES = 1
-
     # How long to wait between reads when streaming data from the elasticsearch server
     TIMEOUT_SECONDS = 5.0
 

--- a/lib/elasticsearch/scroll_enumerator.rb
+++ b/lib/elasticsearch/scroll_enumerator.rb
@@ -3,8 +3,13 @@ require "uri"
 module Elasticsearch
   class ScrollEnumerator < Enumerator
     # How long to hold a scroll cursor open between requests
-    # We should be able to keep this low, since these are only for internal use
-    SCROLL_TIMEOUT_MINUTES = 1
+    # We want to keep this low (eg, 1 minute), because scroll contexts can be
+    # quite expensive.
+    # However, the scroll timeout in old releases of elasticsearch is based on
+    # the time since the scan operation started, not the time since the last
+    # activity happened in the scan, so until we upgrade to elasticsearch
+    # 0.90.12+, we should set this high.
+    SCROLL_TIMEOUT_MINUTES = 60
 
     # The number of documents to retrieve at once.
     # Gotcha: this is actually the number of documents per shard, so there will

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -295,7 +295,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_can_fetch_documents_by_format
-    search_pattern = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=500"
+    search_pattern = "http://example.com:9200/test-index/_search?scroll=60m&search_type=scan&size=500"
     stub_request(:get, search_pattern).with(
       body: MultiJson.encode({query: {term: {format: "organisation"}}})
     ).to_return(
@@ -316,7 +316,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_can_fetch_documents_by_format_with_certain_fields
-    search_pattern = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=500"
+    search_pattern = "http://example.com:9200/test-index/_search?scroll=60m&search_type=scan&size=500"
     query = {
       query: {term: {format: "organisation"}},
       fields: ["title", "link"]
@@ -344,7 +344,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   def test_can_fetch_documents_by_format_with_fields_not_in_mappings
     # Notably, we want to be able to query for organisation acronyms before we
     # work out how best to add them to the mappings
-    search_pattern = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=500"
+    search_pattern = "http://example.com:9200/test-index/_search?scroll=60m&search_type=scan&size=500"
     query = {
       query: {term: {format: "organisation"}},
       fields: ["title", "link", "wumpus"]
@@ -371,7 +371,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
 
   def test_all_documents_size
     # Test that we can count the documents without retrieving them all
-    search_pattern = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=50"
+    search_pattern = "http://example.com:9200/test-index/_search?scroll=60m&search_type=scan&size=50"
     stub_request(:get, search_pattern).with(
       body: MultiJson.encode({query: {match_all: {}}})
     ).to_return(
@@ -381,7 +381,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_all_documents
-    search_uri = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=50"
+    search_uri = "http://example.com:9200/test-index/_search?scroll=60m&search_type=scan&size=50"
 
     stub_request(:get, search_uri).with(
       body: MultiJson.encode({query: {match_all: {}}})
@@ -405,7 +405,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_changing_scroll_id
-    search_uri = "http://example.com:9200/test-index/_search?scroll=1m&search_type=scan&size=2"
+    search_uri = "http://example.com:9200/test-index/_search?scroll=60m&search_type=scan&size=2"
 
     Elasticsearch::Index.stubs(:scroll_batch_size).returns(2)
 
@@ -461,7 +461,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def scroll_uri(scroll_id)
-     "http://example.com:9200/_search/scroll?scroll=1m&scroll_id=#{scroll_id}"
+     "http://example.com:9200/_search/scroll?scroll=60m&scroll_id=#{scroll_id}"
   end
 
   def scroll_response_body(scroll_id, total_results, results)


### PR DESCRIPTION
Set the timeout to 60 minutes, to work around timeout in old versions of
elasticsearch being from start of scan, not from last action.  Remove
unused old SCROLL_TIMEOUT_MINUTES value from index.rb
