### PR TITLE
Add a doctype for policies

### DIFF
--- a/config/schema/default/doctypes/policy.json
+++ b/config/schema/default/doctypes/policy.json
@@ -1,0 +1,3 @@
+{
+  "properties": {}
+}


### PR DESCRIPTION
This commit adds a doctype file for policies. It contains no additional properties and is published by Policy Publisher. [Ticket](https://trello.com/c/TvQngvWL/70-add-policies-to-rummager).
