### PR TITLE
Normalize the query when parsing parameters

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -13,11 +13,11 @@ class UnifiedSearchBuilder
 
   def initialize(params, metaindex)
     @params = params
-    @query = query_normalized
+    @query = params[:query]
     if @params[:debug][:disable_best_bets]
       @best_bets_checker = BestBetsChecker.new(metaindex, nil)
     else
-      @best_bets_checker = BestBetsChecker.new(metaindex, query_normalized)
+      @best_bets_checker = BestBetsChecker.new(metaindex, @query)
     end
   end
 
@@ -34,20 +34,6 @@ class UnifiedSearchBuilder
     }.reject{ |key, value|
       [nil, [], {}].include?(value)
     }]
-  end
-
-  def query_normalized
-    if @params[:query].nil?
-      return nil
-    end
-    # Put the query into NFKC-normal form to ensure that accent handling works
-    # correctly in elasticsearch.
-    normalizer = UNF::Normalizer.instance
-    query = normalizer.normalize(@params[:query], :nfkc).strip
-    if query.length == 0
-      return nil
-    end
-    query
   end
 
   def base_query

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -195,6 +195,30 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     assert_equal(expected_params(query: "hello"), p.parsed_params)
   end
 
+  should "strip whitespace from the query" do
+    p = SearchParameterParser.new("q" => ["cheese "])
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params(query: "cheese"), p.parsed_params)
+  end
+
+  should "put the query in normalized form" do
+    p = SearchParameterParser.new("q" => ["cafe\u0300 "])
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params(query: "caf\u00e8"), p.parsed_params)
+  end
+
+  should "complain about invalid unicode in the query" do
+    p = SearchParameterParser.new("q" => ["\xff"])
+
+    assert_equal("Invalid unicode in query", p.error)
+    assert !p.valid?
+    assert_equal(expected_params(query: nil), p.parsed_params)
+  end
+
   should "understand filter paramers" do
     p = SearchParameterParser.new({"filter_organisations" => ["hm-magic"]})
 

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -101,13 +101,6 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       )
     end
 
-    should "strip whitespace from the query" do
-      assert_equal(
-        "cheese",
-        @builder.query_normalized
-      )
-    end
-
     should "have correct 'from' parameter in payload" do
       assert_equal(
         0,
@@ -232,25 +225,6 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     should "not have facets in payload" do
       assert_does_not_contain(
         @builder.payload.keys, :facets
-      )
-    end
-  end
-
-  context "building search with unicode" do
-    setup do
-      stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          query: "cafe\u0300 ",
-        ),
-        @metasearch_index
-      )
-    end
-
-    should "put the query in normalized form" do
-      assert_equal(
-        "caf\u00e8",
-        @builder.query_normalized
       )
     end
   end


### PR DESCRIPTION
This allows any errors to be caught and reported as part of the
validation process, rather than causing the builder to blow up and
trigger a 500 error.
