### PR TITLE
Add new "metadata" property to schema

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -735,6 +735,13 @@ mappings:
         format:      { type: string, index: not_analyzed, include_in_all: false }
         indexable_content: { type: string, index: analyzed }
         link:        { type: string, index: not_analyzed, include_in_all: false }
+
+        # Note: the "metadata" property is intended for the storage of additional
+        # non-searchable document properties. This allows additional information
+        # to be stored and displayed in search results without having to make
+        # changes to the schema.
+        metadata: { type: object, index: no }
+
         operational_field: { type: string, index: not_analyzed, include_in_all: false }
         organisations: { type: string, index: not_analyzed, include_in_all: false }
         organisation_state: { type: string, index: not_analyzed, include_in_all: false }


### PR DESCRIPTION
The "metadata" property is intended for the storage of additional non-searchable document properties. This allows additional information to be stored and displayed in search results without having to make
changes to the schema.

Note that it is non-searchable as index is set to "no" and it's of type "object".

The immediate use for this is to allow us to store and display additional meta-information for statistics announcements in whitehall, i.e. things like the release display text, change note, date precision, etc. Adding these as explicit properties in the schema makes little sense as we do not intend to make them searchable.
