### PR TITLE
Add URLs without slash at start of string

### DIFF
--- a/lib/elasticsearch/sitemap.rb
+++ b/lib/elasticsearch/sitemap.rb
@@ -108,7 +108,7 @@ class SitemapGenerator
     builder = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
         chunk.each do |url|
-          url = "#{base_url}#{url}" if url.start_with?("/")
+          url = URI.join(base_url, url) unless url.start_with?("http")
           xml.url {
             xml.loc url
           }

--- a/test/unit/sitemap_generator_test.rb
+++ b/test/unit/sitemap_generator_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "elasticsearch/sitemap"
+
+class SitemapGeneratorTest < MiniTest::Unit::TestCase
+  def test_should_generate_sitemap
+    sitemap = SitemapGenerator.new('')
+
+    sitemap_xml = sitemap.generate_xml([ 'https://www.gov.uk/page', '/another-page', 'yet-another-page' ])
+    doc = Nokogiri::XML(sitemap_xml)
+    urls = doc.css('url > loc').map(&:inner_html)
+    assert_equal urls[0], 'https://www.gov.uk/page'
+    assert_equal urls[1], 'http://www.dev.gov.uk/another-page'
+    assert_equal urls[2], 'http://www.dev.gov.uk/yet-another-page'
+  end
+end


### PR DESCRIPTION
Due to an error in Specialist Publisher, we were sending URLs without a slash at the start as the ID to Rummager. The sitemap uses these IDs to build all the URLs and if they start with a slash assumes they are local and prepends https://www.gov.uk to them.

This commit changes the check to do this unless the URL starts with http, in which case it is an external URL. Previously this assumed that if it started with a slash, it was an internal URL and appended the slash.

[Ticket](https://govuk.zendesk.com/agent/tickets/856504).
