### PR TITLE
Date filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,3 +42,4 @@ group :development do
 end
 
 gem "debugger", group: [:development, :test]
+gem "pry", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     chronic (0.9.1)
     ci_reporter (1.7.1)
       builder (>= 2.1.2)
+    coderay (1.1.0)
     columnize (0.8.9)
     connection_pool (1.1.0)
     crack (0.3.2)
@@ -51,6 +52,7 @@ GEM
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     metaclass (0.0.1)
+    method_source (0.8.2)
     mime-types (1.19)
     minitest (4.6.1)
     mocha (0.13.2)
@@ -64,6 +66,10 @@ GEM
     nokogiri (1.5.5)
     null_logger (0.0.1)
     plek (1.5.0)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-logstasher (0.0.3)
       logstash-event
@@ -138,6 +144,7 @@ DEPENDENCIES
   multi_json (= 1.3.6)
   nokogiri (= 1.5.5)
   plek (= 1.5.0)
+  pry
   rack (= 1.5.2)
   rack-logstasher (= 0.0.3)
   rack-test

--- a/app.rb
+++ b/app.rb
@@ -352,7 +352,10 @@ class Rummager < Sinatra::Application
       specialist_sectors: specialist_sector_registry,
     }
 
-    parser = SearchParameterParser.new(parse_query_string(request.query_string))
+    parser = SearchParameterParser.new(
+      parse_query_string(request.query_string),
+      current_index.mappings,
+    )
 
     unless parser.valid?
       status 422

