### PR TITLE
Don't deref nil in bulk load of new index.

### DIFF
--- a/lib/bulk_loader.rb
+++ b/lib/bulk_loader.rb
@@ -12,7 +12,11 @@ class BulkLoader
     new_index = index_group.create_index
     @logger.info "Created index #{new_index.real_name}"
     old_index = index_group.current_real
-    @logger.info "Old index #{old_index.real_name}"
+    if old_index.nil?
+      @logger.info "No old index"
+    else
+      @logger.info "Old index #{old_index.real_name}"
+    end
 
     if old_index
       old_index.with_lock do


### PR DESCRIPTION
Fix a dereference of nil in the bulk load script which happened if there
was no existing index with the same alias before the script ran.
