### PR TITLE
Return 422 for validation errors on unified_search

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -340,7 +340,7 @@ class Rummager < Sinatra::Application
     parser = SearchParameterParser.new(request.params)
 
     unless parser.valid?
-      status 400
+      status 422
       return MultiJson.encode({
         error: parser.error,
       })

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -107,7 +107,7 @@ class UnifiedSearchTest < MultiIndexTest
 
   def test_validates_integer_params
     get "/unified_search?start=a"
-    assert_equal last_response.status, 400
+    assert_equal last_response.status, 422
     assert_equal parsed_response, {"error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)"}
   end
 
@@ -118,7 +118,7 @@ class UnifiedSearchTest < MultiIndexTest
 
   def test_validates_unknown_params
     get "/unified_search?foo&bar=1"
-    assert_equal last_response.status, 400
+    assert_equal last_response.status, 422
     assert_equal parsed_response, {"error" => "Unexpected parameters: foo, bar"}
   end
 


### PR DESCRIPTION
This follows the policy decision in
https://github.com/alphagov/styleguides/blob/master/api.md
