### PR TITLE
Helpful error for unconfigured document types

### DIFF
--- a/lib/document.rb
+++ b/lib/document.rb
@@ -13,6 +13,9 @@ class Document
 
   def self.from_hash(hash, mappings, es_score = nil)
     type = hash["_type"] || "edition"
+    if mappings[type].nil?
+      raise "Unexpected document type '#{type}'. Document types must be configured"
+    end
     field_names = mappings[type]["properties"].keys.map(&:to_s)
     self.new(field_names, hash, es_score)
   end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -69,6 +69,17 @@ class DocumentTest < MiniTest::Unit::TestCase
     assert_equal "best_bet", document.elasticsearch_export["_type"]
   end
 
+  def test_should_raise_helpful_error_for_unconfigured_types
+    hash = {
+      "_id" => "jobs_exact",
+      "_type" => "cheese"
+    }
+
+    assert_raises RuntimeError do
+      Document.from_hash(hash, default_mappings)
+    end
+  end
+
   def test_should_ignore_fields_not_in_mappings
     hash = {
       "title" => "TITLE",


### PR DESCRIPTION
Previously this was giving:

```
NoMethodError - undefined method `[]' for nil:NilClass:
    /var/govuk/rummager/lib/document.rb:16:in `from_hash'
```
