### PR TITLE
Use entities in searches

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -364,7 +364,7 @@ class Rummager < Sinatra::Application
       })
     end
 
-    searcher = UnifiedSearcher.new(unified_index, metasearch_index, registries, registry_by_field, suggester)
+    searcher = UnifiedSearcher.new(unified_index, metasearch_index, registries, registry_by_field, suggester, settings.search_config.entity_extractor)
     MultiJson.encode searcher.search(parser.parsed_params)
   end
 

--- a/config/initializers/entity_extraction.rb
+++ b/config/initializers/entity_extraction.rb
@@ -1,6 +1,6 @@
-# This file is overwritten on deployment, you can enable entity extraction by
-# setting:
-#
-#   settings.search_config.enable_entity_extraction = true
-#
-# By default it's disabled, except when RACK_ENV='development'
+# This file may be overwritten on deployment to activate entity extraction in
+# production. We default to disabled in production.
+
+settings.search_config.enable_entity_extraction = (
+  %w{development test}.include?(ENV['RACK_ENV'])
+)

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -9,7 +9,7 @@ class SearchConfig
   attr_accessor :enable_entity_extraction
 
   def initialize
-    @enable_entity_extraction = in_development_environment?
+    @enable_entity_extraction = nil
   end
 
   def search_server
@@ -72,10 +72,13 @@ class SearchConfig
   end
 
   def entity_extractor
-    @entity_extractor ||= if @enable_entity_extraction && !in_development_environment?
-      standard_entity_extractor
-    elsif @enable_entity_extraction && in_development_environment?
-      error_swallowing_entity_extractor
+    raise "Must set 'enable_entity_extraction' in initializer" if @enable_entity_extraction.nil?
+    @entity_extractor ||= if @enable_entity_extraction
+      if in_development_environment?
+        error_swallowing_entity_extractor
+      else
+        standard_entity_extractor
+      end
     else
       null_entity_extractor
     end
@@ -95,7 +98,7 @@ private
   end
 
   def in_development_environment?
-    ENV['RACK_ENV'] == 'development'
+    %w{development test}.include?(ENV['RACK_ENV'])
   end
 
   def config_for(kind)

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -11,7 +11,7 @@ class UnifiedSearchBuilder
   GOVERNMENT_BOOST_FACTOR = 0.4
   POPULARITY_OFFSET = 0.001
 
-  def initialize(params, metaindex)
+  def initialize(params, metaindex, entity_extractor)
     @params = params
     @query = params[:query]
     if @params[:debug][:disable_best_bets]
@@ -19,6 +19,7 @@ class UnifiedSearchBuilder
     else
       @best_bets_checker = BestBetsChecker.new(metaindex, @query)
     end
+    @entity_extractor = entity_extractor
   end
 
   def payload
@@ -76,7 +77,7 @@ class UnifiedSearchBuilder
   end
 
   def boost_filters
-    format_boosts + [time_boost] + [closed_org_boost] + [devolved_org_boost]
+    (format_boosts + [time_boost, closed_org_boost, devolved_org_boost, entities_boost]).compact
   end
 
   def best_bets
@@ -397,4 +398,14 @@ class UnifiedSearchBuilder
     }
   end
 
+  def entities_boost
+    {
+      filter: { terms: { entities: find_entities} },
+      boost: 20
+    } unless find_entities.empty?
+  end
+
+  def find_entities
+    @entities ||= @entity_extractor.call(@query) || []
+  end
 end

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -400,12 +400,12 @@ class UnifiedSearchBuilder
 
   def entities_boost
     {
-      filter: { terms: { entities: find_entities} },
+      filter: { terms: { entities: entities} },
       boost: 20
-    } unless find_entities.empty?
+    } unless entities.empty?
   end
 
-  def find_entities
+  def entities
     @entities ||= @entity_extractor.call(@query) || []
   end
 end

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -6,19 +6,21 @@ require "unified_search_presenter"
 
 class UnifiedSearcher
 
-  attr_reader :index, :registries, :registry_by_field, :suggester
+  attr_reader :index, :registries, :registry_by_field, :suggester, :entity_extractor
 
-  def initialize(index, metaindex, registries, registry_by_field, suggester)
+  def initialize(index, metaindex, registries, registry_by_field, suggester,
+                 entity_extractor)
     @index = index
     @metaindex = metaindex
     @registries = registries
     @registry_by_field = registry_by_field
     @suggester = suggester
