### PR TITLE
Use old query structure to improve ranking

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -1,7 +1,11 @@
+require "elasticsearch/escaping"
 require "unf"
 
 # Builds a query for a search across all GOV.UK indices
 class UnifiedSearchBuilder
+  include Elasticsearch::Escaping
+
+  DEFAULT_QUERY_ANALYZER = "query_default"
 
   def initialize(params)
     @params = params
@@ -36,15 +40,18 @@ class UnifiedSearchBuilder
   end
 
   def base_query
-    query = query_normalized
-    if query.nil?
+    @query = query_normalized
+    if @query.nil?
       return { match_all: {} }
     end
     {
-      match: {
-        _all: {
-          query: query
-        }
+      custom_filters_score: {
+        query: {
+          bool: {
+            should: [core_query, promoted_items_query].compact
+          }
+        },
+        filters: format_boosts + [time_boost]
       }
     }
   end
@@ -143,6 +150,154 @@ class UnifiedSearchBuilder
       result[field_name] = facet_hash
     end
     result
+  end
+
+  def core_query
+    {
+      bool: {
+        must: must_conditions,
+        should: should_conditions
+      }
+    }
+  end
+
+  def should_conditions
+    exact_field_boosts + [ exact_match_boost, shingle_token_filter_boost ]
+  end
+
+  def exact_field_boosts
+    match_fields.map {|field_name, _|
+      {
+        match_phrase: {
+          field_name => {
+            query: escape(@query),
+            analyzer: DEFAULT_QUERY_ANALYZER,
+          }
+        }
+      }
+    }
+  end
+
+  def exact_match_boost
+    {
+      multi_match: {
+        query: escape(@query),
+        operator: "and",
+        fields: match_fields.keys,
+        analyzer: DEFAULT_QUERY_ANALYZER
+      }
+    }
+  end
+
+  def shingle_token_filter_boost
+    {
+      multi_match: {
+        query: escape(@query),
+        operator: "or",
+        fields: match_fields.keys,
+        analyzer: "shingled_query_analyzer"
+      }
+    }
+  end
+
+  def promoted_items_query
+    {
+      query_string: {
+        default_field: "promoted_for",
+        query: escape(@query),
+        boost: 100
+      }
+    }
+  end
+
+  def query_string_query
+    {
+      match: {
+        _all: {
+          query: escape(@query),
+          analyzer: DEFAULT_QUERY_ANALYZER,
+          minimum_should_match: minimum_should_match
+        }
+      }
+    }
+  end
+
+  def minimum_should_match
+    # The following specification generates the following values for minimum_should_match
+    #
+    # Number of | Minimum
+    # optional  | should
+    # clauses   | match
+    # ----------+---------
+    # 1         | 1
+    # 2         | 2
+    # 3         | 2
+    # 4         | 3
+    # 5         | 3
+    # 6         | 3
+    # 7         | 3
+    # 8+        | 50%
+    #
+    # This table was worked out by using the comparison feature of
+    # bin/search with various example queries of different lengths (3, 4, 5,
+    # 7, 9 words) and inspecting the consequences on search results.
+    #
+    # Reference for the minimum_should_match syntax:
+    # http://lucene.apache.org/solr/api-3_6_2/org/apache/solr/util/doc-files/min-should-match.html
+    #
+    # In summary, a clause of the form "N<M" means when there are MORE than
+    # N clauses then M clauses should match. So, 2<2 means when there are
+    # MORE than 2 clauses then 2 should match.
+    "2<2 3<3 7<50%"
+  end
+
+  def must_conditions
+    [query_string_query].compact
+  end
+
+  def match_fields
+    {
+      "title" => 5,
+      "acronym" => 5, # Ensure that organisations rank brilliantly for their acronym
+      "description" => 2,
+      "indexable_content" => 1,
+    }
+  end
+
+  def boosted_formats
+    {
+      # Mainstream formats
+      "smart-answer"      => 1.5,
+      "transaction"       => 1.5,
+      # Inside Gov formats
+      "topical_event"     => 1.5,
+      "minister"          => 1.7,
+      "organisation"      => 2.5,
+      "topic"             => 1.5,
+      "document_series"   => 1.3,
+      "document_collection" => 1.3,
+      "operational_field" => 1.5,
+    }
+  end
+
+  def format_boosts
+    boosted_formats.map do |format, boost|
+      {
+        filter: { term: { format: format } },
+        boost: boost
+      }
+    end
+  end
+
+  # An implementation of http://wiki.apache.org/solr/FunctionQuery#recip
+  # Curve for 2 months: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427e5qr62u0si
+  #
+  # Behaves as a freshness boost for newer documents with a public_timestamp and search_format_types announcement
+  def time_boost
+    {
+      filter: { term: { search_format_types: "announcement" } },
+      script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+    }
   end
 
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -39,10 +39,54 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   end
 
   CHEESE_QUERY = {
-    match: {
-      _all: {
-        query: "cheese"
-      }
+    custom_filters_score: {
+      query: {bool: {
+        should: [
+          {bool: {
+            must: [
+              {match: {_all: {
+                query: 'cheese',
+                analyzer: 'query_default',
+                minimum_should_match: '2<2 3<3 7<50%'
+              }}},
+            ],
+            should: [
+              {match_phrase: {'title' => {query: 'cheese', analyzer: 'query_default'}}},
+              {match_phrase: {'acronym' => {query: 'cheese', analyzer: 'query_default'}}},
+              {match_phrase: {'description' => {query: 'cheese', analyzer: 'query_default'}}},
+              {match_phrase: {'indexable_content' => {query: 'cheese', analyzer: 'query_default'}}},
+              {multi_match: {
+                query: 'cheese',
+                operator: 'and',
+                fields: ['title', 'acronym', 'description', 'indexable_content'],
+                analyzer: 'query_default',
+              }},
+              {multi_match: {
+                query: 'cheese',
+                operator: 'or',
+                fields: ['title', 'acronym', 'description', 'indexable_content'],
+                analyzer: 'shingled_query_analyzer',
+              }},
+            ]}},
+          {query_string: {
+            default_field: 'promoted_for',
+            query: 'cheese',
+            boost: 100,
+          }}
+        ]
+      }},
+      filters: [
+        {filter: {term: {format: 'smart-answer'}}, boost: 1.5},
+        {filter: {term: {format: 'transaction'}}, boost: 1.5},
+        {filter: {term: {format: 'topical_event'}}, boost: 1.5},
+        {filter: {term: {format: 'minister'}}, boost: 1.7},
+        {filter: {term: {format: 'organisation'}}, boost: 2.5},
+        {filter: {term: {format: 'topic'}}, boost: 1.5},
+        {filter: {term: {format: 'document_series'}}, boost: 1.3},
+        {filter: {term: {format: 'document_collection'}}, boost: 1.3},
+        {filter: {term: {format: 'operational_field'}}, boost: 1.5},
+        {filter: {term: {search_format_types: 'announcement'}}, script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"}
+      ]
     }
   }
 


### PR DESCRIPTION
Copy the query structure used for the old endpoint to improve the
ranking produced.  This ranking isn't great, but is significantly better
than the pure elasticsearch ranking, and we're going to start by just
making minor tweaks to this until we have the ability to use features
based on popularity and click through as a base of our ranking.

This is for https://www.pivotaltracker.com/story/show/69916060

After applying this patch, my local healthcheck returns:

```
INFO  Mainstream score: 614015/1237544 (49.62%)
INFO  1121 of 1825 succeeded
INFO  Government score: 25017/47459 (52.71%)
INFO  411 of 734 succeeded
INFO  Detailed score: 5319/8180 (65.02%)
INFO  309 of 481 succeeded
INFO  Overall score: 644351/1293183 (49.83%)
INFO  1841 of 3040 succeeded
```

For comparison, healthcheck before applying this patch returns:

```
INFO  Mainstream score: 140604/1237544 (11.36%)
INFO  383 of 1825 succeeded
INFO  Government score: 15919/47459 (33.54%)
INFO  279 of 734 succeeded
INFO  Detailed score: 3488/8180 (42.64%)
INFO  133 of 481 succeeded
INFO  Overall score: 160011/1293183 (12.37%)
INFO  795 of 3040 succeeded
```

And, healthcheck on the old api returns:

```
INFO  Mainstream score: 835747/1237544 (67.53%)
INFO  1383 of 1825 succeeded
INFO  Government score: 27332/47459 (57.59%)
INFO  431 of 734 succeeded
INFO  Detailed score: 7030/8180 (85.94%)
INFO  405 of 481 succeeded
INFO  Overall score: 870109/1293183 (67.28%)
INFO  2219 of 3040 succeeded
```
