### PR TITLE
Autocorrect 'Milliband' searches and don't offer spelling suggestions

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -476,6 +476,7 @@ synonyms: [
   "maintance => maintenance",
   "maternaty => maternity",
   "milage => mileage",
+  "milliband => miliband",
   "mimimum => minimum",
   "minimun => minimum",
   "minium => minimum",

--- a/config/suggest/ignore.txt
+++ b/config/suggest/ignore.txt
@@ -37,6 +37,7 @@ login
 marmaris
 mesothelioma
 miliband
+milliband
 modaf
 motorbility
 mumbai


### PR DESCRIPTION
- Add 'milliband' to ignore list to remove unhelpful ‘did you mean’
  suggestions
- Return results matching ‘miliband’ instead
