### PR TITLE
Add new field for stats announcement state

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -112,6 +112,7 @@ mappings:
         section:     { type: string, index: not_analyzed, include_in_all: false }
         specialist_sectors: { type: string, index: not_analyzed, include_in_all: false }
         slug:        { type: string, index: not_analyzed, include_in_all: false }
+        statistics_announcement_state: { type: string, index: not_analyzed, include_in_all: false }
         subsection:  { type: string, index: not_analyzed, include_in_all: false }
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
         tags: { type: string, index: not_analyzed, include_in_all: false }


### PR DESCRIPTION
This is required so that "cancelled" announcements can be queried and listed separately on the front-end.

To help deliver the following stories:

https://www.pivotaltracker.com/story/show/76536688
https://www.agileplannerapp.com/boards/173808/cards/5477
