### PR TITLE
Add / to the list of characters to escape

### DIFF
--- a/lib/elasticsearch/escaping.rb
+++ b/lib/elasticsearch/escaping.rb
@@ -1,7 +1,7 @@
 module Elasticsearch
   module Escaping
     LUCENE_SPECIAL_CHARACTERS = Regexp.new("(" + %w[
-      + - && || ! ( ) { } [ ] ^ " ~ * ? : \\
+      + - && || ! ( ) { } [ ] ^ " ~ * ? : \\ /
     ].map { |s| Regexp.escape(s) }.join("|") + ")")
 
     LUCENE_BOOLEANS = /\b(AND|OR|NOT)\b/


### PR DESCRIPTION
This is a fix for migration from elasticsearch 0.20.6 to 0.90+.
Elasticsearch 0.90+ uses Lucene 4.  One change in Lucene 4 from Lucene 3
is that a / character in a query denotes the start of a regular
expression.  We don't want to use regular expressions in our queries, so
add / to the list of characters to escape.  This change fixes the
test_should_not_match_on_slug integration test.

For more information:
https://github.com/elasticsearch/elasticsearch/issues/2980
