### PR TITLE
Change get and delete endpoints to accept a type

### DIFF
--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -96,6 +96,28 @@ class ElasticsearchDeletionTest < IntegrationTest
   end
 
   def test_should_delete_an_item_with_a_full_url
+    get "/documents/edition/http:%2F%2Fexample.com%2F"
+    assert last_response.ok?
+
+    delete "/documents/edition/http:%2F%2Fexample.com%2F"
+    assert last_response.ok?
+
+    get "/documents/edition/http:%2F%2Fexample.com%2F"
+    assert last_response.not_found?
+  end
+
+  def test_should_delete_a_nonedition_by_type_and_id
+    get "/metasearch-test/documents/best_bet/jobs_exact"
+    assert last_response.ok?
+
+    delete "/metasearch-test/documents/best_bet/jobs_exact"
+    assert last_response.ok?
+
+    get "/metasearch-test/documents/best_bet/jobs_exact"
+    assert last_response.not_found?
+  end
+
+  def test_should_default_type_to_edition_and_id_to_link
     get "/documents/http:%2F%2Fexample.com%2F"
     assert last_response.ok?
 

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -267,7 +267,7 @@ eos
   end
 
   def test_get_document
-    document_url = "http://example.com:9200/test-index/_all/%2Fan-example-link"
+    document_url = "http://example.com:9200/test-index/edition/%2Fan-example-link"
     document_hash = {
       "_type" => "edition",
       "link" => "/an-example-link",
@@ -363,7 +363,7 @@ eos
   end
 
   def test_get_document_not_found
-    document_url = "http://example.com:9200/test-index/_all/%2Fa-bad-link"
+    document_url = "http://example.com:9200/test-index/edition/%2Fa-bad-link"
 
     not_found_response = {
       "_index" => "rummager",


### PR DESCRIPTION
```
GET /documents/a-slug
DELETE /documents/a-slug
```

becomes

```
GET /documents/edition/a-slug
DELETE /documents/edition/a-slug
```

Before this PR, get and delete take a "link" parameter.  "get" actually
works internally by looking up the document by the its id, whereas
"delete" works by deleting all documents with the given value in the
link field.  This only works if the link field is equal to the id.  This
isn't actually true; recommended links have no value in the link field,
and best bets don't even have a link field.

Instead, we're going to change the get and delete endpoints to accept
paths of the form "type/id".  Currently, the only types that external
apps will ever send here are "edition" and "best_bet", so for the
purposes of the migration, we only support those two types.  If the
supplied path doesn't start with one of those two types, assume it's an
edition type.

One this is merged, we'll update Rummageable to always send the type
when deleting documents
(https://github.com/alphagov/rummageable/pull/18) and change any calls
to the "get" endpoint similarly (if there are any).  Finally, we'll
remove the support for omitting the "type" part.
