### PR TITLE
Revert "Remove combined search endpoints."

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -6,6 +6,6 @@ topic_registry_index: "government"
 document_series_registry_index: "government"
 document_collection_registry_index: "government"
 world_location_registry_index: "government"
-# These indices are passed in this order to Unified Search
+# These indices are passed in this order to GovukSearcher
 govuk_index_names: ["mainstream", "detailed", "government"]
 metasearch_index_name: "metasearch"

--- a/lib/govuk_search_presenter.rb
+++ b/lib/govuk_search_presenter.rb
@@ -1,0 +1,46 @@
+require "result_set_presenter"
+
+# Presents a combined set of results for a GOV.UK site search
+class GovukSearchPresenter
+
+  STREAM_TITLES = {
+    "top-results" => "Top results",
+    "services-information" => "Services and information",
+    "departments-policy" => "Departments and policy"
+  }
+
+  # The `result_sets` hash should be a map from stream names to ResultSet
+  # instances.
+  #
+  # `presenter_context` should be a map from registry names to registries,
+  # which gets passed to the ResultSetPresenter class. For example:
+  #
+  #     { organisation_registry: OrganisationRegistry.new(...) }
+  def initialize(result_sets, presenter_context = {})
+    unknown_keys = result_sets.keys - STREAM_TITLES.keys
+    if unknown_keys.any?
+      raise ArgumentError, "Unrecognised streams: #{unknown_keys.join(', ')}"
+    end
+
+    @result_sets = result_sets
+    @presenter_context = presenter_context
+  end
+
+  def present
+    output = {"streams" => {}}
+    presenters.each do |key, rs_presenter|
+      presented_stream = rs_presenter.present
+      output["streams"][key] = presented_stream.merge("title" => STREAM_TITLES[key])
+    end
+
+    output
+  end
+
+private
+
+  def presenters
+    Hash[@result_sets.map {|key, result_set|
+      [key, ResultSetPresenter.new(result_set, @presenter_context)]
+    }]
+  end
+end

--- a/lib/govuk_searcher.rb
+++ b/lib/govuk_searcher.rb
@@ -1,0 +1,36 @@
+# Combines search results across indices for the GOV.UK site search
+class GovukSearcher
+  def initialize(mainstream_index, detailed_index, government_index)
+    @mainstream_index = mainstream_index
+    @detailed_index = detailed_index
+    @government_index = government_index
+  end
+
+  # Search and combine the indices and return a hash of ResultSet objects
+  def search(query, organisation = nil, sort = nil)
+    mainstream_results = @mainstream_index.search(query)
+    detailed_results = @detailed_index.search(query)
+    government_results = @government_index.search(query,
+      organisation: organisation, sort: sort)
+
+    if organisation || sort
+      unfiltered_government_results = @government_index.search(query)
+    else
+      unfiltered_government_results = government_results
+    end
+
+    # si == services and information
+    si_results = mainstream_results.merge(detailed_results.weighted(0.8))
+
+    top_results = si_results.merge(unfiltered_government_results.weighted(0.6)).take(3)
+
+    remaining_si = si_results - top_results
+    remaining_government = government_results - top_results
+
+    {
+      "top-results" => top_results,
+      "services-information" => remaining_si,
+      "departments-policy" => remaining_government
+    }
+  end
+end

--- a/test/functional/multiple_backends_test.rb
+++ b/test/functional/multiple_backends_test.rb
@@ -4,11 +4,11 @@ require "integration_test_helper"
 class MultipleBackendsTest < IntegrationTest
   def test_passes_search_to_chosen_backend
     chosen_index = mock("chosen index")
-    chosen_index.expects(:advanced_search).returns(stub(results: [], total: 0))
+    chosen_index.expects(:search).returns(stub(results: [], total: 0))
     OrganisationRegistry.any_instance.stubs(:all).returns([])
     Elasticsearch::SearchServer.any_instance.stubs(:index).returns(stub("other index"))
     Elasticsearch::SearchServer.any_instance.stubs(:index).with("chosen").returns(chosen_index)
