### PR TITLE
Use popularity data to improve search result weightings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ file suitable for loading into an elasticsearch index using rummager's
 In many cases, you should be able to fetch the `page-traffic.dump` data from
 preview.
 FIXME: describe how to get hold of a copy of `page-traffic.dump` data from
-preview, once jobs are set up to regularly extract this.
+preview, once jobs are set up to regularly extract this.  This will be
+implemented as part of
+https://www.pivotaltracker.com/s/projects/1010882/stories/70737424
 
 The [search-analytics project
 README](https://github.com/alphagov/search-analytics) describes how to set up

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ development, you need to run both of these commands:
 
 ## Indexing GOV.UK content
 
+### Memory requirements
+
 In order to build the search index on a VM, you'll need to ensure that your VM
 has sufficient memory: 4Gb is probably a good amount; with 2Gb, the indexing
 process has a tendency to get killed by the out of memory killer.  Do this by
@@ -47,6 +49,38 @@ memory and killing itself.  Do this by editing
     env ES_HEAP_SIZE="1024m"
 
 Restart the VM (eg, with `vagrant reload`) after making these changes.
+
+### Popularity information
+
+The gov.uk search uses page popularity information extracted from Google
+Analytics as one of the factors in weighting search results.  This is extracted
+from Google Analytics by the search-analytics project, which produces a dump
+file suitable for loading into an elasticsearch index using rummager's
+`bulk_load` tool.  This should be loaded into the `page-traffic` index.
+
+In many cases, you should be able to fetch the `page-traffic.dump` data from
+preview.
+FIXME: describe how to get hold of a copy of `page-traffic.dump` data from
+preview, once jobs are set up to regularly extract this.
+
+The [search-analytics project
+README](https://github.com/alphagov/search-analytics) describes how to set up
+and run the extraction of page traffic information from Google Analytics, if
+you need to get the data yourself.
+
+Once you have the popularity data in a file named `page-traffic.dump`, load it
+into elasticsearch using:
+
+    bundle exec bin/bulk_load page-traffic < page-traffic.dump
+
+The popularity information won't affect search results until an index migration
+is run after populating the page-traffic index. As part of the migration, the
+popularity for each document will be computed from the page-traffic index and
+merged into the documents. To do this, run:
+
+    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_index
+
+### Indexing panopticon content
 
 Since search indexing happens through Panopticon's single registration API,
 you'll need to have both Panopticon and Rummager running. By default, Panopticon

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -791,6 +791,7 @@ mappings:
         link:        { type: string, index: not_analyzed, include_in_all: false }
         indexable_content: { type: string, index: analyzed }
         promoted_for: { type: string, index: analyzed, include_in_all: false }
+        popularity: { type: float, stored: true }
         organisations: { type: string, index: not_analyzed, include_in_all: false }
   metasearch:
     best_bet:
@@ -833,6 +834,7 @@ mappings:
         organisation_state: { type: string, index: not_analyzed, include_in_all: false }
         people: { type: string, index: not_analyzed, include_in_all: false }
         promoted_for: { type: string, index: analyzed, include_in_all: false }
+        popularity: { type: float, stored: true }
         public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -777,6 +777,7 @@ mappings:
       ]
       properties:
         path_components: { type: string, index: not_analyzed }
+        rank_14: { type: float, stored: true }
 
   page_traffic_test:
     page_traffic:
@@ -803,6 +804,7 @@ mappings:
       ]
       properties:
         path_components: { type: string, index: not_analyzed }
+        rank_14: { type: float, stored: true }
 
   default:
     edition:

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -752,8 +752,8 @@ index:
           min_shingle_size: 2
 mappings:
 
