### PR TITLE
Add doctype for Contact

### DIFF
--- a/config/schema/default/doctypes/contact.json
+++ b/config/schema/default/doctypes/contact.json
@@ -1,0 +1,9 @@
+{
+  "properties": {
+    "contact_group": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false
+    }
+  }
+}


### PR DESCRIPTION
As we want Contacts#index to be powered for a Finder and want to put contacts into the search index, this commit adds a Contact doctype. There's probably more information we should add to this at a later
date when we better understand what Users might try searching to find a Contact.

The only metadata for a Contact added in this commit is a ContactGroup which is a way of grouping the Contacts together within each Org. Income Tax, VAT and Tax Credits are a few examples of those within HMRC.