--- a/config/schema/default/doctypes/cma_case.json
+++ b/config/schema/default/doctypes/cma_case.json
@@ -299,7 +299,7 @@
     },
     "opened_date": {
       "type": "date",
-      "index": "no"
+      "index": "analyzed"
     },
     "closed_date": {
       "type": "date",

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -168,6 +168,9 @@ module Elasticsearch
         if blocked_items.any?
           raise IndexLocked
         else
+          # TODO This error should include the error messages from
+          # elasticsearch, not just the IDs of the documents that weren't
+          # inserted
           raise BulkIndexFailure.new(failed_items.map { |item| item["index"]["_id"] })
         end
       end

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -308,15 +308,24 @@ private
   private
     def parse_dates(values)
       values.map { |combined_from_and_to|
-        from = parse_date(combined_from_and_to.match(/from:([^,]+)/)[1])
-        to = parse_date(combined_from_and_to.match(/to:([^,]+)/)[1])
+        dates = combined_from_and_to.split(",").reduce({}) { |dates, param|
+          key, date = param.split(":")
+          dates.merge(key => parse_date(date))
+        }
 
-        Value.new(from, to)
+        Value.new(
+          dates.fetch("from", null_date),
+          dates.fetch("to", null_date),
+        )
       }
     end
 
     def parse_date(string)
       Date.parse(string) rescue nil
+    end
+
+    def null_date
+      OpenStruct.new(iso8601: nil)
     end
 
     Value = Struct.new(:from, :to)

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -194,6 +194,17 @@ class UnifiedSearchBuilder
     {"terms" => { field => filter_values } }
   end
 
+  def date_filter(field, filter_values)
+    {
+      "range" => {
+        field => {
+          "from" => filter_values["from"],
+          "to" => filter_values["to"],
+        }.reject { |_, v| v.nil? }
+      }
+    }
+  end
+
   # Get a list of fields being sorted by
   def sort_fields
     order = @params[:order]

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -167,10 +167,10 @@ class UnifiedSearchBuilder
   end
 
   def filters_hash(excluding=[])
-    filter_groups = @params[:filters].reject { |field, filter_values|
-      excluding.include? field
-    }.map { |field, filter_values|
-      terms_filter(field, filter_values)
+    filter_groups = @params.fetch(:filters).reject { |filter|
+      excluding.include?(filter.field_name)
+    }.map { |filter|
+      filter_hash(filter)
     }
 
     # exclude any specialist sector documents from the search results, as we
@@ -190,16 +190,29 @@ class UnifiedSearchBuilder
     combine_filters(filter_groups)
   end
 
-  def terms_filter(field, filter_values)
-    {"terms" => { field => filter_values } }
+  def filter_hash(filter)
+    case filter.type
+    when "string"
+      terms_filter(filter)
+    when "date"
+      date_filter(filter)
+    else
+      raise "Filter type not supported"
+    end
   end
 
-  def date_filter(field, filter_values)
+  def terms_filter(filter)
+    {"terms" => { filter.field_name => filter.values } }
+  end
+
+  def date_filter(filter)
+    value = filter.values.first
+
     {
       "range" => {
-        field => {
-          "from" => filter_values["from"],
-          "to" => filter_values["to"],
+        filter.field_name => {
+          "from" => value["from"].iso8601,
+          "to" => value["to"].iso8601,
         }.reject { |_, v| v.nil? }
       }
     }

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -128,7 +128,7 @@ private
   # Returns the requested number of options, but will additionally return any
   # options which are part of a filter. 
   def facet_options(field, calculated_options, facet_parameters)
-    applied_options = @applied_filters.fetch(field, [])
+    applied_options = filter_values_for_field(field)
 
     all_options = calculated_options.map { |option|
       [option["term"], option["count"]]
@@ -148,6 +148,12 @@ private
     }
 
     top_facet_options(option_objects, facet_parameters[:requested])
+  end
+
+  def filter_values_for_field(field)
+    filter = @applied_filters.find { |filter| filter.field_name == field }
+
+    filter ? filter.values : []
   end
 
   def presented_facets

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -258,6 +258,7 @@ class SearchTest < IntegrationTest
       "fields" => sample_document_attributes.merge("specialist_sectors" => ["oil-and-gas/licensing"])
     }
 
+    stub_index.expects(:mappings).returns(mappings)
     stub_index.expects(:raw_search).returns({"hits" => {"hits" => [document], "total" => 1}})
     stub_index.expects(:index_name).returns("mainstream,government,detailed")
     stub_metasearch_index.expects(:analyzed_best_bet_query).with("bob").returns("bob")

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -61,7 +61,7 @@ class MultiIndexTest < IntegrationTest
   def insert_document(index_name, attributes)
     insert_stub_popularity_data(attributes["link"])
     post "/#{index_name}/documents", MultiJson.encode(attributes)
-    assert last_response.ok?
+    assert last_response.ok?, "Failed to insert document"
     commit_index(index_name)
   end
 

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -164,7 +164,38 @@ class UnifiedSearchTest < MultiIndexTest
       "tags" => [],
       "topics" => ["farming"],
       "section" => ["1"],
+      "opened_date" => Time.parse("2014-04-01 09:00").iso8601,
     }
   end
   private :cma_case_attributes
+
+  def test_can_filter_between_dates
+    insert_document("mainstream_test", cma_case_attributes)
+
+    get "/unified_search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
+    assert last_response.ok?
+    assert_equal 1, parsed_response.fetch("total")
+    assert_equal(
+      hash_including(
+        "title" => cma_case_attributes.fetch("title"),
+        "link" => cma_case_attributes.fetch("link"),
+      ),
+      parsed_response.fetch("results").fetch(0),
+    )
+  end
+
+  def test_can_filter_between_dates_with_reversed_parameter_order
+    insert_document("mainstream_test", cma_case_attributes)
+
+    get "/unified_search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
+    assert last_response.ok?
+    assert_equal 1, parsed_response.fetch("total")
+    assert_equal(
+      hash_including(
+        "title" => cma_case_attributes.fetch("title"),
+        "link" => cma_case_attributes.fetch("link"),
+      ),
+      parsed_response.fetch("results").fetch(0),
+    )
+  end
 end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -164,7 +164,7 @@ class UnifiedSearchTest < MultiIndexTest
       "tags" => [],
       "topics" => ["farming"],
       "section" => ["1"],
-      "opened_date" => Time.parse("2014-04-01 09:00").iso8601,
+      "opened_date" => "2014-04-01",
     }
   end
   private :cma_case_attributes

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -198,4 +198,34 @@ class UnifiedSearchTest < MultiIndexTest
       parsed_response.fetch("results").fetch(0),
     )
   end
+
+  def test_can_filter_from_date
+    insert_document("mainstream_test", cma_case_attributes)
+
+    get "/unified_search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
+    assert last_response.ok?
+    assert_equal 1, parsed_response.fetch("total")
+    assert_equal(
+      hash_including(
+        "title" => cma_case_attributes.fetch("title"),
+        "link" => cma_case_attributes.fetch("link"),
+      ),
+      parsed_response.fetch("results").fetch(0),
+    )
+  end
+
+  def test_can_filter_to_date
+    insert_document("mainstream_test", cma_case_attributes)
+
+    get "/unified_search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
+    assert last_response.ok?
+    assert_equal 1, parsed_response.fetch("total")
+    assert_equal(
+      hash_including(
+        "title" => cma_case_attributes.fetch("title"),
+        "link" => cma_case_attributes.fetch("link"),
+      ),
+      parsed_response.fetch("results").fetch(0),
+    )
+  end
 end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -228,4 +228,22 @@ class UnifiedSearchTest < MultiIndexTest
       parsed_response.fetch("results").fetch(0),
     )
   end
