### PR TITLE
Allow facet example scope of "query"

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -68,6 +68,12 @@ class BaseParameterParser
     value.link
   )
 
+  # Scopes that are allowed when requesting examples for facets
+  #  - query: Return only examples that match the query and filters
+  #  - global: Return examples for the facet regardless of whether they match
+  #            the query and filters
+  ALLOWED_EXAMPLE_SCOPES = [:global, :query]
+
   # The fields listed here are the only ones that can be returned in search
   # results.  These are listed and validated explicitly, rather than simply
   # allowing any field in the schema, to keep the set of such fields as minimal
@@ -532,12 +538,12 @@ private
       example_scope: example_scope,
     }
 
-    if @parsed_params[:examples] > 0 && @parsed_params[:example_scope] != :global
+    if @parsed_params[:examples] > 0 && !ALLOWED_EXAMPLE_SCOPES.include?(@parsed_params[:example_scope])
       # global scope means that examples are looked up for each facet value
       # across the whole collection, not just for documents matching the query.
       # This is likely to be a surprising default, so we require that callers
       # explicitly ask for it.
-      @errors << %{example_scope parameter must currently be set to global when requesting examples}
+      @errors << %{example_scope parameter must be set to 'query' or 'global' when requesting examples}
       @parsed_params[:examples] = 0
     end
 
@@ -618,6 +624,8 @@ private
     scope = single_param("example_scope", facet_description)
     if scope == "global"
       :global
+    elsif scope == "query"
+      :query
     else
       nil
     end

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -25,8 +25,8 @@ class UnifiedSearchBuilder
     Hash[{
       from: @params[:start],
       size: @params[:count],
-      query: query_hash_with_best_bets,
-      filter: filters_hash,
+      query: query,
+      filter: filter,
       fields: @params[:return_fields],
       sort: sort_list,
       facets: facets_hash,
@@ -34,6 +34,14 @@ class UnifiedSearchBuilder
     }.reject{ |key, value|
       [nil, [], {}].include?(value)
     }]
+  end
+
+  def query
+    @_query ||= query_hash_with_best_bets
+  end
+
+  def filter
+    @_filter ||= filters_hash
   end
 
   def base_query

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -20,7 +20,8 @@ class UnifiedSearcher
   def search(params)
     builder = UnifiedSearchBuilder.new(params, @metaindex)
     es_response = index.raw_search(builder.payload)
-    example_fetcher = FacetExampleFetcher.new(index, es_response, params)
+    example_fetcher = FacetExampleFetcher.new(index, es_response, params,
+                                              builder)
     facet_examples = example_fetcher.fetch
     UnifiedSearchPresenter.new(
       es_response,

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -528,15 +528,36 @@ class SearchParameterParserTest < ShouldaUnitTestCase
       })}}), p.parsed_params)
   end
 
-  should "require the example_scope to be set to global" do
-    # Global scope is the only supported scope at present, but it's likely to
-    # be a surprising default, so we require that callers explicitly specify
-    # it.
+  should "require the example_scope to be set" do
     p = SearchParameterParser.new("facet_organisations" => ["10,examples:5,example_fields:slug:title"])
 
-    assert_equal("example_scope parameter must currently be set to global when requesting examples", p.error)
+    assert_equal("example_scope parameter must be set to 'query' or 'global' when requesting examples", p.error)
     assert !p.valid?
     assert_equal(expected_params({facets: {}}), p.parsed_params)
+  end
+
+  should "allow example_scope to be set to 'query'" do
+    p = SearchParameterParser.new("facet_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:query"])
+
+    assert p.valid?
+    assert_equal(expected_params({
+      facets: {
+        "organisations" => expected_facet_params({
+          requested: 10,
+          examples: 5,
+          example_fields: ["slug", "title"],
+          example_scope: :query,
+        })
+      }
+    }), p.parsed_params)
+  end
+
+  should "complain about an invalid example_scope option" do
+    p = SearchParameterParser.new("facet_organisations" => ["10,examples:5,example_scope:invalid"])
+
+    assert_equal("example_scope parameter must be set to 'query' or 'global' when requesting examples", p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
   end
 
   should "complain about a repeated example_scope option" do


### PR DESCRIPTION
Previously, when requesting examples for facet values, the only allowed
scope has been "global" - ie, return examples for the facet field
regardless of whether they match the query or not.

This adds the option of "query" scope - ie, return only examples which
match the query and filters.

The motivation of doing this now is to allow us to make services and
information pages only list examples which are produced by the
organisation the services and information page is for.

For example, on the HMRC services and information page, with global
scope we have a "Maritime Safety" section for which none of the 4
examples come from HMRC.  If the "query" scope is requested, it would contain only
examples which are tagged with HMRC.

(Note - this won't change anything on the site immediately: we'd also need to modify whitehall to request "query" scope to turn this option on on the services and information pages.)
