### PR TITLE
Add tag field

### DIFF
--- a/elasticsearch_schema.yml
+++ b/elasticsearch_schema.yml
@@ -779,6 +779,8 @@ mappings:
         indexable_content: { type: string, index: analyzed }
         popularity: { type: float, stored: true }
         organisations: { type: string, index: not_analyzed, include_in_all: false }
+        specialist_sectors: { type: string, index: "no", include_in_all: false }
+        tags: { type: string, index: not_analyzed, include_in_all: false }
   metasearch: &metasearch
     best_bet:
       _all: { enabled: false }
@@ -826,9 +828,11 @@ mappings:
         relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }
         section:     { type: string, index: not_analyzed, include_in_all: false }
+        specialist_sectors: { type: string, index: "no", include_in_all: false }
         slug:        { type: string, index: not_analyzed, include_in_all: false }
         subsection:  { type: string, index: not_analyzed, include_in_all: false }
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
+        tags: { type: string, index: not_analyzed, include_in_all: false }
         title:       { type: string, index: analyzed }
         topics: { type: string, index: not_analyzed, include_in_all: false }
         world_locations: { type: string, index: not_analyzed, include_in_all: false }

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -427,8 +427,18 @@ module Elasticsearch
         doc_hash["popularity"] = pop
       end
 
+      doc_hash = prepare_tag_field(doc_hash)
       doc_hash = prepare_if_best_bet(doc_hash)
       doc_hash
+    end
+
+    def prepare_tag_field(doc_hash)
+      tags = []
+      
+      tags.concat(Array(doc_hash["organisations"]).map { |org| "organisation:#{org}" })
+      tags.concat(Array(doc_hash["specialist_sectors"]).map { |sector| "sector:#{sector}" })
+
+      doc_hash.merge("tags" => tags)
     end
 
     # If a document is a best bet, and is using the stemmed_query field, we

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -10,11 +10,11 @@ class SearchParameterParser
   ALLOWED_SORT_FIELDS = %w(public_timestamp)
 
   # The fields listed here are the only ones which can be used to filter by.
-  ALLOWED_FILTER_FIELDS = %w(organisations section format)
+  ALLOWED_FILTER_FIELDS = %w(organisations section format tag)
 
   # The fields listed here are the only ones which can be used to calculated
   # facets for.  This should be a subset of ALLOWED_FILTER_FIELDS
-  ALLOWED_FACET_FIELDS = %w(organisations section format)
+  ALLOWED_FACET_FIELDS = %w(organisations section format tag)
 
   # The fields listed here are the only ones that can be returned in search
   # results.  These are listed and validated explicitly, rather than simply
@@ -27,6 +27,7 @@ class SearchParameterParser
 
     public_timestamp
     organisations topics world_locations document_series
+    tag
 
     format display_type
     section subsection subsubsection

--- a/test/integration/elasticsearch_amendment_test.rb
+++ b/test/integration/elasticsearch_amendment_test.rb
@@ -19,6 +19,7 @@ class ElasticsearchAmendmentTest < IntegrationTest
     {
       "title" => "TITLE",
       "description" => "DESCRIPTION",
+      "organisations" => "hm-magic",
       "format" => "answer",
       "link" => "/an-example-answer",
       "indexable_content" => "HERE IS SOME CONTENT"
@@ -56,6 +57,24 @@ class ElasticsearchAmendmentTest < IntegrationTest
     parsed_response = MultiJson.decode(last_response.body)
 
     updates = {"title" => "A new title"}
+    sample_document_attributes.merge(updates).each do |key, value|
+      assert_equal value, parsed_response[key]
+    end
+  end
+
+  def test_should_amend_tags_correctly
+    post "/documents/%2Fan-example-answer", [
+      "specialist_sectors[]=oil-and-gas/licensing",
+    ].join("&")
+
+    get "/documents/%2Fan-example-answer"
+    assert last_response.ok?
+    parsed_response = MultiJson.decode(last_response.body)
+
+    updates = {
+      "tags" => ["organisation:hm-magic", "sector:oil-and-gas/licensing"],
+      "specialist_sectors" => ["oil-and-gas/licensing"],
+    }
     sample_document_attributes.merge(updates).each do |key, value|
       assert_equal value, parsed_response[key]
     end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -136,7 +136,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":1.0}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":1.0,"tags":[]}
     eos
     response = <<-eos
 {"took":5,"items":[
@@ -164,7 +164,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"not_an_edition","_id":"some_id"}}
-{"_type":"not_an_edition","_id":"some_id","title":"TITLE ONE","link":"/a/link","popularity":1.0}
+{"_type":"not_an_edition","_id":"some_id","title":"TITLE ONE","link":"/a/link","popularity":1.0,"tags":[]}
   eos
     response = <<-eos
 {"took":5,"items":[
@@ -237,7 +237,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0,"tags":[]}
 eos
     response = <<-eos
 {"took":5,"items":[


### PR DESCRIPTION
This adds a tag field to the index.

The tag field will contain a list of entries of the form "organisation:hm-revenue-customs" or "sector:oil-and-gas/licensing".  It may be used for facetting

If we need them, we'll add "primary_tag" field in future to hold the primary tags of each type (where that is a valid concept).  We could also parse tags which have a heirarchy into a separate field if we need to return parent tag facets, but we don't need that right now.

Also, and specialist_sectors to schema; these are received from clients, but are not indexed, only stored; they're actually indexed as part of the tag field, but need to be stored so that the amend action can work.

Pivotal story: https://www.pivotaltracker.com/story/show/73457476
