### PR TITLE
Add metasearch index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,5 @@ group :development do
   # (Intelligent) reloading server in development
   gem "mr-sparkle", "0.2.0"
 end
+
+gem "debugger", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,15 @@ GEM
     chronic (0.9.1)
     ci_reporter (1.7.1)
       builder (>= 2.1.2)
+    columnize (0.8.9)
     connection_pool (1.1.0)
     crack (0.3.2)
+    debugger (1.6.6)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.2)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.2)
     ffi (1.9.0)
     ffi-aspell (0.0.3)
       ffi (>= 1.0.11)
@@ -132,6 +139,7 @@ PLATFORMS
 DEPENDENCIES
   aws-ses (= 0.4.4)
   ci_reporter (= 1.7.1)
+  debugger
   ffi-aspell (= 0.0.3)
   gds-api-adapters (= 7.18.0)
   json (= 1.7.7)

--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ end
 def index_names
   case ENV["RUMMAGER_INDEX"]
   when "all"
-    all_index_names
+    content_index_names
   when String
     [ENV["RUMMAGER_INDEX"]]
   else
@@ -66,8 +66,6 @@ def index_names
   end
 end
 
-def all_index_names
-  search_config.index_names
+def content_index_names
+  search_config.content_index_names
 end
-
-

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,5 +1,6 @@
 base_uri: "http://localhost:9200"
-index_names: ["mainstream", "detailed", "government", "service-manual"]
+content_index_names: ["mainstream", "detailed", "government", "service-manual"]
+auxiliary_index_names: ["page-traffic"]
 organisation_registry_index: "government"
 topic_registry_index: "government"
 document_series_registry_index: "government"

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,6 +1,6 @@
 base_uri: "http://localhost:9200"
 content_index_names: ["mainstream", "detailed", "government", "service-manual"]
-auxiliary_index_names: ["page-traffic"]
+auxiliary_index_names: ["page-traffic", "metasearch"]
 organisation_registry_index: "government"
 topic_registry_index: "government"
 document_series_registry_index: "government"

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -727,6 +727,10 @@ index:
           type: custom
           tokenizer: standard
           filter: [standard, lowercase, stop, stemmer_override, stemmer_english, filter_shingle]
+        exact_match:
+          type: custom
+          tokenizer: keyword
+          filter: [trim, lowercase]
       filter:
         synonym:
           type: synonym
@@ -756,6 +760,13 @@ mappings:
         indexable_content: { type: string, index: analyzed }
         promoted_for: { type: string, index: analyzed, include_in_all: false }
         organisations: { type: string, index: not_analyzed, include_in_all: false }
