### PR TITLE
Make sitemap generation more robust

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -264,7 +264,7 @@ module Elasticsearch
 
       batch_size = self.class.scroll_batch_size
       ScrollEnumerator.new(@client, search_body, batch_size) do |hit|
-        hit["fields"]["link"]
+        hit.fetch("fields", {})["link"]
       end
     end
 

--- a/lib/elasticsearch/sitemap.rb
+++ b/lib/elasticsearch/sitemap.rb
@@ -92,7 +92,9 @@ class SitemapGenerator
 
       @sitemap_indices.each do |index|
         index.all_document_links(EXCLUDED_FORMATS).each do |document|
-          yielder << document
+          if document
+            yielder << document
+          end
         end
       end
     end

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -75,6 +75,9 @@ class SitemapTest < IntegrationTest
         "indexable_content" => "Tax, benefits, roads and stuff"
       },
       {
+        "title" => "Bad document missing a link field",
+      },
+      {
         "title" => "Some content from Inside Gov",
         "description" => "We list some inside gov results in the mainstream index.",
         "format" => "inside-government-link",


### PR DESCRIPTION
If a document in the search index is missing a 'link' field, sitemap generation will currently fail.  This commit changes sitemap generation to simply skip such documents.

We ought not to have such documents, but it's better to generate a sitemap without them than to fail to update the sitemap at all due to them.

Related pivotal ticket: https://www.pivotaltracker.com/n/projects/780127/stories/86689164
