### PR TITLE
Add control over ordering of facet values

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -236,6 +236,21 @@ class Rummager < Sinatra::Application
   #   returned for the field.  Subsequent options are optional, and are colon
   #   separated key:value pairs:
   #
+  #   - order:<colon separated list of ordering types>
+  #
+  #     The available ordering types are:
+  #
+  #     - count: order by the number of documents in the search matching the
+  #       facet value.
+  #     - slug: the slug in the facet value
+  #     - link: the link in the facet value
+  #     - title: the title in the facet value
+  #     - filtered: whether the value is used in an active filter
+  #     
+  #     Each ordering may be preceded by a "-" to sort in descending order.
+  #     Multiple orderings can be specified, in priority order, separated by a
+  #     colon.  The default ordering is "filtered:-count:slug".
+  #
   #   - examples:<integer number of example values to return>  This causes
   #     facet values to contain an "examples" hash as an additional field,
   #     which contains details of example documents which match the query.  The

--- a/lib/facet_option.rb
+++ b/lib/facet_option.rb
@@ -1,0 +1,55 @@
+# An option in a list of facets
+#
+# Knows how to compare itself to other options, for sorting.
+class FacetOption
+  attr_reader :value, :count, :applied
+  include Comparable
+
+  def initialize(value, count, applied, orderings)
+    @value = value
+    @count = count
+    @applied = applied
+    @orderings = orderings
+  end
+
+  def as_hash
+    {
+      value: @value,
+      documents: @count,
+    }
+  end
+
+  def <=>(other)
+    @orderings.each do |ordering, dir|
+      cmp = cmp_by(ordering, other)
+      if !cmp.nil? && cmp != 0
+        return cmp * dir
+      end
+    end
+    id <=> other.id
+  end
+
+  def id
+    value.fetch("slug", "")
+  end
+
+private
+  def cmp_by(ordering, other)
+    case ordering
+    when :filtered
+      (
+        applied ? 0 : 1
+      ) <=> (
+        other.applied ? 0 : 1
+      )
+    when :count
+      count <=> other.count
+    when :"value.slug"
+      value.fetch("slug", "") <=> other.value.fetch("slug", "")
+    when :"value.title"
+      value.fetch("title", "") <=> other.value.fetch("title", "")
+    when :"value.link"
+      value.fetch("link", "") <=> other.value.fetch("link", "")
+    end
+  end
+end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -59,8 +59,8 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal({
       "section" => {
         "options" => [
-          {"value"=>"2", "documents"=>3},
-          {"value"=>"1", "documents"=>3},
+          {"value"=>{"slug"=>"1"}, "documents"=>3},
+          {"value"=>{"slug"=>"2"}, "documents"=>3},
         ],
         "documents_with_no_value" => 0,
         "total_options" => 2,
@@ -76,7 +76,7 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal({
       "section" => {
         "options" => [
-          {"value"=>"2", "documents"=>3},
+          {"value"=>{"slug"=>"1"}, "documents"=>3},
         ],
         "documents_with_no_value" => 0,
         "total_options" => 2,
@@ -91,13 +91,13 @@ class UnifiedSearchTest < MultiIndexTest
     facets = parsed_response["facets"]
     assert_equal({
       "value" => {
-        "slug" => "2",
+        "slug" => "1",
         "example_info" => {
           "total" => 3,
           "examples" => [
-            {"section" => ["2"], "title" => "Sample mainstream document 2", "link" => "/mainstream-2"},
-            {"section" => ["2"], "title" => "Sample detailed document 2", "link" => "/detailed-2"},
-            {"section" => ["2"], "title" => "Sample government document 2", "link" => "/government-2"},
+            {"section" => ["1"], "title" => "Sample mainstream document 1", "link" => "/mainstream-1"},
+            {"section" => ["1"], "title" => "Sample detailed document 1", "link" => "/detailed-1"},
+            {"section" => ["1"], "title" => "Sample government document 1", "link" => "/government-1"},
           ]
         }
       },

--- a/test/unit/facet_option_test.rb
+++ b/test/unit/facet_option_test.rb
@@ -1,0 +1,107 @@
+require "test_helper"
+require "facet_option"
+
+class FacetOptionTest  < MiniTest::Unit::TestCase
+  def test_convert_to_hash
+    assert_equal(
+      {value: {"title" => "Hello"}, documents: 1},
+      FacetOption.new({"title" => "Hello"}, 1, true, []).as_hash,
+    )
+  end
+
+  def test_id_is_slug
+    assert_equal(
+      "a_slug",
+      FacetOption.new({"title" => "Hello", "slug" => "a_slug"}, 1, true, []).id,
+    )
+  end
+
+  def test_compare_by_filtered_first
+    orderings = [[:filtered, 1]]
+    assert(
+      FacetOption.new({}, 0, true, orderings) <
+      FacetOption.new({}, 0, false, orderings)
+    )
+  end
+
+  def test_compare_by_filtered_last
+    orderings = [[:filtered, -1]]
+    assert(
+      FacetOption.new({}, 0, false, orderings) <
+      FacetOption.new({}, 0, true, orderings)
+    )
+  end
+
+  def test_compare_by_count_ascending
+    orderings = [[:count, 1]]
+    assert(
+      FacetOption.new({}, 5, false, orderings) <
+      FacetOption.new({}, 6, false, orderings)
+    )
+  end
+
+  def test_compare_by_count_descending
+    orderings = [[:count, -1]]
+    assert(
+      FacetOption.new({}, 6, false, orderings) <
+      FacetOption.new({}, 5, false, orderings)
+    )
+  end
+
+
+  def test_compare_by_slug_ascending
+    orderings = [[:"value.slug", 1]]
+    assert(
+      FacetOption.new({"slug" => "a"}, 0, false, orderings) <
+      FacetOption.new({"slug" => "b"}, 0, false, orderings)
+    )
+  end
+
+  def test_compare_by_slug_descending
+    orderings = [[:"value.slug", -1]]
+    assert(
+      FacetOption.new({"slug" => "b"}, 0, false, orderings) <
+      FacetOption.new({"slug" => "a"}, 0, false, orderings)
+    )
+  end
+
+  def test_compare_by_title_ascending
+    orderings = [[:"value.title", 1]]
+    assert(
+      FacetOption.new({"title" => "a"}, 0, false, orderings) <
+      FacetOption.new({"title" => "b"}, 0, false, orderings)
+    )
+  end
+
+  def test_compare_by_title_descending
+    orderings = [[:"value.title", -1]]
+    assert(
+      FacetOption.new({"title" => "b"}, 0, false, orderings) <
+      FacetOption.new({"title" => "a"}, 0, false, orderings)
+    )
+  end
+
+  def test_compare_by_link_ascending
+    orderings = [[:"value.link", 1]]
+    assert(
+      FacetOption.new({"link" => "a"}, 0, false, orderings) <
+      FacetOption.new({"link" => "b"}, 0, false, orderings)
+    )
+  end
+
+  def test_compare_by_link_descending
+    orderings = [[:"value.link", -1]]
+    assert(
+      FacetOption.new({"link" => "b"}, 0, false, orderings) <
+      FacetOption.new({"link" => "a"}, 0, false, orderings)
+    )
+  end
+
+  def test_fall_back_to_slug_ordering
+    orderings = [[:count, 1]]
+    assert(
+      FacetOption.new({"slug" => "a"}, 5, false, orderings) <
+      FacetOption.new({"slug" => "b"}, 5, false, orderings)
+    )
+  end
+end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -340,7 +340,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         query: "cheese",
         filters: {},
         return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        facets: {"organisations" => {requested: 1, examples: 0, example_fields: []}},
+        facets: {"organisations" => {requested: 1, examples: 0, example_fields: [], order: SearchParameterParser::DEFAULT_FACET_SORT}},
         debug: {},
       })
     end
@@ -365,7 +365,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
     should "have correct top facet option" do
       facet = @results[:facets]["organisations"]
-      assert_equal({value: "a", documents: 2}, facet[:options][0])
+      assert_equal({value: {"slug" => "a"}, documents: 2}, facet[:options][0])
     end
 
     should "include requested number of facets" do


### PR DESCRIPTION
Returned facet values can be ordered by setting the "order" option in a
facet parameter.  The available orderings are:
- count: order by the number of documents in the search matching the
  facet value.
- slug: the slug in the facet value
- link: the link in the facet value
- title: the title in the facet value
- filtered: whether the value is used in an active filter

Each ordering may be preceded by a "-" to sort in descending order.
Multiple orderings can be specified, in priority order, separated by a
colon.  The default ordering is "filtered:-count:slug".

Previously, the hard-coded ordering was equivalent to "filtered:-count",
with items with an equal count being returned in whatever order
elasticsearch returned the values (which is, I believe, dependent on
insertion order of documents in the elasticsearch database).  Some tests
needed updating to reflect the final sort by slug instead of
elasticsearch order.

This also changes the return format of all facets to the "expanded"
form.  ie: instead of returning a string for the value, return a hash,
containing at the minimum a "slug" key.  This was already the return
format for the organisations and specialist_sections facets, which are
the only ones in use, and it's better (and less code) to be consistent.
This change did result in an unfortunately large amount of test churn,
sadly.

Related story: https://www.pivotaltracker.com/story/show/75037392
