### PR TITLE
Add facet calculation to unified search API

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -218,6 +218,17 @@ class Rummager < Sinatra::Application
   #   of the filter groups, and they will be considered to match a filter group
   #   if any of the individual filters in that group match.
   #
+  #   facet_FIELD: (where FIELD is a fieldname); count up values which are
+  #   present in the field in the documents matched by the search, and return
+  #   information about these.  The value of this parameter is the limit on the
+  #   number of distinct field values which will be returned.
+  #
+  #   When combining facet calculation and filters, the API tries to do the
+  #   "right" thing for most user interfaces.  This means that when calculating
+  #   facet values for field A, if there are filters for field A and B, the
+  #   facet values are calculated as if the filters for field B are applied,
+  #   but not those for field A.
+  #
   #
   # For example:
   #
@@ -229,6 +240,7 @@ class Rummager < Sinatra::Application
   #      filter_organisations[]=cabinet-office&
   #      filter_organisations[]=driver-vehicle-licensing-agency&
   #      filter_section[]=driving
+  #      facet_organisations=10
   #
   # Returns something like:
   #
@@ -241,7 +253,18 @@ class Rummager < Sinatra::Application
   #       "offset": 0,
   #       "spelling_suggestions": [
   #         ...
-  #       ]
+  #       ],
+  #       "facets": {
+  #         "organisations": {
+  #           "options": [
+  #             {
+  #               "value": "department-for-business-innovation-skills",
+  #               "documents": 788
+  #             }, ...],
+  #           "documents_with_no_value": 1610,
+  #           "total_options": 94
+  #         }
+  #       }
   #     }
   #
   get "/unified_search.?:request_format?" do
@@ -261,7 +284,8 @@ class Rummager < Sinatra::Application
       order = params["order"]
 
       searcher = UnifiedSearcher.new(unified_index, registries)
-      MultiJson.encode searcher.search(start, count, query, order, filters)
+      MultiJson.encode searcher.search(start, count, query, order, filters,
+                                       facets)
     rescue ArgumentError => e
       status 400
       MultiJson.encode({ error: e.message })
@@ -451,5 +475,20 @@ private
       end
     end
     filters
+  end
+
+  def facets
+    facets = {}
+    request.params.each do |key, count|
+      if m = key.match(/\Afacet_(.*)/)
+        begin
+          count = Integer(count, 10)
+        rescue ArgumentError
+          raise ArgumentError, "Invalid value \"#{count}\" for facet parameter \"#{key}\" (expected integer)"
+        end
+        facets[m[1]] = count
+      end
+    end
+    facets
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -277,13 +277,21 @@ class Rummager < Sinatra::Application
         document_collection_registry: document_collection_registry,
         world_location_registry: world_location_registry
       }
+      registry_by_field = {
+        organisations: organisation_registry,
+        topics: topic_registry,
+        document_series: document_series_registry,
+        document_collections: document_collection_registry,
+        world_locations: world_location_registry
+      }
 
       start = params["start"]
       count = params["count"]
       query = params["q"]
       order = params["order"]
 
-      searcher = UnifiedSearcher.new(unified_index, registries)
+      searcher = UnifiedSearcher.new(unified_index, registries,
+                                     registry_by_field)
       MultiJson.encode searcher.search(start, count, query, order, filters,
                                        facets)
     rescue ArgumentError => e

--- a/lib/field_presenter.rb
+++ b/lib/field_presenter.rb
@@ -1,5 +1,3 @@
-
-
 class FieldPresenter
   attr_reader :registry_by_field
 

--- a/lib/field_presenter.rb
+++ b/lib/field_presenter.rb
@@ -1,0 +1,38 @@
+
+
+class FieldPresenter
+  attr_reader :registry_by_field
+
+  def initialize(registry_by_field)
+    @registry_by_field = registry_by_field
+  end
+
+  # Expand a field given a slug, if the field should be expanded.
+  def expand(field, slug)
+    if should_expand(field)
+      value_by_slug(field, slug)
+    else
+      slug
+    end
+  end
+
+  # Return true if the field should be expanded (ie, there is a registry for
+  # it).
+  def should_expand(field)
+    !! registry_by_field[field.to_sym]
+  end
+
+  # Return an expanded value for a field given a slug.  Always returns a hash
+  # with at least the key "slug".
+  def value_by_slug(field, slug)
+    registry = registry_by_field[field.to_sym]
+    if registry
+      value = registry[slug]
+      if value
+        return value.to_hash.merge("slug" => slug)
+      end
+    end
+    {"slug" => slug}
+  end
+
+end

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -110,22 +110,19 @@ class UnifiedSearchBuilder
 
   def sort_filters
     # Filters to ensure that fields being sorted by exist.
