### PR TITLE
Add last_update field to ALLOWED_SORT_FIELDS

### DIFF
--- a/config/schema/default/core.json
+++ b/config/schema/default/core.json
@@ -43,6 +43,11 @@
       "type": "date",
       "index": "not_analyzed",
       "include_in_all": false
+    },
+    "last_update": {
+      "type": "date",
+      "index": "not_analyzed",
+      "include_in_all": false
     }
   }
 }

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -8,6 +8,7 @@ class BaseParameterParser
   # elasticsearch, and because elasticsearch gives fairly obscure error
   # messages if undefined sort fields are used.
   ALLOWED_SORT_FIELDS = %w(
+    last_update
     public_timestamp
   )
 
@@ -78,6 +79,7 @@ class BaseParameterParser
     display_type
     document_series
     format
+    last_update
     link
     organisation_state
     organisations


### PR DESCRIPTION
This is so we can use this field as a sort field to maintain finder-api's ordering when filtering results on finder-frontend. 

This field is provided by `specialist-publisher` -- see alphagov/specialist-publisher#250
