### PR TITLE
Allow returning/faceting browse page and manuals

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -49,6 +49,8 @@ class BaseParameterParser
   # restriction could be relaxed in future.
   ALLOWED_FACET_EXAMPLE_FIELDS = %w(
     format
+    mainstream_browse_pages
+    manual
     organisations
     section
     specialist_sectors
@@ -92,6 +94,8 @@ class BaseParameterParser
     last_update
     latest_change_note
     link
+    mainstream_browse_pages
+    manual
     organisation_state
     organisations
     public_timestamp


### PR DESCRIPTION
The "mainstream_browse_pages" and "manual" fields should be allowed to
be returned as fields in documents, and used for facet examples.