-    get "/chosen/advanced_search?q=example"
+    get "/chosen/search?q=example"
   end
 
   def test_actions_other_than_search_use_primary_backend_as_default
@@ -19,7 +19,7 @@ class MultipleBackendsTest < IntegrationTest
 
   def test_responds_with_404_if_backend_not_found
     Elasticsearch::SearchServer.any_instance.expects(:index).with("chosen").raises(Elasticsearch::NoSuchIndex)
-    get "/chosen/advanced_search?q=example"
+    get "/chosen/search?q=example"
     assert_equal 404, last_response.status
   end
 end

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -1,0 +1,265 @@
+# encoding: utf-8
+require "integration_test_helper"
+require 'document_series_registry'
+require 'document_collection_registry'
+require "organisation_registry"
+require "topic_registry"
+require "world_location_registry"
+
+class SearchTest < IntegrationTest
+
+  def bus_timetables_document_series
+    Document.new(
+      %w(link title),
+      {
+        link: "/government/organisations/department-for-transport/series/bus-timetables",
+        title: "Bus Timetables"
+      }
+    )
+  end
+
+  def learning_to_drive_document_collection
+    Document.new(
+      %w(link title),
+      {
+        link: "/government/collections/learning-to-drive",
+        title: "Learning to Drive"
+      }
+    )
+  end
+
+  def angola_world_location
+    Document.new(
+      %w(link title),
+      {
+        link: "/government/world/angola",
+        title: "Angola"
+      }
+    )
+  end
+
+  def mod_organisation
+    Document.new(
+      %w(link title),
+      {
+        link: "/government/organisations/ministry-of-defence",
+        title: "Ministry of Defence (MoD)"
+      }
+    )
+  end
+
+  def dft_organisation
+    Document.new(
+      %w(link title acronym),
+      {
+        link: "/government/organisations/department-for-transport",
+        title: "Department for Transport",
+        acronym: "DFT"
+      }
+    )
+  end
+
+  def housing_topic
+    Document.new(
+      %w(link title),
+      {
+        link: "/government/topics/housing",
+        title: "Housing"
+      }
+    )
+  end
+
+  def setup
+    OrganisationRegistry.any_instance.stubs(:all).returns([])
+  end
+
+  def test_returns_json_for_search_results
+    stub_index.expects(:search).returns(stub(results: [sample_document], total: 1))
+    get "/search", {q: "bob"}, "HTTP_ACCEPT" => "application/json"
+    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)["results"]
+    assert_match(/application\/json/, last_response.headers["Content-Type"])
+  end
+
+  def test_returns_semantic_response_for_invalid_query
+    get "/search", { q: "bob", sort: "not_in_schema" }
+    assert_equal 422, last_response.status
+    assert_equal "Sorting on unknown property: not_in_schema", last_response.body
+  end
+
+  def test_returns_json_when_requested_with_url_suffix
+    stub_index.expects(:search).returns(stub(results: [sample_document], total: 1))
+    get "/search.json", {q: "bob"}
+    assert_equal [sample_document_attributes], MultiJson.decode(last_response.body)["results"]
+    assert_match(/application\/json/, last_response.headers["Content-Type"])
+  end
+
+  def test_returns_spelling_suggestions_when_hash_requested
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    get "/search.json", {q: "speling"}
+    assert_equal ["spelling"], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
+  def test_does_not_suggest_corrections_for_organisation_acronyms
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    OrganisationRegistry.any_instance.expects(:all)
+      .returns([dft_organisation])
+    get "/search.json", {q: "DFT"} # DFT would get a suggestion
+    assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
+  def test_matches_organisation_acronyms_in_any_letter_case
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    OrganisationRegistry.any_instance.expects(:all)
+      .returns([dft_organisation])
+    get "/search.json", {q: "dft"} # DFT would get a suggestion
+    assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
+  def test_handles_organisations_without_acronyms_for_suggestions
+    organisation_without_acronym = Document.new(
+      %w(link title acronym),
+      {
+        link: "/government/organisations/acronymless-department",
+        title: "Acronymless Department"
+      }
+    )
+
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    OrganisationRegistry.any_instance.expects(:all)
+      .returns([organisation_without_acronym])
+    get "/search.json", {q: "pies"}
+    assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
+  def test_does_not_suggest_corrections_for_words_in_ignore_file
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    get "/search.json", {q: "sorn"} # sorn would get a suggestion
+    assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
+  def test_does_not_suggest_corrections_for_numbers_or_words_containing_numbers
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    get "/search.json", {q: "v5c 2013"} # v5c would get a suggestion
+    assert_equal [], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
+  def test_does_not_suggest_corrections_in_blacklist_file
+    stub_index.expects(:search).returns(stub(results: [], total: 0))
+    get "/search.json", {q: "penison"} # penison would get an inappropriate suggestion
+    assert_equal ["pension"], MultiJson.decode(last_response.body)["spelling_suggestions"]
+  end
+
+  def test_handles_results_with_document_series
+    mappings = default_mappings
+    mappings["edition"]["properties"]["document_series"] = {"type" => "string"}
+    document = Document.from_hash(
+      sample_document_attributes.merge(document_series: ["bus-timetables"]),
+      mappings
+    )
+
+    stub_index.expects(:search).returns(stub(results: [document], total: 1))
+    DocumentSeriesRegistry.any_instance.expects(:[])
+      .with("bus-timetables")
+      .returns(bus_timetables_document_series)
+    get "/search.json", {q: "bob"}
+    first_result = MultiJson.decode(last_response.body)["results"].first
+    assert_equal 1, first_result["document_series"].size
+    assert_equal bus_timetables_document_series.title, first_result["document_series"][0]["title"]
+  end
+
+  def test_handles_results_with_document_collections
+    mappings = default_mappings
+    mappings["edition"]["properties"]["document_collections"] = {"type" => "string"}
+    document = Document.from_hash(
+      sample_document_attributes.merge(document_collections: ["learning-to-drive"]),
+      mappings
+    )
+
+    stub_index.expects(:search).returns(stub(results: [document], total: 1))
+    DocumentCollectionRegistry.any_instance.expects(:[])
+      .with("learning-to-drive")
+      .returns(learning_to_drive_document_collection)
+    get "/search.json", {q: "bob"}
+    first_result = MultiJson.decode(last_response.body)["results"].first
+    assert_equal 1, first_result["document_collections"].size
+    assert_equal learning_to_drive_document_collection.title, first_result["document_collections"][0]["title"]
+  end
+
+  def test_handles_results_with_organisations
+    mappings = default_mappings
+    mappings["edition"]["properties"]["organisations"] = {"type" => "string"}
+    document = Document.from_hash(
+      sample_document_attributes.merge(organisations: ["ministry-of-defence"]),
+      mappings
+    )
+
+    stub_index.expects(:search).returns(stub(results: [document], total: 1))
+    OrganisationRegistry.any_instance.expects(:[])
+      .with("ministry-of-defence")
+      .returns(mod_organisation)
+    get "/search.json", {q: "bob"}
+    first_result = MultiJson.decode(last_response.body)["results"].first
+    assert_equal 1, first_result["organisations"].size
+    assert_equal mod_organisation.title, first_result["organisations"][0]["title"]
+  end
+
+  def test_handles_results_with_topics
+    mappings = default_mappings
+    mappings["edition"]["properties"]["topics"] = {"type" => "string"}
+    document = Document.from_hash(
+      sample_document_attributes.merge(topics: ["housing"]),
+      mappings
+    )
+
+    stub_index.expects(:search).returns(stub(results: [document], total: 1))
+    TopicRegistry.any_instance.expects(:[])
+      .with("housing")
+      .returns(housing_topic)
+    get "/search.json", {q: "bob"}
+    first_result = MultiJson.decode(last_response.body)["results"].first
+    assert_equal 1, first_result["topics"].size
+    assert_equal housing_topic.title, first_result["topics"][0]["title"]
+  end
+
+  def test_handles_results_with_world_locations
+    mappings = default_mappings
+    mappings["edition"]["properties"]["world_locations"] = {"type" => "string"}
+    document = Document.from_hash(
+      sample_document_attributes.merge(world_locations: ["angola"]),
+      mappings
+    )
+
+    stub_index.expects(:search).returns(stub(results: [document], total: 1))
+    WorldLocationRegistry.any_instance.expects(:[])
+      .with("angola")
+      .returns(angola_world_location)
+    get "/search.json", {q: "bob"}
+    first_result = MultiJson.decode(last_response.body)["results"].first
+    assert_equal 1, first_result["world_locations"].size
+    assert_equal angola_world_location.title, first_result["world_locations"][0]["title"]
+  end
+
+  def test_returns_404_when_requested_with_non_json_url
+    stub_index.expects(:search).never
+    get "/search.xml", {q: "bob"}
+    assert last_response.not_found?
+  end
+
+  def test_should_ignore_edge_spaces_and_codepoints_below_0x20
+    stub_index.expects(:search).never
+    get "/search", {q: " \x02 "}
+    refute_match(/we can’t find any results/, last_response.body)
+  end
+
+  def test_returns_404_for_empty_queries
+    stub_index.expects(:search).never
+    get "/search"
+    assert last_response.not_found?
+  end
+
+  def test_returns_503_when_elasticsearch_timesout
+    stub_index.expects(:search).raises(RestClient::RequestTimeout)
+    get "/search.json", { q: "search term" }
+    assert_equal 503, last_response.status
+  end
+end

