### PR TITLE
Facet examples

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -230,8 +230,39 @@ class Rummager < Sinatra::Application
   #
   #   facet_FIELD: (where FIELD is a fieldname); count up values which are
   #   present in the field in the documents matched by the search, and return
-  #   information about these.  The value of this parameter is the requested
-  #   number of distinct field values to be returned for the field.
+  #   information about these.  The value of this parameter is a comma
+  #   separated list of options; the first option in the list is an integer
+  #   which controls the requested number of distinct field values to be
+  #   returned for the field.  Subsequent options are optional, and are colon
+  #   separated key:value pairs:
+  #
+  #   - examples:<integer number of example values to return>  This causes
+  #     facet values to contain an "examples" hash as an additional field,
+  #     which contains details of example documents which match the query.  The
+  #     examples are sorted by decreasing popularity.  An example facet value
+  #     in a response with this option set as "examples:1" might look like:
+  #
+  #         "value" => {
+  #           "slug" => "an-example-facet-slug",
+  #           "examples" => {
+  #             "total" => 3,  # The total number of matching examples
+  #             "examples" => [
+  #               {"title" => "Title of the first example", "link" => "/foo"},
+  #             ],
+  #           }
+  #         }
+  #
+  #   - example_scope:global.  If the examples option is supplied, the
+  #     example_scope:global option must be supplied too; this causes the
+  #     returned examples to be taken from all documents in which the facet
+  #     field has the given slug, rather than only from such documents which
+  #     match the query.
+  #
+  #   - example_fields:<colon separated list of fields>.  If the examples
+  #     option is supplied, this lists the fields which are returned for
+  #     each example.  By default, only a small number of fields are returned
+  #     for each.  Note that the list is colon separated rather than comma
+  #     separated, since commas are used to separate different options.
   #
   #   Regardless of the parameter value, a facet value will be returned for any
   #   filter which is in place on the field. This may cause the requested

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -327,8 +327,9 @@ module Elasticsearch
     end
 
     def msearch(bodies)
+      header_json = "{}"
       payload = bodies.map { |body|
-        "{}\n#{body.to_json}\n"
+        "#{header_json}\n#{body.to_json}\n"
       }.join("")
       logger.debug "Request payload: #{payload}"
       path = "_msearch"

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -326,6 +326,15 @@ module Elasticsearch
       MultiJson.decode(@client.get_with_payload(path, json_payload))
     end
 
+    def msearch(bodies)
+      payload = bodies.map { |body|
+        "{}\n#{body.to_json}\n"
+      }.join("")
+      logger.debug "Request payload: #{payload}"
+      path = "_msearch"
+      MultiJson.decode(@client.get_with_payload(path, payload))
+    end
+
     # Convert a best bet query to a string formed by joining the normalised
     # words in the query with spaces.
     def analyzed_best_bet_query(query)

--- a/lib/facet_example_fetcher.rb
+++ b/lib/facet_example_fetcher.rb
@@ -1,0 +1,72 @@
+# Fetch example values for facets
+class FacetExampleFetcher
+  def initialize(index, es_response, params)
+    @index = index
+    @response_facets = es_response["facets"]
+    @params = params
+  end
+
+  # Fetch all requested example facet values
+  # Returns {field_name => {facet_value => {total: count, examples: [{field: value}, ...]}}}
+  # ie: a hash keyed by field name, containing hashes keyed by facet value with
+  # values containing example information for the value.
+  def fetch
+    facets = @params[:facets]
+    if facets.nil? || @response_facets.nil?
+      return {}
+    end
+    result = {}
+    facets.each do |field_name, facet_params|
+      examples = facet_params[:examples]
+      if examples > 0
+        result[field_name] = fetch_for_field(field_name, facet_params)
+      end
+    end
+    result
+  end
+
+private
+  # Fetch facet examples for a given field
+  def fetch_for_field(field_name, facet_params)
+    example_count = facet_params[:examples]
+    example_fields = facet_params[:example_fields]
+
+    facet_options = @response_facets.fetch(field_name, {}).fetch("terms", [])
+
+    slugs = facet_options.map { |option|
+      option["term"]
+    }
+    fetch_by_slug(field_name, slugs, example_count, example_fields)
+  end
+
+  def facet_example_searches(field_name, slugs, example_count, example_fields)
+    slugs.map { |slug|
+      {
+        query: {
+          filtered: {
+            filter: { term: { field_name => slug } },
+          }
+        },
+        size: example_count,
+        fields: example_fields,
+        sort: [ { popularity: { order: :desc } } ],
+      }
+    }
+  end
+
+  # Fetch facet examples for a set of slugs
+  def fetch_by_slug(field_name, slugs, example_count, example_fields)
+    searches = facet_example_searches(field_name, slugs, example_count, example_fields)
+    responses = @index.msearch(searches)
+    response_list = responses["responses"]
+    result = {}
+    slugs.zip(response_list) { |slug, response|
+      hits = response["hits"]
+      result[slug] = {
+        total: hits["total"],
+        examples: hits["hits"].map { |hit| hit["fields"] },
+      }
+    }
+    result
+  end
+end

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -5,7 +5,9 @@ class BaseParameterParser
   # sorting by arbitrary fields can be expensive in terms of memory usage in
   # elasticsearch, and because elasticsearch gives fairly obscure error
   # messages if undefined sort fields are used.
