### PR TITLE
Add history-mode fields to Edition schema

### DIFF
--- a/config/schema/document_types/edition.json
+++ b/config/schema/document_types/edition.json
@@ -27,6 +27,8 @@
     "world_locations",
     "has_official_document",
     "has_command_paper",
-    "has_act_paper"
+    "has_act_paper",
+    "is_political",
+    "government"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -298,5 +298,13 @@
 
   "railway_type": {
     "type": "identifiers"
+  },
+
+  "is_political": {
+    "type": "boolean"
+  },
+
+  "government": {
+    "type": "identifier"
   }
 }


### PR DESCRIPTION
- `government`: slug/id, of the Government that first published the
  document
- `is_political`: boolean, true if the content is considered political

These fields will be used to mark some search results as being under
history mode, where political content from previous governments will
be marked as such. This will need to know if a government is current
and the name (not slug) needs to be displayed in the UI,

Government will be expanded from the slug via the Government API [1],
which will be done by Rummager, or the Frontend.

Indexing `is_political` and `government`, rather than `is_historic`,
means that when a government ends it's results will be updated
without needing to reindex all political documents.

[1] https://www.gov.uk/api/governments
