### PR TITLE
Add a script to lock/unlock writes to an index

### DIFF
--- a/bin/lock_updates
+++ b/bin/lock_updates
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+PROJECT_ROOT = File.dirname(__FILE__) + "/../"
+LIBRARY_PATH = PROJECT_ROOT + "lib/"
+
+$LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
+
+require "logging"
+require "search_config"
+require "slop"
+require "bulk_loader"
+
+Slop.parse(help: true) do
+  search_config = SearchConfig.new
+  banner %Q{Usage: #{File.basename(__FILE__)} {#{search_config.index_names.join("|")}} lock|unlock
+
+Lock/Unlock an index for writes.
+
+This is useful for bulk rebuilds - lock the index before starting the export of the data.
+
+}
+  run do |opts, args|
+    if args.size == 2 && %w{lock unlock}.include?(args[1])
+      index = search_config.search_server.index_group(args[0])
+      if args[1] == "lock"
+        index.current_real.lock
+      else
+        index.current_real.unlock
+      end
+    else
+      puts self
+    end
+  end
+end
+


### PR DESCRIPTION
This is useful to block updates while a dump/reload is going on, to
ensure that no changes get lost.
