### PR TITLE
Replace the FieldDefinitions object with a hash

### DIFF
--- a/lib/schema/document_types.rb
+++ b/lib/schema/document_types.rb
@@ -37,7 +37,10 @@ class DocumentTypeParser
     end
 
     fields = Hash[field_names.map { |field_name|
-      [field_name, field_definitions.get(field_name)]
+      field_definition = field_definitions.fetch(field_name) do
+        raise_error(%{Undefined field "#{field_name}"})
+      end
+      [field_name, field_definition]
     }]
 
     add_allowed_values_to_field_definitions(fields, allowed_values)
@@ -103,7 +106,7 @@ class DocumentTypesParser
   end
 
   def parse
-    @field_definitions = FieldDefinitions.parse(config_path)
+    @field_definitions = FieldDefinitionParser.new(config_path).parse
 
     Hash[document_type_paths.map { |document_type, file_path|
       [

--- a/test/unit/schema/document_types_test.rb
+++ b/test/unit/schema/document_types_test.rb
@@ -77,13 +77,20 @@ class DocumentTypesTest < ShouldaUnitTestCase
 
   context "when configuration is invalid" do
     setup do
-      @definitions = FieldDefinitions.parse(File.expand_path('../../../config/schema', File.dirname(__FILE__)))
+      @definitions = FieldDefinitionParser.new(File.expand_path('../../../config/schema', File.dirname(__FILE__))).parse
       @parser = DocumentTypeParser.new("/config/path/doc_type.json", nil, @definitions)
     end
 
     should "fail if document type doesn't specify `fields`" do
       DocumentTypeParser.any_instance.stubs(:load_json).returns({})
       assert_raises_message(%{Missing "fields", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
+    end
+
+    should "fail if document type specifies unknown entries in `fields`" do
+      DocumentTypeParser.any_instance.stubs(:load_json).returns({
+        "fields" => ["unknown_field"],
+      })
+      assert_raises_message(%{Undefined field \"unknown_field\", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
 
     should "fail if document type has an unknown property" do

--- a/test/unit/schema/field_definitions_test.rb
+++ b/test/unit/schema/field_definitions_test.rb
@@ -5,34 +5,27 @@ class FieldDefinitionsTest < ShouldaUnitTestCase
 
   context "after loading definitions" do
     setup do
-      @definitions = FieldDefinitions.parse(File.expand_path('../../../config/schema', File.dirname(__FILE__)))
+      @definitions = FieldDefinitionParser.new(File.expand_path('../../../config/schema', File.dirname(__FILE__))).parse
     end
 
     should "recognise the `link` field definition" do
-      assert_equal "link", @definitions.get("link").name
+      assert_equal "link", @definitions["link"].name
     end
 
     should "know that the `link` field has type `identifier`" do
-      assert_equal "identifier", @definitions.get("link").type.name
+      assert_equal "identifier", @definitions["link"].type.name
     end
 
     should "know that the `link` field has a description" do
-      refute @definitions.get("link").description.empty?
+      refute @definitions["link"].description.empty?
     end
 
     should "know that the `link` field has no children" do
-      assert @definitions.get("link").children.nil?
+      assert @definitions["link"].children.nil?
     end
 
     should "know that the `attachments` field has a child of `title` of type searchable_text" do
-      assert_equal "searchable_text", @definitions.get("attachments").children.get("title").type.name
-    end
-
-    should "raise an error for unknown fields" do
-      exc = assert_raises(RuntimeError) do
-        @definitions.get("unknown")
-      end
-      assert_equal %{Undefined field "unknown"}, exc.message
+      assert_equal "searchable_text", @definitions["attachments"].children["title"].type.name
     end
   end
 


### PR DESCRIPTION
The FieldDefinitions object is just a wrapper around a hash, with a
`.get` method to look up values, and a `.es_config` method which was
only used during parsing.  It's note helping much with structuring anything,
and when making use of the definitions it would be easier if we just had a hash,
so this commit replaces the FieldDefinitions object with a hash.
