### PR TITLE
Log output from sitemap generation

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,5 @@
 set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
-job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv search bundle exec rake :task'
+job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv search bundle exec rake :task :output'
 
 # Sitemap filenames are generated based on the current day and hour. Putting
 # this at 10 past gets around any problems that might arise from running just


### PR DESCRIPTION
I think that logs from this were being lost without this change. I want a bit
more information about what happens when the rake task runs.
