### PR TITLE
Validate unified_search parameters

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -50,6 +50,9 @@ private
   def process(params)
     @params = params
     @errors = []
+
+    # @used_params is populated as a side effect of the methods used to build
+    # up the hash of parsed params.
     @used_params = []
 
     @parsed_params = {

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -97,7 +97,7 @@ private
     disallowed_fields = fields - ALLOWED_RETURN_FIELDS
     fields = fields - disallowed_fields
 
-    unless disallowed_fields.empty?
+    if disallowed_fields.any?
       @errors << "Some requested fields are not valid return fields: #{disallowed_fields}"
     end
     fields

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -1,0 +1,171 @@
+class SearchParameterParser
+
+  attr_reader :parsed_params
+
+  # The fields listed here are the only ones which the search results can be
+  # ordered by.  These are listed and validated explicitly because
+  # sorting by arbitrary fields can be expensive in terms of memory usage in
+  # elasticsearch, and because elasticsearch gives fairly obscure error
+  # messages if undefined sort fields are used.
+  ALLOWED_SORT_FIELDS = %w(public_timestamp)
+
+  # The fields listed here are the only ones which can be used to filter by.
+  ALLOWED_FILTER_FIELDS = %w(organisations section format)
+
+  # The fields listed here are the only ones which can be used to calculated
+  # facets for.  This should be a subset of ALLOWED_FILTER_FIELDS
+  ALLOWED_FACET_FIELDS = %w(organisations section format)
+
+  # The fields listed here are the only ones that can be returned in search
+  # results.  These are listed and validated explicitly, rather than simply
+  # allowing any field in the schema, to keep the set of such fields as minimal
+  # as possible.  This lets us reorganise the way other fields are stored and
+  # indexed without having to check that we don't break the display of search
+  # results.
+  ALLOWED_RETURN_FIELDS = %w(
+    title description link slug
+
+    public_timestamp
+    organisations topics world_locations document_series
+
+    format display_type
+    section subsection subsubsection
+
+  )
+
+  def initialize(params)
+    process(params)
+  end
+
+  def valid?
+    @errors.empty?
+  end
+
+  def error
+    @errors.join(". ")
+  end
+
+private
+
+  def process(params)
+    @params = params
+    @errors = []
+    @used_params = []
+
+    @parsed_params = {
+      start: integer_param("start", 0),
+      count: integer_param("count", 10),
+      query: string_param("q"),
+      order: order,
+      return_fields: return_fields,
+      filters: filters,
+      facets: facets,
+    }
+
+    unused_params = @params.keys - @used_params
+    unless unused_params.empty?
+      @errors << "Unexpected parameters: #{unused_params.join(', ')}"
+    end
+  end
+
+  # Get the order for search results to be returned in.
+  def order
+    order = string_param("order")
+    if order.nil?
+      return nil
+    end
+    if order.start_with?('-')
+      field = order[1..-1]
+      dir = "desc"
+    else
+      field = order
+      dir = "asc"
+    end
+    unless ALLOWED_SORT_FIELDS.include?(field)
+      @errors << "\"#{field}\" is not a valid sort field"
+      return nil
+    end
+    return [field, dir]
+  end
+
+  # Get a list of the fields to request in results from elasticsearch
+  def return_fields
+    fields = string_param("fields")
+    if fields.nil?
+      return ALLOWED_RETURN_FIELDS
+    end
+    disallowed_fields = fields - ALLOWED_RETURN_FIELDS
+    fields = fields - disallowed_fields
+
+    unless disallowed_fields.empty?
+      @errors << "Some requested fields are not valid return fields: #{disallowed_fields}"
+    end
+    fields
+  end
+
+  def filters
+    filters = {}
+    @params.each do |key, value|
+      if (m = key.match(/\Afilter_(.*)/))
+        field = m[1]
+        if ALLOWED_FILTER_FIELDS.include? field
+          filters[field] = [*value]
+        else
+          @errors << "\"#{field}\" is not a valid filter field"
+        end
+        @used_params << key
+      end
+    end
+    filters
+  end
+
+  def facets
+    facets = {}
+    @params.each do |key, value|
+      if (m = key.match(/\Afacet_(.*)/))
+        field = m[1]
+        if ALLOWED_FACET_FIELDS.include? field
+          count = parse_positive_integer(value, "facet \"#{field}\"")
+          unless count.nil?
+            facets[field] = count
+          end
+        else
+          @errors << "\"#{field}\" is not a valid facet field"
+        end
+        @used_params << key
+      end
+    end
+    facets
+  end
+
+  def integer_param(param_name, default)
+    value = @params[param_name]
+    @used_params << param_name
+    unless value.nil?
+      value = parse_positive_integer(value, "parameter \"#{param_name}\"")
+    end
+    if value.nil?
+      return default
+    end
+    value
+  end
+
+  def parse_positive_integer(value, description)
+    begin
+      result = Integer(value, 10)
+    rescue ArgumentError
+      @errors << "Invalid value \"#{value}\" for #{description} (expected positive integer)"
+      return nil
+    end
+    if result < 0
+      @errors << "Invalid negative value \"#{value}\" for #{description} (expected positive integer)"
+      return nil
+    end
+    result
+  end
+
+  def string_param(param_name)
+    @used_params << param_name
+    @params[param_name]
+  end
+end

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -14,14 +14,12 @@ class UnifiedSearcher
   end
 
   # Search and combine the indices and return a hash of ResultSet objects
-  def search(start, count, query, order, filters, facet_fields)
-    start = start || 0
-    count = count || 10
-    builder = UnifiedSearchBuilder.new(start, count, query, order, filters, nil, facet_fields)
+  def search(params)
+    builder = UnifiedSearchBuilder.new(params)
 
     results = index.raw_search(builder.payload)
     results = {
-      start: start,
+      start: params[:start],
       results: results["hits"]["hits"].map do |result|
         doc = result.delete("fields")
         doc[:_metadata] = result
@@ -33,7 +31,7 @@ class UnifiedSearcher
     UnifiedSearchPresenter.new(
       results,
       @index.index_name.split(","),
-      facet_fields,
+      params[:facets],
       registries,
       registry_by_field,
     ).present

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -19,6 +19,7 @@ class MultiIndexTest < IntegrationTest
         add_field_to_mappings("public_timestamp", "date")
       end
       add_field_to_mappings("topics")
+      add_field_to_mappings("section")
       create_test_index(index_name)
       add_sample_documents(index_name, 2)
       commit_index(index_name)
@@ -43,6 +44,7 @@ class MultiIndexTest < IntegrationTest
       if i % 2 == 0
         fields["topics"] = ["farming"]
       end
+      fields["section"] = ["#{i}"]
       if short_index_name == "government"
         fields["public_timestamp"] = "#{i+2000}-01-01T00:00:00"
       end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -35,9 +35,19 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal ["/government-2", "/government-1"], links
   end
 
+  def test_filter_by_section
+    get "/unified_search?filter_section=1"
+    assert last_response.ok?
+    links = parsed_response["results"].map do |result|
+      result["link"]
+    end
+    links.sort!
+    assert_equal links, ["/detailed-1", "/government-1", "/mainstream-1"], links
+  end
+
   def test_only_contains_fields_which_are_present
     get "/unified_search?q=important&order=public_timestamp"
-    results = parsed_response["results"] 
+    results = parsed_response["results"]
     refute_includes results[0].keys, "topics"
     assert_equal ["farming"], results[1]["topics"]
   end
@@ -45,7 +55,7 @@ class UnifiedSearchTest < MultiIndexTest
   def test_facet_counting
     get "/unified_search?q=important&facet_section=2"
     assert_equal 6, parsed_response["total"]
-    facets = parsed_response["facets"] 
+    facets = parsed_response["facets"]
     assert_equal({
       "section" => {
         "options" => [
@@ -62,7 +72,7 @@ class UnifiedSearchTest < MultiIndexTest
   def test_facet_counting_missing_options
     get "/unified_search?q=important&facet_section=1"
     assert_equal 6, parsed_response["total"]
-    facets = parsed_response["facets"] 
+    facets = parsed_response["facets"]
     assert_equal({
       "section" => {
         "options" => [
@@ -75,4 +85,20 @@ class UnifiedSearchTest < MultiIndexTest
     }, facets)
   end
 
+  def test_validates_integer_params
+    get "/unified_search?start=a"
+    assert_equal last_response.status, 400
+    assert_equal parsed_response, {"error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)"}
+  end
+
+  def test_allows_integer_params_leading_zeros
+    get "/unified_search?start=09"
+    assert last_response.ok?
+  end
+
+  def test_validates_unknown_params
+    get "/unified_search?foo&bar=1"
+    assert_equal last_response.status, 400
+    assert_equal parsed_response, {"error" => "Unexpected parameters: foo, bar"}
+  end
 end

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -111,14 +111,6 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     assert_equal(expected_params(query: "search-term"), p.parsed_params)
   end
 
-  should "understand the q parameter" do
-    p = SearchParameterParser.new({"q" => "search-term"})
-
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(query: "search-term"), p.parsed_params)
-  end
-
   should "understand filter paramers" do
     p = SearchParameterParser.new({"filter_organisations" => "hm-magic"})
 

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -1,0 +1,232 @@
+require "test_helper"
+require "search_parameter_parser"
+
+class SearchParameterParserTest < ShouldaUnitTestCase
+
+  def expected_params(params)
+    {
+      start: 0,
+      count: 10,
+      query: nil,
+      order: nil,
+      return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
+      filters: {},
+      facets: {},
+    }.merge(params)
+  end
+
+  should "return valid params given nothing" do
+    p = SearchParameterParser.new({})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "complain about an unknown parameter" do
+    p = SearchParameterParser.new({"p" => "extra"})
+
+    assert_equal("Unexpected parameters: p", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "complain about multiple unknown parameters" do
+    p = SearchParameterParser.new({"p" => "extra", "boo" => "goose"})
+
+    assert_equal("Unexpected parameters: p, boo", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "understand the start parameter" do
+    p = SearchParameterParser.new({"start" => "5"})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params(start: 5), p.parsed_params)
+  end
+
+  should "complain about a non-integer start parameter" do
+    p = SearchParameterParser.new({"start" => "5.5"})
+
+    assert_equal("Invalid value \"5.5\" for parameter \"start\" (expected positive integer)", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "complain about a negative start parameter" do
+    p = SearchParameterParser.new({"start" => "-1"})
+
+    assert_equal("Invalid negative value \"-1\" for parameter \"start\" (expected positive integer)", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "complain about a non-decimal start parameter" do
+    p = SearchParameterParser.new({"start" => "x"})
+
+    assert_equal("Invalid value \"x\" for parameter \"start\" (expected positive integer)", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "understand the count parameter" do
+    p = SearchParameterParser.new({"count" => "5"})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params(count: 5), p.parsed_params)
+  end
+
+  should "complain about a non-integer count parameter" do
+    p = SearchParameterParser.new({"count" => "5.5"})
+
+    assert_equal("Invalid value \"5.5\" for parameter \"count\" (expected positive integer)", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "complain about a negative count parameter" do
+    p = SearchParameterParser.new({"count" => "-1"})
+
+    assert_equal("Invalid negative value \"-1\" for parameter \"count\" (expected positive integer)", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "complain about a non-decimal count parameter" do
+    p = SearchParameterParser.new({"count" => "x"})
+
+    assert_equal("Invalid value \"x\" for parameter \"count\" (expected positive integer)", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "understand the q parameter" do
+    p = SearchParameterParser.new({"q" => "search-term"})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params(query: "search-term"), p.parsed_params)
+  end
+
+  should "understand the q parameter" do
+    p = SearchParameterParser.new({"q" => "search-term"})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params(query: "search-term"), p.parsed_params)
+  end
+
+  should "understand filter paramers" do
+    p = SearchParameterParser.new({"filter_organisations" => "hm-magic"})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params(filters: {"organisations" => ["hm-magic"]}), p.parsed_params)
+  end
+
+  should "understand multiple filter paramers" do
+    p = SearchParameterParser.new({"filter_organisations" => ["hm-magic", "hmrc"]})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params(filters: {"organisations" => ["hm-magic", "hmrc"]}), p.parsed_params)
+  end
+
+  should "complain about disallowed filter fields" do
+    p = SearchParameterParser.new({"filter_spells" => "levitation",
+                                   "filter_organisations" => "hm-magic"})
+
+    assert_equal("\"spells\" is not a valid filter field", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({filters: {"organisations" => ["hm-magic"]}}), p.parsed_params)
+  end
+
+  should "understand an ascending sort" do
+    p = SearchParameterParser.new({"order" => "public_timestamp"})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params({order: ["public_timestamp", "asc"]}), p.parsed_params)
+  end
+
+  should "understand a descending sort" do
+    p = SearchParameterParser.new({"order" => "-public_timestamp"})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params({order: ["public_timestamp", "desc"]}), p.parsed_params)
+  end
+
+  should "complain about disallowed sort fields" do
+    p = SearchParameterParser.new({"order" => "spells"})
+
+    assert_equal("\"spells\" is not a valid sort field", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "complain about disallowed descending sort fields" do
+    p = SearchParameterParser.new({"order" => "-spells"})
+
+    assert_equal("\"spells\" is not a valid sort field", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "understand a facet field" do
+    p = SearchParameterParser.new({"facet_organisations" => "10"})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params({facets: {"organisations" => 10}}), p.parsed_params)
+  end
+
+  should "understand multiple facet fields" do
+    p = SearchParameterParser.new({
+      "facet_organisations" => "10",
+      "facet_section" => "5",
+    })
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params({facets: {"organisations" => 10, "section" => 5}}), p.parsed_params)
+  end
+
+  should "complain about disallowed facet fields" do
+    p = SearchParameterParser.new({"facet_spells" => "10",
+                                   "facet_organisations" => "10"})
+
+    assert_equal("\"spells\" is not a valid facet field", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({facets: {"organisations" => 10}}), p.parsed_params)
+  end
+
+  should "complain about invalid values for facet parameter" do
+    p = SearchParameterParser.new({"facet_spells" => "levitation",
+                                   "facet_organisations" => "magic"})
+
+    assert_equal("\"spells\" is not a valid facet field. Invalid value \"magic\" for facet \"organisations\" (expected positive integer)", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
+  should "understand the fields parameter" do
+    p = SearchParameterParser.new({"fields" => ["title", "description"]})
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params({return_fields: ["title", "description"]}), p.parsed_params)
+  end
+
+  should "complain about invalid fields parameters" do
+    p = SearchParameterParser.new({"fields" => ["title", "waffle"]})
+
+    assert_equal("Some requested fields are not valid return fields: [\"waffle\"]", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({return_fields: ["title"]}), p.parsed_params)
+  end
+
+end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -6,7 +6,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "unfiltered search" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 20, "cheese ", nil, {}, nil, nil)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        order: nil,
+        filters: {},
+        fields: nil,
+        facets: nil,
+      })
     end
 
     should "strip whitespace from the query" do
@@ -46,8 +54,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "search with one filter" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 10, "cheese ", nil,
-        {"organisations" => ["hm-magic"]}, nil, nil)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: nil,
+        filters: {"organisations" => ["hm-magic"]},
+        fields: nil,
+        facets: nil,
+      })
     end
 
     should "have filter in payload" do
@@ -71,8 +86,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "search with a filter with multiple options" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 10, "cheese ", nil,
-        {"organisations" => ["hm-magic", "hmrc"]}, nil, nil)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: nil,
+        filters: {"organisations" => ["hm-magic", "hmrc"]},
+        fields: nil,
+        facets: nil,
+      })
     end
 
     should "have filter in payload" do
