### PR TITLE
Add missing_options value to facet results

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -262,7 +262,8 @@ class Rummager < Sinatra::Application
   #               "documents": 788
   #             }, ...],
   #           "documents_with_no_value": 1610,
-  #           "total_options": 94
+  #           "total_options": 94,
+  #           "missing_options": 84
   #         }
   #       }
   #     }

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -77,7 +77,8 @@ private
           }
         end,
         documents_with_no_value: facet_info["missing"],
-        total_options: options.length
+        total_options: options.length,
+        missing_options: options.length - display_options.length,
       }
     end
     result

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -54,6 +54,23 @@ class UnifiedSearchTest < MultiIndexTest
         ],
         "documents_with_no_value" => 0,
         "total_options" => 2,
+        "missing_options" => 0,
+      }
+    }, facets)
+  end
+
+  def test_facet_counting_missing_options
+    get "/unified_search?q=important&facet_section=1"
+    assert_equal 6, parsed_response["total"]
+    facets = parsed_response["facets"] 
+    assert_equal({
+      "section" => {
+        "options" => [
+          {"value"=>"2", "documents"=>3},
+        ],
+        "documents_with_no_value" => 0,
+        "total_options" => 2,
+        "missing_options" => 1,
       }
     }, facets)
   end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -240,6 +240,10 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     should "have correct total number of options" do
       assert_equal(2, @output[:facets]["organisations"][:total_options])
     end
+
+    should "have correct number of missing options" do
+      assert_equal(1, @output[:facets]["organisations"][:missing_options])
+    end
   end
 
   context "results with facet counting only" do
@@ -271,6 +275,10 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
     should "have correct total number of options" do
       assert_equal(2, @output[:facets]["organisations"][:total_options])
+    end
+
+    should "have correct number of missing options" do
+      assert_equal(2, @output[:facets]["organisations"][:missing_options])
     end
   end
 
@@ -340,6 +348,11 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     should "have correct total number of options" do
       assert_equal(2, @output[:facets]["organisations"][:total_options])
       assert_equal(2, @output[:facets]["topics"][:total_options])
+    end
+
+    should "have correct number of missing options" do
+      assert_equal(1, @output[:facets]["organisations"][:missing_options])
+      assert_equal(1, @output[:facets]["topics"][:missing_options])
     end
   end
 

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -219,6 +219,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     should "include requested number of facets" do
       facet = @results[:facets]["organisations"]
       assert_equal(2, facet[:total_options])
+      assert_equal(1, facet[:missing_options])
     end
 
     should "include number of documents with no value" do


### PR DESCRIPTION
This makes it easy to display how many options have been missed from a
list of options in the frontend.
