### PR TITLE
Add content_id to schema

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -4,6 +4,7 @@
     "title",
     "description",
     "link",
+    "content_id",
     "indexable_content",
     "popularity",
     "organisations",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -16,6 +16,10 @@
     "type": "identifier"
   },
 
+  "content_id": {
+    "type": "identifier"
+  },
+
   "indexable_content": {
     "type": "searchable_text"
   },


### PR DESCRIPTION
This will enable us to reference and search documents based on their content_id. Specifically, we're going to reference whitehall document's new-world "policies" using their content_ids.

Story: https://trello.com/c/h2t4VlGE/31-allow-documents-in-whitehall-to-be-tagged-to-new-policy-areas
