### PR TITLE
Always return active filters in facets

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -221,8 +221,12 @@ class Rummager < Sinatra::Application
   #
   #   facet_FIELD: (where FIELD is a fieldname); count up values which are
   #   present in the field in the documents matched by the search, and return
-  #   information about these.  The value of this parameter is the limit on the
-  #   number of distinct field values which will be returned.
+  #   information about these.  The value of this parameter is the requested
+  #   number of distinct field values to be returned for the field.
+  #
+  #   Regardless of the parameter value, a facet value will be returned for any
+  #   filter which is in place on the field. This may cause the requested
+  #   number of values to be exceeded.
   #
   #   fields[]: fields to be returned in the result documents.  By default, all
   #   allowed fields will be returned, but this can be used to restrict the

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -84,6 +84,7 @@ private
     top_unapplied = options.slice(0, requested_count).reject do |option|
       applied.include? option
     end
+
     applied + top_unapplied
   end
 

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -22,6 +22,7 @@ class UnifiedSearcher
       es_response,
       params[:start],
       @index.index_name.split(","),
+      params[:filters],
       params[:facets],
       registries,
       registry_by_field,


### PR DESCRIPTION
Also, always return active filters first in facets.  eg, if a filter is
applied for organisation "HMRC", the facet value for the organisation
field will always contain "HMRC" first.

It's possible in various ways for the search UI to have filters which
are applied but whose values are not represented in the results of the
query.  This change makes these filters come back in the facet values,
so that they get displayed in the UI and can be removed by the user.

Fixes https://www.pivotaltracker.com/story/show/69915644
