### PR TITLE
Add policies attr to core doctype

### DIFF
--- a/config/schema/default/core.json
+++ b/config/schema/default/core.json
@@ -39,6 +39,11 @@
       "index": "not_analyzed",
       "include_in_all": false
     },
+    "policies": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false
+    },
     "mainstream_browse_pages": {
       "type": "string",
       "index": "not_analyzed",


### PR DESCRIPTION
As we want content to be tagged to Policies, this commit adds the policies attribute to the core doctype.