--- a/test/integration/combined_search_test.rb
+++ b/test/integration/combined_search_test.rb
@@ -1,0 +1,45 @@
+require "integration_test_helper"
+require "rest-client"
+require_relative "multi_index_test"
+
+class CombinedSearchTest < MultiIndexTest
+
+  def test_returns_success
+    get "/govuk/search?q=important"
+    assert last_response.ok?
+  end
+
+  def test_returns_streams
+    get "/govuk/search?q=important"
+    expected_streams = [
+      "top-results",
+      "services-information",
+      "departments-policy"
+    ].to_set
+    assert_equal expected_streams, parsed_response["streams"].keys.to_set
+  end
+
+  def test_blocks_requests_in_formats_other_than_json
+    get "/govuk/search.xml?q=important"
+    assert_equal 404, last_response.status
+
+    get "/some_index/search.haml?q=important"
+    assert_equal 404, last_response.status
+
+    get "/some_index/advanced_search.soap?page=1&per_page=1&q=important"
+    assert_equal 404, last_response.status
+
+    get "/organisations.fishslice"
+    assert_equal 404, last_response.status
+  end
+
+  def test_returns_3_top_results
+    get "/govuk/search?q=important"
+    assert_equal 3, parsed_response["streams"]["top-results"]["results"].count
+  end
+
+  def test_returns_spelling_suggestions
+    get "/govuk/search?q=afgananistan"
+    assert parsed_response["spelling_suggestions"].include? "Afghanistan"
+  end
+end

