### PR TITLE
Adjust schema for statistics announcements

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -730,8 +730,7 @@ mappings:
         display_type: { type: string, index: not_analyzed, include_in_all: false }
         document_collections: { type: string, index: not_analyzed, include_in_all: false }
         document_series: { type: string, index: not_analyzed, include_in_all: false }
-        expected_release_text: { type: string, index: not_analyzed, include_in_all: false }
-        expected_release_timestamp: { type: date, index: not_analyzed, include_in_all: false }
+        release_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         format:      { type: string, index: not_analyzed, include_in_all: false }
         indexable_content: { type: string, index: analyzed }
         link:        { type: string, index: not_analyzed, include_in_all: false }


### PR DESCRIPTION
We no longer need an explicitly property for the release text as we'll be able to put that in the new metadata property.

This assumes that https://github.com/alphagov/rummager/pull/199 will be merged.
