### PR TITLE
Add support for document_type filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Rummager is now primarily based on elasticsearch.
 Install [elasticsearch 0.90](http://www.elasticsearch.org/downloads/0-90-13/).
 Rummager doesn't yet work with 1.0 or later.
 
+Install [Redis 2.x](http://redis.io/download)
+
+Install [GNU Aspell](http://aspell.net)
+
 Run the application with `./startup.sh` this uses shotgun/thin.
 
 To create indices, or to update them to the latest index settings, run:

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -10,7 +10,19 @@ class SearchParameterParser
   ALLOWED_SORT_FIELDS = %w(public_timestamp)
 
   # The fields listed here are the only ones which can be used to filter by.
-  ALLOWED_FILTER_FIELDS = %w(organisations section format specialist_sectors)
+  ALLOWED_FILTER_FIELDS = %w(
+    document_type
+    format
+    organisations
+    section
+    specialist_sectors
+  )
+
+  # Incoming filter fields will have their names transformed according to the
+  # following mapping. Fields not listed here will be passed through unchanged.
+  FILTER_NAME_MAPPING = {
+    "document_type" => "_type",
+  }
 
   # The fields listed here are the only ones which can be used to calculated
   # facets for.  This should be a subset of ALLOWED_FILTER_FIELDS
@@ -113,7 +125,7 @@ private
       if (m = key.match(/\Afilter_(.*)/))
         field = m[1]
         if ALLOWED_FILTER_FIELDS.include? field
-          filters[field] = [*value]
+          filters[filter_name_lookup(field)] = [*value]
         else
           @errors << %{"#{field}" is not a valid filter field}
         end
@@ -121,6 +133,10 @@ private
       end
     end
     filters
+  end
+
+  def filter_name_lookup(name)
+    FILTER_NAME_MAPPING.fetch(name, name)
   end
 
   def facets

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -25,7 +25,6 @@ class MultiIndexTest < IntegrationTest
       add_field_to_mappings("section")
       create_test_index(index_name)
       add_sample_documents(index_name, 2)
-      commit_index(index_name)
     end
   end
 
@@ -56,10 +55,15 @@ class MultiIndexTest < IntegrationTest
   def add_sample_documents(index_name, count)
     attributes = sample_document_attributes(index_name, count)
     attributes.each do |sample_document|
-      insert_stub_popularity_data(sample_document["link"])
-      post "/#{index_name}/documents", MultiJson.encode(sample_document)
-      assert last_response.ok?
+      insert_document(index_name, sample_document)
     end
+  end
+
+  def insert_document(index_name, attributes)
+    insert_stub_popularity_data(attributes["link"])
+    post "/#{index_name}/documents", MultiJson.encode(attributes)
+    assert last_response.ok?
+    commit_index(index_name)
   end
 
   def commit_index(index_name)

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -120,4 +120,31 @@ class UnifiedSearchTest < MultiIndexTest
     assert first_hit_explain.keys.include?("description")
     assert first_hit_explain.keys.include?("details")
   end
+
+  def test_can_scope_by_document_type
+    insert_document("mainstream_test", cma_case_attributes)
+    get "/unified_search?filter_document_type=cma_case"
+    assert last_response.ok?
+    assert_equal 1, parsed_response.fetch("total")
+    assert_equal(
+      hash_including(
+        "title" => cma_case_attributes.fetch("title"),
+        "link" => cma_case_attributes.fetch("link"),
+      ),
+      parsed_response.fetch("results").fetch(0),
+    )
+  end
+
+  def cma_case_attributes
+    {
+      "title" => "Somewhat Unique CMA Case",
+      "link" => "/cma-cases/somewhat-unique-cma-case",
+      "indexable_content" => "Mergers of cheeses and faces",
+      "_type" => "cma_case",
+      "tags" => [],
+      "topics" => ["farming"],
+      "section" => ["1"],
+    }
+  end
+  private :cma_case_attributes
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,31 @@ module TestHelpers
   def load_yaml_fixture(filename)
     YAML.load_file(File.expand_path("fixtures/#{filename}", File.dirname(__FILE__)))
   end
+
+  # This can be used to partially match a hash in the context of an assert_equal
+  # e.g. The following would pass
+  #
+  # assert_equal hash_including(one: 1), {one: 1, two: 2}
+  #
+  def hash_including(subset)
+    HashIncludingMatcher.new(subset)
+  end
+
+  class HashIncludingMatcher
+    def initialize(subset)
+      @subset = subset
+    end
+
+    def ==(other)
+      @subset.all? { |k,v|
+        other.has_key?(k) && other[k] == v
+      }
+    end
+
+    def inspect
+      @subset.inspect
+    end
+  end
 end
 
 class MiniTest::Unit::TestCase

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -137,6 +137,15 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     assert_equal(expected_params({filters: {"organisations" => ["hm-magic"]}}), p.parsed_params)
   end
 
+  should "rewrite document_type filter to _type filter" do
+    p = SearchParameterParser.new("filter_document_type" => "cma_case")
+
+    assert_equal(
+      hash_including(filters: { "_type" => ["cma_case"] }),
+      p.parsed_params
+    )
+  end
+
   should "understand an ascending sort" do
     p = SearchParameterParser.new({"order" => "public_timestamp"})
 


### PR DESCRIPTION
Allow filtering by elasticsearch's _type field. This will be used for finder-frontend.
