### PR TITLE
Remove content_id from default field

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -4,7 +4,6 @@
     "title",
     "description",
     "link",
-    "content_id",
     "indexable_content",
     "popularity",
     "organisations",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -16,10 +16,6 @@
     "type": "identifier"
   },
 
-  "content_id": {
-    "type": "identifier"
-  },
-
   "indexable_content": {
     "type": "searchable_text"
   },


### PR DESCRIPTION
We are no longer using content_id to map to policies, which makes the content_id redundant in the field definitions.
