### PR TITLE
Specify encoding as UTF-8 when reading JSON

### DIFF
--- a/lib/schema_config.rb
+++ b/lib/schema_config.rb
@@ -78,7 +78,7 @@ private
   end
 
   def load_json(file_path)
-    JSON.parse(File.read(File.join(config_path, file_path)))
+    JSON.parse(File.read(File.join(config_path, file_path), encoding: 'UTF-8'))
   end
 
   def doctype_path


### PR DESCRIPTION
This isn't necessary in dev, or when running from the command line on a
preview box, but in the live preview environment, some pound signs in a
schema file were causing a:

```
Encoding::InvalidByteSequenceError: "\xC2" on US-ASCII
```

error when loading the schema json (in schema_config.rb, "load_json")

We're not sure why there's a difference; current theories are that it's
due to something missing in locale data.  Rather than investigate right
now, we're just going to specify that the file should be read as UTF-8.
