### PR TITLE
Added new stats release announcement fields

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -710,6 +710,8 @@ mappings:
         display_type: { type: string, index: not_analyzed, include_in_all: false }
         document_collections: { type: string, index: not_analyzed, include_in_all: false }
         document_series: { type: string, index: not_analyzed, include_in_all: false }
+        expected_release_text: { type: string, index: not_analyzed, include_in_all: false }
+        expected_release_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         format:      { type: string, index: not_analyzed, include_in_all: false }
         indexable_content: { type: string, index: analyzed }
         link:        { type: string, index: not_analyzed, include_in_all: false }


### PR DESCRIPTION
A new content type is being added to whitehall called `StatisticalReleaseAnnouncement`. This will be used to pre-announce forthcoming statistical releases. We require two extra fields in the search index to allow us to list these in search results:
1. `expected_release_timestamp` - a timestamp representing the expected release of the stats for sorting purposes (so we can show the soonest first) 
2. `expected_release_text` - a textual version of the expected release date to be displayed on the site, as the timestamp will sometimes only be an approximation, e.g. "April 2015".
