### PR TITLE
Add policies to allowed filters

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -19,6 +19,7 @@ class BaseParameterParser
     mainstream_browse_pages
     manual
     organisations
+    policies
     section
     specialist_sectors
   )
@@ -36,6 +37,7 @@ class BaseParameterParser
     mainstream_browse_pages
     manual
     organisations
+    policies
     section
     specialist_sectors
   )
@@ -98,6 +100,7 @@ class BaseParameterParser
     manual
     organisation_state
     organisations
+    policies
     public_timestamp
     section
     slug


### PR DESCRIPTION
With the policy finder, we need to be able to filter by the policies attr. This commit adds it to the `ALLOWED_FILTER_FIELDS` array so we can use it.