--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -91,7 +91,7 @@ class ElasticsearchDeletionTest < IntegrationTest
 
     commit_index
 
-    get "/unified_search.json?q=cheese"
+    get "/search.json?q=cheese"
     assert_no_results
   end
 
@@ -116,7 +116,7 @@ class ElasticsearchDeletionTest < IntegrationTest
     end
 
     ["badger", "benefits"].each do |query|
-      get "/unified_search.json?q=#{query}"
+      get "/search.json?q=#{query}"
       assert_no_results
     end
   end

--- a/test/integration/elasticsearch_migration_test.rb
+++ b/test/integration/elasticsearch_migration_test.rb
@@ -57,7 +57,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     # Test that a reindex re-adds all the documents with new
     # stemming settings
 
-    get "/unified_search?q=directive"
+    get "/search?q=directive"
     assert_equal 2, MultiJson.decode(last_response.body)["results"].length
 
     @stemmer["rules"] = ["directive => directive"]
@@ -68,10 +68,10 @@ class ElasticsearchMigrationTest < IntegrationTest
 
     index_group.switch_to new_index
 
-    get "/unified_search?q=directive"
+    get "/search?q=directive"
     assert_result_links "/important"
 
-    get "/unified_search?q=direct"
+    get "/search?q=direct"
     assert_result_links "/aliens"
   end
 end

