### PR TITLE
Add manual to manual_section schema

### DIFF
--- a/config/schema/default/doctypes/manual_section.json
+++ b/config/schema/default/doctypes/manual_section.json
@@ -1,3 +1,8 @@
 {
-  "properties": {}  
+  "properties": {
+    "manual": {
+      "type": "string",
+      "index": "not_analyzed"
+    }
+  }
 }


### PR DESCRIPTION
We want this for scoping search results to sections of a manual.
