### PR TITLE
Allow filtering by "mainstream_browse_pages"

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -16,6 +16,7 @@ class BaseParameterParser
   ALLOWED_FILTER_FIELDS = %w(
     document_type
     format
+    mainstream_browse_pages
     manual
     organisations
     section
@@ -32,6 +33,7 @@ class BaseParameterParser
   # facets for.  This should be a subset of ALLOWED_FILTER_FIELDS
   ALLOWED_FACET_FIELDS = %w(
     format
+    mainstream_browse_pages
     manual
     organisations
     section


### PR DESCRIPTION
This can be used to make searches be restricted to a particular
mainstream browse page, or to get information on the mainstream browse
pages which are represented in the results of a search.
