### PR TITLE
Add errbit configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "redis-namespace", "1.3.1"
 gem "plek", "1.5.0"
 gem "gds-api-adapters", "7.18.0"
 gem "rack-logstasher", "0.0.3"
+gem 'airbrake', '4.0.0'
 gem "unf", "0.1.3"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,9 @@ GEM
       i18n (~> 0.6)
       multi_json (~> 1.0)
     addressable (2.3.3)
+    airbrake (4.0.0)
+      builder
+      multi_json
     ansi (1.4.3)
     aws-ses (0.4.4)
       builder
@@ -136,6 +139,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (= 4.0.0)
   aws-ses (= 0.4.4)
   ci_reporter (= 1.7.1)
   debugger

--- a/config.rb
+++ b/config.rb
@@ -4,6 +4,7 @@ require "search_config"
 require_relative "exception_mailer"
 require "ses_mailer"  # For the exception_notification initialiser
 require "config/logging"
+require "airbrake"
 
 set :search_config, SearchConfig.new
 set :default_index_name, "mainstream"
@@ -19,3 +20,8 @@ disable :show_exceptions
 initializers_path = File.expand_path("config/initializers/*.rb", File.dirname(__FILE__))
 
 Dir[initializers_path].each { |f| require f }
+
+configure do
+  Airbrake.configuration.ignore << "Sinatra::NotFound"
+  use Airbrake::Sinatra
+end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,1 @@
+# This is overwritten on deploy

--- a/lib/tasks/airbrake.rake
+++ b/lib/tasks/airbrake.rake
@@ -1,0 +1,3 @@
+require 'airbrake/tasks'
+
+require_relative '../../config/initializers/airbrake'


### PR DESCRIPTION
So we can see errors in production without trawling through an obscure google group.
