### PR TITLE
Allow filtering by link

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -17,6 +17,7 @@ class BaseParameterParser
     document_collections
     document_type
     format
+    link
     mainstream_browse_pages
     manual
     organisations


### PR DESCRIPTION
So that in manual filtering works we need to be able to filter search results by link.

Pivotal: https://www.pivotaltracker.com/story/show/88435634