+    @entity_extractor = entity_extractor
   end
 
   # Search and combine the indices and return a hash of ResultSet objects
   def search(params)
-    builder = UnifiedSearchBuilder.new(params, @metaindex)
+    builder = UnifiedSearchBuilder.new(params, @metaindex, entity_extractor)
     es_response = index.raw_search(builder.payload)
     example_fetcher = FacetExampleFetcher.new(index, es_response, params,
                                               builder)

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -263,6 +263,7 @@ class SearchTest < IntegrationTest
     stub_index.expects(:index_name).returns("mainstream,government,detailed")
     stub_metasearch_index.expects(:analyzed_best_bet_query).with("bob").returns("bob")
     stub_metasearch_index.expects(:raw_search).returns({"hits" => {"hits" => []}})
+    stub_entity_extractor
     SpecialistSectorRegistry.any_instance.expects(:[])
       .with("oil-and-gas/licensing")
       .returns(oil_gas_sector_fields)

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -16,6 +16,12 @@ class MultiIndexTest < IntegrationTest
     @auxiliary_indexes.each do |index|
       create_test_index(index)
     end
+
+    reset_content_indexes
+    populate_content_indexes
+  end
+
+  def reset_content_indexes
     INDEX_NAMES.each do |index_name|
       try_remove_test_index(index_name)
       if index_name == "government_test"
@@ -24,6 +30,11 @@ class MultiIndexTest < IntegrationTest
       add_field_to_mappings("topics")
       add_field_to_mappings("section")
       create_test_index(index_name)
+    end
+  end
+
+  def populate_content_indexes
+    INDEX_NAMES.each do |index_name|
       add_sample_documents(index_name, 2)
     end
   end

--- a/test/integration/search_entity_boosting_test.rb
+++ b/test/integration/search_entity_boosting_test.rb
@@ -1,0 +1,51 @@
+require "integration_test_helper"
+require "rest-client"
+require_relative "multi_index_test"
+
+class SearchEntityBoostingTest < MultiIndexTest
+  include Fixtures::EntityExtractorStubs
+
+  def populate_content_indexes
+    stub_entity_extractor("cheese sandwich", ["1"])
+    insert_document(INDEX_NAMES.first, {
+      "title" => "A",
+      "link" => "/a",
+      "indexable_content" => "cheese",
+    })
+    insert_document(INDEX_NAMES.first, {
+      "title" => "B",
+      "link" => "/b",
+      "indexable_content" => "cheese sandwich",
+    })
+    commit_index(INDEX_NAMES.first)
+    assert last_response.ok?, "Failed to insert document"
+  end
+
+  def insert_document(index_name, attributes)
+    post "/#{index_name}/documents", MultiJson.encode(attributes)
+    assert last_response.ok?, "Failed to insert document"
+  end
+
+  def assert_result_links_in_order(expected)
+    links = parsed_response["results"].map do |result|
+      result["link"]
+    end
+
+    assert_equal expected, links
+  end
+
+  def test_result_order_not_affected_if_no_named_entities_in_query
+    get "/unified_search?q=cheese"
+    assert_equal 200, last_response.status
+    assert_result_links_in_order ["/a", "/b"]
+  end
+
+  def test_queries_with_named_entities_boost_documents_containing_those_entities
+    stub_entity_extractor("cheese", ["1"])
+
+    get "/unified_search?q=cheese"
+    assert_equal 200, last_response.status
+    assert_result_links_in_order ["/b", "/a"]
+  end
+
+end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -9,6 +9,10 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   # Set BASE_FILTERS if needed to add some default filters to search.
   BASE_FILTERS = nil
 