--- a/test/integration/elasticsearch_search_test.rb
+++ b/test/integration/elasticsearch_search_test.rb
@@ -140,50 +140,57 @@ class ElasticsearchSearchTest < IntegrationTest
   end
 
   def test_documents_with_public_timestamp_exhibit_a_decay_boost
-    get "/unified_search.json?q=mali"
+    get "/search.json?q=mali"
     assert last_response.ok?
     assert_result_links "/mali-1", "/mali-2", "/mali-3"
   end
 
   def test_should_search_by_content
-    get "/unified_search.json?q=badger"
+    get "/search.json?q=badger"
     assert last_response.ok?
     assert_result_links "/an-example-answer"
   end
 
   def test_can_scope_by_organisation
-    get "/unified_search.json?q=written&filter_organisations[]=home-office"
+    get "/search.json?q=written&organisation_slug=home-office"
     assert last_response.ok?
     assert_result_links "/written-by-ho"
   end
 
   def test_no_results_when_scoped_by_organisation
-    get "/unified_search.json?q=written&filter_organisations[]=ministry-of-justice"
+    get "/search.json?q=written&organisation_slug=ministry-of-justice"
     assert last_response.ok?
     assert_result_links # assert no results
   end
 
+  def test_can_sort_results_by_date
+    get "/search.json?q=mali&sort=public_timestamp&order=asc"
+    assert last_response.ok?
+    # Results should come out oldest-first
+    assert_result_links "/mali-3", "/mali-2", "/mali-1", order: true
+  end
+
   def test_should_match_stems
-    get "/unified_search.json?q=badgers"
+    get "/search.json?q=badgers"
     assert last_response.ok?
     assert_result_links "/an-example-answer"
   end
 
   def test_should_search_by_title
-    get "/unified_search.json?q=cheese"
+    get "/search.json?q=cheese"
     assert last_response.ok?
     assert_result_links "/an-example-answer"
   end
 
   def test_should_search_by_description
-    get "/unified_search.json?q=hummus"
+    get "/search.json?q=hummus"
     assert last_response.ok?
     assert_result_links "/an-example-answer"
   end
 
   def test_should_not_match_on_slug
     ["example", "%2Fan-example-answer"].each do |escaped_query|
-      get "/unified_search.json?q=#{escaped_query}"
+      get "/search.json?q=#{escaped_query}"
       assert last_response.ok?
       assert_no_results
     end
@@ -191,47 +198,47 @@ class ElasticsearchSearchTest < IntegrationTest
 
   def test_should_escape_lucene_characters
     ["badger)", "badger\\"].each do |problem|
-      get "/unified_search.json?q=#{CGI.escape(problem)}"
+      get "/search.json?q=#{CGI.escape(problem)}"
       assert last_response.ok?
       assert_result_links "/an-example-answer"
     end
   end
 
   def test_should_not_match_on_format
-    get "/unified_search.json?q=answer"
+    get "/search.json?q=answer"
     assert last_response.ok?
     assert_no_results
   end
 
   def test_should_not_match_on_section
-    get "/unified_search.json?q=crime"
+    get "/search.json?q=crime"
     assert last_response.ok?
     assert_no_results
   end
 
   def test_should_not_fail_on_conjunctions
     ["cheese AND ", "cheese OR ", " AND cheese", " OR cheese"].each do |term|
-      get "/unified_search.json?q=#{CGI.escape term}"
+      get "/search.json?q=#{CGI.escape term}"
       assert last_response.ok?
       assert_result_links "/an-example-answer"
     end
   end
 
   def test_should_not_fail_on_NOT
-    get "/unified_search.json?q=NOT"
+    get "/search.json?q=NOT"
     assert last_response.ok?
   end
 
   def test_should_not_parse_conjunctions_in_words
     # Testing a SHOUTY QUERY because Lucene only treats capitalised
     # conjunctions as special operators
-    get "/unified_search.json?q=PORK+PIES"
+    get "/search.json?q=PORK+PIES"
     assert last_response.ok?
     assert_result_links "/pork-pies"
   end
 
   def test_promoted_items_float_to_top_if_query_contains_a_promoted_keyword
