### PR TITLE
Add disable_synonyms debug option

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -188,6 +188,8 @@ private
         options[:disable_best_bets] = true
       when "disable_popularity"
         options[:disable_popularity] = true
+      when "disable_synonyms"
+        options[:disable_synonyms] = true
       when "explain"
         options[:explain] = true
       else

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -245,5 +245,10 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     assert_equal expected_params({debug: {explain: true}}), p.parsed_params
   end
 
+  should "understand disable_synonyms in the debug parameter" do
+    p = SearchParameterParser.new({"debug" => "disable_synonyms"})
 
+    assert p.valid?
+    assert_equal expected_params({debug: {disable_synonyms: true}}), p.parsed_params
+  end
 end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -42,37 +42,34 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     @metasearch_index.expects(:analyzed_best_bet_query).returns("cheese")
   end
 
-  def setup_best_bets_query(best_bets, worst_bets)
-    params = {
+  def query_options(options={})
+    {
       start: 0,
-      count: 10,
-      query: "cheese ",
+      count: 20,
+      query: "cheese",
       order: nil,
       filters: {},
       fields: nil,
       facets: nil,
       debug: {},
-    }
+    }.merge(options)
+  end
+
+  def setup_best_bets_query(best_bets, worst_bets)
     setup_best_bets([], [])
-    @builder_without_best_bets = UnifiedSearchBuilder.new(params, @metasearch_index)
+    @builder_without_best_bets = UnifiedSearchBuilder.new(query_options, @metasearch_index)
     @query_without_best_bets = @builder_without_best_bets.payload[:query]
     setup_best_bets(best_bets, worst_bets)
-    @builder = UnifiedSearchBuilder.new(params, @metasearch_index)
+    @builder = UnifiedSearchBuilder.new(query_options, @metasearch_index)
   end
 
   context "unfiltered search" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        order: nil,
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options,
+        @metasearch_index
+      )
     end
 
     should "strip whitespace from the query" do
@@ -113,16 +110,12 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with one filter" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: nil,
-        filters: {"organisations" => ["hm-magic"]},
-        fields: nil,
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          filters: {"organisations" => ["hm-magic"]},
+        ),
+        @metasearch_index
+      )
     end
 
     should "have filter in payload" do
@@ -147,16 +140,12 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with a filter with multiple options" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: nil,
-        filters: {"organisations" => ["hm-magic", "hmrc"]},
-        fields: nil,
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          filters: {"organisations" => ["hm-magic", "hmrc"]},
+        ),
+        @metasearch_index
+      )
     end
 
     should "have filter in payload" do
@@ -182,19 +171,15 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with multiple filters" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: nil,
-        filters: {
-          "organisations" => ["hm-magic", "hmrc"],
-          "section" => ["levitation"],
-        },
-        fields: nil,
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          filters: {
+            "organisations" => ["hm-magic", "hmrc"],
+            "section" => ["levitation"],
+          }
+        ),
+        @metasearch_index
+      )
     end
 
     should "have filter in payload" do
@@ -223,17 +208,12 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "building search with unicode" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cafe\u0300 ",
-        order: nil,
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
-
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          query: "cafe\u0300 ",
+        ),
+        @metasearch_index
+      )
     end
 
     should "put the query in normalized form" do
@@ -247,16 +227,12 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with ascending sort" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: ["public_timestamp", "asc"],
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          order: ["public_timestamp", "asc"],
+        ),
+        @metasearch_index
+      )
     end
 
     should "have sort in payload" do
@@ -300,16 +276,12 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with descending sort" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: ["public_timestamp", "desc"],
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          order: ["public_timestamp", "desc"],
+        ),
+        @metasearch_index
+      )
     end
 
     should "have sort in payload" do
@@ -352,16 +324,12 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with explicit return fields" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: nil,
-        filters: {},
-        return_fields: ['title'],
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          return_fields: ['title'],
+        ),
+        @metasearch_index
+      )
     end
 
     should "have correct fields in payload" do
