### PR TITLE
Identify entities during indexing

### DIFF
--- a/config/initializers/entity_extraction.rb
+++ b/config/initializers/entity_extraction.rb
@@ -1,0 +1,6 @@
+# This file is overwritten on deployment, you can enable entity extraction by
+# setting:
+#
+#   settings.search_config.enable_entity_extraction = true
+#
+# By default it's disabled, except when RACK_ENV='development'

--- a/config/schema/default/core.json
+++ b/config/schema/default/core.json
@@ -24,6 +24,11 @@
       "type": "float",
       "stored": true
     },
+    "entities": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false
+    },
     "organisations": {
       "type": "string",
       "index": "not_analyzed",

--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -107,6 +107,7 @@ mappings:
         organisation_state: { type: string, index: not_analyzed, include_in_all: false }
         people: { type: string, index: not_analyzed, include_in_all: false }
         popularity: { type: float, stored: true }
+        entities: { type: string, index: not_analyzed, include_in_all: false }
         public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }
         search_format_types: { type: string, index: not_analyzed, include_in_all: false }

--- a/lib/connection_error_swallower.rb
+++ b/lib/connection_error_swallower.rb
@@ -1,0 +1,18 @@
+class ConnectionErrorSwallower < SimpleDelegator
+  attr_reader :logger
+
+  def initialize(obj, options = {})
+    super(obj)
+    @logger = options[:logger] || Logging.logger["ConnectionErrorSwallower"]
+    @had_connection_error = false
+  end
+
+  def call(*args)
+    return nil if @had_connection_error
+    super
+  rescue Errno::ECONNREFUSED => e
+    logger.error(e)
+    @had_connection_error = true
+    nil
+  end
+end

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -531,7 +531,7 @@ module Elasticsearch
 
     def prepare_entities_field(doc_hash)
       entities = entity_extractor.call(doc_hash['indexable_content'] || "")
-      if entities.any?
+      if entities
         doc_hash.merge("entities" => entities)
       else
         doc_hash

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -478,6 +478,7 @@ module Elasticsearch
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_mainstream_browse_page_field(doc_hash)
         doc_hash = prepare_tag_field(doc_hash)
+        doc_hash = prepare_entities_field(doc_hash)
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
@@ -518,11 +519,24 @@ module Elasticsearch
 
     def prepare_tag_field(doc_hash)
       tags = []
-      
+
       tags.concat(Array(doc_hash["organisations"]).map { |org| "organisation:#{org}" })
       tags.concat(Array(doc_hash["specialist_sectors"]).map { |sector| "sector:#{sector}" })
 
       doc_hash.merge("tags" => tags)
+    end
+
+    def prepare_entities_field(doc_hash)
+      entities = entity_extractor.call(doc_hash['indexable_content'] || "")
+      if entities.any?
+        doc_hash.merge("entities" => entities)
+      else
+        doc_hash
+      end
+    end
+
+    def entity_extractor
+      @search_config.entity_extractor
     end
 
     # If a document is a best bet, and is using the stemmed_query field, we

--- a/lib/entity_extractor_client.rb
+++ b/lib/entity_extractor_client.rb
@@ -11,37 +11,15 @@ class EntityExtractorClient
     @service_base_url = URI.parse(service_base_url)
     @options = default_options.merge(options)
     @logger = options[:logger] || Logging.logger[self]
-    @swallow_connection_errors = options[:swallow_connection_errors] || false
-    @had_connection_error = false
   end
 
   def call(document)
-    if swallow_connection_errors? && had_connection_error?
-      nil
-    else
-      response = RestClient.post(extract_url, document, @options)
-      JSON.parse(response)
-    end
-  rescue Errno::ECONNREFUSED => e
-    if swallow_connection_errors?
-      logger.error(e)
-      @had_connection_error = true
-      nil
-    else
-      raise
-    end
+    response = RestClient.post(extract_url, document, @options)
+    JSON.parse(response)
   end
 
 private
   attr_reader :logger
