### PR TITLE
Use redis.yml values to configure Sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,15 +1,16 @@
-# This file will be overwritten on deployment
 require "sidekiq"
 
+redis_config_hash = YAML.load_file("config/redis.yml").symbolize_keys
+
 if ENV["RACK_ENV"]
-  namespace = "rummager-#{ENV['RACK_ENV']}"
+  namespace = "#{redis_config_hash[:namespace]}-#{ENV['RACK_ENV']}"
 else
-  namespace = "rummager"
+  namespace = "#{redis_config_hash[:namespace]}"
 end
 
 redis_config = {
-  :url => "redis://localhost:6379/0",
-  :namespace => namespace
+  url: "redis://#{redis_config_hash[:host]}:#{redis_config_hash[:port]}/0",
+  namespace: namespace
 }
 
 Sidekiq.configure_server do |config|

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,0 +1,3 @@
+host: 127.0.0.1
+port: 6379
+namespace: rummager


### PR DESCRIPTION
Bringing Rummager into line with other applications a redis.yml file is
now being used to hold the Redis config values. These are now being used
by Sidekiq.

https://www.pivotaltracker.com/story/show/82640998
