### PR TITLE
Don't filter out documents missing the sort field

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -123,7 +123,7 @@ class UnifiedSearchBuilder
   end
 
   def query_hash
-    query = filtered_query
+    query = base_query
     {
       indices: {
         indices: [:government],
@@ -138,20 +138,6 @@ class UnifiedSearchBuilder
     }
   end
 
-  def filtered_query
-    filter = sort_filters
-    if filter.nil?
-      base_query
-    else
-      {
-        filtered: {
-          filter: filter,
-          query: base_query,
-        }
-      }
-    end
-  end
-
   def combine_filters(filters)
     if filters.length == 0
       nil
@@ -160,15 +146,6 @@ class UnifiedSearchBuilder
     else
       {"and" => filters}
     end
-  end
-
-  def sort_filters
-    # Filters to ensure that fields being sorted by exist.
-    combine_filters(
-      sort_fields.map { |field|
-        {"exists" => {"field" => field}}
-      }
-    )
   end
 
   def filters_hash(excluding=[])

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -24,7 +24,12 @@ class UnifiedSearchTest < MultiIndexTest
     links = parsed_response["results"].map do |result|
       result["link"]
     end
-    assert_equal ["/government-1", "/government-2"], links
+
+    # The government links have dates, so appear before all the other links
+    assert_equal ["/government-1", "/government-2"], links.slice(0, 2)
+
+    # The other documents have no dates, so appear in an undefined order
+    assert_equal ["/detailed-1", "/detailed-2", "/mainstream-1", "/mainstream-2"], links.slice(2, 6).sort
   end
 
   def test_sort_by_date_descending
@@ -32,7 +37,12 @@ class UnifiedSearchTest < MultiIndexTest
     links = parsed_response["results"].map do |result|
       result["link"]
     end
-    assert_equal ["/government-2", "/government-1"], links
+
+    # The government links have dates, so appear before all the other links
+    assert_equal ["/government-2", "/government-1"], links.slice(0, 2)
+
+    # The other documents have no dates, so appear in an undefined order
+    assert_equal ["/detailed-1", "/detailed-2", "/mainstream-1", "/mainstream-2"], links.slice(2, 6).sort
   end
 
   def test_filter_by_section

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -291,19 +291,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
         @builder.sort_list
       )
     end
-
-    should "have filter in query hash" do
-      assert_equal(
-        {"exists" => {"field" => "public_timestamp"}},
-        @builder.query_hash[:indices][:query][:custom_boost_factor][:query][:filtered][:filter]
-      )
-      assert_equal(
-        {"exists" => {"field" => "public_timestamp"}},
-        @builder.query_hash[:indices][:no_match_query][:filtered][:filter]
-      )
-    end
   end
-
 
   context "search with descending sort" do
     setup do
@@ -332,17 +320,6 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     should "not have facets in payload" do
       assert_does_not_contain(
         @builder.payload.keys, :facets
-      )
-    end
-
-    should "have filter in query hash" do
-      assert_equal(
-        {"exists" => {"field" => "public_timestamp"}},
-        @builder.query_hash[:indices][:query][:custom_boost_factor][:query][:filtered][:filter]
-      )
-      assert_equal(
-        {"exists" => {"field" => "public_timestamp"}},
-        @builder.query_hash[:indices][:no_match_query][:filtered][:filter]
       )
     end
 

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -114,13 +114,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     }
   }
 
-  BASE_TIMESTAMP_EXISTS_WITH_CHEESE_QUERY = {
-    filtered: {
-      filter: {"exists" => {"field" => "public_timestamp"}},
-      query: BASE_CHEESE_QUERY,
-    }
-  }
-
   CHEESE_QUERY = {
     indices: {
       indices: [:government],
@@ -131,19 +124,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         }
       },
       no_match_query: BASE_CHEESE_QUERY
-    }
-  }
-
-  TIMESTAMP_EXISTS_WITH_CHEESE_QUERY = {
-    indices: {
-      indices: [:government],
-      query: {
-        custom_boost_factor: {
-          query: BASE_TIMESTAMP_EXISTS_WITH_CHEESE_QUERY,
-          boost_factor: 0.4
-        }
-      },
-      no_match_query: BASE_TIMESTAMP_EXISTS_WITH_CHEESE_QUERY
     }
   }
 
@@ -241,7 +221,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
-        query: TIMESTAMP_EXISTS_WITH_CHEESE_QUERY,
+        query: CHEESE_QUERY,
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
         sort: [{"public_timestamp" => {order: "asc", missing: "_last"}}],
         filter: BASE_FILTERS,


### PR DESCRIPTION
This was necessary with an older elasticsearch which (and my memory is
shaky here) either errored or gave unexpected results for documents
missing the sort field.  Since we're now wanting documents missing the
sort field to appear at the end of the list of documents, remove this
filter.
