### PR TITLE
Expand specialist sectors

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,6 +15,7 @@ require "organisation_set_presenter"
 require "document_series_registry"
 require "document_collection_registry"
 require "organisation_registry"
+require "specialist_sector_registry"
 require "suggester"
 require "topic_registry"
 require "world_location_registry"
@@ -62,6 +63,10 @@ class Rummager < Sinatra::Application
   def world_location_registry
     index_name = settings.search_config.world_location_registry_index
     @@world_location_registry ||= WorldLocationRegistry.new(search_server.index(index_name)) if index_name
+  end
+
+  def specialist_sector_registry
+    @@specialist_sector_registry ||= SpecialistSectorRegistry.new(unified_index)
   end
 
   def govuk_indices
@@ -289,14 +294,16 @@ class Rummager < Sinatra::Application
       topic_registry: topic_registry,
       document_series_registry: document_series_registry,
       document_collection_registry: document_collection_registry,
-      world_location_registry: world_location_registry
+      world_location_registry: world_location_registry,
+      specialist_sector_registry: specialist_sector_registry,
     }
     registry_by_field = {
       organisations: organisation_registry,
       topics: topic_registry,
       document_series: document_series_registry,
       document_collections: document_collection_registry,
-      world_locations: world_location_registry
+      world_locations: world_location_registry,
+      specialist_sectors: specialist_sector_registry,
     }
 
     parser = SearchParameterParser.new(request.params)

--- a/config/schema/default/core.json
+++ b/config/schema/default/core.json
@@ -31,7 +31,7 @@
     },
     "specialist_sectors": {
       "type": "string",
-      "index": "no",
+      "index": "not_analyzed",
       "include_in_all": false
     },
     "tags": {

--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -110,7 +110,7 @@ mappings:
         relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }
         section:     { type: string, index: not_analyzed, include_in_all: false }
-        specialist_sectors: { type: string, index: "no", include_in_all: false }
+        specialist_sectors: { type: string, index: not_analyzed, include_in_all: false }
         slug:        { type: string, index: not_analyzed, include_in_all: false }
         subsection:  { type: string, index: not_analyzed, include_in_all: false }
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -69,6 +69,11 @@ private
         world_location_by_slug(slug)
       end
     end
+    if result['specialist_sectors']
+      result['specialist_sectors'].map! do |slug|
+        sector_by_slug(slug)
+      end
+    end
     result
   end
 
@@ -110,6 +115,10 @@ private
 
   def world_location_registry
     @context[:world_location_registry]
+  end
+
+  def specialist_sector_registry
+    @context[:specialist_sector_registry]
   end
 
   def spelling_suggestions
@@ -156,6 +165,15 @@ private
     world_location = world_location_registry && world_location_registry[slug]
     if world_location
       world_location.to_hash.merge("slug" => slug)
+    else
+      {"slug" => slug}
+    end
+  end
+
+  def sector_by_slug(slug)
+    sector = specialist_sector_registry && specialist_sector_registry[slug]
+    if sector
+      sector.to_hash.merge("slug" => slug)
     else
       {"slug" => slug}
     end

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -10,11 +10,11 @@ class SearchParameterParser
   ALLOWED_SORT_FIELDS = %w(public_timestamp)
 
   # The fields listed here are the only ones which can be used to filter by.
-  ALLOWED_FILTER_FIELDS = %w(organisations section format tags)
+  ALLOWED_FILTER_FIELDS = %w(organisations section format specialist_sectors)
 
   # The fields listed here are the only ones which can be used to calculated
   # facets for.  This should be a subset of ALLOWED_FILTER_FIELDS
-  ALLOWED_FACET_FIELDS = %w(organisations section format tags)
+  ALLOWED_FACET_FIELDS = %w(organisations section format specialist_sectors)
 
   # The fields listed here are the only ones that can be returned in search
   # results.  These are listed and validated explicitly, rather than simply
@@ -27,11 +27,10 @@ class SearchParameterParser
 
     public_timestamp
     organisations topics world_locations document_series
-    tags
+    specialist_sectors
 
     format display_type
     section subsection subsubsection
