### PR TITLE
Remove gemfury

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-source "https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/"
 
 gem "unicorn", "4.6.2"
 gem "raindrops", "0.11.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     activesupport (3.2.12)


### PR DESCRIPTION
I don't believe it is needed anymore as we have now published most the gems which were private on rubygems.
