### PR TITLE
Make RUMMAGER_INDEX=all refer to all indexes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,14 +58,10 @@ end
 def index_names
   case ENV["RUMMAGER_INDEX"]
   when "all"
-    content_index_names
+    search_config.index_names
   when String
     [ENV["RUMMAGER_INDEX"]]
   else
     raise "You must specify an index name in RUMMAGER_INDEX, or 'all'"
   end
-end
-
-def content_index_names
-  search_config.content_index_names
 end


### PR DESCRIPTION
Currently, it only refers to all indexes holding content.  This is
frequently confusing people.  Instead, make RUMMAGER_INDEX=all refer to
all indexes used by rummager.

This means that auxiliary indexes are also migrated when a
deploy:migrations is done - currently, they're not being.  This means
that if we changed the schemas of the auxiliary indexes, they wouldn't
be updated automatically, which also seems undesirable.