+  def stub_entity_extractor
+    stub("entity extractor", call: [])
+  end
+
   def stub_zero_best_bets
     @metasearch_index = stub("metasearch index")
     @metasearch_index.stubs(:raw_search).returns({
@@ -72,10 +76,11 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
 
   def setup_best_bets_query(best_bets, worst_bets)
     setup_best_bets([], [])
-    @builder_without_best_bets = UnifiedSearchBuilder.new(query_options, @metasearch_index)
+    @builder_without_best_bets = UnifiedSearchBuilder.new(query_options, @metasearch_index, stub_entity_extractor)
     @query_without_best_bets = @builder_without_best_bets.payload[:query]
     setup_best_bets(best_bets, worst_bets)
-    @builder = UnifiedSearchBuilder.new(query_options, @metasearch_index)
+    @builder = UnifiedSearchBuilder.new(query_options, @metasearch_index,
+                                        stub_entity_extractor)
   end
 
   def with_base_filters(filter)
@@ -96,7 +101,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder = UnifiedSearchBuilder.new(
         query_options,
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -136,7 +142,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
         query_options(
           filters: [ text_filter("organisations", ["hm-magic"]) ],
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -166,7 +173,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
         query_options(
           filters: [ text_filter("organisations", ["hm-magic", "hmrc"]) ],
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -200,7 +208,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
             text_filter("section", ["levitation"]),
           ],
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -235,7 +244,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
         query_options(
           order: ["public_timestamp", "asc"],
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -273,7 +283,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
         query_options(
           order: ["public_timestamp", "desc"],
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -311,7 +322,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
         query_options(
           return_fields: ['title'],
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -330,7 +342,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
         query_options(
           facets: {"organisations" => 10},
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -364,7 +377,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
           filters: [ text_filter("organisations", ["hm-magic"]) ],
           facets: {"organisations" => 10},
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -397,7 +411,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
           filters: [ text_filter("section", "levitation") ],
           facets: {"organisations" => 10},
         ),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -502,12 +517,16 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     end
   end
 
+  context "" do
+  end
+
   context "search with debug disabling use of best bets" do
     setup do
       # No need to set up best bets query.
       @builder = UnifiedSearchBuilder.new(
         query_options(debug: {disable_best_bets: true}),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -521,7 +540,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder = UnifiedSearchBuilder.new(
         query_options(debug: {disable_popularity: true}),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -537,7 +557,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder = UnifiedSearchBuilder.new(
         query_options(debug: {explain: true}),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 
@@ -551,11 +572,13 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       stub_zero_best_bets
       @builder_with_synonyms = UnifiedSearchBuilder.new(
         query_options,
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
       @builder_without_synonyms = UnifiedSearchBuilder.new(
         query_options(debug: {disable_synonyms: true}),
-        @metasearch_index
+        @metasearch_index,
+        stub_entity_extractor,
       )
     end
 

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -74,13 +74,20 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     )
   end
 
+  def make_search_builder(options={})
+    UnifiedSearchBuilder.new(
+      query_options(options),
+      @metasearch_index,
+      stub_entity_extractor
+    )
+  end
+
   def setup_best_bets_query(best_bets, worst_bets)
     setup_best_bets([], [])
-    @builder_without_best_bets = UnifiedSearchBuilder.new(query_options, @metasearch_index, stub_entity_extractor)
+    @builder_without_best_bets = make_search_builder
     @query_without_best_bets = @builder_without_best_bets.payload[:query]
     setup_best_bets(best_bets, worst_bets)
-    @builder = UnifiedSearchBuilder.new(query_options, @metasearch_index,
-                                        stub_entity_extractor)
+    @builder = make_search_builder
   end
 
   def with_base_filters(filter)
@@ -99,11 +106,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "unfiltered search" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options,
-        @metasearch_index,
-        stub_entity_extractor,
-      )
+      @builder = make_search_builder
     end
 
     should "have correct 'from' parameter in payload" do
@@ -138,12 +141,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with one filter" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          filters: [ text_filter("organisations", ["hm-magic"]) ],
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        filters: [ text_filter("organisations", ["hm-magic"]) ]
       )
     end
 
@@ -169,12 +168,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with a filter with multiple options" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          filters: [ text_filter("organisations", ["hm-magic", "hmrc"]) ],
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        filters: [ text_filter("organisations", ["hm-magic", "hmrc"]) ],
       )
     end
 
@@ -201,15 +196,11 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with multiple filters" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          filters: [
-            text_filter("organisations", ["hm-magic", "hmrc"]),
-            text_filter("section", ["levitation"]),
-          ],
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        filters: [
+          text_filter("organisations", ["hm-magic", "hmrc"]),
+          text_filter("section", ["levitation"]),
+        ],
       )
     end
 
@@ -240,12 +231,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with ascending sort" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          order: ["public_timestamp", "asc"],
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        order: ["public_timestamp", "asc"],
       )
     end
 
@@ -279,12 +266,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with descending sort" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          order: ["public_timestamp", "desc"],
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        order: ["public_timestamp", "desc"],
       )
     end
 
@@ -318,12 +301,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with explicit return fields" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          return_fields: ['title'],
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        return_fields: ['title'],
       )
     end
 
@@ -338,12 +317,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with facet" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          facets: {"organisations" => 10},
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        facets: {"organisations" => 10},
       )
     end
 
@@ -372,13 +347,9 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with facet and filter on same field" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          filters: [ text_filter("organisations", ["hm-magic"]) ],
-          facets: {"organisations" => 10},
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        filters: [ text_filter("organisations", ["hm-magic"]) ],
+        facets: {"organisations" => 10},
       )
     end
 
