### PR TITLE
Add Issued date to MedicalSafetyAlert schema

### DIFF
--- a/config/schema/default/doctypes/medical_safety_alert.json
+++ b/config/schema/default/doctypes/medical_safety_alert.json
@@ -119,6 +119,10 @@
           }
         ]
       }
+    },
+    "issued_date": {
+      "type": "date",
+      "index": "analyzed"
     }
   }
 }


### PR DESCRIPTION
This introduces the issued_date attribute for searching medical safety alerts

Trello ticket:
https://trello.com/c/QFE3nYlc/361-add-issued-date-to-medical-safety-alerts-2
