### PR TITLE
Populate 'public_timestamp' for all documents

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -473,6 +473,7 @@ module Elasticsearch
         doc_hash = prepare_mainstream_browse_page_field(doc_hash)
         doc_hash = prepare_tag_field(doc_hash)
         doc_hash = prepare_format_field(doc_hash)
+        doc_hash = prepare_public_timestamp_field(doc_hash)
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
@@ -523,6 +524,14 @@ module Elasticsearch
     def prepare_format_field(doc_hash)
       if doc_hash["format"].nil?
         doc_hash.merge("format" => doc_hash["_type"])
+      else
+        doc_hash
+      end
+    end
+
+    def prepare_public_timestamp_field(doc_hash)
+      if doc_hash["public_timestamp"].nil? && !doc_hash["last_update"].nil?
+        doc_hash.merge("public_timestamp" => doc_hash["last_update"])
       else
         doc_hash
       end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -322,6 +322,39 @@ eos
     assert_requested(bulk_request)
   end
 
+  def test_should_populate_public_timestamp_based_on_last_update_field
+    stub_popularity_index_requests(["/document/thing"], 1.0)
+
+    json_document = {
+      "_type" => "edition",
+      "link" => "/document/thing",
+      "last_update" => "2015-03-26T10:300:00.006+00:00"
+    }
+
+    document = stub("document", elasticsearch_export: json_document)
+
+    payload = <<-EOS
+{"index":{"_type":"edition","_id":"/document/thing"}}
+{"_type":"edition","link":"/document/thing","last_update":"2015-03-26T10:300:00.006+00:00","popularity":1.0,"tags":[],"format":"edition","public_timestamp":"2015-03-26T10:300:00.006+00:00"}
+    EOS
+
+  response = <<-EOS
+{"took":5,"items":[
+  { "index": { "_index":"test-index", "_type":"edition", "_id":"/document/thing", "ok":true } }
+]}
+EOS
+
+    bulk_request = stub_request(:post, "http://example.com:9200/test-index/_bulk").with(
+        body: payload,
+        headers: {"Content-Type" => "application/json"}
+    ).to_return(body: response)
+
+    @wrapper.add [document]
+
+    assert_requested(bulk_request)
+  end
+
+
   def test_should_allow_custom_timeouts_on_add
     stub_response = stub("response", body: '{"items": []}')
     RestClient::Request.expects(:execute)


### PR DESCRIPTION
specialist-publisher sets 'last_update' as the timestamp signifying the freshness of a document. This is semantically identical to 'public_timestamp', which is the field that other publishing applications use. To ease the transition to using 'public_timestamp' across all applications (and removing 'last_update'), 'public_timestamp' will be set on any documents that are indexed with 'last_update'. A re-index will update all existing documents.

This change will allow us to update finder-frontend to order rummager queries by 'public_timestamp', which will mean results can be fetched for both specialist content and whitehall content (whitehall content doesn't set 'last_update' so ordering by 'last_update' excludes them from results).
