### PR TITLE
Memoize entity extractor client

### DIFF
--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -72,7 +72,7 @@ class SearchConfig
   end
 
   def entity_extractor
-    if @enable_entity_extraction && !in_development_environment?
+    @entity_extractor ||= if @enable_entity_extraction && !in_development_environment?
       standard_entity_extractor
     elsif @enable_entity_extraction && in_development_environment?
       error_swallowing_entity_extractor


### PR DESCRIPTION
This avoids opening it for every document added, and also means that in
the development environment it remembers if it's swallowed an exception
and should no longer make calls to the service.
