### PR TITLE
Fix access to config for non-sinatra scripts

### DIFF
--- a/lib/elasticsearch/index_group.rb
+++ b/lib/elasticsearch/index_group.rb
@@ -18,13 +18,15 @@ module Elasticsearch
   class IndexGroup
     attr_reader :promoted_results
 
-    def initialize(base_uri, name, index_settings, mappings, promoted_results = [])
+    def initialize(base_uri, name, index_settings, mappings, promoted_results = [],
+                   search_config)
       @base_uri = base_uri
       @client = Client.new(base_uri)
       @name = name
       @index_settings = index_settings
       @mappings = mappings
       @promoted_results = promoted_results
+      @search_config = search_config
     end
 
     def create_index
@@ -38,7 +40,8 @@ module Elasticsearch
 
       logger.info "Created index #{index_name}"
 
-      Index.new(@base_uri, index_name, @mappings, @promoted_results)
+      Index.new(@base_uri, index_name, @mappings, @promoted_results,
+                @search_config)
     end
 
     def switch_to(index)
@@ -84,7 +87,7 @@ module Elasticsearch
     end
 
     def current
-      Index.new(@base_uri, @name, @mappings, @promoted_results)
+      Index.new(@base_uri, @name, @mappings, @promoted_results, @search_config)
     end
 
     # The unaliased version of the current index
@@ -94,7 +97,8 @@ module Elasticsearch
     def current_real
       current_index = current
       if current_index.exists?
-        Index.new(@base_uri, current.real_name, @mappings, @promoted_results)
+        Index.new(@base_uri, current.real_name, @mappings, @promoted_results,
+                  @search_config)
       else
         nil
       end

--- a/lib/elasticsearch/search_server.rb
+++ b/lib/elasticsearch/search_server.rb
@@ -8,15 +8,17 @@ module Elasticsearch
   class SearchServer
     DEFAULT_MAPPING_KEY = "default"
 
-    def initialize(base_uri, schema, index_names, content_index_names)
+    def initialize(base_uri, schema, index_names, content_index_names,
+                   search_config)
       @base_uri = URI.parse(base_uri)
       @schema = schema
       @index_names = index_names
       @content_index_names = content_index_names
+      @search_config = search_config
     end
 
     def index_group(prefix)
-      IndexGroup.new(@base_uri, prefix, index_settings(prefix), mappings(prefix), promoted_results)
+      IndexGroup.new(@base_uri, prefix, index_settings(prefix), mappings(prefix), promoted_results, @search_config)
     end
 
     def index(prefix)

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -9,6 +9,7 @@ class SearchConfig
       elasticsearch_schema,
       index_names,
       content_index_names,
+      self,
     )
   end
 

--- a/test/functional/index_group_test.rb
+++ b/test/functional/index_group_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 require "multi_json"
 require "elasticsearch/search_server"
 require "elasticsearch/index_group"
+require "search_config"
 
 class IndexGroupTest < MiniTest::Unit::TestCase
 
@@ -38,6 +39,7 @@ class IndexGroupTest < MiniTest::Unit::TestCase
       @schema,
       ["mainstream", "custom"],
       ["mainstream"],
+      SearchConfig.new
     )
   end
 
@@ -344,7 +346,7 @@ class IndexGroupTest < MiniTest::Unit::TestCase
     name = "my_index"
     index_settings = {"settings" => {}}
     mappings = {"default" => {}}
-    index_group = Elasticsearch::IndexGroup.new(base_uri, name, index_settings, mappings, promoted_results)
+    index_group = Elasticsearch::IndexGroup.new(base_uri, name, index_settings, mappings, promoted_results, SearchConfig.new)
 
     assert_equal promoted_results, index_group.current.promoted_results
   end

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "elasticsearch/index"
+require "search_config"
 require "webmock"
 
 class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
@@ -7,7 +8,8 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
 
   def setup
     base_uri = URI.parse("http://example.com:9200")
