### PR TITLE
Bias search results away from government content

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -6,6 +6,7 @@ class UnifiedSearchBuilder
   include Elasticsearch::Escaping
 
   DEFAULT_QUERY_ANALYZER = "query_default"
+  GOVERNMENT_BOOST_FACTOR = 0.4
 
   def initialize(params)
     @params = params
@@ -57,6 +58,22 @@ class UnifiedSearchBuilder
   end
 
   def query_hash
+    query = filtered_query
+    {
+      indices: {
+        indices: [:government],
+        query: {
+          custom_boost_factor: {
+            query: query,
+            boost_factor: GOVERNMENT_BOOST_FACTOR
+          }
+        },
+        no_match_query: query
+      }
+    }
+  end
+
+  def filtered_query
     filter = sort_filters
     if filter.nil?
       base_query

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -219,7 +219,11 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     should "have filter in query hash" do
       assert_equal(
         {"exists" => {"field" => "public_timestamp"}},
-        @builder.query_hash[:filtered][:filter]
+        @builder.query_hash[:indices][:query][:custom_boost_factor][:query][:filtered][:filter]
+      )
+      assert_equal(
+        {"exists" => {"field" => "public_timestamp"}},
+        @builder.query_hash[:indices][:no_match_query][:filtered][:filter]
       )
     end
   end
@@ -266,7 +270,11 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     should "have filter in query hash" do
       assert_equal(
         {"exists" => {"field" => "public_timestamp"}},
-        @builder.query_hash[:filtered][:filter]
+        @builder.query_hash[:indices][:query][:custom_boost_factor][:query][:filtered][:filter]
+      )
+      assert_equal(
+        {"exists" => {"field" => "public_timestamp"}},
+        @builder.query_hash[:indices][:no_match_query][:filtered][:filter]
       )
     end
   end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -38,7 +38,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     }]
   end
 
-  CHEESE_QUERY = {
+  BASE_CHEESE_QUERY = {
     custom_filters_score: {
       query: {bool: {
         should: [
@@ -90,10 +90,36 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     }
   }
 
-  TIMESTAMP_EXISTS_WITH_CHEESE_QUERY = {
+  BASE_TIMESTAMP_EXISTS_WITH_CHEESE_QUERY = {
     filtered: {
       filter: {"exists" => {"field" => "public_timestamp"}},
-      query: CHEESE_QUERY,
+      query: BASE_CHEESE_QUERY,
+    }
+  }
+
+  CHEESE_QUERY = {
+    indices: {
+      indices: [:government],
+      query: {
+        custom_boost_factor: {
+          query: BASE_CHEESE_QUERY,
+          boost_factor: 0.4
+        }
+      },
+      no_match_query: BASE_CHEESE_QUERY
+    }
+  }
+
+  TIMESTAMP_EXISTS_WITH_CHEESE_QUERY = {
+    indices: {
+      indices: [:government],
+      query: {
+        custom_boost_factor: {
+          query: BASE_TIMESTAMP_EXISTS_WITH_CHEESE_QUERY,
+          boost_factor: 0.4
+        }
+      },
+      no_match_query: BASE_TIMESTAMP_EXISTS_WITH_CHEESE_QUERY
     }
   }
 


### PR DESCRIPTION
The large number of long government documents overwhelms the other
content somewhat, so multiply the scores of government documents by a
constant to reduce them.  The constant chosen here is 0.4, which is the
result of running the health check with various different constants, and
choosing the value which gave the best balance of government versus
other documents.

![health_check_as_government_bias_varies](https://cloud.githubusercontent.com/assets/73564/2786883/e696b592-cb7f-11e3-8d95-740724dd9021.png)

https://www.pivotaltracker.com/story/show/69916174
