### PR TITLE
Remove unused method indices_for_sitemap

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -62,12 +62,6 @@ class Rummager < Sinatra::Application
     @@world_location_registry ||= WorldLocationRegistry.new(search_server.index(index_name)) if index_name
   end
 
-  def indices_for_sitemap
-    settings.search_config.index_names.map do |index_name|
-      search_server.index(index_name)
-    end
-  end
-
   def govuk_indices
     settings.search_config.govuk_index_names.map do |index_name|
       search_server.index(index_name)

--- a/lib/elasticsearch/sitemap.rb
+++ b/lib/elasticsearch/sitemap.rb
@@ -89,8 +89,8 @@ class SitemapGenerator
     Enumerator.new do |yielder|
       # Hard-code the site root, as it isn't listed in any search index
       yielder << "/"
-      indices_for_sitemap = @sitemap_indices
-      indices_for_sitemap.each do |index|
+
+      @sitemap_indices.each do |index|
         index.all_document_links(EXCLUDED_FORMATS).each do |document|
           yielder << document
         end


### PR DESCRIPTION
Found this unused method whilst looking into how sitemap generation works.