-    filters = []
-    sort_fields.each do |field|
-      filters << {"exists" => {"field" => field}}
-    end
-    combine_filters(filters)
+    combine_filters(sort_fields.map do |field|
+      {"exists" => {"field" => field}}
+    end)
   end
 
   def filters_hash(excluding=[])
-    filter_groups = []
-    @filters.each do |field, filter_values|
+    filter_groups = @filters.reject do |field, filter_values|
       unless ALLOWED_FILTER_FIELDS.include? field
         raise ArgumentError, "Filtering by \"#{field}\" is not allowed"
       end
-      unless excluding.include? field
-        filter_groups << terms_filter(field, filter_values)
-      end
+      excluding.include? field
+    end.map do |field, filter_values|
+      terms_filter(field, filter_values)
     end
     # Don't add additional filters to filter_groups without making sure that
     # the facet_filter values used in facets include the filter too.  It's

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -5,11 +5,12 @@ require "unified_search_presenter"
 
 class UnifiedSearcher
 
-  attr_reader :index, :registries
+  attr_reader :index, :registries, :registry_by_field
 
-  def initialize(index, registries)
+  def initialize(index, registries, registry_by_field)
     @index = index
     @registries = registries
+    @registry_by_field = registry_by_field
   end
 
   # Search and combine the indices and return a hash of ResultSet objects
@@ -33,7 +34,8 @@ class UnifiedSearcher
       results,
       @index.index_name.split(","),
       facet_fields,
-      registries
+      registries,
+      registry_by_field,
     ).present
   end
 end

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -13,10 +13,10 @@ class UnifiedSearcher
   end
 
   # Search and combine the indices and return a hash of ResultSet objects
-  def search(start, count, query, order, filters)
+  def search(start, count, query, order, filters, facet_fields)
     start = start || 0
     count = count || 10
-    builder = UnifiedSearchBuilder.new(start, count, query, order, filters, nil)
+    builder = UnifiedSearchBuilder.new(start, count, query, order, filters, nil, facet_fields)
 
     results = index.raw_search(builder.payload)
     results = {
@@ -27,10 +27,12 @@ class UnifiedSearcher
         doc
       end,
       total: results["hits"]["total"],
+      facets: results["facets"],
     }
     UnifiedSearchPresenter.new(
       results,
       @index.index_name.split(","),
+      facet_fields,
       registries
     ).present
   end

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -39,6 +39,7 @@ class MultiIndexTest < IntegrationTest
         "link" => "/#{short_index_name}-#{i}",
         "indexable_content" => "Something something important content",
       }
+      fields["section"] = i
       if i % 2 == 0
         fields["topics"] = ["farming"]
       end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -42,4 +42,20 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal ["farming"], results[1]["topics"]
   end
 
+  def test_facet_counting
+    get "/unified_search?q=important&facet_section=2"
+    assert_equal 6, parsed_response["total"]
+    facets = parsed_response["facets"] 
+    assert_equal({
+      "section" => {
+        "options" => [
+          {"value"=>"2", "documents"=>3},
+          {"value"=>"1", "documents"=>3},
+        ],
+        "documents_with_no_value" => 0,
+        "total_options" => 2,
+      }
+    }, facets)
+  end
+
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -57,7 +57,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     setup do
       @combined_index = stub("unified index")
-      @searcher = UnifiedSearcher.new(@combined_index, {})
+      @searcher = UnifiedSearcher.new(@combined_index, {}, {})
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -91,7 +91,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     setup do
       @combined_index = stub("unified index")
-      @searcher = UnifiedSearcher.new(@combined_index, {})
+      @searcher = UnifiedSearcher.new(@combined_index, {}, {})
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -126,7 +126,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     setup do
       @combined_index = stub("unified index")
-      @searcher = UnifiedSearcher.new(@combined_index, {})
+      @searcher = UnifiedSearcher.new(@combined_index, {}, {})
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -162,7 +162,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     setup do
       @combined_index = stub("unified index")
-      @searcher = UnifiedSearcher.new(@combined_index, {})
+      @searcher = UnifiedSearcher.new(@combined_index, {}, {})
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,


### PR DESCRIPTION
This adds support for supplying facet_<fieldname> parameters to the API,
which return counts of the top values in that field in documents which
match the query.

For fields which have registries associated with them (eg, organisations), the values returned are expanded to give display data as well as the slug for each value.

This is designed to support multi-select facets in the API, and to
support having several active facet fields at a time.  To do this
correctly, the "filters" part of the request payload sent to
elasticsearch needs to contain only filters related to facet fields.
Any other filters are now included in the "query" part of the request
payload using a "filtered" query in elasticsearch.

This PR is to support https://www.pivotaltracker.com/story/show/66950220 "Add organisation filtering to simplified search results page".
