### PR TITLE
Supporting adding non-edition documents from hash.

### DIFF
--- a/lib/document.rb
+++ b/lib/document.rb
@@ -10,7 +10,8 @@ class Document
   end
 
   def self.from_hash(hash, mappings, es_score = nil)
-    field_names = mappings["edition"]["properties"].keys.map(&:to_s)
+    type = hash["_type"] || "edition"
+    field_names = mappings[type]["properties"].keys.map(&:to_s)
     self.new(field_names, hash, es_score)
   end
 

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -50,6 +50,27 @@ class DocumentTest < MiniTest::Unit::TestCase
     assert_equal [1,2], document.elasticsearch_export["topics"]
   end
 
+  def test_should_use_the_specified_mappings_if_given
+    hash = {
+      "_type" => "best_bet",
+      "query" => "jobs"
+    }
+
+    mappings = default_mappings.merge(
+      "best_bet" => {
+        "properties" => {
+          "query" => { "type" => "string", "index" => "not_analyzed" }
+        }
+      }
+    )
+
+    document = Document.from_hash(hash, mappings)
+
+    assert_equal "jobs", document.to_hash["query"]
+    assert_equal "jobs", document.query
+    assert_equal "jobs", document.elasticsearch_export["query"]
+  end
+
   def test_should_ignore_fields_not_in_mappings
     hash = {
       "title" => "TITLE",


### PR DESCRIPTION
Uses an optional `_type` parameter in the hash.
Defaults to "edition".
