### PR TITLE
Add doctype for countryside stewardship grants

### DIFF
--- a/config/schema/default/doctypes/countryside_stewardship_grant.json
+++ b/config/schema/default/doctypes/countryside_stewardship_grant.json
@@ -1,0 +1,160 @@
+{
+  "properties": {
+    "grant_type": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false,
+      "details": {
+        "name": "Grant type",
+        "allowed_values": [
+          {
+            "label": "Option",
+            "value": "option"
+          },
+          {
+            "label": "Capital",
+            "value": "capital"
+          }
+        ]
+      }
+    },
+    "land_use": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false,
+      "details": {
+        "name": "Land use",
+        "allowed_values": [
+          {
+            "label": "Access",
+            "value": "access"
+          },
+          {
+            "label": "Arable land",
+            "value": "arable-land"
+          },
+          {
+            "label": "Boundaries",
+            "value": "boundaries"
+          },
+          {
+            "label": "Coast",
+            "value": "coast"
+          },
+          {
+            "label": "Farmland wildlife",
+            "value": "farmland-wildlife"
+          },
+          {
+            "label": "Flood risk",
+            "value": "flood-risk"
+          },
+          {
+            "label": "Grassland",
+            "value": "grassland"
+          },
+          {
+            "label": "Historic environment",
+            "value": "historic-environment"
+          },
+          {
+            "label": "Livestock management",
+            "value": "livestock-management"
+          },
+          {
+            "label": "Organic land",
+            "value": "organic-land"
+          },
+          {
+            "label": "Trees (non-woodland)",
+            "value": "trees-non-woodland)"
+          },
+          {
+            "label": "Uplands",
+            "value": "uplands"
+          },
+          {
+            "label": "Vegetation control",
+            "value": "vegetation-control"
+          },
+          {
+            "label": "Water quality",
+            "value": "water-quality"
+          },
+          {
+            "label": "Wildlife package",
+            "value": "wildlife-package"
+          },
+          {
+            "label": "Woodland",
+            "value": "woodland"
+          }
+        ]
+      }
+    },
+    "tiers_or_standalone_items": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false,
+      "details": {
+        "name": "Tiers or standalone items",
+        "allowed_values": [
+          {
+            "label": "Higher Tier",
+            "value": "higher-tier"
+          },
+          {
+            "label": "Mid Tier",
+            "value": "mid-tier"
+          },
+          {
+            "label": "Standalone capital items",
+            "value": "standalone-capital-items"
+          }
+        ]
+      }
+    },
+    "funding_per_unit_per_year": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false,
+      "details": {
+        "name": "Funding (per unit per year)",
+        "allowed_values": [
+          {
+            "label": "Up to £100",
+            "value": "up-to-100"
+          },
+          {
+            "label": "£101 to £200",
+            "value": "101-to-200"
+          },
+          {
+            "label": "£201 to £300",
+            "value": "201-to-300"
+          },
+          {
+            "label": "£301 to £400",
+            "value": "301-to-400"
+          },
+          {
+            "label": "£401 to £500",
+            "value": "401-to-500"
+          },
+          {
+            "label": "More than £500",
+            "value": "more-than-500"
+          },
+          {
+            "label": "Up to 50% actual costs",
+            "value": "up-to-50-actual-costs"
+          },
+          {
+            "label": "More than 50% actual costs",
+            "value": "more-than-50-actual-costs"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a Finder which be published by DEFRA editors from Specialist Publisher. It has `grant_type`, `land_use`, `tiers_or_standalone_items` and `funding_per_unit_per_year` as search facets.
