### PR TITLE
Add history mode fields to Edition schema

### DIFF
--- a/config/schema/document_types/edition.json
+++ b/config/schema/document_types/edition.json
@@ -27,6 +27,9 @@
     "world_locations",
     "has_official_document",
     "has_command_paper",
-    "has_act_paper"
+    "has_act_paper",
+    "is_political",
+    "is_historic",
+    "government_name"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -298,5 +298,20 @@
 
   "railway_type": {
     "type": "identifiers"
+  },
+
+  "is_political": {
+    "description": "If the content is considered political in nature, reflecting views of the government it was published under",
+    "type": "boolean"
+  },
+
+  "is_historic": {
+    "description": "If the content is political and published by a previous government, it is considered historic and not reflecting of the current government",
+    "type": "boolean"
+  },
+
+  "government_name": {
+    "description": "The name of the Government that first published this document, eg, '1970 to 1974 Conservative government'",
+    "type": "unsearchable_text"
   }
 }


### PR DESCRIPTION
Updated version of: https://github.com/alphagov/rummager/pull/378

**New fields:**
- `is_political`: _boolean_
  - If the content is considered political in nature, relfecting
    views of the government it was published under
- `is_historic`: _boolean_
  - If the content is political and published by a previous
    government, it is considered historic and not relfective of the
    current government and can be marked as such.
- `government_name`: _unsearchable_text_
  - The name of the Government that first published
    this document, eg, "1970 to 1974 Conservative government"

These fields will be used to mark some search results as being under
history mode, where political content from previous governments will
displayed in the UI as associtated to the government that published
it.

`government_name` is stored as text, rather than an identifier, as
governments are not repsented in content store. Storing the text
isn't normalised, but storing the identifier would require either
Rummager or the frontend to perform expansion from identifier to
name.

Note: if a government name is edited (in WH publisher, currently)
then content associated to that government will need to be reindexed
for the updated name to be reflected in search results. This isn't
something we expect to happen very often, and are happy running a
manual reindex if required

Note: when a government is ended (in WH publisher, currently) all
political documents will need to be re-index, to set `is_historic`
in search. This is a once every ~5 year change, and we're happy
running a reindex task in this instance.

It's possible this could be done as an async task that happens as
a result of the government being ended in the publishing tool.

As discussed with @edds and @rboulton this morning.