@@ -97,11 +119,18 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "search with multiple filters" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 10, "cheese ", nil,
-        {
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: nil,
+        filters: {
           "organisations" => ["hm-magic", "hmrc"],
           "section" => ["levitation"],
-        }, nil, nil)
+        },
+        fields: nil,
+        facets: nil,
+      })
     end
 
     should "have filter in payload" do
@@ -129,8 +158,16 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "building search with unicode" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 20, "cafe\u0300 ", nil, {}, nil,
-        nil)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cafe\u0300 ",
+        order: nil,
+        filters: {},
+        fields: nil,
+        facets: nil,
+      })
+
     end
 
     should "put the query in normalized form" do
@@ -143,8 +180,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "search with ascending sort" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 10, "cheese ", "public_timestamp",
-        {}, nil, nil)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: ["public_timestamp", "asc"],
+        filters: {},
+        fields: nil,
+        facets: nil,
+      })
     end
 
     should "have sort in payload" do
@@ -183,8 +227,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "search with descending sort" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 10, "cheese ", "-public_timestamp",
-        {}, nil, nil)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: ["public_timestamp", "desc"],
+        filters: {},
+        fields: nil,
+        facets: nil,
+      })
     end
 
     should "have sort in payload" do
@@ -220,33 +271,17 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     end
   end
 
