### PR TITLE
Add extra AAIB fields

### DIFF
--- a/config/schema/default/doctypes/aaib_report.json
+++ b/config/schema/default/doctypes/aaib_report.json
@@ -73,6 +73,18 @@
     "date_of_occurrence": {
       "type": "date",
       "index": "no"
+    },
+    "registration": {
+      "type": "string",
+      "index": "analyzed"
+    },
+    "aircraft_type": {
+      "type": "string",
+      "index": "analyzed"
+    },
+    "location": {
+      "type": "string",
+      "index": "analyzed"
     }
   }
 }


### PR DESCRIPTION
Adding extra fields for aircraft_type, registration and location to the AAIB reports. [Ticket](https://trello.com/c/aqPo7Nww/236-add-extra-fields-into-aaib-specialist-publisher).
