### PR TITLE
Allow filtering and facetting by "manual"

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -16,6 +16,7 @@ class BaseParameterParser
   ALLOWED_FILTER_FIELDS = %w(
     document_type
     format
+    manual
     organisations
     section
     specialist_sectors
@@ -31,6 +32,7 @@ class BaseParameterParser
   # facets for.  This should be a subset of ALLOWED_FILTER_FIELDS
   ALLOWED_FACET_FIELDS = %w(
     format
+    manual
     organisations
     section
     specialist_sectors


### PR DESCRIPTION
This can be used to make searches be restricted to a particular manual,
or to get information on the manuals which have sections matching the
search.
