### PR TITLE
Analyse date of occurrence on AAIB reports

### DIFF
--- a/config/schema/default/doctypes/aaib_report.json
+++ b/config/schema/default/doctypes/aaib_report.json
@@ -72,7 +72,7 @@
     },
     "date_of_occurrence": {
       "type": "date",
-      "index": "no"
+      "index": "analyzed"
     },
     "registration": {
       "type": "string",


### PR DESCRIPTION
In order to implement date filtering on AAIB reports, the `date_of_occurrence` value needs analysed.