-    get "/unified_search.json?q=promoted+jobs+in+birmingham"
+    get "/search.json?q=promoted+jobs+in+birmingham"
     assert last_response.ok?
     assert_result_links "/promoted", "/not-promoted"
   end

--- a/test/unit/govuk_search_presenter_test.rb
+++ b/test/unit/govuk_search_presenter_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+require "govuk_search_presenter"
+
+class GovukSearchPresenterTest < ShouldaUnitTestCase
+
+  context "no streams" do
+    setup do
+      @presenter = GovukSearchPresenter.new({})
+    end
+
+    should "present an empty set of streams" do
+      assert_equal({"streams" => {}}, @presenter.present)
+    end
+  end
+
+  context "unknown streams" do
+    should "reject unknown streams" do
+      assert_raises ArgumentError do
+        GovukSearchPresenter.new("cheese" => [])
+      end
+    end
+
+    should "report unknown streams in the exception" do
+      begin
+        GovukSearchPresenter.new("cheese" => []) and flunk
+      rescue ArgumentError => e
+        assert e.message.include? "cheese"
+      end
+    end
+  end
+
+  context "multiple streams" do
+    def stub_presenter
+      stub(present: {"results" => []})
+    end
+
+    setup do
+      @top_results = stub("top results")
+      @si_results = stub("S&I results")
+      @presenter = GovukSearchPresenter.new(
+        "top-results" => @top_results,
+        "services-information" => @si_results
+      )
+    end
+
+    should "instantiate a ResultSetPresenter per stream" do
+      ResultSetPresenter.expects(:new).with(@top_results, {}).returns(stub_presenter)
+      ResultSetPresenter.expects(:new).with(@si_results, {}).returns(stub_presenter)
+      @presenter.present
+    end
+
+    should "include results from each stream" do
+      ResultSetPresenter.stubs(:new).returns(stub_presenter)
+      output = @presenter.present
+      assert_equal(
+        ["top-results", "services-information"].to_set,
+        output["streams"].keys.to_set
+      )
+    end
+
+    should "insert titles" do
+      ResultSetPresenter.stubs(:new).returns(stub_presenter)
+      output = @presenter.present
+      streams = output["streams"]
+
+      assert_equal "Top results", streams["top-results"]["title"]
+      assert_equal "Services and information", streams["services-information"]["title"]
+    end
+  end
+
+  context "with ResultSetPresenter context" do
+    setup do
+      @top_results = stub("top results")
+      @si_results = stub("S&I results")
+      presenters = {
+        "top-results" => @top_results
+      }
+      @context = stub("presenter context")
+      @presenter = GovukSearchPresenter.new(
+        {"top-results" => @top_results},
+        @context
+      )
+    end
+
+    should "pass the presenter context on to child presenters" do
+      ResultSetPresenter.expects(:new)
+          .with(@top_results, @context)
+          .returns(stub_presenter)
+      @presenter.present
+    end
+  end
+end

