### PR TITLE
Fix drug safety update date filtering

### DIFF
--- a/config/schema/default/doctypes/drug_safety_update.json
+++ b/config/schema/default/doctypes/drug_safety_update.json
@@ -105,7 +105,7 @@
     },
     "first_published_at": {
       "type": "date",
-      "index": "no"
+      "index": "analyzed"
     }
   }
 }


### PR DESCRIPTION
The first_published_at date field previously wasn't analysed. This commit changes that so we can filter it on Finder Frontend.
