### PR TITLE
Avoid an empty msearch call when no facets

### DIFF
--- a/lib/facet_example_fetcher.rb
+++ b/lib/facet_example_fetcher.rb
@@ -36,7 +36,11 @@ private
     slugs = facet_options.map { |option|
       option["term"]
     }
-    fetch_by_slug(field_name, slugs, example_count, example_fields)
+    if slugs.empty?
+      {}
+    else
+      fetch_by_slug(field_name, slugs, example_count, example_fields)
+    end
   end
 
   def facet_example_searches(field_name, slugs, example_count, example_fields)

--- a/test/unit/facet_example_fetcher_test.rb
+++ b/test/unit/facet_example_fetcher_test.rb
@@ -82,4 +82,32 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
       }, @fetcher.fetch)
     end
   end
+
+  context "one facet but no documents match query" do
+    setup do
+      @index = stub("content index")
+      @example_fields = %w{link title other_field}
+      main_query_response = {"facets" => {
+        "sector" => {
+          "terms" => [
+          ]
+        }
+      }}
+      params = {
+        facets: {
+          "sector" => {
+            requested: 10,
+            examples: 2,
+            example_fields: @example_fields,
+            example_scope: :global
+          }
+        }
+      }
+      @fetcher = FacetExampleFetcher.new(@index, main_query_response, params)
+    end
+
+    should "request and return facet examples" do
+      assert_equal({"sector" => {}}, @fetcher.fetch)
+    end
+  end
 end


### PR DESCRIPTION
When requesting facet examples if there are no facets, we need to avoid
making a call to elasticsearch's msearch endpoint, because that returns
a 400 error if given an empty list of queries to run.
