### PR TITLE
Added temporary fix for MAA regulatory articles

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -558,6 +558,10 @@ synonyms: [
   "wether => whether, weather",
   "wharehouse => warehouse",
   "wheather => whether, weather",
+  
+  # Temporary fix for MAA regulatory articles
+  "RA1002 => RA 1002",
+  "RA1003 => RA 1003",
 
   # Temporary fix for payroll terms
   # "480 => 480, payroll",


### PR DESCRIPTION
To ensure users searching for articles using RA code numbers without spaces can still find the info they're looking for