@@ -406,13 +377,9 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with facet and filter on different field" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(
-          filters: [ text_filter("section", "levitation") ],
-          facets: {"organisations" => 10},
-        ),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        filters: [ text_filter("section", "levitation") ],
+        facets: {"organisations" => 10},
       )
     end
 
@@ -520,10 +487,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with debug disabling use of best bets" do
     setup do
       # No need to set up best bets query.
-      @builder = UnifiedSearchBuilder.new(
-        query_options(debug: {disable_best_bets: true}),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        debug: {disable_best_bets: true}
       )
     end
 
@@ -535,10 +500,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with debug disabling use of popularity" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(debug: {disable_popularity: true}),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        debug: {disable_popularity: true}
       )
     end
 
@@ -552,10 +515,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with debug explain" do
     setup do
       stub_zero_best_bets
-      @builder = UnifiedSearchBuilder.new(
-        query_options(debug: {explain: true}),
-        @metasearch_index,
-        stub_entity_extractor,
+      @builder = make_search_builder(
+        debug: {explain: true},
       )
     end
 
@@ -567,16 +528,8 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
   context "search with debug disabling use of synonyms" do
     setup do
       stub_zero_best_bets
-      @builder_with_synonyms = UnifiedSearchBuilder.new(
-        query_options,
-        @metasearch_index,
-        stub_entity_extractor,
-      )
-      @builder_without_synonyms = UnifiedSearchBuilder.new(
-        query_options(debug: {disable_synonyms: true}),
-        @metasearch_index,
-        stub_entity_extractor,
-      )
+      @builder_with_synonyms = make_search_builder
+      @builder_without_synonyms = make_search_builder(debug: {disable_synonyms: true})
     end
 
     should "not mention the query_default analyzer" do

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -517,9 +517,6 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     end
   end
 
-  context "" do
-  end
-
   context "search with debug disabling use of best bets" do
     setup do
       # No need to set up best bets query.

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -163,12 +163,16 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     end
   end
 
+  def make_searcher
+    UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
+  end
+
   context "unfiltered, unsorted search" do
 
     setup do
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
-      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
+      @searcher = make_searcher
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -220,7 +224,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     setup do
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
-      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
+      @searcher = make_searcher
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -269,7 +273,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     setup do
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
-      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
+      @searcher = make_searcher
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -318,7 +322,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     setup do
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
-      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
+      @searcher = make_searcher
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -47,6 +47,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     stub('Suggester', suggestions: ['cheese'])
   end
 
+  def stub_entity_extractor
+    stub('Entity Extractor', call: ["1", "2"])
+  end
+
   def text_filter(field_name, values)
     SearchParameterParser::TextFieldFilter.new(field_name, values)
   end
@@ -106,6 +110,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
             {filter: {term: {search_format_types: 'announcement'}}, script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"},
             {filter: {term: {organisation_state: 'closed'}}, boost: 0.3},
             {filter: {term: {organisation_state: 'devolved'}}, boost: 0.3},
+            {filter: {terms: {entities: ['1', '2']}}, boost: 20},
           ],
           score_mode: 'multiply',
         }
@@ -163,7 +168,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     setup do
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
-      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester)
+      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -215,7 +220,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     setup do
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
-      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester)
+      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -264,7 +269,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     setup do
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
-      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester)
+      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,
@@ -313,7 +318,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     setup do
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
-      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester)
+      @searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester, stub_entity_extractor)
       @combined_index.expects(:raw_search).with({
         from: 0,
         size: 20,


### PR DESCRIPTION
When a search is performed, make a call to the entity extractor service to see if any known named entities are found in the query.  If they are, boost results containing those entities.  The boost is probably much too high at present, but this is deliberate so that we can clearly see its effect.

The entity extractor is only currently enabled in preview. It is currently disabled in production and staging, so this will have no effect there.

In development, if the service isn't running this will report an error to the console, but proceed as if no entities were found, so this shouldn't make it harder to develop other applications which depend on calls to rummager.

@heathd and @rboulton paired on this.
