### PR TITLE
Rename device alerts to medical devices

### DIFF
--- a/config/schema/default/doctypes/drug_device_alert.json
+++ b/config/schema/default/doctypes/drug_device_alert.json
@@ -10,11 +10,11 @@
         "preposition": "for",
         "allowed_values": [
           {
-            "label": "Drugs",
+            "label": "Drug Alert",
             "value": "drugs"
           },
           {
-            "label": "Devices",
+            "label": "Medical Device Alert",
             "value": "devices"
           }
         ]


### PR DESCRIPTION
[Ticket](https://trello.com/c/vsK026Nw/310-alerts-finder-devices-should-be-medical-devices)
