### PR TITLE
Allow history mode fields to be returned

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -96,6 +96,8 @@ class BaseParameterParser
     document_collections
     document_series
     format
+    government_name
+    is_historic
     last_update
     latest_change_note
     link


### PR DESCRIPTION
These were added in https://github.com/alphagov/rummager/pull/379

`is_historic` and `government_name` are used in display of search results

`political` is not used yet, and can be marked as allowed when required
