### PR TITLE
Remove the downweight_closed_orgs debug parameter

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -459,8 +459,6 @@ private
         options[:disable_popularity] = true
       when "disable_synonyms"
         options[:disable_synonyms] = true
-      when "downweight_closed_orgs"
-        options[:downweight_closed_orgs] = true
       when "explain"
         options[:explain] = true
       else

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -82,13 +82,7 @@ class UnifiedSearchBuilder
   end
 
   def boost_filters
-    boosts = format_boosts + [time_boost]
-
-    if @params[:debug][:downweight_closed_orgs]
-      boosts << closed_org_boost
-    end
-
-    boosts
+    format_boosts + [time_boost] + [closed_org_boost]
   end
 
   def best_bets

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -103,7 +103,8 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
             {filter: {term: {format: 'document_series'}}, boost: 1.3},
             {filter: {term: {format: 'document_collection'}}, boost: 1.3},
             {filter: {term: {format: 'operational_field'}}, boost: 1.5},
-            {filter: {term: {search_format_types: 'announcement'}}, script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"}
+            {filter: {term: {search_format_types: 'announcement'}}, script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"},
+            {filter: {term: {organisation_state: 'closed'}}, boost: 0.3},
           ],
           score_mode: 'multiply',
         }


### PR DESCRIPTION
I've been testing this with all the examples we've currently got, and it
downweights the organisations correctly for the example searches, but
still returns them at or near the top for searches for the exact name of
the closed organisation.  Therefore, let's just deploy this without the
parameter.
