### PR TITLE
Reduce prominence of contacts in search results

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -384,6 +384,7 @@ class UnifiedSearchBuilder
       "document_series"   => 1.3,
       "document_collection" => 1.3,
       "operational_field" => 1.5,
+      "contact"           => 0.3,
     }
   end
 

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -105,6 +105,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
             {filter: {term: {format: 'document_series'}}, boost_factor: 1.3},
             {filter: {term: {format: 'document_collection'}}, boost_factor: 1.3},
             {filter: {term: {format: 'operational_field'}}, boost_factor: 1.5},
+            {filter: {term: {format: 'contact'}}, boost_factor: 0.3},
             {filter: {term: {search_format_types: 'announcement'}}, script_score: {
               script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
             }},


### PR DESCRIPTION
Documents of format "contact" tend to be short, and as a result get
higher weights than seem to be useful for searches which match them.
Reduce their prominence accordingly, to give the direct content on that
subject a chance to be shown first.

We've tested the effect of this with the top searches for which contact format items were coming up, and the contact pages are still present in search but with a more appropriate (slightly lower) ranking.