-  context "search with invalid parameters" do
-    should "complain about disallowed filters" do
-      assert_raises ArgumentError do
-        UnifiedSearchBuilder.new(0, 10, "cheese", nil,
-          {"spells" => ["levitation"]}, nil, nil).payload
-      end
-    end
-
-    should "complain about disallowed sort fields" do
-      assert_raises ArgumentError do
-        UnifiedSearchBuilder.new(0, 10, "cheese", "spells",
-          {}, nil, nil).payload
-      end
-    end
-
-    should "complain about disallowed return fields" do
-      assert_raises ArgumentError do
-        UnifiedSearchBuilder.new(0, 10, "cheese", nil,
-          {}, ["invalid_field"], nil).payload
-      end
-    end
-  end
-
   context "search with explicit return fields" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 20, "cheese ", nil, {}, ['title'],
-        nil)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: nil,
+        filters: {},
+        return_fields: ['title'],
+        facets: nil,
+      })
     end
 
     should "have correct fields in payload" do
@@ -259,8 +294,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "search with facet" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 10, "cheese ", nil, {}, nil,
-        "organisations" => 10)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: nil,
+        filters: {},
+        fields: nil,
+        facets: {"organisations" => 10},
+      })
     end
 
     should "not have filter in payload" do
@@ -286,9 +328,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "search with facet and filter on same field" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 10, "cheese ", nil,
-        {"organisations" => ["hm-magic"]}, nil,
-        "organisations" => 10)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: nil,
+        filters: {"organisations" => ["hm-magic"]},
+        fields: nil,
+        facets: {"organisations" => 10},
+      })
     end
 
     should "have correct filter" do
