### PR TITLE
Populate `format` field for all documents

### DIFF
--- a/config/schema/default/core.json
+++ b/config/schema/default/core.json
@@ -3,6 +3,11 @@
     "enabled": true
   },
   "properties": {
+    "format": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false
+    },
     "title": {
       "type": "string",
       "index": "analyzed"

--- a/config/schema/default/doctypes/edition.json
+++ b/config/schema/default/doctypes/edition.json
@@ -1,10 +1,5 @@
 {
   "properties": {
-    "format": {
-      "type": "string",
-      "index": "not_analyzed",
-      "include_in_all": false
-    },
     "section": {
       "type": "string",
       "index": "not_analyzed",

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -478,6 +478,7 @@ module Elasticsearch
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_mainstream_browse_page_field(doc_hash)
         doc_hash = prepare_tag_field(doc_hash)
+        doc_hash = prepare_format_field(doc_hash)
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
@@ -523,6 +524,14 @@ module Elasticsearch
       tags.concat(Array(doc_hash["specialist_sectors"]).map { |sector| "sector:#{sector}" })
 
       doc_hash.merge("tags" => tags)
+    end
+
+    def prepare_format_field(doc_hash)
+      if doc_hash["format"].nil?
+        doc_hash.merge("format" => doc_hash["_type"])
+      else
+        doc_hash
+      end
     end
 
     # If a document is a best bet, and is using the stemmed_query field, we

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -144,7 +144,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":1.0,"tags":[]}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":1.0,"tags":[],"format":"edition"}
     eos
     response = <<-eos
 {"took":5,"items":[
@@ -172,7 +172,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"not_an_edition","_id":"some_id"}}
-{"_type":"not_an_edition","_id":"some_id","title":"TITLE ONE","link":"/a/link","popularity":1.0,"tags":[]}
+{"_type":"not_an_edition","_id":"some_id","title":"TITLE ONE","link":"/a/link","popularity":1.0,"tags":[],"format":"not_an_edition"}
   eos
     response = <<-eos
 {"took":5,"items":[
@@ -193,7 +193,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":1.0,"tags":[]}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":1.0,"tags":[],"format":"edition"}
     eos
     stub_request(:post, "http://example.com:9200/test-index/_bulk").with(
         body: payload,
@@ -245,7 +245,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0,"tags":[]}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0,"tags":[],"format":"edition"}
 eos
     response = <<-eos
 {"took":5,"items":[
@@ -275,7 +275,7 @@ eos
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","specialist_sectors":["oil-and-gas/licensing","oil-and-gas/onshore-oil-and-gas"],"organisations":["hm-magic"],"popularity":1.0,"tags":["organisation:hm-magic","sector:oil-and-gas/licensing","sector:oil-and-gas/onshore-oil-and-gas"]}
+{"_type":"edition","link":"/foo/bar","specialist_sectors":["oil-and-gas/licensing","oil-and-gas/onshore-oil-and-gas"],"organisations":["hm-magic"],"popularity":1.0,"tags":["organisation:hm-magic","sector:oil-and-gas/licensing","sector:oil-and-gas/onshore-oil-and-gas"],"format":"edition"}
     eos
     response = <<-eos
 {"took":5,"items":[
@@ -304,7 +304,7 @@ eos
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","section":"benefits","subsection":"entitlement","popularity":1.0,"mainstream_browse_pages":["benefits/entitlement"],"tags":[]}
+{"_type":"edition","link":"/foo/bar","section":"benefits","subsection":"entitlement","popularity":1.0,"mainstream_browse_pages":["benefits/entitlement"],"tags":[],"format":"edition"}
     eos
     response = <<-eos
 {"took":5,"items":[


### PR DESCRIPTION
For non-edition document types, we've not been setting a value for the
`format` field.  This makes various things awkward (analysis, switching
presenters based on a document type but falling back to switching on
format, etc.).  We even have code in the frontend to handle the missing
`format` field by using the `document_type` value when it's missing: https://github.com/alphagov/frontend/blob/master/app/presenters/non_edition_result.rb#L12

Instead, add `format` to the "core" fields (ie, defined for every
document type), and set the value of `format` for any non-edition
document type to be the same as the document type.  As we evolve the
index to avoid having a monolithic "edition" type we'll keep updating
this field, until when we finally remove the edition type in favour of
separate document types for each format, the format field will always
have the same value as the document type.  At that point, we'll remove
the `format` field in favour of using the document type.

Note on testing: I considered adding a specific test case for this to
the `test/unit/elasticsearch_index_test.rb`, but decided against it at
present.  This test file needed to be altered in several places to
expect the correct value in the format field, so the code is covered.
However, `test/unit/elasticsearch_index_test.rb` is a very crufty file
which is in heavy need of refactoring - adding a test to this file
wouldn't increase coverage, but would make it harder to refactor the
test file.
