### PR TITLE
Add script to dump links.

### DIFF
--- a/bin/dump_links
+++ b/bin/dump_links
@@ -2,8 +2,6 @@
 LIBRARY_PATH = File.join(File.dirname(__FILE__), "..", "lib")
 $LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
 
-require 'set'
-
 require "elasticsearch/search_server"
 require "search_config"
 

--- a/bin/dump_links
+++ b/bin/dump_links
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
-PROJECT_ROOT = File.dirname(__FILE__) + "/../"
-LIBRARY_PATH = PROJECT_ROOT + "lib/"
+LIBRARY_PATH = File.join(File.dirname(__FILE__), "..", "lib")
 $LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
 
 require 'set'

--- a/bin/dump_links
+++ b/bin/dump_links
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+PROJECT_ROOT = File.dirname(__FILE__) + "/../"
+LIBRARY_PATH = PROJECT_ROOT + "lib/"
+$LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
+
+require 'set'
+
+require "elasticsearch/search_server"
+require "search_config"
+
+def all_links(indices)
+  Enumerator.new do |yielder|
+    indices.each do |index|
+      index.all_document_links.each do |link|
+        yielder << [link, index.index_name]
+      end
+    end
+  end
+end
+
+# The indexes which make up GOV.UK. Excludes the Service Manual
+search_config = SearchConfig.new
+index_names = search_config.index_names
+search_server = search_config.search_server
+indices = index_names.map { |name| search_server.index(name) }
+
+all_links(indices).each do |link, index_name|
+  puts "#{link},#{index_name}"
+end


### PR DESCRIPTION
This script simply iterates through all indexes, dumping the contents of
the "link" field, and the index name, as one entry per line.  This is
intended to be used to check the contents of an index, both now (to
resolve https://www.pivotaltracker.com/story/show/67319636 ) and
whenever we are concerned that there may be documents missing or present
that shouldn't be.

It should take no more than a few seconds to run.
