### PR TITLE
Send "missing": "_last" with timestamp ordered searches.

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -234,8 +234,7 @@ class UnifiedSearchBuilder
 
   # Get a list describing the sort order (or nil)
   def sort_list
-    order = @params[:order]
-    if order.nil?
+    if @params[:order].nil?
       # Sort by popularity when there's no explicit ordering, and there's no
       # query (so there's no relevance scores).
       if @query.nil? && !(@params[:debug][:disable_popularity])
@@ -244,7 +243,10 @@ class UnifiedSearchBuilder
         return nil
       end
     end
-    [{ order[0] => { order: order[1] } }]
+
+    field, order = @params[:order]
+
+    [{field => {order: order, missing: "_last"}}]
   end
 
   def facets_hash

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -285,9 +285,9 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       )
     end
 
-    should "have correct sort list" do
+    should "put documents without a timestamp at the bottom" do
       assert_equal(
-        [{"public_timestamp" => {order: "asc"}}],
+        [{"public_timestamp" => {order: "asc", missing: "_last"}}],
         @builder.sort_list
       )
     end
@@ -335,13 +335,6 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       )
     end
 
-    should "have correct sort list" do
-      assert_equal(
-        [{"public_timestamp" => {order: "desc"}}],
-        @builder.sort_list
-      )
-    end
-
     should "have filter in query hash" do
       assert_equal(
         {"exists" => {"field" => "public_timestamp"}},
@@ -350,6 +343,13 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       assert_equal(
         {"exists" => {"field" => "public_timestamp"}},
         @builder.query_hash[:indices][:no_match_query][:filtered][:filter]
+      )
+    end
+
+    should "put documents without a timestamp at the bottom" do
+      assert_equal(
+        [{"public_timestamp" => {order: "desc", missing: "_last"}}],
+        @builder.sort_list
       )
     end
   end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -243,7 +243,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         size: 20,
         query: TIMESTAMP_EXISTS_WITH_CHEESE_QUERY,
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        sort: [{"public_timestamp" => {order: "asc"}}],
+        sort: [{"public_timestamp" => {order: "asc", missing: "_last"}}],
         filter: BASE_FILTERS,
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}


### PR DESCRIPTION
This puts documents at the bottom of the results if they have no `public_timestamp` field rather than not returning them at all.

https://www.pivotaltracker.com/story/show/82952646