+
+  def test_cannot_provide_date_filter_key_multiple_times
+    get "/unified_search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
+    assert_equal 422, last_response.status
+    assert_equal(
+      {"error" => %{Too many values (2) for parameter "opened_date" (must occur at most once)}},
+      parsed_response,
+    )
+  end
+
+  def test_cannot_provide_invalid_dates_for_date_filter
+    get "/unified_search?filter_document_type=cma_case&filter_opened_date=from:not-a-date"
+    assert_equal 422, last_response.status
+    assert_equal(
+      {"error" => %{Invalid value "not-a-date" for parameter "opened_date" (expected ISO8601 date}},
+      parsed_response,
+    )
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,7 +44,7 @@ module TestHelpers
 
     def ==(other)
       @subset.all? { |k,v|
-        other.has_key?(k) && other[k] == v
+        other.has_key?(k) && v == other[k]
       }
     end
 

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -212,7 +212,17 @@ class SearchParameterParserTest < ShouldaUnitTestCase
 
     assert_equal("", p.error)
     assert p.valid?
-    assert_equal(expected_params(filters: {"organisations" => ["hm-magic", "hmrc"]}), p.parsed_params)
+    assert_equal(
+      expected_params(
+        filters: {
+          "organisations" => [
+            text_filter("hm-magic"),
+            text_filter("hmrc"),
+          ],
+        }
+      ),
+      p.parsed_params,
+    )
   end
 
   should "complain about disallowed filter fields" do
@@ -221,7 +231,10 @@ class SearchParameterParserTest < ShouldaUnitTestCase
 
     assert_equal(%{"spells" is not a valid filter field}, p.error)
     assert !p.valid?
-    assert_equal(expected_params({filters: {"organisations" => ["hm-magic"]}}), p.parsed_params)
+    assert_equal(
+      expected_params(filters: {"organisations" => [text_filter("hm-magic")]}),
+      p.parsed_params,
+    )
   end
 
   should "rewrite document_type filter to _type filter" do
@@ -231,7 +244,7 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     )
 
     assert_equal(
-      hash_including(filters: { "_type" => ["cma_case"] }),
+      hash_including(filters: { "_type" => [text_filter("cma_case")] }),
       parser.parsed_params,
     )
   end
