### PR TITLE
Add empty schemas for manual and manual section.

### DIFF
--- a/config/schema/default/doctypes/manual.json
+++ b/config/schema/default/doctypes/manual.json
@@ -1,0 +1,3 @@
+{
+  "properties": {}  
+}

--- a/config/schema/default/doctypes/manual_section.json
+++ b/config/schema/default/doctypes/manual_section.json
@@ -1,0 +1,3 @@
+{
+  "properties": {}  
+}


### PR DESCRIPTION
Rummager needs these to know these doctypes exist, but they have no additional
metadata other than what's already present in core.