@@ -314,9 +362,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   context "search with facet and filter on different field" do
     setup do
-      @builder = UnifiedSearchBuilder.new(0, 10, "cheese ", nil,
-        {"section" => ["levitation"]}, nil,
-        "organisations" => 10)
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 10,
+        query: "cheese ",
+        order: nil,
+        filters: {"section" => ["levitation"]},
+        fields: nil,
+        facets: {"organisations" => 10},
+      })
     end
 
     should "have correct filter" do

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -62,7 +62,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         from: 0,
         size: 20,
         query: CHEESE_QUERY,
-        fields: UnifiedSearchBuilder::ALLOWED_RETURN_FIELDS,
+        fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}
       })
@@ -70,7 +70,14 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         "mainstream,detailed,government"
       )
 
-      @results = @searcher.search(0, 20, "cheese", nil, {}, nil)
+      @results = @searcher.search({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        order: nil,
+        filters: {},
+        return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
+      })
     end
 
     should "include results from all indexes" do
@@ -96,7 +103,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         from: 0,
         size: 20,
         query: TIMESTAMP_EXISTS_WITH_CHEESE_QUERY,
-        fields: UnifiedSearchBuilder::ALLOWED_RETURN_FIELDS,
+        fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
         sort: [{"public_timestamp" => {order: "asc"}}],
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}
@@ -105,7 +112,14 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         "mainstream,detailed,government"
       )
 
