### PR TITLE
Fix nonedition support

### DIFF
--- a/lib/document.rb
+++ b/lib/document.rb
@@ -7,6 +7,8 @@ class Document
     @attributes = {}
     @es_score = es_score
     update_attributes!(attributes)
+    @id = attributes["_id"]
+    @type = attributes["_type"]
   end
 
   def self.from_hash(hash, mappings, es_score = nil)
@@ -51,7 +53,8 @@ class Document
           doc[key] = value
         end
       end
-      doc["_type"] = "edition"
+      doc["_type"] = @type || "edition"
+      doc["_id"] = @id if @id
     end
   end
 

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -393,7 +393,12 @@ module Elasticsearch
     end
 
     def index_action(doc_hash)
-      {"index" => {"_type" => doc_hash["_type"], "_id" => doc_hash["link"]}}
+      {
+        "index" => {
+          "_type" => doc_hash["_type"],
+          "_id" => (doc_hash["_id"] || doc_hash["link"])
+        }
+      }
     end
 
     def result_promoter

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -90,7 +90,7 @@ module Elasticsearch
         alias_info = MultiJson.decode(@client.get("_aliases"))
       rescue RestClient::ResourceNotFound => e
         response_body = MultiJson.decode(e.http_body)
-        if response_body['error'].start_with?("IndexMissingException") then 
+        if response_body['error'].start_with?("IndexMissingException") then
           return nil
         end
         raise

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -50,8 +50,9 @@ class DocumentTest < MiniTest::Unit::TestCase
     assert_equal [1,2], document.elasticsearch_export["topics"]
   end
 
-  def test_should_use_the_specified_mappings_if_given
+  def test_should_permit_nonedition_documents
     hash = {
+      "_id" => "jobs_exact",
       "_type" => "best_bet",
       "query" => "jobs"
     }
@@ -69,6 +70,11 @@ class DocumentTest < MiniTest::Unit::TestCase
     assert_equal "jobs", document.to_hash["query"]
     assert_equal "jobs", document.query
     assert_equal "jobs", document.elasticsearch_export["query"]
+
+    refute document.to_hash.has_key?("_type")
+    refute document.to_hash.has_key?("_id")
+    assert_equal "jobs_exact", document.elasticsearch_export["_id"]
+    assert_equal "best_bet", document.elasticsearch_export["_type"]
   end
 
   def test_should_ignore_fields_not_in_mappings


### PR DESCRIPTION
Additional `_id` and `_type` support for non-edition documents.
