### PR TITLE
Elasticsearch upgrade

### DIFF
--- a/lib/elasticsearch/index_group.rb
+++ b/lib/elasticsearch/index_group.rb
@@ -54,7 +54,7 @@ module Elasticsearch
       # Response of the form:
       #   { "index_name" => { "aliases" => { "a1" => {}, "a2" => {} } }
       aliased_indices = indices.select { |name, details|
-        details["aliases"].include? @name
+        details.fetch("aliases", {}).include? @name
       }
 
       # For any existing indices with this alias, remove the alias
@@ -103,7 +103,7 @@ module Elasticsearch
 
     def clean
       alias_map.each do |name, details|
-        delete(name) if details["aliases"].empty?
+        delete(name) if details.fetch("aliases", {}).empty?
       end
     end
 

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -447,7 +447,7 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
             should: [
               @query_without_best_bets,
               {
-                custom_boost_factor: {
+                function_score: {
                   query: {
                     ids: { values: ["/foo"] },
                   },
@@ -473,13 +473,13 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
             should: [
               @query_without_best_bets,
               {
-                custom_boost_factor: {
+                function_score: {
                   query: { ids: { values: ["/foo"] }, },
                   boost_factor: 2000000,
                 }
               },
               {
-                custom_boost_factor: {
+                function_score: {
                   query: { ids: { values: ["/bar"] }, },
                   boost_factor: 1000000,
                 }
@@ -533,10 +533,13 @@ class UnifiedSearcherBuilderTest < ShouldaUnitTestCase
       )
     end
 
-    should "have not have a custom_score clause to add popularity in payload" do
+    should "have not have a function_score clause to add popularity in payload" do
       query = @builder.payload[:query]
       refute_match(/popularity/, query.to_s)
-      assert query[:indices][:query][:custom_boost_factor][:query].keys == [:custom_filters_score]
+      assert_equal(
+        query[:indices][:query][:function_score][:query].keys,
+        [:function_score]
+      )
     end
   end
 

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -59,9 +59,11 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   end
 
   BASE_CHEESE_QUERY = {
-    custom_score: {
+    function_score: {
+      boost_mode: :multiply,
       query: {
-        custom_filters_score: {
+        function_score: {
+          boost_mode: :multiply,
           query: {bool: {
             should: [
               {bool: {
@@ -93,24 +95,28 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
               },
             ]
           }},
-          filters: [
-            {filter: {term: {format: 'smart-answer'}}, boost: 1.5},
-            {filter: {term: {format: 'transaction'}}, boost: 1.5},
-            {filter: {term: {format: 'topical_event'}}, boost: 1.5},
-            {filter: {term: {format: 'minister'}}, boost: 1.7},
-            {filter: {term: {format: 'organisation'}}, boost: 2.5},
-            {filter: {term: {format: 'topic'}}, boost: 1.5},
-            {filter: {term: {format: 'document_series'}}, boost: 1.3},
-            {filter: {term: {format: 'document_collection'}}, boost: 1.3},
-            {filter: {term: {format: 'operational_field'}}, boost: 1.5},
-            {filter: {term: {search_format_types: 'announcement'}}, script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"},
-            {filter: {term: {organisation_state: 'closed'}}, boost: 0.3},
-            {filter: {term: {organisation_state: 'devolved'}}, boost: 0.3},
+          functions: [
+            {filter: {term: {format: 'smart-answer'}}, boost_factor: 1.5},
+            {filter: {term: {format: 'transaction'}}, boost_factor: 1.5},
+            {filter: {term: {format: 'topical_event'}}, boost_factor: 1.5},
+            {filter: {term: {format: 'minister'}}, boost_factor: 1.7},
+            {filter: {term: {format: 'organisation'}}, boost_factor: 2.5},
+            {filter: {term: {format: 'topic'}}, boost_factor: 1.5},
+            {filter: {term: {format: 'document_series'}}, boost_factor: 1.3},
+            {filter: {term: {format: 'document_collection'}}, boost_factor: 1.3},
+            {filter: {term: {format: 'operational_field'}}, boost_factor: 1.5},
+            {filter: {term: {search_format_types: 'announcement'}}, script_score: {
+              script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+            }},
+            {filter: {term: {organisation_state: 'closed'}}, boost_factor: 0.3},
+            {filter: {term: {organisation_state: 'devolved'}}, boost_factor: 0.3},
           ],
           score_mode: 'multiply',
         }
       },
-      script: "_score * (doc['popularity'].value + #{UnifiedSearchBuilder::POPULARITY_OFFSET})"
+      script_score: {
+        script: "doc['popularity'].value + #{UnifiedSearchBuilder::POPULARITY_OFFSET}"
+      },
     }
   }
 
@@ -118,7 +124,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     indices: {
       indices: [:government],
       query: {
-        custom_boost_factor: {
+        function_score: {
           query: BASE_CHEESE_QUERY,
           boost_factor: 0.4
         }


### PR DESCRIPTION
I'd like to upgrade to a recent elasticsearch release fairly soon.  This PR contains some of the changes needed to make rummager work with both the current elasticsearch 0.90 release, and with the elasticsearch 1.x release series.  Other changes are required, but are harder to make work compatibly. I'd like to get these merged first before diving into them.

The results of searches in rummager should be identical before and after these changes.  I've verified this by comparing searches on my VM, but can't see any easy way to make an automated test of this (other than the existing testsuite), without doing really fragile things like encoding expected scores into the testsuite.

The changes are described fully in the individual commits, but consist of handling a change to the response type from the `/_aliases` endpoint, and switching some deprecated query types to newer equivalents.