-
-  def swallow_connection_errors?
-    @swallow_connection_errors
-  end
-
-  def had_connection_error?
-    @had_connection_error
-  end
 
   def extract_url
     service_base_url.clone.tap do |url|

--- a/lib/entity_extractor_client.rb
+++ b/lib/entity_extractor_client.rb
@@ -3,19 +3,37 @@ require 'json'
 
 class EntityExtractorClient
   attr_reader :service_base_url
-  def initialize(service_base_url)
+
+  DEFAULT_OPEN_TIMEOUT_IN_SECONDS = 1
+  DEFAULT_READ_TIMEOUT_IN_SECONDS = 1
+
+  def initialize(service_base_url, options = {})
     @service_base_url = URI.parse(service_base_url)
+    @options = default_options.merge(options)
+    @logger = options[:logger] || Logging.logger[self]
   end
 
   def call(document)
-    response = RestClient.post(extract_url, document)
+    response = RestClient.post(extract_url, document, @options)
     JSON.parse(response)
+  rescue RestClient::Exception => e
+    logger.error(e)
+    nil
   end
 
 private
+  attr_reader :logger
+
   def extract_url
     service_base_url.clone.tap do |url|
       url.path = '/extract'
     end.to_s
+  end
+
+  def default_options
+    {
+      timeout: DEFAULT_READ_TIMEOUT_IN_SECONDS,
+      open_timeout: DEFAULT_OPEN_TIMEOUT_IN_SECONDS
+    }
   end
 end

--- a/lib/entity_extractor_client.rb
+++ b/lib/entity_extractor_client.rb
@@ -1,0 +1,21 @@
+require 'rest-client'
+require 'json'
+
+class EntityExtractorClient
+  attr_reader :service_base_url
+  def initialize(service_base_url)
+    @service_base_url = URI.parse(service_base_url)
+  end
+
+  def call(document)
+    response = RestClient.post(extract_url, document)
+    JSON.parse(response)
+  end
+
+private
+  def extract_url
+    service_base_url.clone.tap do |url|
+      url.path = '/extract'
+    end.to_s
+  end
+end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -1,8 +1,15 @@
 require "yaml"
 require "elasticsearch/search_server"
 require "schema_config"
+require "entity_extractor_client"
+require "plek"
 
 class SearchConfig
