### PR TITLE
Expand specialist document metadata from schema

### DIFF
--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -2,9 +2,10 @@ require "active_support/inflector"
 
 class ResultSetPresenter
 
-  def initialize(result_set, context = {})
+  def initialize(result_set, context = {}, mappings = {})
     @result_set = result_set
     @context = context
+    @mappings = mappings
   end
 
   def present
@@ -24,7 +25,7 @@ private
   end
 
   def build_result(document)
-    result = document.to_hash
+    result = expand_metadata(document.to_hash)
 
     if result['document_series'] && should_expand_document_series?
       result['document_series'] = result['document_series'].map do |slug|
@@ -159,5 +160,43 @@ private
     else
       {"slug" => slug}
     end
+  end
+
+  def expand_metadata(document_attrs)
+    params_to_expand = document_attrs.select { |k, _|
+      schema_get_expandable_fields(document_attrs).include?(k)
+    }
+
+    expanded_params = params_to_expand.reduce({}) { |params, (field_name, values)|
+      params.merge(
+        field_name => Array(values).map { |values|
+          schema_get_field_label(document_attrs, field_name, values)
+        }
+      )
+    }
+
+    document_attrs.merge(expanded_params)
+  end
+
+  def schema_get_field_label(document, field_name, value)
+    schema(document)
+      .fetch("properties")
+      .fetch(field_name, {})
+      .fetch("details", {})
+      .fetch("allowed_values", [])
+      .find {|allowed_value| allowed_value.fetch("value") == value }
+  end
+
+  def schema(document)
+    @mappings.fetch(document.fetch(:_metadata, {}).fetch("_type", nil), {})
+  end
+
+  def schema_get_expandable_fields(document)
+    schema(document)
+      .fetch("properties", {})
+      .select { |_, value|
+        value.fetch("details", {}).fetch("allowed_values", {}).any?
+      }
+      .keys
   end
 end

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 class BaseParameterParser
 
   # The fields listed here are the only ones which the search results can be
@@ -253,7 +255,7 @@ private
     if fields.empty?
       return DEFAULT_RETURN_FIELDS
     end
-    disallowed_fields = fields - ALLOWED_RETURN_FIELDS
+    disallowed_fields = fields - allowed_return_fields
     fields = fields - disallowed_fields
 
     if disallowed_fields.any?
@@ -292,6 +294,54 @@ private
     end
 
     filters
+  end
+
+  def schema
+    schema_mappings
+      .merge( no_document_type => null_schema )
+      .fetch(document_type) {
+        raise "Schema not found for #{document_type}"
+      }
+  end
+
+  def schema_fields
+    schema.fetch("properties").keys
+  end
+
+  def allowed_filter_fields
+    ALLOWED_FILTER_FIELDS + schema_fields
+  end
+
+  def allowed_return_fields
+    ALLOWED_RETURN_FIELDS + schema_fields
+  end
+
+  def schema_get_field_type(field_name)
+    schema
+      .fetch("properties")
+      .fetch(field_name, {})
+      .fetch("type", "string")
+  end
+
+  def null_schema
+    {
+      "properties" => {},
+    }
+  end
+
+  def document_type
+    @document_types && @document_types.first
+  end
+
+  def build_filter(field_name, values)
+    type = schema_get_field_type(field_name)
+
+    field_class = {
+      "date" => DateFieldFilter,
+      "string" => TextFieldFilter,
+    }.fetch(type)
+
+    field_class.new(field_name, values)
   end
 
   class Filter
@@ -365,50 +415,6 @@ private
     end
   end
 
-  def build_filter(field_name, values)
-    type = schema_get_field_type(field_name)
-
-    field_class = {
-      "date" => DateFieldFilter,
-      "string" => TextFieldFilter,
-    }.fetch(type)
-
-    field_class.new(field_name, values)
-  end
-
-  def allowed_filter_fields
-    ALLOWED_FILTER_FIELDS + schema_fields
-  end
-
-  def schema_get_field_type(field_name)
-    schema
-      .fetch("properties")
-      .fetch(field_name, {})
-      .fetch("type", "string")
-  end
-
-  def schema_fields
-    schema.fetch("properties").keys
-  end
-
-  def schema
-    schema_mappings
-      .merge( no_document_type => null_schema )
-      .fetch(document_type) {
-        raise "Schema not found for #{document_type}"
-      }
-  end
-
-  def null_schema
-    {
-      "properties" => {},
-    }
-  end
-
-  def document_type
-    @document_types && @document_types.first
-  end
-
   def filter_name_lookup(name)
     FILTER_NAME_MAPPING.fetch(name, name)
   end
@@ -420,7 +426,7 @@ private
         field = m[1]
         value = single_param(key)
         if ALLOWED_FACET_FIELDS.include? field
-          facet_parser = FacetParameterParser.new(field, value)
+          facet_parser = FacetParameterParser.new(field, value, allowed_return_fields)
           if facet_parser.valid?
             facets[field] = facet_parser.parsed_params
           else
@@ -462,10 +468,11 @@ private
 end
 
 class FacetParameterParser < BaseParameterParser
-  attr_reader :parsed_params, :errors
+  attr_reader :parsed_params, :errors, :allowed_return_fields
 
-  def initialize(field, value)
+  def initialize(field, value, allowed_return_fields)
     @field = field
+    @allowed_return_fields = allowed_return_fields
     process(value)
   end
 
@@ -567,9 +574,9 @@ private
   def example_fields
     fields = character_separated_param("example_fields", ":")
     if fields.empty?
-      return DEFAULT_FACET_EXAMPLE_FIELDS 
+      return DEFAULT_FACET_EXAMPLE_FIELDS
     end
