### PR TITLE
Handle param parsing with missing parameters

### DIFF
--- a/helpers.rb
+++ b/helpers.rb
@@ -35,9 +35,13 @@ module Helpers
 
     (query_string || '').split(/[&;] */n).each do |p|
       name, value = p.split('=', 2).map { |s| unescape(s) }
+
+      # Ignore parameters with missing names or values
+      next if name.nil?
+
       name.gsub!(/\[\]\Z/, "")
       params[name] ||= []
-      params[name] << value
+      params[name] << value unless value.nil?
     end
 
     return params.to_params_hash

--- a/test/unit/helpers_test.rb
+++ b/test/unit/helpers_test.rb
@@ -25,6 +25,8 @@ class HelpersTest < MiniTest::Unit::TestCase
       ["foo=bar=baz", {"foo" => ["bar=baz"]}],
       ["foo[bar]=baz", {"foo[bar]" => ["baz"]}],
       ["foo[]=baz&q=more", {"foo" => ["baz"], "q" => ["more"]}],
+      ["foo=baz&&q=more", {"foo" => ["baz"], "q" => ["more"]}],
+      ["foo=baz&boo&q=more", {"foo" => ["baz"], "boo" => [], "q" => ["more"]}],
     ].each do |qs, expected|
       assert_equal expected, parse_query_string(qs)
     end


### PR DESCRIPTION
Previously, any "&&" sections in the query parameters caused a 500 error.
