### PR TITLE
Fix cache lifetime for specialist sector registry

### DIFF
--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -5,7 +5,7 @@ module Registry
     CACHE_LIFETIME = 12 * 3600  # 12 hours
 
     def initialize(index, format, fields = %w{slug link title}, clock = Time)
-      @cache = TimedCache.new(CACHE_LIFETIME, clock) { fetch }
+      @cache = TimedCache.new(self.class::CACHE_LIFETIME, clock) { fetch }
       @fields = fields
       @format = format
       @index = index
@@ -75,7 +75,7 @@ module Registry
   end
 
   class SpecialistSector < BaseRegistry
-    CACHE_LIFETIME_SECONDS = 300
+    CACHE_LIFETIME = 300
 
     def initialize(index)
       super(index, "specialist_sector", %w{link title})

--- a/test/unit/specialist_sector_registry_test.rb
+++ b/test/unit/specialist_sector_registry_test.rb
@@ -50,4 +50,10 @@ class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
       .once
     assert @specialist_sector_registry["oil-and-gas/licensing"]
   end
+
+  def test_uses_300_second_cache_lifetime
+    TimedCache.expects(:new).with(300, anything)
+
+    Registry::SpecialistSector.new(@index)
+  end
 end


### PR DESCRIPTION
Due to a misnamed constant, and ruby's scoping, the reduced lifetime for
this registry wasn't being picked up.

This bug crept in with isome refactoring in #353 because the reduced
cache lifetime wasn't actually tested anywhere.  This adds a test for
it.
