### PR TITLE
Don't import html_search_client; it's been removed

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -16,7 +16,6 @@ require "slop"
 require 'health_check/logging_config'
 require 'health_check/checker'
 require 'health_check/local_search_client'
-require 'health_check/html_search_client'
 require 'health_check/json_search_client'
 require 'health_check/downloader'
 require 'health_check/basic_auth_credentials'


### PR DESCRIPTION
This is needed to un-break the health-check.
