### PR TITLE
Correct schema for best bets

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -800,9 +800,9 @@ mappings:
     best_bet:
       _all: { enabled: false }
       properties:
-        exact_query: { type: string, index: analyzed, analyzer: "exact_match" }
-        stem_query:  { type: string, index: analyzed }
-        details:     { type: string, index: not_analyzed }
+        exact_query:   { type: string, index: analyzed, analyzer: "exact_match" }
+        stemmed_query: { type: string, index: analyzed }
+        details:       { type: string, index: not_analyzed }
   government:
     edition:
       _all: { enabled: true }


### PR DESCRIPTION
We'd named the stemmed query field stem_query, but search-admin is
emitting stemmed_query.  It doesn't really matter which is used, so
switch rummager's config.
