### PR TITLE
Make Jenkins test merge result of branches

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Try to merge master into the current branch, and abort if it doesn't exit
+# cleanly (ie there are conflicts). This will be a noop if the current branch
+# is master.
+git merge --no-commit origin/master || git merge --abort
+
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 # DELETE STATIC SYMLINKS AND RECONNECT...


### PR DESCRIPTION
Almost all of the time we are writing code to be merged into master sooner rather than later. Rather than testing the HEAD of the branch in Jenkins this commit adds a command to the build script which merges the branch with master before building it.