-
   )
 
   def initialize(params)

--- a/lib/specialist_sector_registry.rb
+++ b/lib/specialist_sector_registry.rb
@@ -1,0 +1,20 @@
+require "timed_cache"
+
+class SpecialistSectorRegistry
+  CACHE_LIFETIME_SECONDS = 1800
+
+  def initialize(index, clock = Time)
+    @index = index
+    @cache = TimedCache.new(CACHE_LIFETIME_SECONDS, clock) { fetch }
+  end
+
+  def [](slug)
+    @cache.get.find { |o| o.slug == slug }
+  end
+
+private
+  def fetch
+    fields = %w{slug link title}
+    @index.documents_by_format("specialist_sector", fields: fields).to_a
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -158,10 +158,18 @@ class IntegrationTest < MiniTest::Unit::TestCase
   end
 
   def stub_index
-    s = stub("stub index")
-    Rummager.any_instance.stubs(:current_index).returns(s)
-    Rummager.any_instance.stubs(:unified_index).returns(s)
-    s
+    return @s if @s
+    @s = stub("stub index")
+    Rummager.any_instance.stubs(:current_index).returns(@s)
+    Rummager.any_instance.stubs(:unified_index).returns(@s)
+    @s
+  end
+
+  def stub_metasearch_index
+    return @ms if @ms
+    @ms = stub("stub metasearch index")
+    Rummager.any_instance.stubs(:metasearch_index).returns(@ms)
+    @ms
   end
 
 private

--- a/test/unit/sector_registry_test.rb
+++ b/test/unit/sector_registry_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+require "document"
+require "specialist_sector_registry"
+
+class SectorRegistryTest < MiniTest::Unit::TestCase
+  def setup
+    @index = stub("elasticsearch index")
+    @specialist_sector_registry = SpecialistSectorRegistry.new(@index)
+  end
+
+  def oil_and_gas
+    Document.new(
+      %w(slug link title),
+      {
+        slug: "oil-and-gas/licensing",
+        link: "/oil-and-gas/licensing",
+        title: "Licensing"
+      }
+    )
+  end
+
+  def test_can_fetch_sector_by_slug
+    @index.stubs(:documents_by_format)
+      .with("specialist_sector", anything)
+      .returns([oil_and_gas])
+    sector = @specialist_sector_registry["oil-and-gas/licensing"]
+    assert_equal oil_and_gas.slug, sector.slug
+    assert_equal oil_and_gas.link, sector.link
+    assert_equal oil_and_gas.title, sector.title
+  end
+
+  def test_only_required_fields_are_requested_from_index
+    @index.expects(:documents_by_format)
+      .with("specialist_sector", fields: %w{slug link title})
+    @specialist_sector_registry["oil-and-gas/licensing"]
+  end
+
+  def test_returns_nil_if_sector_not_found
+    @index.stubs(:documents_by_format)
+      .with("specialist_sector", anything)
+      .returns([oil_and_gas])
+    sector = @specialist_sector_registry["foo"]
+    assert_nil sector
+  end
+
+  def test_document_enumerator_is_traversed_only_once
+    document_enumerator = stub("enumerator")
+    document_enumerator.expects(:to_a).returns([oil_and_gas]).once
+    @index.stubs(:documents_by_format)
+      .with("specialist_sector", anything)
+      .returns(document_enumerator)
+      .once
+    assert @specialist_sector_registry["oil-and-gas/licensing"]
+  end
+
+  def test_uses_cache
+    # Make sure we're using TimedCache#get; TimedCache is tested elsewhere, so
+    # we don't need to worry about cache expiry tests here.
+    TimedCache.any_instance.expects(:get).returns([oil_and_gas])
+    assert @specialist_sector_registry["oil-and-gas/licensing"]
+  end
+end


### PR DESCRIPTION
This expands the "specialist_sectors" field when returned in search results or facets to include the link and title information available from specialist_sector format documents.

The specialist_sector format documents don't yet exist in the production index, but will be added by https://www.pivotaltracker.com/story/show/73972778
