### PR TITLE
Always configure the location field the same way

### DIFF
--- a/config/schema/default/doctypes/aaib_report.json
+++ b/config/schema/default/doctypes/aaib_report.json
@@ -82,7 +82,7 @@
     },
     "location": {
       "type": "string",
-      "index": "analyzed"
+      "index": "not_analyzed"
     }
   }
 }


### PR DESCRIPTION
The "location" field is defined in three doctypes currently:
aaib_report, european_structural_investment_fund and
international_development_fund.  In two of these cases, it is defined as
not_analyzed, but in the aaib_report case it is defined as analyzed.

It will be much easier to make elasticsearch behave usefully if all our
fields have the same configuration (for example, if we attempted to
compute a facet across the location field currently, we'd get exact
values back from the ESI and IDF documents which could be passed into a
terms filter, but would get individual tokenised and stemmed words back
from the AAIB documents which wouldn't work in such a filter).

Fortunately, the AAIB location field is currently not being searched on
at all: it's only being used for display.  Therefore, this PR changes
the schema so that the "not_analyzed" value is used for all "location"
fields, and this should have no effect on searches.
