### PR TITLE
Fake a slug for sector documents

### DIFF
--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -155,7 +155,7 @@ private
   def sector_by_slug(slug)
     sector = specialist_sector_registry && specialist_sector_registry[slug]
     if sector
-      sector.to_hash.merge("slug" => slug)
+      sector
     else
       {"slug" => slug}
     end

--- a/lib/specialist_sector_registry.rb
+++ b/lib/specialist_sector_registry.rb
@@ -9,12 +9,26 @@ class SpecialistSectorRegistry
   end
 
   def [](slug)
-    @cache.get.find { |o| o.slug == slug }
+    @cache.get[slug]
   end
 
 private
   def fetch
-    fields = %w{slug link title}
-    @index.documents_by_format("specialist_sector", fields: fields).to_a
+    fields = %w{link title}
+    Hash[@index.documents_by_format("specialist_sector", fields: fields).map { |document|
+      # Specialist sector documents don't come from whitehall and so they don't
+      # have a slug in search.  Panopticon constructs the link field from the
+      # slug (held in panopticon) by adding a '/' prefix, so rather than do the
+      # work now to add a slug and reindex the sectors, we construct a slug
+      # field for the cached sector results in SpecialistSectorRegistry by
+      # removing this '/'.
+      #
+      # This can be removed if the slug is ever actually added to
+      # specialist_sector documents.
+      fields = document.to_hash
+      slug = fields["link"][1..-1]
+      fields["slug"] = slug
+      [slug, fields]
+    }]
   end
 end

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -39,14 +39,12 @@ class SearchTest < IntegrationTest
     )
   end
 
-  def oil_gas_sector
-    Document.new(
-      %w(link title),
-      {
-        link: "/oil-and-gas/licensing",
-        title: "Licensing"
-      }
-    )
+  def oil_gas_sector_fields
+    {
+      "link" => "/oil-and-gas/licensing",
+      "title" => "Licensing",
+      "slug" => "oil-and-gas/licensing",
+    }
   end
 
   def mod_organisation
@@ -266,11 +264,13 @@ class SearchTest < IntegrationTest
     stub_metasearch_index.expects(:raw_search).returns({"hits" => {"hits" => []}})
     SpecialistSectorRegistry.any_instance.expects(:[])
       .with("oil-and-gas/licensing")
-      .returns(oil_gas_sector)
+      .returns(oil_gas_sector_fields)
     get "/unified_search.json", {q: "bob"}
     first_result = MultiJson.decode(last_response.body)["results"].first
     assert_equal 1, first_result["specialist_sectors"].size
-    assert_equal oil_gas_sector.title, first_result["specialist_sectors"][0]["title"]
+    assert_equal oil_gas_sector_fields["title"], first_result["specialist_sectors"][0]["title"]
+    assert_equal oil_gas_sector_fields["link"], first_result["specialist_sectors"][0]["link"]
+    assert_equal oil_gas_sector_fields["slug"], first_result["specialist_sectors"][0]["slug"]
   end
 
   def test_returns_404_when_requested_with_non_json_url

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -223,15 +223,15 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
   end
 
   def test_expands_sectors
-    oil_gas_sector = Document.new(
-      %w(link title),
-      link: "/oil-and-gas/licensing",
-      title: "Licensing"
-    )
+    oil_gas_sector_fields = {
+      "link" => "/oil-and-gas/licensing",
+      "title" => "Licensing",
+      "slug" => "oil-and-gas/licensing",
+    }
     specialist_sector_registry = stub("sector registry")
     specialist_sector_registry.expects(:[])
       .with("oil-and-gas/licensing")
-      .returns(oil_gas_sector)
+      .returns(oil_gas_sector_fields)
 
     presenter = ResultSetPresenter.new(
       single_result_with_sectors("oil-and-gas/licensing"),

--- a/test/unit/sector_registry_test.rb
+++ b/test/unit/sector_registry_test.rb
@@ -8,15 +8,15 @@ class SectorRegistryTest < MiniTest::Unit::TestCase
     @specialist_sector_registry = SpecialistSectorRegistry.new(@index)
   end
 
+  def oil_and_gas_fields
+    {
+      "link" => "/oil-and-gas/licensing",
+      "title" => "Licensing"
+    }
+  end
+
   def oil_and_gas
-    Document.new(
-      %w(slug link title),
-      {
-        slug: "oil-and-gas/licensing",
-        link: "/oil-and-gas/licensing",
-        title: "Licensing"
-      }
-    )
+    Document.new(%w(link title), oil_and_gas_fields)
   end
 
   def test_can_fetch_sector_by_slug
@@ -24,14 +24,14 @@ class SectorRegistryTest < MiniTest::Unit::TestCase
       .with("specialist_sector", anything)
       .returns([oil_and_gas])
     sector = @specialist_sector_registry["oil-and-gas/licensing"]
-    assert_equal oil_and_gas.slug, sector.slug
-    assert_equal oil_and_gas.link, sector.link
-    assert_equal oil_and_gas.title, sector.title
+    assert_equal oil_and_gas.link, sector["link"]
+    assert_equal oil_and_gas.title, sector["title"]
   end
 
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
-      .with("specialist_sector", fields: %w{slug link title})
+      .with("specialist_sector", fields: %w{link title})
+      .returns([])
     @specialist_sector_registry["oil-and-gas/licensing"]
   end
 
@@ -45,7 +45,9 @@ class SectorRegistryTest < MiniTest::Unit::TestCase
 
   def test_document_enumerator_is_traversed_only_once
     document_enumerator = stub("enumerator")
-    document_enumerator.expects(:to_a).returns([oil_and_gas]).once
+    document_enumerator.expects(:map).returns([
+      ["oil-and-gas/licensing", oil_and_gas],
+    ]).once
     @index.stubs(:documents_by_format)
       .with("specialist_sector", anything)
       .returns(document_enumerator)
@@ -56,7 +58,7 @@ class SectorRegistryTest < MiniTest::Unit::TestCase
   def test_uses_cache
     # Make sure we're using TimedCache#get; TimedCache is tested elsewhere, so
     # we don't need to worry about cache expiry tests here.
-    TimedCache.any_instance.expects(:get).returns([oil_and_gas])
+    TimedCache.any_instance.expects(:get).returns({"oil-and-gas/licensing" => oil_and_gas_fields})
     assert @specialist_sector_registry["oil-and-gas/licensing"]
   end
 end


### PR DESCRIPTION
Specialist sector documents don't come from whitehall and so they don't
have a slug in search.  Panopticon constructs the link field from the
slug (held in panopticon) by adding a '/' prefix, so rather than do the
work now to add a slug and reindex the sectors, we construct a slug
field for the cached sector results in SpecialistSectorRegistry by
removing this '/'.

If the slug field is added in future, this hack can be removed, but it
shouldn't break anything if it isn't.

Fixes https://www.pivotaltracker.com/story/show/74843014
