### PR TITLE
Exclude specialist sector documents from unified search results

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -173,6 +173,16 @@ class UnifiedSearchBuilder
       terms_filter(field, filter_values)
     }
 
+    # exclude any specialist sector documents from the search results, as we
+    # currently do not wish to display them
+    filter_groups << {
+      "not" => {
+        "term" => {
+          "format" => "specialist_sector"
+        }
+      }
+    }
+
     # Don't add additional filters to filter_groups without making sure that
     # the facet_filter values used in facets include the filter too.  It's
     # usually better to add additional filters to the query, so that they

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -43,12 +43,17 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   end
 
   def query_options(options={})
+    base_filters = {
+      'not' => { 'term' => { 'format' => 'specialist_sector' } }
+    }
+    extra_filters = options.delete(:filters) || {}
+
     {
       start: 0,
       count: 20,
       query: "cheese",
       order: nil,
-      filters: {},
+      filters: base_filters.merge(extra_filters),
       fields: nil,
       facets: nil,
       debug: {},


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/73972778

This changes unified search so that documents with the format "specialist_sector" are excluded from search results. 

To do this, the `UnifiedSearchBuilder` class is changed so that every query includes a `not` filter. Also, lots of unit tests in `unified_searcher_test.rb` and `unified_search_builder_test.rb` have been updated to include the new filter in stub data to keep the tests passing.
