### PR TITLE
Make delete path work when queueing enabled

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -430,7 +430,7 @@ class Rummager < Sinatra::Application
     end
 
     if settings.enable_queue
-      current_index.delete_queued(document_link)
+      current_index.delete_queued(type, id)
       json_result 202, "Queued"
     else
       simple_json_result(current_index.delete(type, id))

--- a/lib/elasticsearch/delete_worker.rb
+++ b/lib/elasticsearch/delete_worker.rb
@@ -4,7 +4,13 @@ module Elasticsearch
   class DeleteWorker < BaseWorker
     forward_to_failure_queue
 
-    def perform(index_name, document_type, document_id)
+    def perform(index_name, document_type, document_id = nil)
+      # Handle previous method signature to cope with leftover queued jobs when
+      # we deploy.
+      if document_id.nil?
+        document_type, document_id = index(index_name).link_to_type_and_id(document_type)
+      end
+
       logger.info "Deleting #{document_type} document '#{document_id}' from '#{index_name}'"
       begin
         index(index_name).delete(document_type, document_id)

--- a/lib/elasticsearch/delete_worker.rb
+++ b/lib/elasticsearch/delete_worker.rb
@@ -4,13 +4,13 @@ module Elasticsearch
   class DeleteWorker < BaseWorker
     forward_to_failure_queue
 
-    def perform(index_name, document_link)
-      logger.info "Deleting document '#{document_link}' from '#{index_name}'"
+    def perform(index_name, document_type, document_id)
+      logger.info "Deleting #{document_type} document '#{document_id}' from '#{index_name}'"
       begin
-        index(index_name).delete(document_link)
+        index(index_name).delete(document_type, document_id)
       rescue Elasticsearch::IndexLocked
         logger.info "Index #{index_name} is locked; rescheduling"
-        self.class.perform_in(LOCK_DELAY, index_name, document_link)
+        self.class.perform_in(LOCK_DELAY, index_name, document_type, document_id)
       end
     end
   end

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -352,8 +352,8 @@ module Elasticsearch
       return true  # For consistency with the Solr API and simple_json_response
     end
 
-    def delete_queued(link)
-      queue.queue_delete(link)
+    def delete_queued(document_type, document_id)
+      queue.queue_delete(document_type, document_id)
     end
 
     def delete_all

--- a/lib/elasticsearch/index_queue.rb
+++ b/lib/elasticsearch/index_queue.rb
@@ -14,8 +14,8 @@ module Elasticsearch
       BulkIndexWorker.perform_async(@index_name, document_hashes)
     end
 
-    def queue_delete(link)
-      DeleteWorker.perform_async(@index_name, link)
+    def queue_delete(document_type, document_id)
+      DeleteWorker.perform_async(@index_name, document_type, document_id)
     end
 
     def queue_amend(link, updates)

--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -41,7 +41,14 @@ class ElasticsearchDeletionTest < IntegrationTest
             "title" => "Some other site",
             "format" => "answer",
             "link" => "http://example.com/",
-          }
+          },
+          {
+            "_type" => "cma_case",
+            "link" => "/cma-cases/merger-investigation",
+            "title" => "Merger investigation",
+            "description" => "An investigation into a merger",
+            "indexable_content" => "Merger merger merger",
+          },
         ]
       },
       {
@@ -106,7 +113,19 @@ class ElasticsearchDeletionTest < IntegrationTest
     assert last_response.not_found?
   end
 
-  def test_should_delete_a_nonedition_by_type_and_id
+  def test_should_accept_a_type_to_delete_a_document
+    delete "/metasearch-test/documents/cma-cases/merger-investigation", _type: "cma_case"
+    assert last_response.ok?
+  end
+
+  def test_should_accept_a_type_to_delete_a_document_when_queuing_enabled
+    app.settings.expects(:enable_queue).returns(true)
+
+    delete "/metasearch-test/documents/cma-cases/merger-investigation", _type: "cma_case"
+    assert last_response.successful?
+  end
+
+  def test_should_delete_a_best_bet_by_type_and_id
     get "/metasearch-test/documents/best_bet/jobs_exact"
     assert last_response.ok?
 

--- a/test/unit/delete_worker_test.rb
+++ b/test/unit/delete_worker_test.rb
@@ -6,13 +6,13 @@ require "elasticsearch/index"
 class DeleteWorkerTest < MiniTest::Unit::TestCase
   def test_deletes_documents
     mock_index = mock("index")
-    mock_index.expects(:delete).with("/foobang")
+    mock_index.expects(:delete).with("edition", "/foobang")
     Elasticsearch::SearchServer.any_instance.expects(:index)
       .with("test-index")
       .returns(mock_index)
 
     worker = Elasticsearch::DeleteWorker.new
-    worker.perform("test-index", "/foobang")
+    worker.perform("test-index", "edition", "/foobang")
   end
 
   def test_retries_when_index_locked
@@ -24,10 +24,10 @@ class DeleteWorkerTest < MiniTest::Unit::TestCase
       .returns(mock_index)
 
     Elasticsearch::DeleteWorker.expects(:perform_in)
-      .with(lock_delay, "test-index", "/foobang")
+      .with(lock_delay, "test-index", "edition", "/foobang")
 
     worker = Elasticsearch::DeleteWorker.new
-    worker.perform("test-index", "/foobang")
+    worker.perform("test-index", "edition", "/foobang")
   end
 
   def test_forwards_to_failure_queue

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -343,13 +343,13 @@ eos
 
   def test_queued_delete
     mock_queue = mock("document queue") do
-      expects(:queue_delete).with("/foobang")
+      expects(:queue_delete).with("edition", "/foobang")
     end
     Elasticsearch::IndexQueue.expects(:new)
       .with("test-index")
       .returns(mock_queue)
 
-    @wrapper.delete_queued("/foobang")
+    @wrapper.delete_queued("edition", "/foobang")
   end
 
   def test_amend

--- a/test/unit/index_queue_test.rb
+++ b/test/unit/index_queue_test.rb
@@ -19,9 +19,9 @@ class IndexQueueTest < MiniTest::Unit::TestCase
 
   def test_can_delete_documents
     Elasticsearch::DeleteWorker.expects(:perform_async)
-      .with("test-index", "/foobang")
+      .with("test-index", "edition", "/foobang")
     queue = Elasticsearch::IndexQueue.new("test-index")
-    queue.queue_delete("/foobang")
+    queue.queue_delete("edition", "/foobang")
   end
 
   def test_can_amend_documents


### PR DESCRIPTION
The delete action takes an optional `_type` parameter, but the queueing
enabled branch of the action hadn't been updated to use it.
