### PR TITLE
Log BadRequest responses from elasticsearch

### DIFF
--- a/lib/elasticsearch/client.rb
+++ b/lib/elasticsearch/client.rb
@@ -88,6 +88,13 @@ module Elasticsearch
 
     def logging_exception_body(&block)
       yield
+    rescue RestClient::BadRequest => error
+      logger.send(
+        @error_log_level,
+        "BadRequest error from elasticsearch. " +
+        "Response: #{error.http_body}"
+      )
+      raise
     rescue RestClient::InternalServerError => error
       logger.send(
         @error_log_level,


### PR DESCRIPTION
This lets us see the body of the response, which contains details of
what went wrong.