-  page_traffic:
-    page_traffic:
+  page-traffic: &page-traffic
+    page-traffic:
       _all: { enabled: false }
       dynamic_templates: [
         {
@@ -779,32 +779,7 @@ mappings:
         path_components: { type: string, index: not_analyzed }
         rank_14: { type: float, stored: true }
 
-  page_traffic_test:
-    page_traffic:
-      _all: { enabled: false }
-      dynamic_templates: [
-        {
-          "view_count": {
-            match: "vc_*",
-            mapping: { type: long, stored: true }
-          }
-        },
-        {
-          "view_fraction": {
-            match: "vf_*",
-            mapping: { type: float, stored: true }
-          }
-        },
-        {
-          "rank": {
-            match: "rank_*",
-            mapping: { type: float, stored: true }
-          }
-        }
-      ]
-      properties:
-        path_components: { type: string, index: not_analyzed }
-        rank_14: { type: float, stored: true }
+  page-traffic-test: *page-traffic
 
   default:
     edition:

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -752,8 +752,34 @@ index:
           min_shingle_size: 2
 mappings:
 
-  page-traffic:
-    page-traffic:
+  page_traffic:
+    page_traffic:
+      _all: { enabled: false }
+      dynamic_templates: [
+        {
+          "view_count": {
+            match: "vc_*",
+            mapping: { type: long, stored: true }
+          }
+        },
+        {
+          "view_fraction": {
+            match: "vf_*",
+            mapping: { type: float, stored: true }
+          }
+        },
+        {
+          "rank": {
+            match: "rank_*",
+            mapping: { type: float, stored: true }
+          }
+        }
+      ]
+      properties:
+        path_components: { type: string, index: not_analyzed }
+
+  page_traffic_test:
+    page_traffic:
       _all: { enabled: false }
       dynamic_templates: [
         {

--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -751,6 +751,33 @@ index:
           max_shingle_size: 2
           min_shingle_size: 2
 mappings:
+
+  page-traffic:
+    page-traffic:
+      _all: { enabled: false }
+      dynamic_templates: [
+        {
+          "view_count": {
+            match: "vc_*",
+            mapping: { type: long, stored: true }
+          }
+        },
+        {
+          "view_fraction": {
+            match: "vf_*",
+            mapping: { type: float, stored: true }
+          }
+        },
+        {
+          "rank": {
+            match: "rank_*",
+            mapping: { type: float, stored: true }
+          }
+        }
+      ]
+      properties:
+        path_components: { type: string, index: not_analyzed }
+
   default:
     edition:
       _all: { enabled: true }

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -441,8 +441,10 @@ module Elasticsearch
         end
         ranks[link] = [rank, ranks[link]].min
       end
+
       Hash[links.map { |link|
-        [link, 1.0 / ranks[link]]
+        popularity_score = (ranks[link] == 0) ? 0 : (1.0 / ranks[link])
+        [link, popularity_score]
       }]
     end
 

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -464,15 +464,23 @@ module Elasticsearch
     end
 
     def open_traffic_index
-      if @index_name.start_with?("page-traffic")
+      if @index_name.start_with?("page_traffic")
         return nil
       end
-      result = settings.search_config.search_server.index("page-traffic")
-      if result.exists?
-        return result
-      else
-        return nil
+
+      traffic_index_name = settings.search_config.auxiliary_index_names.find {|index|
+        index.start_with?("page_traffic")
+      }
+
+      if traffic_index_name
+        result = settings.search_config.search_server.index(traffic_index_name)
+
+        if result.exists?
+          return result
+        end
       end
+
+      return nil
     end
 
     def result_promoter

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -380,8 +380,12 @@ module Elasticsearch
     # See <http://www.elasticsearch.org/guide/reference/api/bulk/>
     def bulk_payload(document_hashes_or_payload)
       if document_hashes_or_payload.is_a?(Array)
+        links = document_hashes_or_payload.map {
+          |doc_hash| doc_hash["link"]
+        }.compact
+        popularities = lookup_popularities(links)
         index_items = document_hashes_or_payload.map do |doc_hash|
-          [index_action(doc_hash).to_json, doc_hash.to_json]
+          [index_action(doc_hash).to_json, index_doc(doc_hash, popularities).to_json]
         end
 
         # Make sure the payload ends with a newline character: elasticsearch
@@ -399,6 +403,76 @@ module Elasticsearch
           "_id" => (doc_hash["_id"] || doc_hash["link"])
         }
       }
+    end
+
+    def index_doc(doc_hash, popularities)
+      unless popularities.nil?
+        link = doc_hash["link"]
+        pop = popularities[link]
+        unless pop.nil?
+          doc_hash["popularity"] = pop
+        end
+      end
+      doc_hash
+    end
+
+    def lookup_popularities(links)
+      if traffic_index.nil?
+        return nil
+      end
+      results = traffic_index.raw_search({
+        query: {
+          terms: {
+            path_components: links
+          }
+        },
+        fields: ["rank_14"],
+        sort: [
+          { rank_14: { order: "asc" }}
+        ],
+        size: 10 * links.size,
+      })
+      ranks = Hash.new(traffic_index_size)
+      results["hits"]["hits"].each do |hit|
+        link = hit["_id"]
+        rank = hit["fields"]["rank_14"]
+        if rank.nil?
+          next
+        end
+        ranks[link] = [rank, ranks[link]].min
+      end
+      Hash[links.map { |link|
+        [link, 1.0 / ranks[link]]
+      }]
+    end
+
+    def traffic_index
+      if @_opened_traffic_index
+        return @_traffic_index
+      end
+      @_traffic_index = open_traffic_index
+      @_opened_traffic_index = true
+      return @_traffic_index
+    end
+
+    def traffic_index_size
+      results = traffic_index.raw_search({
+        query: { match_all: {}},
+        size: 0
+      })
+      results["hits"]["total"]
+    end
+
+    def open_traffic_index
+      if @index_name.start_with?("page-traffic")
+        return nil
+      end
+      result = settings.search_config.search_server.index("page-traffic")
+      if result.exists?
+        return result
+      else
+        return nil
+      end
     end
 
     def result_promoter

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -449,12 +449,12 @@ module Elasticsearch
     end
 
     def traffic_index
-      if @_opened_traffic_index
-        return @_traffic_index
+      if @opened_traffic_index
+        return @traffic_index
       end
-      @_traffic_index = open_traffic_index
-      @_opened_traffic_index = true
-      return @_traffic_index
+      @traffic_index = open_traffic_index
+      @opened_traffic_index = true
+      return @traffic_index
     end
 
     def traffic_index_size

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -466,12 +466,12 @@ module Elasticsearch
     end
 
     def open_traffic_index
-      if @index_name.start_with?("page_traffic")
+      if @index_name.start_with?("page-traffic")
         return nil
       end
 
       traffic_index_name = settings.search_config.auxiliary_index_names.find {|index|
-        index.start_with?("page_traffic")
+        index.start_with?("page-traffic")
       }
 
       if traffic_index_name

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -24,6 +24,10 @@ class SearchConfig
     elasticsearch["auxiliary_index_names"] || []
   end
 
+  def auxiliary_index_names
+    elasticsearch["auxiliary_index_names"]
+  end
+
   def elasticsearch_schema
     @elasticsearch_schema ||= config_for("elasticsearch_schema")
   end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -24,10 +24,6 @@ class SearchConfig
     elasticsearch["auxiliary_index_names"] || []
   end
 
-  def auxiliary_index_names
-    elasticsearch["auxiliary_index_names"]
-  end
-
   def elasticsearch_schema
     @elasticsearch_schema ||= config_for("elasticsearch_schema")
   end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -4,8 +4,6 @@ require "elasticsearch/search_server"
 class SearchConfig
 
   def search_server
-    puts "index_names: #{index_names}"
-    puts "content_index_names: #{content_index_names}"
     Elasticsearch::SearchServer.new(
       elasticsearch["base_uri"],
       elasticsearch_schema,

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -4,6 +4,8 @@ require "elasticsearch/search_server"
 class SearchConfig
 
   def search_server
+    puts "index_names: #{index_names}"
+    puts "content_index_names: #{content_index_names}"
     Elasticsearch::SearchServer.new(
       elasticsearch["base_uri"],
       elasticsearch_schema,

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -7,6 +7,7 @@ class UnifiedSearchBuilder
 
   DEFAULT_QUERY_ANALYZER = "query_default"
   GOVERNMENT_BOOST_FACTOR = 0.4
+  POPULARITY_OFFSET = 0.001
 
   def initialize(params)
     @params = params
@@ -46,13 +47,18 @@ class UnifiedSearchBuilder
       return { match_all: {} }
     end
     {
-      custom_filters_score: {
+      custom_score: {
         query: {
-          bool: {
-            should: [core_query, promoted_items_query].compact
+          custom_filters_score: {
+            query: {
+              bool: {
+                should: [core_query, promoted_items_query].compact
+              }
+            },
+            filters: format_boosts + [time_boost]
           }
         },
-        filters: format_boosts + [time_boost]
+        script: "_score * (doc['popularity'].value + #{POPULARITY_OFFSET})"
       }
     }
   end

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -11,6 +11,7 @@ class UnifiedSearchBuilder
 
   def initialize(params)
     @params = params
+    @query = query_normalized
   end
 
   def payload
@@ -42,7 +43,6 @@ class UnifiedSearchBuilder
   end
 
   def base_query
-    @query = query_normalized
     if @query.nil?
       return { match_all: {} }
     end
@@ -143,6 +143,11 @@ class UnifiedSearchBuilder
   def sort_list
     order = @params[:order]
     if order.nil?
+      # Sort by popularity when there's no explicit ordering, and there's no
+      # query (so there's no relevance scores).
+      if @query.nil?
+        return [{ "popularity" => { order: "desc" } }]
+      end
       return nil
     end
     [{ order[0] => { order: order[1] } }]

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -147,8 +147,9 @@ class UnifiedSearchBuilder
       # query (so there's no relevance scores).
       if @query.nil?
         return [{ "popularity" => { order: "desc" } }]
+      else
+        return nil
       end
-      return nil
     end
     [{ order[0] => { order: order[1] } }]
   end

--- a/test/fixtures/default_mappings.rb
+++ b/test/fixtures/default_mappings.rb
@@ -17,5 +17,36 @@ module Fixtures
         }
       }
     end
+
+    def page_traffic_mappings
+      {
+        "page-traffic" => {
+          "_all" => { "enabled" => false },
+          "dynamic_templates" => [
+            {
+              "view_count" => {
+                "match" => "vc_*",
+                "mapping" => { "type" => "long", "stored" => true }
+              }
+            },
+            {
+              "view_fraction" => {
+                "match" => "vf_*",
+                "mapping" => { "type" => "float", "stored" => true }
+              }
+            },
+            {
+              "rank" => {
+                "match" => "rank_*",
+                "mapping" => { "type" => "float", "stored" => true }
+              }
+            }
+          ],
+          "properties" => {
+            "path_components" => { "type" => "string", "index" => "not_analyzed" }
+          }
+        }
+      }
+    end
   end
 end

--- a/test/integration/bulk_loader_test.rb
+++ b/test/integration/bulk_loader_test.rb
@@ -9,6 +9,8 @@ class BulkLoaderTest < IntegrationTest
     stub_elasticsearch_settings
     enable_test_index_connections
     try_remove_test_index
+    clean_popularity_index
+
     @sample_document = {
       "title" => "TITLE",
       "description" => "DESCRIPTION",
@@ -20,6 +22,7 @@ class BulkLoaderTest < IntegrationTest
 
   def teardown
     clean_index_group
+    clean_popularity_index
   end
 
   def retrieve_document_from_rummager(link)

--- a/test/integration/bulk_loader_test.rb
+++ b/test/integration/bulk_loader_test.rb
@@ -29,8 +29,9 @@ class BulkLoaderTest < IntegrationTest
 
   def assert_document_is_in_rummager(document)
     retrieved = retrieve_document_from_rummager(document['link'])
+    retrieved_document_keys = retrieved.keys - ["popularity"]
 
-    assert_equal document.keys.sort, retrieved.keys.sort
+    assert_equal document.keys.sort, retrieved_document_keys.sort
 
     document.each do |key, value|
       assert_equal value, retrieved[key], "Field #{key} should be '#{value}' but was '#{retrieved[key]}'"
@@ -52,7 +53,7 @@ class BulkLoaderTest < IntegrationTest
   end
 
   def test_indexes_documents
-    create_test_index
+    create_test_indexes
 
     bulk_loader = BulkLoader.new(app.settings.search_config, @default_index_name)
     bulk_loader.load_from(StringIO.new(index_payload(@sample_document)))
@@ -61,7 +62,9 @@ class BulkLoaderTest < IntegrationTest
   end
 
   def test_updates_an_existing_document
-    create_test_index
+    create_test_indexes
+    insert_stub_popularity_data(@sample_document["link"])
+
     index_group = search_server.index_group(@default_index_name)
     old_index = index_group.current_real
 

--- a/test/integration/elasticsearch_indexing_test.rb
+++ b/test/integration/elasticsearch_indexing_test.rb
@@ -28,8 +28,9 @@ class ElasticsearchIndexingTest < IntegrationTest
 
   def assert_document_is_in_rummager(document)
     retrieved = retrieve_document_from_rummager(document['link'])
+    retrieved_document_keys = retrieved.keys - ["popularity"]
 
-    assert_equal document.keys.sort, retrieved.keys.sort
+    assert_equal document.keys.sort, retrieved_document_keys.sort
 
     document.each do |key, value|
       assert_equal value, retrieved[key], "Field #{key} should be '#{value}' but was '#{retrieved[key]}'"

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -55,6 +55,7 @@ class MultiIndexTest < IntegrationTest
   def add_sample_documents(index_name, count)
     attributes = sample_document_attributes(index_name, count)
     attributes.each do |sample_document|
+      insert_stub_popularity_data(sample_document["link"])
       post "/#{index_name}/documents", MultiJson.encode(sample_document)
       assert last_response.ok?
     end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -39,18 +39,19 @@ class InvalidTestIndex < ArgumentError; end
 module ElasticsearchIntegration
   # Make sure that we're dealing with a test index (of the form <foo>_test)
   def check_index_name(index_name)
-    unless /^[a-z]+_test($|-)/.match index_name
+    unless /^[a-z_]+_test($|-)/.match index_name
       raise InvalidTestIndex, index_name
     end
   end
 
-  def stub_elasticsearch_settings(content_index_names = ["rummager_test"], default = nil, auxiliary_index_names=[])
+  def stub_elasticsearch_settings(content_index_names = ["rummager_test"], default = nil, auxiliary_index_names=["page_traffic_test"])
     (content_index_names + auxiliary_index_names).each do |n|
       check_index_name(n)
     end
     check_index_name(default) unless default.nil?
 
     @default_index_name = default || content_index_names.first
+    @auxiliary_indexes = auxiliary_index_names
 
     app.settings.search_config.stubs(:elasticsearch).returns({
       "base_uri" => "http://localhost:9200",
@@ -71,7 +72,7 @@ module ElasticsearchIntegration
   end
 
   def enable_test_index_connections
-    WebMock.disable_net_connect!(allow: %r{http://localhost:9200/(_search/scroll|_aliases|[a-z]+_test.*)})
+    WebMock.disable_net_connect!(allow: %r{http://localhost:9200/(_search/scroll|_aliases|[a-z_]+_test.*)})
   end
 
   def search_server

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -39,12 +39,12 @@ class InvalidTestIndex < ArgumentError; end
 module ElasticsearchIntegration
   # Make sure that we're dealing with a test index (of the form <foo>_test)
   def check_index_name(index_name)
-    unless /^[a-z_]+_test($|-)/.match index_name
+    unless /^[a-z_-]+(_|-)test($|-)/.match index_name
       raise InvalidTestIndex, index_name
     end
   end
 
-  def stub_elasticsearch_settings(content_index_names = ["rummager_test"], default = nil, auxiliary_index_names=["page_traffic_test"])
+  def stub_elasticsearch_settings(content_index_names = ["rummager_test"], default = nil, auxiliary_index_names=["page-traffic-test"])
     (content_index_names + auxiliary_index_names).each do |n|
       check_index_name(n)
     end
@@ -72,7 +72,7 @@ module ElasticsearchIntegration
   end
 
   def enable_test_index_connections
-    WebMock.disable_net_connect!(allow: %r{http://localhost:9200/(_search/scroll|_aliases|[a-z_]+_test.*)})
+    WebMock.disable_net_connect!(allow: %r{http://localhost:9200/(_search/scroll|_aliases|[a-z_-]+(_|-)test.*)})
   end
 
   def search_server
@@ -97,8 +97,8 @@ module ElasticsearchIntegration
       "rank_14" => 10,
     }
 
-    response = RestClient.post("http://localhost:9200/page_traffic_test/page_traffic/", document_atts.to_json)
-    RestClient.post "http://localhost:9200/page_traffic_test/_refresh", nil
+    response = RestClient.post("http://localhost:9200/page-traffic-test/page-traffic/", document_atts.to_json)
+    RestClient.post "http://localhost:9200/page-traffic-test/_refresh", nil
   end
 
   def try_remove_test_index(index_name = @default_index_name)
@@ -121,7 +121,7 @@ module ElasticsearchIntegration
   end
 
   def clean_popularity_index
-    try_remove_test_index 'page_traffic_test'
+    try_remove_test_index 'page-traffic-test'
   end
 
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -120,6 +120,10 @@ module ElasticsearchIntegration
     end
   end
 
+  def clean_popularity_index
+    try_remove_test_index 'page_traffic_test'
+  end
+
 end
 
 class IntegrationTest < MiniTest::Unit::TestCase

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -44,15 +44,18 @@ module ElasticsearchIntegration
     end
   end
 
-  def stub_elasticsearch_settings(content_index_names = ["rummager_test"], default = nil)
-    content_index_names.each do |n| check_index_name(n) end
+  def stub_elasticsearch_settings(content_index_names = ["rummager_test"], default = nil, auxiliary_index_names=[])
+    (content_index_names + auxiliary_index_names).each do |n|
+      check_index_name(n)
+    end
     check_index_name(default) unless default.nil?
 
     @default_index_name = default || content_index_names.first
 
     app.settings.search_config.stubs(:elasticsearch).returns({
       "base_uri" => "http://localhost:9200",
-      "content_index_names" => content_index_names
+      "content_index_names" => content_index_names,
+      "auxiliary_index_names" => auxiliary_index_names
     })
     app.settings.stubs(:default_index_name).returns(@default_index_name)
     app.settings.stubs(:enable_queue).returns(false)

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -85,6 +85,22 @@ module ElasticsearchIntegration
     index_group.switch_to(index)
   end
 
+  def create_test_indexes
+    (@auxiliary_indexes + [@default_index_name]).each do |index|
+      create_test_index(index)
+    end
+  end
+
+  def insert_stub_popularity_data(path)
+    document_atts = {
+      "path_components" => path,
+      "rank_14" => 10,
+    }
+
+    response = RestClient.post("http://localhost:9200/page_traffic_test/page_traffic/", document_atts.to_json)
+    RestClient.post "http://localhost:9200/page_traffic_test/_refresh", nil
+  end
+
   def try_remove_test_index(index_name = @default_index_name)
     check_index_name(index_name)
     RestClient.delete "http://localhost:9200/#{CGI.escape(index_name)}"

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -97,7 +97,7 @@ module ElasticsearchIntegration
       "rank_14" => 10,
     }
 
-    response = RestClient.post("http://localhost:9200/page-traffic-test/page-traffic/", document_atts.to_json)
+    RestClient.post "http://localhost:9200/page-traffic-test/page-traffic/", document_atts.to_json
     RestClient.post "http://localhost:9200/page-traffic-test/_refresh", nil
   end
 
@@ -123,7 +123,6 @@ module ElasticsearchIntegration
   def clean_popularity_index
     try_remove_test_index 'page-traffic-test'
   end
-
 end
 
 class IntegrationTest < MiniTest::Unit::TestCase

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -9,14 +9,14 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     @base_uri = URI.parse("http://example.com:9200")
     @wrapper = Elasticsearch::Index.new(@base_uri, "test-index", default_mappings)
 
-    @traffic_index = Elasticsearch::Index.new(@base_uri, "page_traffic", page_traffic_mappings)
+    @traffic_index = Elasticsearch::Index.new(@base_uri, "page-traffic", page_traffic_mappings)
     @wrapper.stubs(:traffic_index).returns(@traffic_index)
-    @traffic_index.stubs(:real_name).returns("page_traffic")
+    @traffic_index.stubs(:real_name).returns("page-traffic")
   end
 
   def stub_popularity_index_requests(paths, popularity, total_pages=10, total_requested=total_pages, paths_to_return=paths)
     # stub the request for total results
-    stub_request(:get, "http://example.com:9200/page_traffic/_search").
+    stub_request(:get, "http://example.com:9200/page-traffic/_search").
             with(:body => { "query" => { "match_all" => {}}, "size" => 0 }.to_json).
             to_return(:status => 200, :body => { "hits" => { "total" => total_pages }}.to_json)
 
@@ -46,7 +46,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       }
     }
 
-    stub_request(:get, "http://example.com:9200/page_traffic/_search").
+    stub_request(:get, "http://example.com:9200/page-traffic/_search").
             with(:body => expected_query.to_json).
             to_return(:status => 200, :body => response.to_json, :headers => {})
   end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -9,14 +9,14 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     @base_uri = URI.parse("http://example.com:9200")
     @wrapper = Elasticsearch::Index.new(@base_uri, "test-index", default_mappings)
 
-    @traffic_index = Elasticsearch::Index.new(@base_uri, "page-traffic", page_traffic_mappings)
+    @traffic_index = Elasticsearch::Index.new(@base_uri, "page_traffic", page_traffic_mappings)
     @wrapper.stubs(:traffic_index).returns(@traffic_index)
-    @traffic_index.stubs(:real_name).returns("page-traffic")
+    @traffic_index.stubs(:real_name).returns("page_traffic")
   end
 
   def stub_popularity_index_requests(paths, popularity, total=10)
     # stub the request for total results
-    stub_request(:get, "http://example.com:9200/page-traffic/_search").
+    stub_request(:get, "http://example.com:9200/page_traffic/_search").
             with(:body => { "query" => { "match_all" => {}}, "size" => 0 }.to_json).
             to_return(:status => 200, :body => { "hits" => { "total" => total }}.to_json)
 
@@ -46,7 +46,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       }
     }
 
-    stub_request(:get, "http://example.com:9200/page-traffic/_search").
+    stub_request(:get, "http://example.com:9200/page_traffic/_search").
             with(:body => expected_query.to_json).
             to_return(:status => 200, :body => response.to_json, :headers => {})
   end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -43,54 +43,59 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   end
 
   BASE_CHEESE_QUERY = {
-    custom_filters_score: {
-      query: {bool: {
-        should: [
-          {bool: {
-            must: [
-              {match: {_all: {
-                query: 'cheese',
-                analyzer: 'query_default',
-                minimum_should_match: '2<2 3<3 7<50%'
-              }}},
-            ],
+    custom_score: {
+      query: {
+        custom_filters_score: {
+          query: {bool: {
             should: [
-              {match_phrase: {'title' => {query: 'cheese', analyzer: 'query_default'}}},
-              {match_phrase: {'acronym' => {query: 'cheese', analyzer: 'query_default'}}},
-              {match_phrase: {'description' => {query: 'cheese', analyzer: 'query_default'}}},
-              {match_phrase: {'indexable_content' => {query: 'cheese', analyzer: 'query_default'}}},
-              {multi_match: {
+              {bool: {
+                must: [
+                  {match: {_all: {
+                    query: 'cheese',
+                    analyzer: 'query_default',
+                    minimum_should_match: '2<2 3<3 7<50%'
+                  }}},
+                ],
+                should: [
+                  {match_phrase: {'title' => {query: 'cheese', analyzer: 'query_default'}}},
+                  {match_phrase: {'acronym' => {query: 'cheese', analyzer: 'query_default'}}},
+                  {match_phrase: {'description' => {query: 'cheese', analyzer: 'query_default'}}},
+                  {match_phrase: {'indexable_content' => {query: 'cheese', analyzer: 'query_default'}}},
+                  {multi_match: {
+                    query: 'cheese',
+                    operator: 'and',
+                    fields: ['title', 'acronym', 'description', 'indexable_content'],
+                    analyzer: 'query_default',
+                  }},
+                  {multi_match: {
+                    query: 'cheese',
+                    operator: 'or',
+                    fields: ['title', 'acronym', 'description', 'indexable_content'],
+                    analyzer: 'shingled_query_analyzer',
+                  }},
+                ]}},
+              {query_string: {
+                default_field: 'promoted_for',
                 query: 'cheese',
-                operator: 'and',
-                fields: ['title', 'acronym', 'description', 'indexable_content'],
-                analyzer: 'query_default',
-              }},
-              {multi_match: {
-                query: 'cheese',
-                operator: 'or',
-                fields: ['title', 'acronym', 'description', 'indexable_content'],
-                analyzer: 'shingled_query_analyzer',
-              }},
-            ]}},
-          {query_string: {
-            default_field: 'promoted_for',
-            query: 'cheese',
-            boost: 100,
-          }}
-        ]
-      }},
-      filters: [
-        {filter: {term: {format: 'smart-answer'}}, boost: 1.5},
-        {filter: {term: {format: 'transaction'}}, boost: 1.5},
-        {filter: {term: {format: 'topical_event'}}, boost: 1.5},
-        {filter: {term: {format: 'minister'}}, boost: 1.7},
-        {filter: {term: {format: 'organisation'}}, boost: 2.5},
-        {filter: {term: {format: 'topic'}}, boost: 1.5},
-        {filter: {term: {format: 'document_series'}}, boost: 1.3},
-        {filter: {term: {format: 'document_collection'}}, boost: 1.3},
-        {filter: {term: {format: 'operational_field'}}, boost: 1.5},
-        {filter: {term: {search_format_types: 'announcement'}}, script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"}
-      ]
+                boost: 100,
+              }}
+            ]
+          }},
+          filters: [
+            {filter: {term: {format: 'smart-answer'}}, boost: 1.5},
+            {filter: {term: {format: 'transaction'}}, boost: 1.5},
+            {filter: {term: {format: 'topical_event'}}, boost: 1.5},
+            {filter: {term: {format: 'minister'}}, boost: 1.7},
+            {filter: {term: {format: 'organisation'}}, boost: 2.5},
+            {filter: {term: {format: 'topic'}}, boost: 1.5},
+            {filter: {term: {format: 'document_series'}}, boost: 1.3},
+            {filter: {term: {format: 'document_collection'}}, boost: 1.3},
+            {filter: {term: {format: 'operational_field'}}, boost: 1.5},
+            {filter: {term: {search_format_types: 'announcement'}}, script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"}
+          ]
+        }
+      },
+      script: "_score * (doc['popularity'].value + #{UnifiedSearchBuilder::POPULARITY_OFFSET})"
     }
   }
 


### PR DESCRIPTION
This relates to https://www.pivotaltracker.com/story/show/66422732

This adds a new index, `page-traffic`, into which page traffic data about each URL on GOV.UK can be imported. For now, we have an initial dump of data we will import, but in a subsequent piece of work we will automate this to pull in data regularly.

Once the page traffic is present, we use it at index time to add a popularity score to each document. This is done for all documents in the index as part of the regular `rummager:migrate_index` Rake task. If a document has no page traffic data, we give it a default popularity score of zero.

When searching, popularity is now included as one of the weighting factors in sorting results returned. We're finding that this significantly improves the quality of search results.