-    @wrapper = Elasticsearch::Index.new(base_uri, "test-index", default_mappings)
+    search_config = SearchConfig.new
+    @wrapper = Elasticsearch::Index.new(base_uri, "test-index", default_mappings, search_config)
   end
 
   def test_pagination_params_are_required

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "elasticsearch/index"
+require "search_config"
 require "webmock"
 
 class ElasticsearchIndexTest < MiniTest::Unit::TestCase
@@ -7,9 +8,10 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
 
   def setup
     @base_uri = URI.parse("http://example.com:9200")
-    @wrapper = Elasticsearch::Index.new(@base_uri, "test-index", default_mappings)
+    search_config = SearchConfig.new
+    @wrapper = Elasticsearch::Index.new(@base_uri, "test-index", default_mappings, search_config)
 
-    @traffic_index = Elasticsearch::Index.new(@base_uri, "page-traffic", page_traffic_mappings)
+    @traffic_index = Elasticsearch::Index.new(@base_uri, "page-traffic", page_traffic_mappings, search_config)
     @wrapper.stubs(:traffic_index).returns(@traffic_index)
     @traffic_index.stubs(:real_name).returns("page-traffic")
   end

--- a/test/unit/search_server_test.rb
+++ b/test/unit/search_server_test.rb
@@ -1,32 +1,33 @@
 require "test_helper"
 require "elasticsearch/search_server"
+require "search_config"
 
 class SearchServerTest < MiniTest::Unit::TestCase
   EMPTY_SCHEMA = { "mappings" => { "default" => nil } }
 
   def test_returns_an_index
-    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"])
+    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"], SearchConfig.new)
     index = search_server.index("a")
     assert index.is_a?(Elasticsearch::Index)
     assert_equal "a", index.index_name
   end
 
   def test_raises_an_error_for_unknown_index
-    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"])
+    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"], SearchConfig.new)
     assert_raises Elasticsearch::NoSuchIndex do
       search_server.index("z")
     end
   end
 
   def test_can_get_multi_index
-    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"])
+    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"], SearchConfig.new)
     index = search_server.index("a,b")
     assert index.is_a?(Elasticsearch::Index)
     assert_equal "a,b", index.index_name
   end
 
   def test_raises_an_error_for_unknown_index_in_multi_index
-    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"])
+    search_server = Elasticsearch::SearchServer.new("http://l", EMPTY_SCHEMA, ["a", "b"], ["a"], SearchConfig.new)
     assert_raises Elasticsearch::NoSuchIndex do
       search_server.index("a,z")
     end
@@ -43,6 +44,7 @@ class SearchServerTest < MiniTest::Unit::TestCase
       schema,
       ["mainstream", "custom"],
       ["mainstream", "custom"],
+      SearchConfig.new,
     )
     promoted_results = server.promoted_results
 
@@ -51,15 +53,17 @@ class SearchServerTest < MiniTest::Unit::TestCase
   end
 
   def test_promoted_results_passed_to_index_group
+    search_config = SearchConfig.new
     server = Elasticsearch::SearchServer.new(
       "http://localhost:9200/",
       EMPTY_SCHEMA,
       ["mainstream", "custom"],
       ["mainstream", "custom"],
+      search_config,
     )
     promoted_results = stub("promoted results")
     server.stubs(:promoted_results).returns(promoted_results)
-    Elasticsearch::IndexGroup.expects(:new).with(anything,anything,anything,anything,promoted_results)
+    Elasticsearch::IndexGroup.expects(:new).with(anything,anything,anything,anything,promoted_results,search_config)
     server.index_group("mainstream")
   end
 


### PR DESCRIPTION
Scripts such as bin/bulk_load which aren't running under sinatra don't
have the settings global variable available.  These have been broken
by a recent change which made the Index class access the settings
global.

Instead, inject the settings into Index via the constructor.  This in
turn requires corresponding updates to IndexGroup and SearchServer.
