### PR TITLE
Update health check to support new search endpoints

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -47,7 +47,7 @@ class HealthCheckCLI
       on 'limit=', "Limit to the first n tests", as: Integer
       on 'a', 'auth=', "Basic auth credentials (of the form 'user:pass'", as: HealthCheck::BasicAuthCredentials
       on 'H', 'html=', "Connect to a frontend at the the given url (eg. #{DEFAULT_HTML_URL})", default: DEFAULT_HTML_URL
-      on 'j', 'json=', "Connect to a content api at the the given url (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
+      on 'j', 'json=', "Connect to a Rummager combined or unified search endpoint at the the given url (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
       on 'v', 'verbose', "Show verbose logging output"
       run(health_checker)
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67321636

This changes the health check component so that the JSON client now supports the "unified" and "combined" search endpoints provided by Rummager. 

It drops support for the old-style Content API `/search.json` endpoint which was not used, and drops support for checking an individual index. This is because indexes are no longer queried on an individual basis - rather, weightings and filters are applied at the new endpoints.
