### PR TITLE
Validate unified_search parameters

### DIFF
--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -19,6 +19,7 @@ class MultiIndexTest < IntegrationTest
         add_field_to_mappings("public_timestamp", "date")
       end
       add_field_to_mappings("topics")
+      add_field_to_mappings("section")
       create_test_index(index_name)
       add_sample_documents(index_name, 2)
       commit_index(index_name)
@@ -42,6 +43,7 @@ class MultiIndexTest < IntegrationTest
       if i % 2 == 0
         fields["topics"] = ["farming"]
       end
+      fields["section"] = ["#{i}"]
       if short_index_name == "government"
         fields["public_timestamp"] = "#{i+2000}-01-01T00:00:00"
       end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -35,11 +35,38 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal ["/government-2", "/government-1"], links
   end
 
+  def test_filter_by_section
+    get "/unified_search?filter_section=1"
+    assert last_response.ok?
+    links = parsed_response["results"].map do |result|
+      result["link"]
+    end
+    links.sort!
+    assert_equal links, ["/detailed-1", "/government-1", "/mainstream-1"], links
+  end
+
   def test_only_contains_fields_which_are_present
     get "/unified_search?q=important&order=public_timestamp"
     results = parsed_response["results"] 
     refute_includes results[0].keys, "topics"
     assert_equal ["farming"], results[1]["topics"]
+  end
+
+  def test_validates_integer_params
+    get "/unified_search?start=a"
+    assert_equal last_response.status, 400
+    assert_equal parsed_response, {"error" => "Invalid value \"a\" for parameter \"start\" (expected integer)"}
+  end
+
+  def test_allows_integer_params_leading_zeros
+    get "/unified_search?start=09"
+    assert last_response.ok?
+  end
+
+  def test_validates_unknown_params
+    get "/unified_search?foo&bar=1"
+    assert_equal last_response.status, 400
+    assert_equal parsed_response, {"error" => "Unexpected parameters: foo,bar"}
   end
 
 end


### PR DESCRIPTION
Ensure that start and count are valid integers, and that no unexpected
parameters are supplied.  Return a 400 status code and an error body for
such invalid parameters, so that typos calling this return an error,
instead of silently falling back to default values.
