### PR TITLE
Add public_timestamp to mainstream schema

### DIFF
--- a/config/schema/default/core.json
+++ b/config/schema/default/core.json
@@ -49,6 +49,11 @@
       "index": "not_analyzed",
       "include_in_all": false
     },
+    "public_timestamp": {
+      "type": "date",
+      "index": "not_analyzed",
+      "include_in_all": false
+    },
     "latest_change_note": {
       "type": "string",
       "index": "not_analyzed",


### PR DESCRIPTION
Public timestamp exists already for whitehall indexes.  We want to be
able to have a comparable timestamp, holding the date of the most recent
major update to a page, for documents from publisher, too (so that we
can put them in the correct order in the 'latest' feed pages).  This
will be populated by future pull requests.