+  metasearch:
+    best_bet:
+      _all: { enabled: false }
+      properties:
+        exact_query: { type: string, index: analyzed, analyzer: "exact_match" }
+        stem_query:  { type: string, index: analyzed }
+        details:     { type: string, index: not_analyzed }
   government:
     edition:
       _all: { enabled: true }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -208,7 +208,7 @@ synonyms: &synonyms [
   "uj, ujm => universal jobmatch",
   "ukba, border agency, uk ba => ukba, border agency, ukvi, uk visas and immigration",
   "utr, unique taxpayer reference",
-  
+
   # Acronyms with spaces or punctuation
   "c v => cv",
   "d l a => dla",
@@ -291,7 +291,7 @@ synonyms: &synonyms [
   "vehicle licence => vehicle licence, tax disc",
   "visa application => visa application, apply uk visa",
   "work trial => work trial, work experience, recruiters",
-  
+
   # Removing terms to return relevant content
   "flood areas => flood",
   "landfill sites => landfill",
@@ -350,7 +350,7 @@ synonyms: &synonyms [
   "v890 => sorn",
   "vaf4 => vaf4a",
   "vat1, vat 1, vat2, vat 2, vat50, vat 50, vat51, vat 51, vat1a, vat 1a, vat1b, vat 1b => vat registration",
-  
+
   # Job searches
   "b26 3qz => jobs",  # Birmingham Airport jobs
 
@@ -633,7 +633,7 @@ synonyms: &synonyms [
   # "waitress => waitress, jobs",
   # "warehouse => warehouse, jobs",
   # "warehousing => warehousing, jobs",
-  
+
   # Override other synonyms
   "horse passport, horse passports => horse passport",
   "pet passport, pet passports => pet passport",

--- a/lib/elasticsearch/search_server.rb
+++ b/lib/elasticsearch/search_server.rb
@@ -8,10 +8,11 @@ module Elasticsearch
   class SearchServer
     DEFAULT_MAPPING_KEY = "default"
 
-    def initialize(base_uri, schema, index_names)
+    def initialize(base_uri, schema, index_names, content_index_names)
       @base_uri = URI.parse(base_uri)
       @schema = schema
       @index_names = index_names
+      @content_index_names = content_index_names
     end
 
     def index_group(prefix)
@@ -29,8 +30,8 @@ module Elasticsearch
       end
     end
 
-    def all_indices
-      @index_names.map do |index_name|
+    def content_indices
+      @content_index_names.map do |index_name|
         index(index_name)
       end
     end

--- a/lib/elasticsearch/sitemap.rb
+++ b/lib/elasticsearch/sitemap.rb
@@ -12,10 +12,10 @@ class Sitemap
     @timestamp = timestamp
   end
 
-  def generate(all_indices)
+  def generate(content_indices)
     FileUtils.mkdir_p(@output_path)
     sitemap_writer = SitemapWriter.new(@output_path, @timestamp)
-    sitemap_filenames = sitemap_writer.write_sitemaps(all_indices)
+    sitemap_filenames = sitemap_writer.write_sitemaps(content_indices)
     return write_index(sitemap_filenames)
   end
 
@@ -55,8 +55,8 @@ class SitemapWriter
     @sitemap_file_count = 0
   end
 
-  def write_sitemaps(all_indices)
-    sitemap_generator = SitemapGenerator.new(all_indices)
+  def write_sitemaps(content_indices)
+    sitemap_generator = SitemapGenerator.new(content_indices)
     # write our sitemap files and return an array of filenames
     sitemap_generator.sitemaps.map do |sitemap_xml|
       filename = next_filename

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -4,15 +4,22 @@ require "elasticsearch/search_server"
 class SearchConfig
 
   def search_server
+    puts "index_names: #{index_names}"
+    puts "content_index_names: #{content_index_names}"
     Elasticsearch::SearchServer.new(
       elasticsearch["base_uri"],
       elasticsearch_schema,
-      index_names
+      index_names,
+      content_index_names,
     )
   end
 
   def index_names
-    elasticsearch["index_names"]
+    elasticsearch["content_index_names"] + elasticsearch["auxiliary_index_names"]
+  end
+
+  def content_index_names
+    elasticsearch["content_index_names"]
   end
 
   def elasticsearch_schema

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -4,8 +4,6 @@ require "elasticsearch/search_server"
 class SearchConfig
 
   def search_server
-    puts "index_names: #{index_names}"
-    puts "content_index_names: #{content_index_names}"
     Elasticsearch::SearchServer.new(
       elasticsearch["base_uri"],
       elasticsearch_schema,
@@ -15,11 +13,15 @@ class SearchConfig
   end
 
   def index_names
-    elasticsearch["content_index_names"] + elasticsearch["auxiliary_index_names"]
+    content_index_names + auxiliary_index_names
   end
 
   def content_index_names
-    elasticsearch["content_index_names"]
+    elasticsearch["content_index_names"] || []
+  end
+
+  def auxiliary_index_names
+    elasticsearch["auxiliary_index_names"] || []
   end
 
   def elasticsearch_schema

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -8,7 +8,7 @@ namespace :sitemap do
 
     output_directory = File.join(PROJECT_ROOT, "public")
     sitemap = Sitemap.new(output_directory)
-    sitemap_index_path = sitemap.generate(search_server.all_indices)
+    sitemap_index_path = sitemap.generate(search_server.content_indices)
 
     sitemap_link_path = File.join(output_directory, "sitemap.xml")
 

--- a/test/functional/index_group_test.rb
+++ b/test/functional/index_group_test.rb
@@ -36,7 +36,8 @@ class IndexGroupTest < MiniTest::Unit::TestCase
     @server = Elasticsearch::SearchServer.new(
       "http://localhost:9200/",
       @schema,
-      ["mainstream", "custom"]
+      ["mainstream", "custom"],
+      ["mainstream"],
     )
   end
 

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -116,20 +116,20 @@ class SitemapTest < IntegrationTest
 
   def test_should_generate_multiple_sitemaps
     SitemapGenerator.stubs(:sitemap_limit).returns(2)
-    generator = SitemapGenerator.new(search_server.all_indices)
+    generator = SitemapGenerator.new(search_server.content_indices)
     sitemap_xml = generator.sitemaps
     assert_equal 3, sitemap_xml.length
   end
 
   def test_should_not_include_recommended_links
-    generator = SitemapGenerator.new(search_server.all_indices)
+    generator = SitemapGenerator.new(search_server.content_indices)
     sitemap_xml = generator.sitemaps
     assert_equal 1, sitemap_xml.length
     refute_includes sitemap_xml[0], "/external-example-answer"
   end
 
   def test_should_not_include_inside_government_links
-    generator = SitemapGenerator.new(search_server.all_indices)
+    generator = SitemapGenerator.new(search_server.content_indices)
     sitemap_xml = generator.sitemaps
     assert_equal 1, sitemap_xml.length
     refute_includes sitemap_xml[0],  "/government/some-content"

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -44,15 +44,15 @@ module ElasticsearchIntegration
     end
   end
 
-  def stub_elasticsearch_settings(index_names = ["rummager_test"], default = nil)
-    index_names.each do |n| check_index_name(n) end
+  def stub_elasticsearch_settings(content_index_names = ["rummager_test"], default = nil)
+    content_index_names.each do |n| check_index_name(n) end
     check_index_name(default) unless default.nil?
 
-    @default_index_name = default || index_names.first
+    @default_index_name = default || content_index_names.first
 
     app.settings.search_config.stubs(:elasticsearch).returns({
       "base_uri" => "http://localhost:9200",
-      "index_names" => index_names
+      "content_index_names" => content_index_names
     })
     app.settings.stubs(:default_index_name).returns(@default_index_name)
     app.settings.stubs(:enable_queue).returns(false)

--- a/test/unit/search_server_test.rb
+++ b/test/unit/search_server_test.rb
@@ -5,28 +5,28 @@ class SearchServerTest < MiniTest::Unit::TestCase
   EMPTY_SCHEMA = { "mappings" => { "default" => nil } }
 
   def test_returns_an_index
-    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"])
+    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"])
     index = search_server.index("a")
     assert index.is_a?(Elasticsearch::Index)
     assert_equal "a", index.index_name
   end
 
   def test_raises_an_error_for_unknown_index
-    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"])
+    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"])
     assert_raises Elasticsearch::NoSuchIndex do
       search_server.index("z")
     end
   end
 
   def test_can_get_multi_index
-    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"])
+    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"])
     index = search_server.index("a,b")
     assert index.is_a?(Elasticsearch::Index)
     assert_equal "a,b", index.index_name
   end
 
   def test_raises_an_error_for_unknown_index_in_multi_index
-    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"])
+    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"])
     assert_raises Elasticsearch::NoSuchIndex do
       search_server.index("a,z")
     end
@@ -41,7 +41,8 @@ class SearchServerTest < MiniTest::Unit::TestCase
     server = Elasticsearch::SearchServer.new(
       "http://localhost:9200/",
       schema,
-      ["mainstream", "custom"]
+      ["mainstream", "custom"],
+      ["mainstream", "custom"],
     )
     promoted_results = server.promoted_results
 
@@ -53,7 +54,8 @@ class SearchServerTest < MiniTest::Unit::TestCase
     server = Elasticsearch::SearchServer.new(
       "http://localhost:9200/",
       EMPTY_SCHEMA,
-      ["mainstream", "custom"]
+      ["mainstream", "custom"],
+      ["mainstream", "custom"],
     )
     promoted_results = stub("promoted results")
     server.stubs(:promoted_results).returns(promoted_results)


### PR DESCRIPTION
Holds information about search such as "best bets", a mechanism for altering the results returned by search.

https://www.pivotaltracker.com/story/show/70447568
