### PR TITLE
Expand specialist document metadata from schema

### DIFF
--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -17,7 +17,7 @@ class UnifiedSearchPresenter
   def initialize(es_response, start, index_names, applied_filters = {},
                  facet_fields = {}, registries = {},
                  registry_by_field = {}, suggestions = [],
-                 facet_examples={})
+                 facet_examples={}, mappings={})
     @start = start
     @results = es_response["hits"]["hits"].map do |result|
       doc = result.delete("fields")
@@ -33,6 +33,7 @@ class UnifiedSearchPresenter
     @registry_by_field = registry_by_field
     @suggestions = suggestions
     @facet_examples = facet_examples
+    @mappings = mappings
   end
 
   def present
@@ -47,7 +48,7 @@ class UnifiedSearchPresenter
 
 private
 
-  attr_reader :registries, :registry_by_field
+  attr_reader :registries, :registry_by_field, :mappings
 
   def presented_results
     # This uses the "standard" ResultSetPresenter to expand fields like
@@ -55,7 +56,7 @@ private
     # the output in other ways.
 
     result_set = ResultSet.new(@results, nil)
-    ResultSetPresenter.new(result_set, registries).present["results"].each do |fields|
+    ResultSetPresenter.new(result_set, registries, mappings).present["results"].each do |fields|
       metadata = fields.delete(:_metadata)
 
       # Replace the "_index" field, which contains the concrete name of the

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -32,6 +32,7 @@ class UnifiedSearcher
       registry_by_field,
       suggested_queries(params[:query]),
       facet_examples,
+      index.mappings,
     ).present
   end
 

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -258,7 +258,7 @@ class SearchTest < IntegrationTest
       "fields" => sample_document_attributes.merge("specialist_sectors" => ["oil-and-gas/licensing"])
     }
 
-    stub_index.expects(:mappings).returns(mappings)
+    stub_index.expects(:mappings).twice.returns(mappings)
     stub_index.expects(:raw_search).returns({"hits" => {"hits" => [document], "total" => 1}})
     stub_index.expects(:index_name).returns("mainstream,government,detailed")
     stub_metasearch_index.expects(:analyzed_best_bet_query).with("bob").returns("bob")

--- a/test/integration/specialist_document_search_test.rb
+++ b/test/integration/specialist_document_search_test.rb
@@ -1,0 +1,37 @@
+require "integration_test_helper"
+require "rest-client"
+require_relative "multi_index_test"
+
+class SpecialistDocumentSearchTest < MultiIndexTest
+  def setup
+    super
+    add_sample_cma_case
+  end
+
+  def add_sample_cma_case
+    # Do the thing
+    cma_case_attributes = {
+      "title" => "Sample CMA Case",
+      "description" => "The CMA is investigating everyone",
+      "link" => "/cma-cases/sample-cma-case",
+      "indexable_content" => "Something something important content",
+      "case_state" => "open",
+      "market_sector" => "energy",
+      "opened_date" => "2014-08-22",
+      "case_type" => "mergers",
+      "_type" => "cma_case",
+      "section" => ["1"],
+    }
+
+    insert_document("mainstream_test", cma_case_attributes)
+  end
+
+  def test_extra_fields_decorated_by_schema
+    get "/unified_search?filter_document_type=cma_case&fields=case_type,description,title"
+
+    first_result = parsed_response["results"].first
+
+    assert first_result.has_key? "case_type"
+    assert first_result["case_type"] == [{"label" => "Mergers", "value" => "mergers"}]
+  end
+end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -143,6 +143,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       org_registry.nil? ? {} : {organisations: org_registry},
       options.fetch(:suggestions, []),
       options.fetch(:facet_examples, {}),
+      options.fetch(:mappings, {})
     )
   end
 

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -39,6 +39,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     }]
   end
 
+  def cma_case_mapping
+    MultiJson.load(File.read("config/schema/default/doctypes/cma_case.json"))
+  end
+
   def stub_suggester
     stub('Suggester', suggestions: ['cheese'])
   end
@@ -190,6 +194,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:index_name).returns(
         "mainstream,detailed,government"
       )
+      @combined_index.expects(:mappings).returns(
+        {
+          "cma_case" => cma_case_mapping
+        }
+      )
 
       @results = @searcher.search({
         start: 0,
@@ -239,6 +248,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:index_name).returns(
         "mainstream,detailed,government"
       )
+      @combined_index.expects(:mappings).returns(
+        {
+          "cma_case" => cma_case_mapping
+        }
+      )
 
       @results = @searcher.search({
         start: 0,
@@ -282,6 +296,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       })
       @combined_index.expects(:index_name).returns(
         "mainstream,detailed,government"
+      )
+      @combined_index.expects(:mappings).returns(
+        {
+          "cma_case" => cma_case_mapping
+        }
       )
 
       @results = @searcher.search({
@@ -343,6 +362,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       })
       @combined_index.expects(:index_name).returns(
         "mainstream,detailed,government"
+      )
+      @combined_index.expects(:mappings).returns(
+        {
+          "cma_case" => cma_case_mapping
+        }
       )
 
       @results = @searcher.search({


### PR DESCRIPTION
When requesting extra fields such as case_type, we want to look up the label in the schema. This commit does that by passing around the index mappings, getting the extra fields and looking them up in the relevant schema. [Ticket](https://trello.com/c/UpIwl3zz/291-rummager-use-the-extra-schema-details-to-flesh-out-the-documents-response-3).
