### PR TITLE
Add suggested queries to unified search

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -300,7 +300,7 @@ class Rummager < Sinatra::Application
       })
     end
 
-    searcher = UnifiedSearcher.new(unified_index, registries, registry_by_field)
+    searcher = UnifiedSearcher.new(unified_index, registries, registry_by_field, suggester)
     MultiJson.encode searcher.search(parser.parsed_params)
   end
 

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -10,7 +10,7 @@ class UnifiedSearchPresenter
   #
   #     { organisation_registry: OrganisationRegistry.new(...) }
   def initialize(es_response, start, index_names, facet_fields = {}, registries = {},
-                 registry_by_field = {})
+                 registry_by_field = {}, suggestions = [])
     @start = start
     @results = es_response["hits"]["hits"].map do |result|
       doc = result.delete("fields")
@@ -23,6 +23,7 @@ class UnifiedSearchPresenter
     @facet_fields = facet_fields
     @registries = registries
     @registry_by_field = registry_by_field
+    @suggestions = suggestions
   end
 
   def present
@@ -31,6 +32,7 @@ class UnifiedSearchPresenter
       total: @total,
       start: @start,
       facets: presented_facets,
+      suggested_queries: @suggestions
     }
   end
 

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -29,7 +29,7 @@ class UnifiedSearcher
     ).present
   end
 
-  private
+private
 
   def suggested_queries(query)
     query.nil? ? [] : @suggester.suggestions(query)

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -25,6 +25,7 @@ class UnifiedSearcher
       params[:facets],
       registries,
       registry_by_field,
+      suggested_queries(params[:query]),
     ).present
   end
 

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -5,12 +5,13 @@ require "unified_search_presenter"
 
 class UnifiedSearcher
 
-  attr_reader :index, :registries, :registry_by_field
+  attr_reader :index, :registries, :registry_by_field, :suggester
 
-  def initialize(index, registries, registry_by_field)
+  def initialize(index, registries, registry_by_field, suggester)
     @index = index
     @registries = registries
     @registry_by_field = registry_by_field
+    @suggester = suggester
   end
 
   # Search and combine the indices and return a hash of ResultSet objects
@@ -25,5 +26,11 @@ class UnifiedSearcher
       registries,
       registry_by_field,
     ).present
+  end
+
+  private
+
+  def suggested_queries(query)
+    query.nil? ? [] : @suggester.suggestions(query)
   end
 end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -101,4 +101,14 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal last_response.status, 400
     assert_equal parsed_response, {"error" => "Unexpected parameters: foo, bar"}
   end
+
+  def test_returns_suggestions_given_query
+    get "/unified_search?q=afgananistan"
+    assert parsed_response["suggested_queries"].include? "Afghanistan"
+  end
+
+  def test_returns_no_suggestions_without_query
+    get "/unified_search"
+    assert_equal [], parsed_response["suggested_queries"]
+  end
 end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -344,4 +344,22 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     end
   end
 
+  context "suggested queries" do
+    should "present suggestions in output" do
+      @suggestions = [
+        "self assessment",
+        "tax returns"
+      ]
+      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES, {}, {}, {}, @suggestions).present
+
+      assert_equal ["self assessment", "tax returns"], @output[:suggested_queries]
+    end
+
+    should "default to an empty array when not present" do
+      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES, {}, {}, {}).present
+
+      assert_equal [], @output[:suggested_queries]
+    end
+  end
+
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -166,6 +166,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     should "include total result count" do
       assert_equal(3, @results[:total])
     end
+
+    should "include suggested queries" do
+      assert_equal ['cheese'], @results[:suggested_queries]
+    end
   end
 
   context "unfiltered, sorted search" do

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -38,6 +38,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     }]
   end
 
+  def stub_suggester
+    stub('Suggester', suggestions: ['cheese'])
+  end
+
   BASE_CHEESE_QUERY = {
     custom_filters_score: {
       query: {bool: {
@@ -127,7 +131,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     setup do
       @combined_index = stub("unified index")
-      @searcher = UnifiedSearcher.new(@combined_index, {}, {})
+      @searcher = UnifiedSearcher.new(@combined_index, {}, {}, stub_suggester)
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -168,7 +172,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     setup do
       @combined_index = stub("unified index")
-      @searcher = UnifiedSearcher.new(@combined_index, {}, {})
+      @searcher = UnifiedSearcher.new(@combined_index, {}, {}, stub_suggester)
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -210,7 +214,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     setup do
       @combined_index = stub("unified index")
-      @searcher = UnifiedSearcher.new(@combined_index, {}, {})
+      @searcher = UnifiedSearcher.new(@combined_index, {}, {}, stub_suggester)
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -252,7 +256,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     setup do
       @combined_index = stub("unified index")
-      @searcher = UnifiedSearcher.new(@combined_index, {}, {})
+      @searcher = UnifiedSearcher.new(@combined_index, {}, {}, stub_suggester)
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/69085756

This adds a `suggested_queries` array to the unified search response. This contains spelling suggestions based on the existing `Suggester` class in Rummager.

We're calling this `suggesed_queries` rather than `spelling_suggestions` as we are considering providing suggestions based on other criteria in the future (such as common search queries for a particular facet/filter combination).
