### PR TITLE
Add policies to government index schema

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -106,6 +106,7 @@ mappings:
         organisations: { type: string, index: not_analyzed, include_in_all: false }
         organisation_state: { type: string, index: not_analyzed, include_in_all: false }
         people: { type: string, index: not_analyzed, include_in_all: false }
+        policies: { type: string, index: not_analyzed, include_in_all: false }
         popularity: { type: float, stored: true }
         public_timestamp: { type: date, index: not_analyzed, include_in_all: false }
         relevant_to_local_government: { type: boolean, index: not_analyzed, include_in_all: false }


### PR DESCRIPTION
This is related to the work in 01c76dd. The commit changes the elasticsearch schema to include the new Policies attr.
