### PR TITLE
Use CGI::parse to parse query parameters

### DIFF
--- a/helpers.rb
+++ b/helpers.rb
@@ -31,20 +31,11 @@ module Helpers
   # end of a parameter name if the parameter has multiple values (but we also
   # have to support being called from Ruby tools which insist on doing this).
   def parse_query_string(query_string)
-    params = KeySpaceConstrainedParams.new
-
-    (query_string || '').split(/[&;] */n).each do |p|
-      name, value = p.split('=', 2).map { |s| unescape(s) }
-
-      # Ignore parameters with missing names or values
-      next if name.nil?
-
-      name.gsub!(/\[\]\Z/, "")
-      params[name] ||= []
-      params[name] << value unless value.nil?
-    end
-
-    return params.to_params_hash
+    CGI::parse(query_string).reduce({}) { |params, (name, values)|
+      params.merge(name.sub(/\[\]\Z/, "") => values) { |_, old, new|
+        old.concat(new)
+      }
+    }
   end
 end
 


### PR DESCRIPTION
This is nicer (less code) than using our hand-rolled parser, though
CGI::parse's code is pretty similar to what we were doing.

This loses the use of Rack's KeySpaceConstrainedParams to limit the
number of parameters, but this is mainly useful for preventing DOSes on
post requests, and we only expose GET endpoints to the public, so this
should be fine.
