### PR TITLE
Fix deletion with elasticsearch 0.90+.

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -324,7 +324,12 @@ module Elasticsearch
     def delete(link)
       begin
         # Can't use a simple delete, because we don't know the type
-        @client.delete "_query", params: {q: "link:#{escape(link)}"}
+        payload = {
+          "term" => {
+            "link" => link
+          }
+        }
+        @client.delete_with_payload "_query", payload.to_json
       rescue RestClient::ResourceNotFound
       rescue RestClient::Forbidden => e
         response_body = MultiJson.decode(e.http_body)


### PR DESCRIPTION
Document deletion uses the delete_by_query API in elasticsearch; the way
in which that expects queries to be escaped has been changed in
elasticsearch 0.90 compared to 0.20, such that documents were not being
deleted by the existing code in elasticsearch 0.90+.  The simplest fix
is just to use the request body to send the query using the query DSL,
since this avoids needing to do any escaping.  Avoiding doing escaping
is better anyway.

This change works with 0.20 and 0.90 series releases.  (It won't work with 1.0 series releases, since the api for delete by query is changed _again_ there, but that can be fixed once we're on 0.90.)
