### PR TITLE
Fix handling of opaque object fields

### DIFF
--- a/lib/document.rb
+++ b/lib/document.rb
@@ -32,10 +32,15 @@ class Document
 
   def get(field_name)
     field_name = field_name.to_s
+    values = @attributes[field_name]
     # Convert to array for consistency between elasticsearch 0.90 and 1.0.
     # When we no longer support elasticsearch <1.0, values in @attributes will
     # always be arrays.
-    values = Array(@attributes[field_name])
+    if values.nil?
+      values = []
+    elsif !(values.is_a?(Array))
+      values = [values]
+    end
     if @field_definitions[field_name].type.multivalued
       values
     else

--- a/test/integration/elasticsearch_indexing_test.rb
+++ b/test/integration/elasticsearch_indexing_test.rb
@@ -51,4 +51,21 @@ class ElasticsearchIndexingTest < IntegrationTest
 
     assert_document_is_in_rummager(@sample_document)
   end
+
+  def test_can_index_fields_of_type_opaque_object
+    create_test_indexes
+
+    document = {
+      "format" => "statistics_announcemnt",
+      "link" => "/a-link",
+      "metadata" => {
+        "confirmed" => true,
+        "display_date" => "27 August 2014 9:30am",
+      },
+    }
+
+    post "/documents", document.to_json
+
+    assert_document_is_in_rummager(document)
+  end
 end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -162,4 +162,14 @@ class DocumentTest < MiniTest::Unit::TestCase
     assert_equal "/batman", weighted_doc.link
     assert_nil weighted_doc.es_score
   end
+
+  def test_should_handle_opaque_object_fields
+    metadata = { "foo" => true, "bar" => 1 }
+    document_hash = {
+      "metadata" => metadata
+    }
+    doc = Document.new(sample_field_definitions(%w(metadata)), document_hash)
+
+    assert_equal metadata, doc.metadata
+  end
 end


### PR DESCRIPTION
When returning documents, Document.get is called for each field in the
document.  This was applying Array() to the value of each field, to
force it into an array, to assist with compatibility with elasticsearch
1.0+ (which always return arrays).

This works fine for scalar values like strings and integers, but for a
hash it converts the hash into an array of "key-value" arrays.  eg,

```
{ "foo" => "bar" }
```

becomes

```
[ ["foo", "bar"] ]
```

This breaks things that use the "metadata" field quite badly, so instead
we need to check for anything other than Array or nil, and simply wrap
such things in an array.

This code can be tidied up once we've migrated to elasticsearch 1.0+
fully.