-    disallowed_fields = fields - ALLOWED_RETURN_FIELDS
+    disallowed_fields = fields - allowed_return_fields
     fields = fields - disallowed_fields
 
     if disallowed_fields.any?

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -17,7 +17,7 @@ class UnifiedSearchPresenter
   def initialize(es_response, start, index_names, applied_filters = {},
                  facet_fields = {}, registries = {},
                  registry_by_field = {}, suggestions = [],
-                 facet_examples={})
+                 facet_examples={}, mappings={})
     @start = start
     @results = es_response["hits"]["hits"].map do |result|
       doc = result.delete("fields")
@@ -33,6 +33,7 @@ class UnifiedSearchPresenter
     @registry_by_field = registry_by_field
     @suggestions = suggestions
     @facet_examples = facet_examples
+    @mappings = mappings
   end
 
   def present
@@ -47,7 +48,7 @@ class UnifiedSearchPresenter
 
 private
 
-  attr_reader :registries, :registry_by_field
+  attr_reader :registries, :registry_by_field, :mappings
 
   def presented_results
     # This uses the "standard" ResultSetPresenter to expand fields like
@@ -55,7 +56,7 @@ private
     # the output in other ways.
 
     result_set = ResultSet.new(@results, nil)
-    ResultSetPresenter.new(result_set, registries).present["results"].each do |fields|
+    ResultSetPresenter.new(result_set, registries, mappings).present["results"].each do |fields|
       metadata = fields.delete(:_metadata)
 
       # Replace the "_index" field, which contains the concrete name of the

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -32,6 +32,7 @@ class UnifiedSearcher
       registry_by_field,
       suggested_queries(params[:query]),
       facet_examples,
+      index.mappings,
     ).present
   end
 

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -258,7 +258,7 @@ class SearchTest < IntegrationTest
       "fields" => sample_document_attributes.merge("specialist_sectors" => ["oil-and-gas/licensing"])
     }
 
-    stub_index.expects(:mappings).returns(mappings)
+    stub_index.expects(:mappings).twice.returns(mappings)
     stub_index.expects(:raw_search).returns({"hits" => {"hits" => [document], "total" => 1}})
     stub_index.expects(:index_name).returns("mainstream,government,detailed")
     stub_metasearch_index.expects(:analyzed_best_bet_query).with("bob").returns("bob")

--- a/test/integration/specialist_document_search_test.rb
+++ b/test/integration/specialist_document_search_test.rb
@@ -1,0 +1,37 @@
+require "integration_test_helper"
+require "rest-client"
+require_relative "multi_index_test"
+
+class SpecialistDocumentSearchTest < MultiIndexTest
+  def setup
+    super
+    add_sample_cma_case
+  end
+
+  def add_sample_cma_case
+    # Do the thing
+    cma_case_attributes = {
+      "title" => "Sample CMA Case",
+      "description" => "The CMA is investigating everyone",
+      "link" => "/cma-cases/sample-cma-case",
+      "indexable_content" => "Something something important content",
+      "case_state" => "open",
+      "market_sector" => "energy",
+      "opened_date" => "2014-08-22",
+      "case_type" => "mergers",
+      "_type" => "cma_case",
+      "section" => ["1"],
+    }
+
+    insert_document("mainstream_test", cma_case_attributes)
+  end
+
+  def test_extra_fields_decorated_by_schema
+    get "/unified_search?filter_document_type=cma_case&fields=case_type,description,title"
+
+    first_result = parsed_response["results"].first
+
+    assert first_result.has_key? "case_type"
+    assert first_result["case_type"] == [{"label" => "Mergers", "value" => "mergers"}]
+  end
+end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -143,6 +143,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       org_registry.nil? ? {} : {organisations: org_registry},
       options.fetch(:suggestions, []),
       options.fetch(:facet_examples, {}),
+      options.fetch(:mappings, {})
     )
   end
 

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -39,6 +39,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     }]
   end
 
+  def cma_case_mapping
+    MultiJson.load(File.read("config/schema/default/doctypes/cma_case.json"))
+  end
+
   def stub_suggester
     stub('Suggester', suggestions: ['cheese'])
   end
@@ -190,6 +194,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:index_name).returns(
         "mainstream,detailed,government"
       )
+      @combined_index.expects(:mappings).returns(
+        {
+          "cma_case" => cma_case_mapping
+        }
+      )
 
       @results = @searcher.search({
         start: 0,
@@ -239,6 +248,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:index_name).returns(
         "mainstream,detailed,government"
       )
+      @combined_index.expects(:mappings).returns(
+        {
+          "cma_case" => cma_case_mapping
+        }
+      )
 
       @results = @searcher.search({
         start: 0,
@@ -282,6 +296,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       })
       @combined_index.expects(:index_name).returns(
         "mainstream,detailed,government"
+      )
+      @combined_index.expects(:mappings).returns(
+        {
+          "cma_case" => cma_case_mapping
+        }
       )
 
       @results = @searcher.search({
@@ -343,6 +362,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       })
       @combined_index.expects(:index_name).returns(
         "mainstream,detailed,government"
+      )
+      @combined_index.expects(:mappings).returns(
+        {
+          "cma_case" => cma_case_mapping
+        }
       )
 
       @results = @searcher.search({


### PR DESCRIPTION
When requesting extra fields such as case_type, we want to look up the label in the schema. This commit does that by passing around the index mappings, getting the extra fields and looking them up in the relevant schema. `allowed_return_fields` now returns the array `ALLOWED_RETURN_FIELDS` and the ones in the schema.
