### PR TITLE
Report the error messages in bulk indexing

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -19,9 +19,9 @@ module Elasticsearch
   class BulkIndexFailure < RuntimeError
     attr_reader :failed_keys
 
-    def initialize(failed_keys)
-      super "Failed inserts: #{failed_keys.join(', ')}"
-      @failed_keys = failed_keys
+    def initialize(failed_items)
+      super "Failed inserts: #{failed_items.map { |id, error| "#{id} (#{error})" }.join(', ')}"
+      @failed_keys = failed_items.map { |id, _| id }
     end
   end
 
@@ -170,7 +170,12 @@ module Elasticsearch
           # TODO This error should include the error messages from
           # elasticsearch, not just the IDs of the documents that weren't
           # inserted
-          raise BulkIndexFailure.new(failed_items.map { |item| item["index"]["_id"] })
+          raise BulkIndexFailure.new(failed_items.map { |item|
+            [
+              item["index"]["_id"],
+              item["index"]["error"],
+            ]
+          })
         end
       end
       response

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -225,7 +225,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       @wrapper.add(documents)
       flunk("No exception raised")
     rescue Elasticsearch::BulkIndexFailure => e
-      assert_equal "Failed inserts: /foo/baz", e.message
+      assert_equal "Failed inserts: /foo/baz (stuff)", e.message
       assert_equal ["/foo/baz"], e.failed_keys
     end
   end


### PR DESCRIPTION
When an error happens with bulk indexing, we currently report the IDs of
the documents which failed, but not the corresponding message.  We're
currently getting such an error report in preview, with no indication of
what is actually going wrong.

This commit adds the error message to the report.
