### PR TITLE
Add policy type to mainstream index

### DIFF
--- a/config/schema/indexes/mainstream.json
+++ b/config/schema/indexes/mainstream.json
@@ -14,6 +14,7 @@
     "manual",
     "manual_section",
     "medical_safety_alert",
+    "policy",
     "raib_report"
   ]
 }


### PR DESCRIPTION
Rummager now validates that all document types being added to the index
are actually configured when indexing (or running a migrate_index);
`policy` documents got added to the mainstream index since I set up the
list of valid document formats in the schema.
