### PR TITLE
Temporarily remove 'death' synonym

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -33,7 +33,7 @@ synonyms: [
   # "car, vehicle",
   "car tax bands, vehicle tax rates",
   # "copyright => copyright, intellectual property",
-  "death, bereavement",
+  # "death, bereavement",
   "emissions, pollution",
   # "fees, costs, prices",
   "hazardous substances, dangerous substances",


### PR DESCRIPTION
This synonym causes missing search results, due to the current search configuration: if you search for ‘death’ it only matches content that contains ‘death’ AND ‘bereavement’ rather than ‘death’ OR ‘bereavement’. So we need to disable it for now, until we can improve how synonyms work.
