### PR TITLE
Always add popularity to content indexes

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -74,6 +74,7 @@ module Elasticsearch
       @client = build_client
       @index_name = index_name
       raise ArgumentError, "Missing index_name parameter" unless @index_name
+      @index_with_popularity = !(settings.search_config.auxiliary_index_names.include? @index_name)
       @mappings = mappings
       @promoted_results = promoted_results
     end
@@ -406,12 +407,13 @@ module Elasticsearch
     end
 
     def index_doc(doc_hash, popularities)
-      unless popularities.nil?
-        link = doc_hash["link"]
-        pop = popularities[link]
-        unless pop.nil?
-          doc_hash["popularity"] = pop
+      if @index_with_popularity
+        pop = 0.0
+        unless popularities.nil?
+          link = doc_hash["link"]
+          pop = popularities[link]
         end
+        doc_hash["popularity"] = pop
       end
       doc_hash
     end


### PR DESCRIPTION
Check if the index is an "auxilary" index, and if not add the popularity
field.  We don't just check if the index is a "content" index, because
many of the tests make indexes which are neither content or auxilary
indexes (eg, "rummager_test"), and these should have popularity values
added.

Previously, we were only adding popularity fields to indexes when a
popularity value was found matching the value of the "link" field.  This
meant that most of our tests were producing documents without a
popularity value.  It turns out that elasticsearch 0.90 is more fussy
about the popularity field existing when used in a script than 0.20, and
as such VMs running 0.90.12 fail their integration tests.

This probably doesn't affect production.  It could if:
- the page-traffic index went missing on production
- an index migration was performed
- no documents contained a popularity value
