### PR TITLE
Only override redis namespace in tests.

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,10 +2,10 @@ require "sidekiq"
 
 redis_config_hash = YAML.load_file("config/redis.yml").symbolize_keys
 
-if ENV["RACK_ENV"]
+if ENV["RACK_ENV"] == "test"
   namespace = "#{redis_config_hash[:namespace]}-#{ENV['RACK_ENV']}"
 else
-  namespace = "#{redis_config_hash[:namespace]}"
+  namespace = redis_config_hash[:namespace]
 end
 
 redis_config = {


### PR DESCRIPTION
This config was added in 6abaf7f to avoid any overspill development and
testing.  The problem is that we're not using the environment suffix in
production at the moment, therefore if this was deployed as is, it would
lose any jobs currently in the queue when the prefix was changed.

This hasn't been a problem up to now because we're overwriting this
initializer at deploy time.  In future, we'll move to only overwriting
the `redis.yml` file instead.
