### PR TITLE
Add debug option to down-rank closed organisations

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -459,6 +459,8 @@ private
         options[:disable_popularity] = true
       when "disable_synonyms"
         options[:disable_synonyms] = true
+      when "downweight_closed_orgs"
+        options[:downweight_closed_orgs] = true
       when "explain"
         options[:explain] = true
       else

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -75,9 +75,20 @@ class UnifiedSearchBuilder
             should: [core_query]
           }
         },
-        filters: format_boosts + [time_boost]
+        filters: boost_filters,
+        score_mode: "multiply",
       }
     }
+  end
+
+  def boost_filters
+    boosts = format_boosts + [time_boost]
+
+    if @params[:debug][:downweight_closed_orgs]
+      boosts << closed_org_boost
+    end
+
+    boosts
   end
 
   def best_bets
@@ -412,6 +423,13 @@ class UnifiedSearchBuilder
     {
       filter: { term: { search_format_types: "announcement" } },
       script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+    }
+  end
+
+  def closed_org_boost
+    {
+      filter: { term: { organisation_state: "closed" } },
+      boost: 0.3,
     }
   end
 

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -104,7 +104,8 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
             {filter: {term: {format: 'document_collection'}}, boost: 1.3},
             {filter: {term: {format: 'operational_field'}}, boost: 1.5},
             {filter: {term: {search_format_types: 'announcement'}}, script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"}
-          ]
+          ],
+          score_mode: 'multiply',
         }
       },
       script: "_score * (doc['popularity'].value + #{UnifiedSearchBuilder::POPULARITY_OFFSET})"


### PR DESCRIPTION
Story at: https://www.pivotaltracker.com/story/show/66655858

This reduces the rank of closed organisations only if
`debug=downweight_closed_orgs` is added to the query parameters.  This
is to allow us to experiment with the down-ranking in production, prior
to applying it by default.

The multiplier of 0.3 was chosen, like all the other magic constants in
unified_search_builder, by trial, error, and gut feeling.

Previously, elasticsearch was combining the weights from the list of
filters it got by picking the first matching filter.  This is the
default method elasticsearch uses for `custom_filters_score`, but this
PR changes it to multiply the weights from all matching filters
together.  Previously only one of the filters would have matched, so
this shouldn't change existing rankings.