-  ALLOWED_SORT_FIELDS = %w(public_timestamp)
+  ALLOWED_SORT_FIELDS = %w(
+    public_timestamp
+  )
 
   # The fields listed here are the only ones which can be used to filter by.
   ALLOWED_FILTER_FIELDS = %w(
@@ -24,7 +26,12 @@ class BaseParameterParser
 
   # The fields listed here are the only ones which can be used to calculated
   # facets for.  This should be a subset of ALLOWED_FILTER_FIELDS
-  ALLOWED_FACET_FIELDS = %w(organisations section format specialist_sectors)
+  ALLOWED_FACET_FIELDS = %w(
+    format
+    organisations
+    section
+    specialist_sectors
+  )
 
   # The fields for which facet examples are allowed to be requested.
   # This is locked down because these can only be requested with the current
@@ -33,7 +40,12 @@ class BaseParameterParser
   # together, but is still potentially expensive.  They could be efficiently
   # calculated with the top-documents aggregator in elasticsearch 1.3, so this
   # restriction could be relaxed in future.
-  ALLOWED_FACET_EXAMPLE_FIELDS = %w(organisations section format specialist_sectors)
+  ALLOWED_FACET_EXAMPLE_FIELDS = %w(
+    format
+    organisations
+    section
+    specialist_sectors
+  )
 
   # The fields listed here are the only ones that can be returned in search
   # results.  These are listed and validated explicitly, rather than simply
@@ -42,31 +54,46 @@ class BaseParameterParser
   # indexed without having to check that we don't break the display of search
   # results.
   ALLOWED_RETURN_FIELDS = %w(
-    title description link slug
-
+    description
+    display_type
+    document_series
+    format
+    link
+    organisations
     public_timestamp
-    organisations topics world_locations document_series
+    section
+    slug
     specialist_sectors
-
-    format display_type
-    section subsection subsubsection
+    subsection
+    subsubsection
+    title
+    topics
+    world_locations
   )
 
   # The fields which are returned by default for search results.
   DEFAULT_RETURN_FIELDS = %w(
-    title description link slug
-
+    description
+    display_type
+    document_series
+    format
+    link
+    organisations
     public_timestamp
-    organisations topics world_locations document_series
+    section
+    slug
     specialist_sectors
-
-    format display_type
-    section subsection subsubsection
+    subsection
+    subsubsection
+    title
+    topics
+    world_locations
   )
 
   # The fields which are returned by default for facet examples.
   DEFAULT_FACET_EXAMPLE_FIELDS = %w(
-    link title
+    link
+    title
   )
 
   attr_reader :parsed_params, :errors

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -224,7 +224,7 @@ class UnifiedSearchBuilder
       return nil
     end
     result = {}
-    facets.each do |field_name, count|
+    facets.each do |field_name, _|
       facet_hash = {
         terms: {
           field: field_name,

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -113,7 +113,8 @@ private
     end
     result = {}
     @facets.each do |field, facet_info|
-      requested_count = @facet_fields[field]
+      facet_parameters = @facet_fields[field]
+      requested_count = facet_parameters[:requested]
       options = facet_info["terms"]
       result[field] = {
         options: present_facet_options(field, options, requested_count),

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -1,5 +1,6 @@
 # Performs a search across all indices used for the GOV.UK site search
 
+require "facet_example_fetcher"
 require "unified_search_builder"
 require "unified_search_presenter"
 
@@ -19,6 +20,8 @@ class UnifiedSearcher
   def search(params)
     builder = UnifiedSearchBuilder.new(params, @metaindex)
     es_response = index.raw_search(builder.payload)
+    example_fetcher = FacetExampleFetcher.new(index, es_response, params)
+    facet_examples = example_fetcher.fetch
     UnifiedSearchPresenter.new(
       es_response,
       params[:start],
@@ -28,6 +31,7 @@ class UnifiedSearcher
       registries,
       registry_by_field,
       suggested_queries(params[:query]),
+      facet_examples,
     ).present
   end
 

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -40,11 +40,10 @@ class MultiIndexTest < IntegrationTest
         "link" => "/#{short_index_name}-#{i}",
         "indexable_content" => "Something something important content",
       }
-      fields["section"] = i
+      fields["section"] = ["#{i}"]
       if i % 2 == 0
         fields["topics"] = ["farming"]
       end
-      fields["section"] = ["#{i}"]
       if short_index_name == "government"
         fields["public_timestamp"] = "#{i+2000}-01-01T00:00:00"
       end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -85,6 +85,26 @@ class UnifiedSearchTest < MultiIndexTest
     }, facets)
   end
 
+  def test_facet_examples
+    get "/unified_search?q=important&facet_section=1,examples:5,example_scope:global,example_fields:link:title:section"
+    assert_equal 6, parsed_response["total"]
+    facets = parsed_response["facets"]
+    assert_equal({
+      "value" => {
+        "slug" => "2",
+        "examples" => {
+          "total" => 3,
+          "examples" => [
+            {"section" => ["2"], "title" => "Sample mainstream document 2", "link" => "/mainstream-2"},
+            {"section" => ["2"], "title" => "Sample detailed document 2", "link" => "/detailed-2"},
+            {"section" => ["2"], "title" => "Sample government document 2", "link" => "/government-2"},
+          ]
+        }
+      },
+      "documents" => 3,
+    }, facets.fetch("section").fetch("options").fetch(0))
+  end
+
   def test_validates_integer_params
     get "/unified_search?start=a"
     assert_equal last_response.status, 400

--- a/test/unit/facet_example_fetcher_test.rb
+++ b/test/unit/facet_example_fetcher_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+require "facet_example_fetcher"
+
+class FacetExampleFetcherTest < ShouldaUnitTestCase
+
+  def query_for_example(field, value, return_fields)
+    {
+      query: {filtered: {filter: {term: {field => value}}}},
+      size: 2,
+      fields: return_fields,
+      sort: [{popularity: {order: :desc}}]
+    }
+  end
+
+  def response_for_example(total_examples, titles)
+    {
+      "hits" => {
+        "total" => total_examples,
+        "hits" => titles.map { |title|
+          {"fields" => {"title" => title}}
+        }
+      }
+    }
+  end
+
+  context "no facet" do
+    setup do
+      @index = stub("content index")
+      @fetcher = FacetExampleFetcher.new(@index, {}, {})
+    end
+
+    should "get an empty hash of examples" do
+      assert_equal({}, @fetcher.fetch)
+    end
+  end
+
+  context "one facet" do
+    setup do
+      @index = stub("content index")
+      @example_fields = %w{link title other_field}
+      main_query_response = {"facets" => {
+        "sector" => {
+          "terms" => [
+            {"term" => "sector_1"},
+            {"term" => "sector_2"},
+          ]
+        }
+      }}
+      params = {
+        facets: {
+          "sector" => {
+            requested: 10,
+            examples: 2,
+            example_fields: @example_fields,
+            example_scope: :global
+          }
+        }
+      }
+      @fetcher = FacetExampleFetcher.new(@index, main_query_response, params)
+    end
+
+    should "request and return facet examples" do
+      @index.expects(:msearch)
+        .with([
+          query_for_example("sector", "sector_1", @example_fields),
+          query_for_example("sector", "sector_2", @example_fields),
+        ]).returns({"responses" => [
+          response_for_example(3, ["example_1", "example_2"]),
+          response_for_example(1, ["example_3"]),
+        ]})
+
+      assert_equal({
+        "sector" => {
+          "sector_1" => {total: 3, examples: [
+              {"title" => "example_1"},
+              {"title" => "example_2"}
+            ]},
+          "sector_2" => {total: 1, examples: [
+              {"title" => "example_3"}
+            ]},
+        }
+      }, @fetcher.fetch)
+    end
+  end
+end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -78,6 +78,10 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     }
   end
 
