### PR TITLE
Add config for HMRC manuals

### DIFF
--- a/config/schema/default/doctypes/hmrc_manual.json
+++ b/config/schema/default/doctypes/hmrc_manual.json
@@ -1,0 +1,3 @@
+{
+  "properties": {}
+}

--- a/config/schema/default/doctypes/hmrc_manual_section.json
+++ b/config/schema/default/doctypes/hmrc_manual_section.json
@@ -1,0 +1,12 @@
+{
+  "properties": {
+    "manual": {
+      "type": "string",
+      "index": "not_analyzed"
+    },
+    "hmrc_manual_section_id": {
+      "type": "string",
+      "index": "not_analyzed"
+    }
+  }
+}


### PR DESCRIPTION
To allow adding HMRC manuals to GOV.UK search.