+  attr_accessor :entity_extractor
+
+  def initialize(options = {})
+    @entity_extractor = options[:entity_extractor] || default_entity_extractor
+  end
 
   def search_server
     Elasticsearch::SearchServer.new(
@@ -61,6 +68,10 @@ class SearchConfig
 
   def metasearch_index_name
     elasticsearch["metasearch_index_name"]
+  end
+
+  def default_entity_extractor
+    EntityExtractorClient.new(Plek.current.find('entity-extractor'))
   end
 
 private

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -72,7 +72,10 @@ class SearchConfig
 
   def entity_extractor
     if @enable_entity_extraction
-      EntityExtractorClient.new(Plek.current.find('entity-extractor'))
+      EntityExtractorClient.new(
+        Plek.current.find('entity-extractor'),
+        swallow_connection_errors: in_development_environment?
+      )
     else
       null_entity_extractor
     end

--- a/test/fixtures/entity_extractor_stubs.rb
+++ b/test/fixtures/entity_extractor_stubs.rb
@@ -1,0 +1,7 @@
+module Fixtures::EntityExtractorStubs
+  def stub_entity_extractor(indexable_content = //, entities = [])
+    stub_request(:post, "#{Plek.current.find('entity-extractor')}/extract")
+      .with(:body => indexable_content)
+      .to_return(:status => 200, :body => entities.to_json)
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "fixtures/entity_extractor_stubs"
 require "app"
 require "elasticsearch/search_server"
 require "sidekiq/testing/inline"  # Make all queued jobs run immediately
@@ -6,6 +7,7 @@ require 'debugger'
 
 module IntegrationFixtures
   include Fixtures::DefaultMappings
+  include Fixtures::EntityExtractorStubs
 
   def sample_document_attributes
     {
@@ -64,6 +66,7 @@ module ElasticsearchIntegration
       "govuk_index_names" => content_index_names,
       "metasearch_index_name" => metasearch_index_name,
     })
+    stub_entity_extractor
     app.settings.stubs(:default_index_name).returns(@default_index_name)
     app.settings.stubs(:enable_queue).returns(false)
   end

--- a/test/unit/connection_error_swallower_test.rb
+++ b/test/unit/connection_error_swallower_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+require "connection_error_swallower"
+require 'logger'
+
+class ConnectionErrorSwallowerTest < MiniTest::Unit::TestCase
+
+  def setup
+    @inner = stub("inner", call: nil)
+    @logstream = StringIO.new
+    @swallower = ConnectionErrorSwallower.new(@inner, logger: Logger.new(@logstream))
+  end
+
+  def test_swallows_first_connection_error_and_returns_nil
+    @inner.stubs(:call).raises(Errno::ECONNREFUSED)
+    assert_nil @swallower.call
+  end
+
+  def test_logs_first_connection_error
+    @inner.stubs(:call).raises(Errno::ECONNREFUSED)
+    @swallower.call
+    assert_match /Connection refused/, @logstream.string
+  end
+
+  def test_silently_swallows_subsequent_errors
+    @inner.stubs(:call).raises(Errno::ECONNREFUSED)
+    @swallower.call
+    assert_nil @swallower.call
+    assert_nil @swallower.call
+
+    matches = @logstream.string.scan(/Connection refused/)
+    assert_equal 1, matches.size, "expected only 'Connection refused' match but got #{matches.size}"
+  end
+
+  def test_reraises_other_exceptions
+    @inner.stubs(:call).raises("another error")
+    assert_raises(RuntimeError) do
+      @swallower.call
+    end
+  end
+end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -290,11 +290,11 @@ eos
     assert_requested(:post, "http://example.com:9200/test-index/_bulk")
   end
 
-  def test_stores_no_entities_if_none_found
+  def test_stores_no_entities_if_entity_extraction_returns_nil_due_to_swallowing_an_error
     stub_popularity_index_requests(["/foo/bar"], 1.0)
 
     indexable_content = "this is the indexable content"
-    @entity_extractor.expects(:call).with(indexable_content).returns([])
+    @entity_extractor.expects(:call).with(indexable_content).returns(nil)
 
     document = stub("document", elasticsearch_export: {
       "_type" => "edition",

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -13,7 +13,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
 
     @traffic_index = Elasticsearch::Index.new(@base_uri, "page-traffic", page_traffic_mappings, search_config)
     @wrapper.stubs(:traffic_index).returns(@traffic_index)
-    @entity_extractor = stub("entity_extractor", call: [])
+    @entity_extractor = stub("entity_extractor", call: nil)
     @wrapper.stubs(:entity_extractor).returns(@entity_extractor)
     @traffic_index.stubs(:real_name).returns("page-traffic")
   end

--- a/test/unit/entity_extractor_client_test.rb
+++ b/test/unit/entity_extractor_client_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+require "entity_extractor_client"
+
+class EntityExtractorClientTest < MiniTest::Unit::TestCase
+  def test_extract_calls_entity_extractor_service_and_deserialises_json_response
+    document = "This is my document"
+    post_stub = stub_request(:post, "http://localhost:3096/extract")
+      .with(body: document)
+      .to_return(
+        status: 200,
+        body: '["1"]'
+      )
+    e = EntityExtractorClient.new("http://localhost:3096/")
+    response = e.call(document)
+
+    assert_equal ["1"], response
+  end
+end

--- a/test/unit/entity_extractor_client_test.rb
+++ b/test/unit/entity_extractor_client_test.rb
@@ -1,18 +1,32 @@
 require "test_helper"
 require "entity_extractor_client"
+require 'logger'
 
 class EntityExtractorClientTest < MiniTest::Unit::TestCase
+  def setup
+    @base_url = "http://localhost:3096"
+    @logstream = StringIO.new
+    @extractor = EntityExtractorClient.new(@base_url, logger: Logger.new(@logstream))
+  end
+
   def test_extract_calls_entity_extractor_service_and_deserialises_json_response
     document = "This is my document"
-    post_stub = stub_request(:post, "http://localhost:3096/extract")
+    stub_request(:post, "#{@base_url}/extract")
       .with(body: document)
       .to_return(
         status: 200,
         body: '["1"]'
       )
-    e = EntityExtractorClient.new("http://localhost:3096/")
-    response = e.call(document)
+    response = @extractor.call(document)
 
     assert_equal ["1"], response
+  end
+
+  def test_logs_message_and_returns_nil_on_timeout
+    stub_request(:post, "#{@base_url}/extract")
+      .with(body: "some text")
+      .to_timeout
+    assert_nil @extractor.call("some text")
+    assert_match /Request Timeout/, @logstream.string
   end
 end

--- a/test/unit/entity_extractor_client_test.rb
+++ b/test/unit/entity_extractor_client_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "entity_extractor_client"
+require "connection_error_swallower"
 require 'logger'
 
 class EntityExtractorClientTest < MiniTest::Unit::TestCase
@@ -20,61 +21,5 @@ class EntityExtractorClientTest < MiniTest::Unit::TestCase
     response = @extractor.call(document)
 
     assert_equal ["1"], response
-  end
-
-  def test_logs_and_swallows_first_connection_error_if_swallowing_connection_errors
-    @extractor = EntityExtractorClient.new(@base_url,
-      logger: Logger.new(@logstream),
-      swallow_connection_errors: true
-    )
-    stub_request(:post, "#{@base_url}/extract")
-      .with(body: "some text")
-      .to_raise(Errno::ECONNREFUSED)
-    assert_nil @extractor.call("some text")
-    assert_match /Connection refused/, @logstream.string
-  end
-
-  def test_silently_swallows_subsequent_connection_errors_if_swallowing_connection_errors
-    @extractor = EntityExtractorClient.new(@base_url,
-      logger: Logger.new(@logstream),
-      swallow_connection_errors: true
-    )
-    stub_request(:post, "#{@base_url}/extract")
-      .with(body: "some text")
-      .to_raise(Errno::ECONNREFUSED)
-
-    assert_nil @extractor.call("some text")
-    assert_nil @extractor.call("some text")
-    assert_nil @extractor.call("some text")
-    matches = @logstream.string.scan(/Connection refused/)
-    assert_equal 1, matches.size, "expected only 'Connection refused' match but got #{matches.size}"
-  end
-
-  def test_raises_connection_error_if_not_swallowing
-    @extractor = EntityExtractorClient.new(@base_url,
-      logger: Logger.new(@logstream),
-      swallow_connection_errors: false
-    )
-    stub_request(:post, "#{@base_url}/extract")
-      .with(body: "some text")
-      .to_raise(Errno::ECONNREFUSED)
-
-    assert_raises(Errno::ECONNREFUSED) do
-      @extractor.call("some text")
-    end
-  end
-
-  def test_raises_timeouts_even_if_swallowing
-    @extractor = EntityExtractorClient.new(@base_url,
-      logger: Logger.new(@logstream),
-      swallow_connection_errors: true
-    )
-    stub_request(:post, "#{@base_url}/extract")
-      .with(body: "some text")
-      .to_timeout
-
-    assert_raises(RestClient::RequestTimeout) do
-      @extractor.call("some text")
-    end
   end
 end


### PR DESCRIPTION
This is part of the [firebreak work to use named entities to improve search results](https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=20185307). 

This PR changes rummager to use the new [entity-extractor](https://github.com/alphagov/entity-extractor) service when indexing documents. Any entities found in the document are stored in the `entities` field of the document in the elasticsearch index.

The `rummager:migrate_index` task has been modified so that it disables entity extraction by default. This is because entitiy extraction could slow down the migration by up to 20 minutes. There is now an option to that rake task to enable entity extraction should it be required, e.g. when first populating the field.

The entity extraction feature is controlled by a config setting `enable_entity_extraction`. This is disabled by default (except if `RACK_ENV=='development'`). It can be overridden by adding an initializer in the deploy scripts.

For the time being we want this disabled in staging/production and only enabled in preview.
