### PR TITLE
Allow requesting organisation_state in results

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -59,6 +59,7 @@ class BaseParameterParser
     document_series
     format
     link
+    organisation_state
     organisations
     public_timestamp
     section

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -9,7 +9,7 @@ class SearchParameterParserTest < ShouldaUnitTestCase
       count: 10,
       query: nil,
       order: nil,
-      return_fields: BaseParameterParser::ALLOWED_RETURN_FIELDS,
+      return_fields: BaseParameterParser::DEFAULT_RETURN_FIELDS,
       filters: {},
       facets: {},
       debug: {},


### PR DESCRIPTION
This field is wanted by frontend so that closed organisations can be
marked in search (https://www.pivotaltracker.com/story/show/75035036)
