### PR TITLE
Rename idf_sector to development_sector

### DIFF
--- a/config/schema/default/doctypes/international_development_fund.json
+++ b/config/schema/default/doctypes/international_development_fund.json
@@ -149,7 +149,7 @@
         ]
       }
     },
-    "idf_sector": {
+    "development_sector": {
       "type": "string",
       "index": "not_analyzed",
       "include_in_all": false,


### PR DESCRIPTION
We don't want to expose the term idf_sector anywhere, so it needs to be changed to development_sector. [Ticket](https://trello.com/c/d1iL0wup/237-change-idf-sector-key-to-development-sector-1).