@@ -375,16 +343,12 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with facet" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: nil,
-        filters: {},
-        fields: nil,
-        facets: {"organisations" => 10},
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          facets: {"organisations" => 10},
+        ),
+        @metasearch_index
+      )
     end
 
     should "not have filter in payload" do
@@ -411,16 +375,13 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with facet and filter on same field" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: nil,
-        filters: {"organisations" => ["hm-magic"]},
-        fields: nil,
-        facets: {"organisations" => 10},
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          filters: {"organisations" => ["hm-magic"]},
+          facets: {"organisations" => 10},
+        ),
+        @metasearch_index
+      )
     end
 
     should "have correct filter" do
@@ -447,16 +408,13 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with facet and filter on different field" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 10,
-        query: "cheese ",
-        order: nil,
-        filters: {"section" => ["levitation"]},
-        fields: nil,
-        facets: {"organisations" => 10},
-        debug: {},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(
+          filters: {"section" => ["levitation"]},
+          facets: {"organisations" => 10},
+        ),
+        @metasearch_index
+      )
     end
 
     should "have correct filter" do
@@ -563,16 +521,10 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with debug disabling use of best bets" do
     setup do
       # No need to set up best bets query.
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        order: nil,
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {disable_best_bets: true},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(debug: {disable_best_bets: true}),
+        @metasearch_index
+      )
     end
 
     should "have not have a bool query in payload" do
@@ -583,16 +535,10 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with debug disabling use of popularity" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        order: nil,
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {disable_popularity: true},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(debug: {disable_popularity: true}),
+        @metasearch_index
+      )
     end
 
     should "have not have a custom_score clause to add popularity in payload" do
@@ -605,16 +551,10 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with debug explain" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        order: nil,
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {explain: true},
-      }, @metasearch_index)
+      @builder = UnifiedSearchBuilder.new(
+        query_options(debug: {explain: true}),
+        @metasearch_index
+      )
     end
 
     should "have not have a custom_score clause to add popularity in payload" do
@@ -625,26 +565,14 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with debug disabling use of synonyms" do
     setup do
       stub_zero_best_bets
-      @builder_with_synonyms = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        order: nil,
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {},
-      }, @metasearch_index)
-      @builder_without_synonyms = UnifiedSearchBuilder.new({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        order: nil,
-        filters: {},
-        fields: nil,
-        facets: nil,
-        debug: {disable_synonyms: true},
-      }, @metasearch_index)
+      @builder_with_synonyms = UnifiedSearchBuilder.new(
+        query_options,
+        @metasearch_index
+      )
+      @builder_without_synonyms = UnifiedSearchBuilder.new(
+        query_options(debug: {disable_synonyms: true}),
+        @metasearch_index
+      )
     end
 
     should "not mention the query_default analyzer" do

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -621,4 +621,37 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       assert @builder.payload[:explain] == true
     end
   end
+
+  context "search with debug disabling use of synonyms" do
+    setup do
+      stub_zero_best_bets
+      @builder_with_synonyms = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        order: nil,
+        filters: {},
+        fields: nil,
+        facets: nil,
+        debug: {},
+      }, @metasearch_index)
+      @builder_without_synonyms = UnifiedSearchBuilder.new({
+        start: 0,
+        count: 20,
+        query: "cheese",
+        order: nil,
+        filters: {},
+        fields: nil,
+        facets: nil,
+        debug: {disable_synonyms: true},
+      }, @metasearch_index)
+    end
+
+    should "not mention the query_default analyzer" do
+      query_with_synonyms = @builder_with_synonyms.payload[:query]
+      query_without_synonyms = @builder_without_synonyms.payload[:query]
+      refute_match(/query_default/, query_without_synonyms.to_s)
+      assert_match(/query_default/, query_with_synonyms.to_s)
+    end
+  end
 end


### PR DESCRIPTION
If debug=disable_synonyms is added to the query parameters, this
disables use of the synonym list by using an analyzer which doesn't
include synonyms in its list of actions.  This is useful for working out
whether synonyms are helping to fix results for particular queries, or
whether they're causing problems.

Implements https://www.pivotaltracker.com/story/show/73295610
