### PR TITLE
Always initialize 'doc' variable as a Hash

### DIFF
--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -20,7 +20,7 @@ class UnifiedSearchPresenter
                  facet_examples={}, mappings={})
     @start = start
     @results = es_response["hits"]["hits"].map do |result|
-      doc = result.delete("fields")
+      doc = result.delete("fields") || {}
       doc[:_metadata] = result
       doc
     end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -207,6 +207,25 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     end
   end
 
+  context "results with no fields" do
+    setup do
+      @empty_result = sample_docs.first.tap {|doc|
+        doc['fields'] = nil
+      }
+      response = sample_es_response.tap {|response|
+        response['hits']['hits'] = [ @empty_result ]
+      }
+
+      @output = UnifiedSearchPresenter.new(response, 0, INDEX_NAMES).present
+    end
+
+    should 'return only basic metadata of fields' do
+      expected_keys = [:index, :es_score, :_id, :document_type]
+
+      assert_equal expected_keys, @output[:results].first.keys
+    end
+  end
+
   context "results with a registry" do
     setup do
       farming_topic_document = Document.new(


### PR DESCRIPTION
In the `UnifiedSearchPresenter`, the current behaviour assumed that the `fields` key returned for an Elasticsearch document is always a hash.

However, if a request is made for only a small number of fields, and the returned document contains none of them, then the `fields` key is nil. This causes an exception when we attempt to assign to the `_metadata`  key, as `doc` is nil.

This fixes this by using the double-pipe convention to fallback to an empty hash, in the case that the value of `fields` is nil.
