### PR TITLE
Allow topics in search results

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -141,16 +141,6 @@ class UnifiedSearchBuilder
       filter_hash(filter)
     }
 
-    # exclude any specialist sector documents from the search results, as we
-    # currently do not wish to display them
-    filter_groups << {
-      "not" => {
-        "term" => {
-          "format" => "specialist_sector"
-        }
-      }
-    }
-
     # Don't add additional filters to filter_groups without making sure that
     # the facet_filter values used in facets include the filter too.  It's
     # usually better to add additional filters to the query, so that they

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -6,13 +6,8 @@ require "search_parameter_parser"
 
 class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
-  BASE_FILTERS = {
-    'not' => {
-      'term' => {
-        'format' => 'specialist_sector'
-      }
-    }
-  }
+  # Set BASE_FILTERS if needed to add some default filters to search.
+  BASE_FILTERS = nil
 
   def stub_zero_best_bets
     @metasearch_index = stub("metasearch index")
@@ -84,12 +79,16 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   end
 
   def with_base_filters(filter)
-    {
-      "and" => [
-        filter,
-        BASE_FILTERS
-      ]
-    }
+    if BASE_FILTERS
+      {
+        "and" => [
+          filter,
+          BASE_FILTERS
+        ]
+      }
+    else
+      filter
+    end
   end
 
   context "unfiltered search" do
@@ -218,7 +217,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
           {"terms" => {"organisations" => ["hm-magic", "hmrc"]}},
           {"terms" => {"section" => ["levitation"]}},
           BASE_FILTERS,
-        ]}
+        ].compact}
       )
     end
 
@@ -351,7 +350,6 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
               order: "count",
               size: 100000,
             },
-            facet_filter: BASE_FILTERS,
           },
         },
         @builder.payload[:facets])
@@ -385,7 +383,6 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
               order: "count",
               size: 100000,
             },
-            facet_filter: BASE_FILTERS,
           },
         },
         @builder.payload[:facets])

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -127,13 +127,8 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     }
   }
 
-  BASE_FILTERS = {
-    'not' => {
-      'term' => {
-        'format' => 'specialist_sector'
-      }
-    }
-  }
+  # Set BASE_FILTERS if needed to add some default filters to search.
+  BASE_FILTERS = nil
 
   def mock_best_bets(query)
     @metasearch_index = stub("metasearch index")
@@ -151,12 +146,16 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   end
 
   def with_base_filters(filter)
-    {
-      "and" => [
-        filter,
-        BASE_FILTERS
-      ]
-    }
+    if BASE_FILTERS
+      {
+        "and" => [
+          filter,
+          BASE_FILTERS
+        ]
+      }
+    else
+      filter
+    end
   end
 
   context "unfiltered, unsorted search" do
@@ -170,7 +169,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         size: 20,
         query: CHEESE_QUERY,
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        filter: BASE_FILTERS,
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}
       })
@@ -224,7 +222,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         query: CHEESE_QUERY,
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
         sort: [{"public_timestamp" => {order: "asc", missing: "_last"}}],
-        filter: BASE_FILTERS,
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}
       })
@@ -328,11 +325,9 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
               order: "count",
               size: 100000,
             },
-            facet_filter: BASE_FILTERS,
           }
         },
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        filter: BASE_FILTERS,
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3},
         "facets" => {"organisations" => {


### PR DESCRIPTION
This removes a filter which hides documents of type "specialist_sector"
(which are now called topics) in search results.

This shouldn't be deployed before a corresponding change in frontend (https://github.com/alphagov/frontend/pull/702) to display a topics more nicely.

The unit tests have been updated to match the expected change, but I've
left the structure for checking that the correct filters are applied
because we're quite likely to add more filters back in future.