+  def facet_params(requested, options={})
+    options.merge(requested: requested)
+  end
+
   INDEX_NAMES = %w(mainstream government detailed)
 
   context "no results" do
@@ -210,7 +214,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         0,
         INDEX_NAMES,
         {},
-        {"organisations" => 1},
+        {"organisations" => facet_params(1)},
       ).present
     end
 
@@ -253,7 +257,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         0,
         INDEX_NAMES,
         {"organisations" => ["hmrc"]},
-        {"organisations" => 2},
+        {"organisations" => facet_params(2)},
       ).present
     end
 
@@ -303,7 +307,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         0,
         INDEX_NAMES,
         {"organisations" => ["hm-cheesemakers"]},
-        {"organisations" => 1},
+        {"organisations" => facet_params(1)},
       ).present
     end
 
@@ -353,7 +357,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         0,
         INDEX_NAMES,
         {},
-        {"organisations" => 0},
+        {"organisations" => facet_params(0)},
       ).present
     end
 
@@ -395,7 +399,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         0,
         INDEX_NAMES,
         {},
-        {"organisations" => 1, "topics" => 1},
+        {"organisations" => facet_params(1), "topics" => facet_params(1)},
         {organisation_registry: org_registry},
         {organisations: org_registry},
       ).present
@@ -465,5 +469,4 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       assert_equal [], @output[:suggested_queries]
     end
   end
