### PR TITLE
Reduce the specialist sector timeout to 5 minutes

### DIFF
--- a/lib/specialist_sector_registry.rb
+++ b/lib/specialist_sector_registry.rb
@@ -1,7 +1,7 @@
 require "timed_cache"
 
 class SpecialistSectorRegistry
-  CACHE_LIFETIME_SECONDS = 1800
+  CACHE_LIFETIME_SECONDS = 300
 
   def initialize(index, clock = Time)
     @index = index


### PR DESCRIPTION
Previously, this was 30 minutes.  This meant that there was a high
chance that when a new sector was created any content tagged to that
sector would not have its tags expanded correctly.  This leads to
sections being shown at the top of 'services and information' which have
no titles.  Reducing the timeout reduces the chance of this happening at
all (since there's a 30 minute CDN cache).

We expect there to be minimal increased load on elasticsearch as a
result of this (particularly since elasticsearch should have the
specialist_sectors field well cached due to other queries), but we'll
monitor load carefully after deploy.

Story: https://www.pivotaltracker.com/story/show/83213448
