### PR TITLE
Make tiers_or_standalone_items a multivalued field

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -228,7 +228,7 @@
   },
 
   "tiers_or_standalone_items": {
-    "type": "identifier"
+    "type": "identifiers"
   },
 
   "funding_amount": {


### PR DESCRIPTION
It is multivalued, and not configuring it as such breaks running
migrations (and will stop new documents with this field in being
indexed).

Similar fix to #386.  With this one fixed, the migrate indexes task runs successfully with a current preview data dump.
