### PR TITLE
Make land_use into a multivalued field

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -224,7 +224,7 @@
   },
 
   "land_use": {
-    "type": "identifier"
+    "type": "identifiers"
   },
 
   "tiers_or_standalone_items": {


### PR DESCRIPTION
It is multivalued, and not configuring it as such breaks running
migrations (and will stop new documents with this field in being
indexed).

(This was never a problem in production because we caught it in
preview.)
