### PR TITLE
Correct regexes used to identify schema files

### DIFF
--- a/lib/schema/document_types.rb
+++ b/lib/schema/document_types.rb
@@ -125,7 +125,7 @@ private
 
   def document_type_paths
     Dir.new(File.join(config_path, "document_types")).select { |filename|
-      filename =~ /\A[a-z]+(_[a-z]+)*\.json\z/
+      filename =~ /\A[a-z][_a-z]*\.json\z/
     }.map { |filename|
       [
         filename.sub(/.json$/, ''),

--- a/lib/schema/index_schema.rb
+++ b/lib/schema/index_schema.rb
@@ -88,7 +88,7 @@ private
 
   def self.index_schema_paths(config_path)
     Dir.new(File.join(config_path, "indexes")).select { |filename|
-      filename =~ /\A[a-z]+(_[a-z]+)*\.json\z/
+      filename =~ /\A[a-z][-a-z]*\.json\z/
     }.map { |filename|
       [
         filename.sub(/.json$/, ''),


### PR DESCRIPTION
The service-manual configuration file wasn't matching the regex used to
identify `index_schema` JSON files.  This commit fixes this regex, and
also tidies both it and the `document_type` regex up:
- indexes must start with a letter, followed by letters and hyphens.
- document_types must start with a letter, followed by letters and
  underscores.
