### PR TITLE
Support filtering to docs with no value in a field

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -141,6 +141,9 @@ class BaseParameterParser
     title
   )
 
+  # A special value used to filter for missing fields.
+  MISSING_FIELD_SPECIAL_VALUE = "_MISSING"
+
   attr_reader :parsed_params, :errors
 
   def valid?
@@ -389,11 +392,12 @@ private
   end
 
   class Filter
-    attr_reader :field_name, :values, :errors
+    attr_reader :field_name, :include_missing, :values, :errors
 
     def initialize(field_name, values)
       @field_name = field_name
-      @values = Array(values)
+      @include_missing = values.include? BaseParameterParser::MISSING_FIELD_SPECIAL_VALUE
+      @values = Array(values).reject { |value| value == BaseParameterParser::MISSING_FIELD_SPECIAL_VALUE }
       @errors = []
     end
 

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -27,7 +27,7 @@ class MultiIndexTest < IntegrationTest
       if index_name == "government_test"
         add_field_to_mappings("public_timestamp", "date")
       end
-      add_field_to_mappings("topics")
+      add_field_to_mappings("specialist_sectors")
       add_field_to_mappings("section")
       create_test_index(index_name)
     end
@@ -53,7 +53,7 @@ class MultiIndexTest < IntegrationTest
       }
       fields["section"] = ["#{i}"]
       if i % 2 == 0
-        fields["topics"] = ["farming"]
+        fields["specialist_sectors"] = ["farming"]
       end
       if short_index_name == "government"
         fields["public_timestamp"] = "#{i+2000}-01-01T00:00:00"

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -55,11 +55,35 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal links, ["/detailed-1", "/government-1", "/mainstream-1"], links
   end
 
+  def test_can_filter_for_missing_section_field
+    get "/unified_search?filter_specialist_sectors=_MISSING"
+    assert last_response.ok?
+    links = parsed_response["results"].map do |result|
+      result["link"]
+    end
+    links.sort!
+    assert_equal ["/detailed-1", "/government-1", "/mainstream-1"], links
+  end
+
+  def test_can_filter_for_missing_or_specific_value_section_field
+    get "/unified_search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
+    assert last_response.ok?
+    links = parsed_response["results"].map do |result|
+      result["link"]
+    end
+    links.sort!
+    assert_equal [
+      "/detailed-1", "/detailed-2",
+      "/government-1", "/government-2",
+      "/mainstream-1", "/mainstream-2",
+    ], links
+  end
+
   def test_only_contains_fields_which_are_present
     get "/unified_search?q=important&order=public_timestamp"
     results = parsed_response["results"]
-    refute_includes results[0].keys, "topics"
-    assert_equal ["farming"], results[1]["topics"]
+    refute_includes results[0].keys, "specialist_sectors"
+    assert_equal [{"slug"=>"farming"}], results[1]["specialist_sectors"]
   end
 
   def test_facet_counting
@@ -173,7 +197,7 @@ class UnifiedSearchTest < MultiIndexTest
       "indexable_content" => "Mergers of cheeses and faces",
       "_type" => "cma_case",
       "tags" => [],
-      "topics" => ["farming"],
+      "specialist_sectors" => ["farming"],
       "section" => ["1"],
       "opened_date" => "2014-04-01",
     }

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -208,7 +208,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
     should "have correct filter" do
       assert_equal(
         @builder.filters_hash,
-        {"and" => [
+        {:and => [
           {"terms" => {"organisations" => ["hm-magic", "hmrc"]}},
           {"terms" => {"section" => ["levitation"]}},
           BASE_FILTERS,


### PR DESCRIPTION
This adds support for a "special" value of `_MISSING` which can be
specified in a filter to cause documents which have no value in the
filter field to be returned.  For example:

```
filter_specialist_sectors=_MISSING
```

would filter the search results to include only those documents which
have no value in the `specialist_sectors` field.

It can be combined with searches for actual values. eg parameters of:

```
filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming
```

would return documents which either had no value, or had a value of
`farming`.

This is primarily of use when using the search index to inspect the
contents of the index, for example using the
[content-explorer](https://github.com/alphagov/govuk-content-explorer)
tool.

The code changes are fairly straightforward.  I've added tests for
parameter parsing, and an integration test to ensure that the generated
searches work correctly.

I've also renamed the field `topics` in some existing tests (and
corresponding fixture generation code) to `specialist_sectors`, because
`topics` isn't actually a field which filtering is allowed on in our
live schema, but specialist_sectors is.