-
 end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -452,6 +452,78 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     end
   end
 
+  context "results with facet examples" do
+    setup do
+      magic_org_document = Document.new(
+        %w(link title),
+        link: "/government/departments/hm-magic",
+        title: "Ministry of Magic"
+      )
+      org_registry = stub("org registry")
+      org_registry.expects(:[])
+        .with("hm-magic")
+        .returns(magic_org_document)
+
+      @output = UnifiedSearchPresenter.new(
+        sample_es_response("facets" => sample_facet_data),
+        0,
+        INDEX_NAMES,
+        {},
+        {"organisations" => facet_params(1),},
+        {organisation_registry: org_registry},
+        {organisations: org_registry},
+        [],
+        {"organisations" => {
+          "hm-magic" => {
+            "total" => 1,
+            "examples" => [{"title" => "Ministry of Magic"}],
+          }
+        }}
+      ).present
+    end
+
+    should "have facets" do
+      assert_contains @output.keys, :facets
+    end
+
+    should "have correct number of facets" do
+      assert_equal 1, @output[:facets].length
+    end
+
+    should "have correct number of facet values" do
+      assert_equal 1, @output[:facets]["organisations"][:options].length
+    end
+
+    should "have org facet value expanded, and include examples" do
+      assert_equal({
+        :value => {
+          "link" => "/government/departments/hm-magic",
+          "title" => "Ministry of Magic",
+          "slug" => "hm-magic",
+          "examples" => {
+            "total" => 1,
+            "examples" => [
+              {"title" => "Ministry of Magic"},
+            ],
+          },
+        },
+        :documents=>7,
+      }, @output[:facets]["organisations"][:options][0])
+    end
+
+    should "have correct number of documents with no value" do
+      assert_equal(8, @output[:facets]["organisations"][:documents_with_no_value])
+    end
+
+    should "have correct total number of options" do
+      assert_equal(2, @output[:facets]["organisations"][:total_options])
+    end
+
+    should "have correct number of missing options" do
+      assert_equal(1, @output[:facets]["organisations"][:missing_options])
+    end
+  end
+
   context "suggested queries" do
     should "present suggestions in output" do
       @suggestions = [

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -340,7 +340,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         query: "cheese",
         filters: {},
         return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        facets: {"organisations" => 1},
+        facets: {"organisations" => {requested: 1, examples: 0, example_fields: []}},
         debug: {},
       })
     end


### PR DESCRIPTION
Add an API to get example documents for each matching facet value.

For example, 

```
/unified_search.json?facet_specialist_sectors=10,examples:5,example_scope:global&count=0&filter_organisations[]=hm-revenue-customs
```

Returns organisation facets for content tagged with HMRC, including an "examples" section in each returned facet, like:

```
options": [
  {
    "value": {
      "slug": "paye/statutory-leave-pay",
      "examples": {
        "total": 21,
        "examples": [
          {
            "title": "Statutory Sick Pay: employee fitness to work",
            "link": "/statutory-sick-pay-employee-fitness-to-work"
          },
          {
            "title": "Statutory Maternity Pay: how different employment types affect what you pay",
            "link": "/statutory-maternity-pay-how-different-employment-types-affect-what-you-pay"
          },
          {
            "title": "Statutory Sick Pay: how different employment types affect what you pay",
            "link": "/statutory-sick-pay-how-different-employment-types-affect-what-you-pay"
          },
          {
            "title": "Statutory Maternity Pay: table of dates for employee entitlement",
            "link": "/government/publications/statutory-maternity-pay-table-of-dates-for-employee-entitlement"
          },
          {
            "title": "Statutory Sick Pay: employee circumstances that affect payment",
            "link": "/statutory-sick-pay-employee-circumstances-that-affect-payment"
          }
        ]
      }
    },
    "documents": 21
  },
  ...    
```

https://www.pivotaltracker.com/story/show/73388400
