### PR TITLE
Add published at to dsu schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
+  remote: https://gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     activesupport (3.2.12)

--- a/config/schema/default/doctypes/drug_safety_update.json
+++ b/config/schema/default/doctypes/drug_safety_update.json
@@ -102,6 +102,10 @@
           }
         ]
       }
+    },
+    "published_date": {
+      "type": "date",
+      "index": "no"
     }
   }
 }

--- a/config/schema/default/doctypes/drug_safety_update.json
+++ b/config/schema/default/doctypes/drug_safety_update.json
@@ -103,7 +103,7 @@
         ]
       }
     },
-    "published_date": {
+    "first_published_at": {
       "type": "date",
       "index": "no"
     }


### PR DESCRIPTION
This pull request allows DrugSafetyUpdate documents to be indexed by rummager for search based on published_at date.

Trello ticket: https://trello.com/c/ZW0i6nya/362-add-first-published-date-to-the-dsu-finder-3-1
