### PR TITLE
Add an organisations field to the mainstream index

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -713,6 +713,7 @@ mappings:
         link:        { type: string, index: not_analyzed, include_in_all: false }
         indexable_content: { type: string, index: analyzed }
         promoted_for: { type: string, index: analyzed, include_in_all: false }
+        organisations: { type: string, index: not_analyzed, include_in_all: false }
   government:
     edition:
       _all: { enabled: true }


### PR DESCRIPTION
In order to supports future scoped search work, we're allowing mainstream content to be tagged with organisations in Panopticon. To include these in the search index, this pull request adds a new organisations field to the Mainstream index schema, based on the equivalent field definition for the government index.
