### PR TITLE
Add debug option to disable use of entities

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -501,6 +501,8 @@ private
         options[:disable_popularity] = true
       when "disable_synonyms"
         options[:disable_synonyms] = true
+      when "disable_entities"
+        options[:disable_entities] = true
       when "explain"
         options[:explain] = true
       else

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -19,7 +19,11 @@ class UnifiedSearchBuilder
     else
       @best_bets_checker = BestBetsChecker.new(metaindex, @query)
     end
-    @entity_extractor = entity_extractor
+    if @params[:debug][:disable_entities]
+      @entity_extractor = ->(_) { [] }
+    else
+      @entity_extractor = entity_extractor
+    end
   end
 
   def payload

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -633,4 +633,12 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     assert p.valid?
     assert_equal expected_params({debug: {disable_synonyms: true}}), p.parsed_params
   end
+
+  should "understand disable_entities in the debug parameter" do
+    p = SearchParameterParser.new("debug" => ["disable_entities"])
+
+    assert p.valid?
+    assert_equal expected_params({debug: {disable_entities: true}}), p.parsed_params
+  end
+
 end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -539,4 +539,32 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       assert_match(/query_default/, query_with_synonyms.to_s)
     end
   end
+
+  context "search with debug disabling use of entities" do
+    setup do
+      stub_zero_best_bets
+      @entity_extractor = stub("entity extractor", call: ["1"])
+    end
+
+    should "mention entities in the query if the disable_entities setting is false" do
+      builder = UnifiedSearchBuilder.new(
+        query_options(debug: {disable_entities: false}),
+        @metasearch_index,
+        @entity_extractor,
+      )
+      query = builder.payload[:query]
+      assert_match(/entities/, query.to_s)
+    end
+
+    should "not mention entities in the query if the disable_entities setting is true" do
+      builder = UnifiedSearchBuilder.new(
+        query_options(debug: {disable_entities: true}),
+        @metasearch_index,
+        @entity_extractor,
+      )
+      @entity_extractor.expects(:call).never
+      query = builder.payload[:query]
+      refute_match(/entities/, query.to_s)
+    end
+  end
 end


### PR DESCRIPTION
This allows use of entity extraction to be disabled at query time by adding `&debug=disable_entities` to the query string parameters.
