### PR TITLE
Return 422 instead of 500 on unknown document_type

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -336,15 +336,16 @@ private
   end
 
   def schema
-    schema_mappings
+    @_schema ||= schema_mappings
       .merge( no_document_type => null_schema )
-      .fetch(document_type) {
-        raise "Schema not found for #{document_type}"
-      }
+      .fetch(document_type) do
+        @errors << %{Schema not found for document type "#{document_type}"%}
+        {}
+      end
   end
 
   def schema_fields
-    schema.fetch("properties").keys
+    schema.fetch("properties", {}).keys
   end
 
   def allowed_filter_fields
@@ -357,7 +358,7 @@ private
 
   def schema_get_field_type(field_name)
     schema
-      .fetch("properties")
+      .fetch("properties", {})
       .fetch(field_name, {})
       .fetch("type", "string")
   end


### PR DESCRIPTION
If a user tries to filter on a document type which isn't known (eg, by
visiting https://www.gov.uk/api/search.json?filter_document_type= ), we
return a 500 error.  Instead, this should return a 422 error, like other
errors produced by the search parameter parser determining that invalid
parameters have been supplied.

This PR will therefore prevent errbit emailing me when users visit this
URL.

This PR also memoizes the call to fetch the schema in
lib/search_parameter_parser.rb - this has the twin benefit of avoiding
looking it up multiple times, and also avoids reporting the error
multiple times.
