### PR TITLE
Remove stemming override for 'permitting'

### DIFF
--- a/config/schema/stems.yml
+++ b/config/schema/stems.yml
@@ -27,7 +27,6 @@ rules: [
   "naturalization => naturalis",  # not natural, nature
   "paye => paye",  # not pay
   "permitted => permitted",
-  "permitting => permitting",  # not permit
   "practical => practical",
   "practice => practice",
   "probate => probate",  # not probation


### PR DESCRIPTION
Environment Agency prefer ‘environmental permit’ and ‘environmental permitting’ to be interchangeable
