### PR TITLE
Override passport tweaks for horse and pet passports

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -635,6 +635,10 @@ synonyms: &synonyms [
   # "waitress => waitress, jobs",
   # "warehouse => warehouse, jobs",
   # "warehousing => warehousing, jobs",
+  
+  # Override other synonyms
+  "horse passport, horse passports => horse passport",
+  "pet passport, pet passports => pet passport",
 
   # Stop word workarounds
   "appendix a => immigration rules appendix a attributes",


### PR DESCRIPTION
Searches for pet passports and horse passports currently return human passport content (despite minimum_should_match), because of the additional terms we added to raise the best passport results (line 285).
