### PR TITLE
Add mainstream_browse_pages field

### DIFF
--- a/config/schema/default/core.json
+++ b/config/schema/default/core.json
@@ -34,6 +34,11 @@
       "index": "not_analyzed",
       "include_in_all": false
     },
+    "mainstream_browse_pages": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false
+    },
     "tags": {
       "type": "string",
       "index": "not_analyzed",

--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -116,6 +116,7 @@ mappings:
         statistics_announcement_state: { type: string, index: not_analyzed, include_in_all: false }
         subsection:  { type: string, index: not_analyzed, include_in_all: false }
         subsubsection:  { type: string, index: not_analyzed, include_in_all: false }
+        mainstream_browse_pages: { type: string, index: not_analyzed, include_in_all: false }
         tags: { type: string, index: not_analyzed, include_in_all: false }
         title:       { type: string, index: analyzed }
         topics: { type: string, index: not_analyzed, include_in_all: false }

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -476,6 +476,7 @@ module Elasticsearch
     def index_doc(doc_hash, popularities)
       if @is_content_index
         doc_hash = prepare_popularity_field(doc_hash, popularities)
+        doc_hash = prepare_mainstream_browse_page_field(doc_hash)
         doc_hash = prepare_tag_field(doc_hash)
       end
 
@@ -490,6 +491,29 @@ module Elasticsearch
         pop = popularities[link]
       end
       doc_hash.merge("popularity" => pop)
+    end
+
+    def prepare_mainstream_browse_page_field(doc_hash)
+      # Mainstream browse pages were modelled as three separate fields:
+      # section, subsection and subsubsection.  This is unhelpful in many ways,
+      # so model them instead as a single field containing the full path.
+      #
+      # In future, we'll get them in this form directly, at which point we'll
+      # also be able to there may be multiple browse pages tagged to a piece of
+      # content.
+      return doc_hash if doc_hash["mainstream_browse_pages"]
+
+      path = [
+        doc_hash["section"],
+        doc_hash["subsection"],
+        doc_hash["subsubsection"]
+      ].compact.join("/")
+
+      if path == ""
+        doc_hash
+      else
+        doc_hash.merge("mainstream_browse_pages" => [path])
+      end
     end
 
     def prepare_tag_field(doc_hash)


### PR DESCRIPTION
Mainstream browse pages were modelled as three separate fields: section,
subsection and subsubsection.  This is unhelpful in many ways (can't
search directly for all content in a subsection, can't facet usefully,
can't represent tagging to multiple browse pages), so model them instead
as a single field containing the full path.

If the mainstream_browse_pages field isn't populated in supplied data,
build it from the "section", "subsection" and "subsubsection" fields.

In future, we'll get them in this form directly, at which point we'll
also be able to there may be multiple browse pages tagged to a piece of
content.
