### PR TITLE
Add a Procfile for starting the sidekiq worker.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,7 @@
+---
+:concurrency:  2
+:require: ./bootstrap_worker.rb
+:logfile: ./log/sidekiq.log
+:queues:
+  - default
+  - failed

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -1,7 +1,6 @@
 namespace :jobs do
 
   task :work do
-    base_path = File.join(File.dirname(__FILE__), "../..")
-    exec("bundle exec sidekiq -c 2 -q default -q failed -r #{base_path}/bootstrap_worker.rb")
+    exec("bundle exec sidekiq -C ./config/sidekiq.yml")
   end
 end


### PR DESCRIPTION
This will allow us to switch from the deprecated
`govuk::app::delayed_job::worker` class in puppet to the more generic
`govuk::app::procfile::worker` class.