--- a/test/unit/govuk_searcher_test.rb
+++ b/test/unit/govuk_searcher_test.rb
@@ -1,0 +1,156 @@
+require "test_helper"
+require "set"
+require "govuk_searcher"
+
+class GovukSearcherTest < ShouldaUnitTestCase
+
+  # results is a set of [score, link] pairs
+  class FakeResultSet < Struct.new(:results)
+    def merge(other)
+      merged_results = (results + other.results).sort.reverse
+      FakeResultSet.new(merged_results)
+    end
+
+    def weighted(factor)
+      weighted_results = results.map { |score, link| [score * factor, link] }
+      FakeResultSet.new(weighted_results)
+    end
+
+    def -(other)
+      new_results = results.reject { |r| other.links.include?(r[1]) }
+      FakeResultSet.new(new_results)
+    end
+
+    def take(count)
+      FakeResultSet.new(results.take(count))
+    end
+
+    def links
+      results.map { |r| r[1] }
+    end
+  end
+
+  context "unfiltered, unsorted search" do
+
+    setup do
+      @mainstream = stub("mainstream index")
+      @detailed = stub("detailed index")
+      @government = stub("government index")
+      @searcher = GovukSearcher.new(@mainstream, @detailed, @government)
+
+      no_parameters = { organisation: nil, sort: nil }
+      # No weighting
+      @mainstream.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[6, "/m1"], [5, "/m2"], [3, "/m3"]])
+      )
+      # Weighted: 5.6, 3.2
+      @detailed.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[7, "/d1"], [4, "/d2"]])
+      )
+      # Weighted: 4.8, 3.6
+      @government.expects(:search).with("cheese", no_parameters).returns(
+        FakeResultSet.new([[8, "/g1"], [6, "/g2"]])
+      )
+
+      @results = @searcher.search("cheese")
+    end
+
+    should "include the three result streams" do
+      assert_equal(
+        ["top-results", "services-information", "departments-policy"].to_set,
+        @results.keys.to_set
+      )
+    end
+
+    should "pull out the top three results" do
+      assert_equal(["/m1", "/d1", "/m2"], @results["top-results"].links)
+    end
+
+    should "display the remaining results in their respective streams" do
+      top_links = @results["top-results"].links
+
+      assert_equal ["/d2", "/m3"], @results["services-information"].links
+      assert_equal ["/g1", "/g2"], @results["departments-policy"].links
+    end
+  end
+
+  context "filtered search" do
+
+    setup do
+      @mainstream = stub("mainstream index")
+      @detailed = stub("detailed index")
+      @government = stub("government index")
+      @searcher = GovukSearcher.new(@mainstream, @detailed, @government)
+
+      no_parameters = { organisation: nil, sort: nil }
+      @mainstream.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[6, "/m1"]])
+      )
+      # Weighted: 4
+      @detailed.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[5, "/d1"]])
+      )
+      # Weighted: 4.8, 3.6
+      @government.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[8, "/g1"], [6, "/g2"]])
+      )
+      @government.expects(:search)
+                 .with("cheese", organisation: "org", sort: nil)
+                 .returns(FakeResultSet.new([[6, "/g1"]]))
+
+      @results = @searcher.search("cheese", "org")
+    end
+
+    should "pull out the top three results, including unfiltered" do
+      assert_equal(["/m1", "/g1", "/d1"], @results["top-results"].links)
+    end
+
+    should "display the remaining results in their respective streams" do
+      top_links = @results["top-results"].links
+
+      assert_equal [], @results["services-information"].links
+      # /g1 was in the top results; /g2 is not in the unfiltered results
+      assert_equal [], @results["departments-policy"].links
+    end
+  end
+
+  context "sorted search" do
+
+    setup do
+      @mainstream = stub("mainstream index")
+      @detailed = stub("detailed index")
+      @government = stub("government index")
+      @searcher = GovukSearcher.new(@mainstream, @detailed, @government)
+
+      no_parameters = { organisation: nil, sort: nil }
+      @mainstream.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[6, "/m1"]])
+      )
+      # Weighted: 4
+      @detailed.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[5, "/d1"]])
+      )
+      # Weighted: 4.8, 3.6
+      @government.expects(:search).with("cheese").returns(
+        FakeResultSet.new([[8, "/g1"], [6, "/g2"]])
+      )
+      @government.expects(:search)
+                 .with("cheese", organisation: nil, sort: "public_timestamp")
+                 .returns(FakeResultSet.new([[6, "/g2"], [8, "/g1"]]))
+
+      @results = @searcher.search("cheese", nil, "public_timestamp")
+    end
+
+    should "pull out the top three results" do
+      assert_equal(["/m1", "/g1", "/d1"], @results["top-results"].links)
+    end
+
+    should "display the remaining results in their respective streams" do
+      top_links = @results["top-results"].links
+
+      assert_equal [], @results["services-information"].links
+      # /g1 was in the top results; /g2 is not in the unfiltered results
+      assert_equal ["/g2"], @results["departments-policy"].links
+    end
+  end
+end


### PR DESCRIPTION
This reverts commit 30d0d53c7d11a48135c9ec2ee120cffa4f9135f2.

This was breaking the design principles app, which it turns out still uses this endpoint.
