### PR TITLE
Enable document_collections field for faceting

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -14,6 +14,7 @@ class BaseParameterParser
 
   # The fields listed here are the only ones which can be used to filter by.
   ALLOWED_FILTER_FIELDS = %w(
+    document_collections
     document_type
     format
     mainstream_browse_pages
@@ -33,6 +34,7 @@ class BaseParameterParser
   # The fields listed here are the only ones which can be used to calculated
   # facets for.  This should be a subset of ALLOWED_FILTER_FIELDS
   ALLOWED_FACET_FIELDS = %w(
+    document_collections
     format
     mainstream_browse_pages
     manual
@@ -91,6 +93,7 @@ class BaseParameterParser
   ALLOWED_RETURN_FIELDS = %w(
     description
     display_type
+    document_collections
     document_series
     format
     last_update


### PR DESCRIPTION
This field was previously not used by anything, so we'd not enabled it
for filtering, faceting, or in return fields for documents.  However, it
would be very useful for the content explorer to be able to display
this, so this PR allows it for all these purposes.
