### PR TITLE
Update cma_case.json

### DIFF
--- a/config/schema/default/doctypes/cma_case.json
+++ b/config/schema/default/doctypes/cma_case.json
@@ -242,7 +242,7 @@
             "value": "mergers-phase-1-found-not-to-qualify"
           },
           {
-            "label": "Mergers - phase 1 public interest interventions",
+            "label": "Mergers - phase 1 public interest intervention",
             "value": "mergers-phase-1-public-interest-interventions"
           },
           {


### PR DESCRIPTION
Removing inaccurate pluralisation of "interventions" to "intervention" in 'Mergers - phase 1 public interest interventions', as requested by Competition and Markets Authority.