-      @results = @searcher.search(0, 20, "cheese", "public_timestamp", {}, nil)
+      @results = @searcher.search({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        order: ["public_timestamp", "asc"],
+        filters: {},
+        return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
+      })
     end
 
     should "include results from all indexes" do
@@ -132,7 +146,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         size: 20,
         query: CHEESE_QUERY,
         filter: {"terms" => {"organisations" => ["ministry-of-magic"]}},
-        fields: UnifiedSearchBuilder::ALLOWED_RETURN_FIELDS,
+        fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}
       })
@@ -140,8 +154,14 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         "mainstream,detailed,government"
       )
 
-      @results = @searcher.search(0, 20, "cheese", nil,
-        {"organisations" => ["ministry-of-magic"]}, nil)
+      @results = @searcher.search({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        filters: {"organisations" => ["ministry-of-magic"]},
+        return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
+        facets: nil,
+      })
     end
 
     should "include results from all indexes" do
@@ -174,7 +194,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
               order: "count",
               size: 100000,
             }}},
-        fields: UnifiedSearchBuilder::ALLOWED_RETURN_FIELDS,
+        fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3},
         "facets" => {"organisations" => {
@@ -189,8 +209,14 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         "mainstream,detailed,government"
       )
 
-      @results = @searcher.search(0, 20, "cheese", nil,
-        {}, "organisations" => 1)
+      @results = @searcher.search({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        filters: {},
+        return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
+        facets: {"organisations" => 1},
+      })
     end
 
     should "include results from all indexes" do


### PR DESCRIPTION
Also, exposes a new parameter "fields" for the unified search endpoint,
which can be used to select which fields are returned in search
results.  This isn't going to be used immediately, but its good to
encourage callers to ask for minimal information, since this puts less
load on elasticsearch and uses less network bandwidth.

We want to do validation at this level to ensure that elasticsearch
can't be called with bad requests that cause it to do things like use up
all its memory, or have surprising bad cache performance.

Create a new SearchParameterParser class which parses and validates the
parameters supplied to the unified search endpoint.  Remove validation
code from app.rb and from UnifiedSearchBuilder.

Validation ensures that start and count are valid positive integers,
that no unexpected parameters are supplied, that only allowed fields are
used for filtering, sorting, faceting and return, and that facet
parameters are valid positive integers.

Return a 400 status code and an explanatory error body for such invalid
parameters.  We're using 400 here instead of 422 because the existing
endpoint already uses that, and because there's controversy over whether
400 and 422 is the best status code to use, so inertia on this seems
the best way forward until a decision is made.
