### PR TITLE
Allow the scope of facets to be controlled

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -545,6 +545,7 @@ private
 
     @parsed_params = {
       requested: requested,
+      scope: scope,
       order: order,
       examples: examples,
       example_fields: example_fields,
@@ -578,6 +579,30 @@ private
       end
     end
     params
+  end
+
+  # The scope of the facet.
+  #
+  # Defaults to "exclude_field_filter", meaning that facet values should be
+  # calculated as if no filters are applied to the field the facet is for.
+  # This is appropriate for populating multi-select facet filter boxes, to
+  # allow other facet values to be chosen.
+  #
+  # May also be 'all_filters", to mean that facet values should be calculated
+  # after applying all filters - ie, just on the documents which will be
+  # included in the result set.
+  def scope
+    value = single_param("scope", facet_description)
+    if value.nil?
+      :exclude_field_filter
+    elsif value == "all_filters"
+      :all_filters
+    elsif value == "exclude_field_filter"
+      :exclude_field_filter
+    else
+      @errors << %{"#{value}" is not a valid scope option#{facet_description}}
+      nil
+    end
   end
 
   def order

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -232,7 +232,7 @@ class UnifiedSearchBuilder
       return nil
     end
     result = {}
-    facets.each do |field_name, _|
+    facets.each do |field_name, options|
       facet_hash = {
         terms: {
           field: field_name,
@@ -244,7 +244,11 @@ class UnifiedSearchBuilder
           size: 100000,
         }
       }
-      facet_filter = filters_hash([field_name])
+      if options[:scope] == :exclude_field_filter
+        facet_filter = filters_hash([field_name])
+      elsif options[:scope] == :all_filters
+        facet_filter = filters_hash([])
+      end
       unless facet_filter.nil?
         facet_hash[:facet_filter] = facet_filter
       end

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -171,6 +171,7 @@ private
         documents_with_no_value: facet_info["missing"],
         total_options: options.length,
         missing_options: [options.length - facet_parameters[:requested], 0].max,
+        scope: facet_parameters[:scope],
       }
     end
     result

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -99,8 +99,21 @@ class UnifiedSearchTest < MultiIndexTest
         "documents_with_no_value" => 0,
         "total_options" => 2,
         "missing_options" => 0,
+        "scope" => "exclude_field_filter",
       }
     }, facets)
+  end
+
+  def test_facet_counting_with_filter_on_field_and_exclude_field_filter_scope
+    get "/unified_search?q=important&facet_section=2"
+    assert_equal 6, parsed_response["total"]
+    facets_without_filter = parsed_response["facets"]
+
+    get "/unified_search?q=important&facet_section=2&filter_section=1"
+    assert_equal 3, parsed_response["total"]
+    facets_with_filter = parsed_response["facets"]
+
+    assert_equal(facets_with_filter, facets_without_filter)
   end
 
   def test_facet_counting_missing_options
@@ -115,6 +128,25 @@ class UnifiedSearchTest < MultiIndexTest
         "documents_with_no_value" => 0,
         "total_options" => 2,
         "missing_options" => 1,
+        "scope" => "exclude_field_filter",
+      }
+    }, facets)
+  end
+
+  def test_facet_counting_with_filter_on_field_and_all_filters_scope
+    get "/unified_search?q=important&facet_section=2,scope:all_filters&filter_section=1"
+    assert_equal 3, parsed_response["total"]
+    facets = parsed_response["facets"]
+
+    assert_equal({
+      "section" => {
+        "options" => [
+          {"value"=>{"slug"=>"1"}, "documents"=>3},
+        ],
+        "documents_with_no_value" => 0,
+        "total_options" => 1,
+        "missing_options" => 0,
+        "scope" => "all_filters",
       }
     }, facets)
   end

--- a/test/unit/search_parameter_parser_test.rb
+++ b/test/unit/search_parameter_parser_test.rb
@@ -19,6 +19,7 @@ class SearchParameterParserTest < ShouldaUnitTestCase
   def expected_facet_params(params)
     {
       requested: 0,
+      scope: :exclude_field_filter,
       order: BaseParameterParser::DEFAULT_FACET_SORT,
       examples: 0,
       example_fields: BaseParameterParser::DEFAULT_FACET_EXAMPLE_FIELDS,
@@ -555,6 +556,29 @@ class SearchParameterParserTest < ShouldaUnitTestCase
           requested: 10,
           order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
       })}}), p.parsed_params)
+  end
+
+  should "understand the scope option in facet parameters" do
+    p = SearchParameterParser.new("facet_organisations" => ["10,scope:all_filters"])
+
+    assert_equal("", p.error)
+    assert p.valid?
+    assert_equal(expected_params({
+      facets: {
+        "organisations" => expected_facet_params({
+          requested: 10,
+          scope: :all_filters,
+        })
+      }
+    }), p.parsed_params)
+  end
+
+  should "complain about invalid scope options in facet parameters" do
+    p = SearchParameterParser.new("facet_organisations" => ["10,scope:unknown"])
+
+    assert_equal(%{"unknown" is not a valid scope option in facet "organisations"}, p.error)
+    assert !p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
   end
 
   should "complain about a repeated examples option" do

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -357,7 +357,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         query: "cheese",
         filters: {},
         return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        facets: {"organisations" => {requested: 1, examples: 0, example_fields: [], order: SearchParameterParser::DEFAULT_FACET_SORT}},
+        facets: {"organisations" => {requested: 1, examples: 0, example_fields: [], order: SearchParameterParser::DEFAULT_FACET_SORT, scope: :exclude_field_filter}},
         debug: {},
       })
     end
@@ -394,6 +394,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     should "include number of documents with no value" do
       facet = @results[:facets]["organisations"]
       assert_equal(7, facet[:documents_with_no_value])
+    end
+
+    should "include requested facet scope" do
+      facet = @results[:facets]["organisations"]
+      assert_equal(:exclude_field_filter, facet[:scope])
     end
   end
 


### PR DESCRIPTION
Currently, when we compute the possible options to include in a facet
field, we ask elasticsearch to add up totals for all documents which
match both the query and "most" of the filters.  Specifically, we
exclude any filters which are set on the field that we're asking for
facet options for.

This is a good default when we're using faceting to populate a
multi-select facet box (such as in our finder interfaces).  However,
it's not a good default if we're trying to provide navigation options
within documents in a subset of the site.  This is exposed, for example,
in the "content explorer" app at
http://govuk-content-explorer.herokuapp.com/ which uses the facets in
the search API to provided details of the variety of options: in that
app, when a filter is applied to a field, it's unhelpful and confusing
that the facet options for that field are calculated without the filter
having been applied.

This PR adds an option to the facet parameters to allow the scope of the
requested facet to be set to either "exclude_field_filter" (the default,
and the current behaviour), or "all_filters" to cause all filters to be
applied when calculating facet options.

For example, if there's no search, but there is a filter on
`organisations` of `hm-revenue-customs`, when requesting a facet on the
`organisations` field the default behaviour would be to return all
possible values of `organisations` in the facet result.  With `scope`
set to `all_filters`, the behaviour would be to return only
organisations for which there is some content tagged to both that
organisation and to `hm-revenue-customs`.

This interface is designed such that other options could be added in
future if desired (a plausible one is "no_filters" to compute facets
only on the "query" part of the search).

For more on the concept of facet scopes, see
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets.html#_scope
