### PR TITLE
Debug option to explain query ranking

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -188,6 +188,8 @@ private
         options[:disable_best_bets] = true
       when "disable_popularity"
         options[:disable_popularity] = true
+      when "explain"
+        options[:explain] = true
       else
         @errors << %{Unknown debug option "#{option}"}
       end

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -29,6 +29,7 @@ class UnifiedSearchBuilder
       fields: @params[:return_fields],
       sort: sort_list,
       facets: facets_hash,
+      explain: @params[:debug][:explain],
     }.reject{ |key, value|
       [nil, [], {}].include?(value)
     }]

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -65,6 +65,11 @@ private
       fields[:es_score] = metadata["_score"]
       fields[:_id] = metadata["_id"]
 
+      explain = metadata["_explanation"]
+      unless explain.nil?
+        fields[:_explanation] = explain
+      end
+
     end
   end
 

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -111,4 +111,13 @@ class UnifiedSearchTest < MultiIndexTest
     get "/unified_search"
     assert_equal [], parsed_response["suggested_queries"]
   end
+
+  def test_debug_explain_returns_explanations
+    get "/unified_search?debug=explain"
+    first_hit_explain = parsed_response["results"].first["_explanation"]
+    refute_nil first_hit_explain
+    assert first_hit_explain.keys.include?("value")
+    assert first_hit_explain.keys.include?("description")
+    assert first_hit_explain.keys.include?("details")
+  end
 end

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -238,4 +238,12 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     assert_equal expected_params({debug: {}}), p.parsed_params
   end
 
+  should "understand explain in the debug parameter" do
+    p = SearchParameterParser.new({"debug" => "explain"})
+
+    assert p.valid?
+    assert_equal expected_params({debug: {explain: true}}), p.parsed_params
+  end
+
+
 end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -601,4 +601,24 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       assert query[:indices][:query][:custom_boost_factor][:query].keys == [:custom_filters_score]
     end
   end
+
+  context "search with debug explain" do
+    setup do
+      stub_zero_best_bets
+      @builder = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        order: nil,
+        filters: {},
+        fields: nil,
+        facets: nil,
+        debug: {explain: true},
+      }, @metasearch_index)
+    end
+
+    should "have not have a custom_score clause to add popularity in payload" do
+      assert @builder.payload[:explain] == true
+    end
+  end
 end


### PR DESCRIPTION
Currently, it's often very hard to say exactly why a document has been returned at a particular position - especially because the indexes on preview and production are often different enough that the rankings are quite different.  For example, https://www.gov.uk/search?q=small+business+pension+rules currently returns https://www.gov.uk/foreign-travel-advice/thailand as the top result, and I can't figure out why.

This PR makes use of elasticsearch's "explain" option to return full details of the calculation performed, which should make this much easier.  The output takes the form of an extra "_explanation" key in each search result, which is a tree of information reflecting the values calculated throughout the query tree.

The returned information could be displayed in the search result list, but until/unless work is done on frontend to enable that, it will only be accessible via the API (ie, /api/search.json).  This is still very helpful.