@@ -265,7 +278,7 @@ class SearchParameterParserTest < ShouldaUnitTestCase
 
       assert_equal(
         hash_including(filters: {
-          "_type" => ["cma_case"],
+          "_type" => [text_filter("cma_case")],
           "case_type" => [text_filter("mergers")],
         }),
         parser.parsed_params
@@ -286,7 +299,7 @@ class SearchParameterParserTest < ShouldaUnitTestCase
 
         assert_equal(
           hash_including(filters: {
-            "_type" => ["cma_case"],
+            "_type" => [text_filter("cma_case")],
             "opened_date" => [
               date_filter("from:2014-04-01 00:00"),
             ],

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 require "json"
 require "set"
 require "unified_search_builder"
+require "search_parameter_parser"
 
 class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
@@ -61,6 +62,17 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       facets: nil,
       debug: {},
     }.merge(options)
+  end
+
+  def text_filter(field_name, values)
+    SearchParameterParser::TextFieldFilter.new(field_name, values)
+  end
+
+  def date_filter(field_name, values)
+    SearchParameterParser::DateFieldFilter.new(
+      field_name,
+      values,
+    )
   end
 
   def setup_best_bets_query(best_bets, worst_bets)
@@ -130,7 +142,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder = UnifiedSearchBuilder.new(
         query_options(
-          filters: {"organisations" => ["hm-magic"]},
+          filters: [ text_filter("organisations", ["hm-magic"]) ],
         ),
         @metasearch_index
       )
@@ -160,7 +172,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder = UnifiedSearchBuilder.new(
         query_options(
-          filters: {"organisations" => ["hm-magic", "hmrc"]},
+          filters: [ text_filter("organisations", ["hm-magic", "hmrc"]) ],
         ),
         @metasearch_index
       )
@@ -191,10 +203,10 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder = UnifiedSearchBuilder.new(
         query_options(
-          filters: {
-            "organisations" => ["hm-magic", "hmrc"],
-            "section" => ["levitation"],
-          }
+          filters: [
+            text_filter("organisations", ["hm-magic", "hmrc"]),
+            text_filter("section", ["levitation"]),
+          ],
         ),
         @metasearch_index
       )
@@ -400,7 +412,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder = UnifiedSearchBuilder.new(
         query_options(
-          filters: {"organisations" => ["hm-magic"]},
+          filters: [ text_filter("organisations", ["hm-magic"]) ],
           facets: {"organisations" => 10},
         ),
         @metasearch_index
@@ -434,7 +446,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder = UnifiedSearchBuilder.new(
         query_options(
-          filters: {"section" => ["levitation"]},
+          filters: [ text_filter("section", "levitation") ],
           facets: {"organisations" => 10},
         ),
         @metasearch_index

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -137,7 +137,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       sample_es_response(options.fetch(:es_response, {})),
       options.fetch(:start, 0),
       INDEX_NAMES,
-      options.fetch(:filters, {}),
+      options.fetch(:filters, []),
       options.fetch(:facets, {}),
       org_registry.nil? ? {} : {organisation_registry: org_registry},
       org_registry.nil? ? {} : {organisations: org_registry},
@@ -222,7 +222,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         sample_es_response,
         0,
         INDEX_NAMES,
-        {},
+        [],
         {},
         {topic_registry: topic_registry},
         {topics: topic_registry},
@@ -275,7 +275,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
-        {},
+        [],
         {"organisations" => facet_params(1)},
       ).present
     end
@@ -318,7 +318,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
-        {"organisations" => ["hmrc"]},
+        [text_filter("organisations", ["hmrc"])],
         {"organisations" => facet_params(2)},
       ).present
     end
@@ -368,7 +368,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
-        {"organisations" => ["hm-cheesemakers"]},
+        [text_filter("organisations", ["hm-cheesemakers"])],
         {"organisations" => facet_params(1)},
       ).present
     end
@@ -418,7 +418,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
-        {},
+        [],
         {"organisations" => facet_params(0)},
       ).present
     end
@@ -542,7 +542,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         sample_es_response("facets" => sample_facet_data_with_topics),
         0,
         INDEX_NAMES,
-        {},
+        [],
         {"organisations" => facet_params(1), "topics" => facet_params(1)},
         {organisation_registry: org_registry},
         {organisations: org_registry},
@@ -604,7 +604,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
-        {},
+        [],
         {"organisations" => facet_params(1),},
         {organisation_registry: org_registry},
         {organisations: org_registry},
@@ -666,15 +666,19 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         "self assessment",
         "tax returns"
       ]
-      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES, {}, {}, {}, {}, @suggestions).present
+      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES, [], {}, {}, {}, @suggestions).present
 
       assert_equal ["self assessment", "tax returns"], @output[:suggested_queries]
     end
 
     should "default to an empty array when not present" do
-      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES, {}, {}, {}, {}).present
+      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES, [], {}, {}, {}).present
 
       assert_equal [], @output[:suggested_queries]
     end
+  end
+
+  def text_filter(field_name, values)
+    SearchParameterParser::TextFieldFilter.new(field_name, values)
   end
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -43,6 +43,17 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     stub('Suggester', suggestions: ['cheese'])
   end
 
+  def text_filter(field_name, values)
+    SearchParameterParser::TextFieldFilter.new(field_name, values)
+  end
+
+  def date_filter(field_name, values)
+    SearchParameterParser::DateFieldFilter.new(
+      field_name,
+      values,
+    )
+  end
+
   BASE_CHEESE_QUERY = {
     custom_score: {
       query: {
@@ -277,7 +288,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         start: 0,
         count: 20,
         query: "cheese",
-        filters: {"organisations" => ["ministry-of-magic"]},
+        filters: [ text_filter("organisations", ["ministry-of-magic"]) ],
         return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
         facets: nil,
         debug: {},


### PR DESCRIPTION
Implements date range filtering for unified search. Done in the form of:

`filter_opening_date=from:2013-01-01,to:2013-03-31`

Ticket: https://trello.com/c/4iReFd0W/293-rummager-add-support-for-date-filtering-1

Also extends the behaviour of `ALLOWED_FILTER_FIELDS` to allow filtering by any field in the document type schema.
### TODO
- [x] Add tests to cover each of the scenarios in the linked ticket (only `from` or `to` provided, rejection of multiple parameters)
