### PR TITLE
Rename examples object to example_info in response

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -244,7 +244,7 @@ class Rummager < Sinatra::Application
   #
   #         "value" => {
   #           "slug" => "an-example-facet-slug",
-  #           "examples" => {
+  #           "example_info" => {
   #             "total" => 3,  # The total number of matching examples
   #             "examples" => [
   #               {"title" => "Title of the first example", "link" => "/foo"},

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -110,7 +110,7 @@ private
       unless result.is_a?(Hash)
         result = {"slug" => result}
       end
-      result["examples"] = field_examples.fetch(slug, [])
+      result["example_info"] = field_examples.fetch(slug, [])
     end
     result
   end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -92,7 +92,7 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal({
       "value" => {
         "slug" => "2",
-        "examples" => {
+        "example_info" => {
           "total" => 3,
           "examples" => [
             {"section" => ["2"], "title" => "Sample mainstream document 2", "link" => "/mainstream-2"},

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -500,7 +500,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           "link" => "/government/departments/hm-magic",
           "title" => "Ministry of Magic",
           "slug" => "hm-magic",
-          "examples" => {
+          "example_info" => {
             "total" => 1,
             "examples" => [
               {"title" => "Ministry of Magic"},


### PR DESCRIPTION
Previously, responses containing facet examples had a "examples" object,
which contained a key called "examples" which actually contained the
examples.  This was confusing and error prone.

Instead, name the outer object "example_info", and just name the inner
list of the actual examples "examples".  Something like:

```
{"example_info": {"total": 5, "examples": [ {...} ] } }
```
