### PR TITLE
Don't require [] on unified_search parameter names

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -337,7 +337,7 @@ class Rummager < Sinatra::Application
       specialist_sectors: specialist_sector_registry,
     }
 
-    parser = SearchParameterParser.new(request.params)
+    parser = SearchParameterParser.new(parse_query_string(request.query_string))
 
     unless parser.valid?
       status 400

--- a/helpers.rb
+++ b/helpers.rb
@@ -20,6 +20,28 @@ module Helpers
     status status_code
     MultiJson.encode("result" => message)
   end
+
+  # Parse a query string, returning a hash of arrays.
+  #
+  # Handles parameters named either simply with their name, or with their
+  # name followed by a pair of square brackets (ie, "name[]").
+  #
+  # We do our own parameter parsing for the search endpoint because we don't
+  # want to force callers to use the Ruby/PHP convention of adding a [] to the
+  # end of a parameter name if the parameter has multiple values (but we also
+  # have to support being called from Ruby tools which insist on doing this).
+  def parse_query_string(query_string)
+    params = KeySpaceConstrainedParams.new
+
+    (query_string || '').split(/[&;] */n).each do |p|
+      name, value = p.split('=', 2).map { |s| unescape(s) }
+      name.gsub!(/\[\]\Z/, "")
+      params[name] ||= []
+      params[name] << value
+    end
+
+    return params.to_params_hash
+  end
 end
 
 class HelperAccessor

--- a/test/unit/helpers_test.rb
+++ b/test/unit/helpers_test.rb
@@ -16,4 +16,17 @@ class HelpersTest < MiniTest::Unit::TestCase
     expects(:status).with(500)
     assert_equal '{"result":"error"}', simple_json_result(false)
   end
+
+  def test_parse_query_string
+    [
+      ["foo=bar", {"foo" => ["bar"]}],
+      ["foo[]=bar", {"foo" => ["bar"]}],
+      ["foo=bar&foo[]=baz", {"foo" => ["bar", "baz"]}],
+      ["foo=bar=baz", {"foo" => ["bar=baz"]}],
+      ["foo[bar]=baz", {"foo[bar]" => ["baz"]}],
+      ["foo[]=baz&q=more", {"foo" => ["baz"], "q" => ["more"]}],
+    ].each do |qs, expected|
+      assert_equal expected, parse_query_string(qs)
+    end
+  end
 end


### PR DESCRIPTION
So that callers don't get a bad request error if they forget to use []
on some parameters, or if they use it on other parameters, strip off the
[] at the end of parameter names, and keep all values of parameters
passed to unified_search, presenting them as lists to the
SearchParameterParser.

This makes it easier to hand-construct queries, easier to call rummager
from languages other than Ruby, and should reduce the number of emails
we get from errbit due to incorrect use or omission of [] when
constructing parameters for calls to rummager.

Returns appropriate explanatory messages if parameters which should
occur at most once are repeated.

As a bonus, parameters such as "fields" or "debug" which take comma
separated lists of values can now be supplied in either that form, or as
repeated instances of the parameter.
