### PR TITLE
Add disable_popularity debug parameter

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -174,6 +174,9 @@ private
   end
 
   def debug_options
+    # Note: this parameter is exposed publically via both the API on GOV.UK and
+    # the query parameters for search on GOV.UK.  Don't make it return anything
+    # sensitive.
     debug = @params["debug"] || ""
     @used_params << "debug"
 
@@ -183,6 +186,8 @@ private
       when ""
       when "disable_best_bets"
         options[:disable_best_bets] = true
+      when "disable_popularity"
+        options[:disable_popularity] = true
       else
         @errors << %{Unknown debug option "#{option}"}
       end

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -223,11 +223,11 @@ class SearchParameterParserTest < ShouldaUnitTestCase
   end
 
   should "understand the debug parameter" do
-    p = SearchParameterParser.new({"debug" => "disable_best_bets,,unknown_option"})
+    p = SearchParameterParser.new({"debug" => "disable_best_bets,disable_popularity,,unknown_option"})
 
     assert_equal(%{Unknown debug option "unknown_option"}, p.error)
     assert !p.valid?
-    assert_equal expected_params({debug: {disable_best_bets: true}}), p.parsed_params
+    assert_equal expected_params({debug: {disable_best_bets: true, disable_popularity: true}}), p.parsed_params
   end
 
   should "ignore empty options in the debug parameter" do

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -597,7 +597,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
     should "have not have a custom_score clause to add popularity in payload" do
       query = @builder.payload[:query]
-      assert query.to_s !~ /popularity/
+      refute_match(/popularity/, query.to_s)
       assert query[:indices][:query][:custom_boost_factor][:query].keys == [:custom_filters_score]
     end
   end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -597,7 +597,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
     should "have not have a custom_score clause to add popularity in payload" do
       query = @builder.payload[:query]
-      assert "#{query}" !~ /popularity/
+      assert query.to_s !~ /popularity/
       assert query[:indices][:query][:custom_boost_factor][:query].keys == [:custom_filters_score]
     end
   end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -601,5 +601,4 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       assert query[:indices][:query][:custom_boost_factor][:query].keys == [:custom_filters_score]
     end
   end
-
 end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -579,4 +579,27 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       assert @builder.payload[:query].keys != [:bool]
     end
   end
+
+  context "search with debug disabling use of popularity" do
+    setup do
+      stub_zero_best_bets
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        order: nil,
+        filters: {},
+        fields: nil,
+        facets: nil,
+        debug: {disable_popularity: true},
+      }, @metasearch_index)
+    end
+
+    should "have not have a custom_score clause to add popularity in payload" do
+      query = @builder.payload[:query]
+      assert "#{query}" !~ /popularity/
+      assert query[:indices][:query][:custom_boost_factor][:query].keys == [:custom_filters_score]
+    end
+  end
+
 end


### PR DESCRIPTION
Adding debug=disable_popularity disables the use of popularity
information when searching.  This is useful for checking the effect of
popularity information on searches.  This can be combined with the
existing disable_best_bets by joining the options with a comma
separator.
