### PR TITLE
Update policy field definition to include slug

### DIFF
--- a/config/schema/document_types/policy.json
+++ b/config/schema/document_types/policy.json
@@ -1,3 +1,5 @@
 {
-  "fields": []
+  "fields": [
+    "slug"
+  ]
 }


### PR DESCRIPTION
Without this, rummager ignores the "slug" field sent by policy-publisher.
