### PR TITLE
Add document_type return field

### DIFF
--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -188,7 +188,11 @@ private
   end
 
   def schema(document)
-    @mappings.fetch(document.fetch(:_metadata, {}).fetch("_type", nil), {})
+    @mappings.fetch(document_type(document), {})
+  end
+
+  def document_type(document)
+    document.fetch(:_metadata, {}).fetch("_type", nil)
   end
 
   def schema_get_expandable_fields(document)

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -78,6 +78,7 @@ private
         fields[:_explanation] = explain
       end
 
+      fields[:document_type] = metadata["_type"]
     end
   end
 

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -148,6 +148,7 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal 1, parsed_response.fetch("total")
     assert_equal(
       hash_including(
+        "document_type" => cma_case_attributes.fetch("_type"),
         "title" => cma_case_attributes.fetch("title"),
         "link" => cma_case_attributes.fetch("link"),
       ),


### PR DESCRIPTION
This completes the features required for Rummager to replace Finder API searching.
