### PR TITLE
Elasticsearch 1.x fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :test do
   gem "rack-test"
   gem "mocha", :require => false
   gem "webmock", "1.9.3", :require => false
+  gem "timecop", "0.7.3"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       tilt (~> 1.3, >= 1.3.3)
     slop (3.4.5)
     tilt (1.3.3)
+    timecop (0.7.3)
     timers (1.1.0)
     turn (0.9.6)
       ansi
@@ -146,6 +147,7 @@ DEPENDENCIES
   simplecov-rcov
   sinatra (= 1.3.4)
   slop (= 3.4.5)
+  timecop (= 0.7.3)
   turn
   unf (= 0.1.3)
   unicorn (= 4.6.2)

--- a/app.rb
+++ b/app.rb
@@ -518,11 +518,11 @@ class Rummager < Sinatra::Application
   end
 
   delete "/?:index?/documents" do
-    # DEPRECATED: the preferred way to do this is now through the
-    # `rummager:switch_to_empty_index` Rake command
 
     if params["delete_all"]
-      action = current_index.delete_all
+      # No longer supported; instead use the
+      # `rummager:switch_to_empty_index` Rake command
+      halt 400
     else
       action = current_index.delete(params["link"])
     end

--- a/lib/best_bets_checker.rb
+++ b/lib/best_bets_checker.rb
@@ -104,9 +104,9 @@ private
     es_response = @index.raw_search(lookup_payload, "best_bet")
     result = []
     es_response["hits"]["hits"].map do |hit|
-      details = JSON.parse(hit["fields"]["details"])
+      details = JSON.parse(Array(hit["fields"]["details"]).first)
       bet_query, _, bet_type = hit["_id"].rpartition('-')
-      stemmed_query_as_term = hit["fields"]["stemmed_query_as_term"]
+      stemmed_query_as_term = Array(hit["fields"]["stemmed_query_as_term"]).first
 
       # The search on the stemmed_query field is overly broad, so here we need
       # to filter out such matches where the query in the bet is not a

--- a/lib/elasticsearch/advanced_search_query_builder.rb
+++ b/lib/elasticsearch/advanced_search_query_builder.rb
@@ -85,7 +85,7 @@ module Elasticsearch
       if @keywords
         {
           query: {
-            custom_filters_score: {
+            function_score: {
               query: {
                 bool: {
                   should: [
@@ -106,9 +106,11 @@ module Elasticsearch
                   ]
                 }
               },
-              filters: [
+              functions: [
                 filter: { term: { search_format_types: "edition" } },
-                script: "((0.15 / ((3.1*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)"
+                script_score: {
+                  script: "((0.15 / ((3.1*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)",
+                }
               ]
             }
           }

--- a/lib/elasticsearch/advanced_search_query_builder.rb
+++ b/lib/elasticsearch/advanced_search_query_builder.rb
@@ -109,7 +109,10 @@ module Elasticsearch
               functions: [
                 filter: { term: { search_format_types: "edition" } },
                 script_score: {
-                  script: "((0.15 / ((3.1*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)",
+                  script: "((0.15 / ((3.1*pow(10,-11)) * abs(now - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)",
+                  params: {
+                    now: time_in_millis_to_nearest_minute
+                  },
                 }
               ]
             }
@@ -118,6 +121,10 @@ module Elasticsearch
       else
         {"query" => {"match_all" => {}}}
       end
+    end
+
+    def time_in_millis_to_nearest_minute
+      (Time.now.to_i / 60) * 60000
     end
 
     def filter_query_hash

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -357,11 +357,6 @@ module Elasticsearch
       queue.queue_delete(document_type, document_id)
     end
 
-    def delete_all
-      @client.delete_with_payload("_query", {match_all: {}}.to_json)
-      commit
-    end
-
     def commit
       @client.post "_refresh", nil
     end

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -570,7 +570,7 @@ module Elasticsearch
       ranks = Hash.new(traffic_index_size)
       results["hits"]["hits"].each do |hit|
         link = hit["_id"]
-        rank = hit["fields"]["rank_14"]
+        rank = Array(hit["fields"]["rank_14"]).first
         if rank.nil?
           next
         end

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -217,9 +217,16 @@ module Elasticsearch
       {
         filter: { term: { search_format_types: "announcement" } },
         script_score: {
-          script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+          script: "((0.05 / ((3.16*pow(10,-11)) * abs(now - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)",
+          params: {
+            now: time_in_millis_to_nearest_minute,
+          },
         }
       }
+    end
+
+    def time_in_millis_to_nearest_minute
+      (Time.now.to_i / 60) * 60000
     end
   end
 end

--- a/lib/elasticsearch/search_query_builder.rb
+++ b/lib/elasticsearch/search_query_builder.rb
@@ -33,13 +33,13 @@ module Elasticsearch
         from: 0,
         size: @limit,
         query: {
-          custom_filters_score: {
+          function_score: {
             query: {
               bool: {
                 should: [core_query]
               }
             },
-            filters: format_boosts + [time_boost]
+            functions: format_boosts + [time_boost]
           }
         },
         sort: sort
@@ -204,7 +204,7 @@ module Elasticsearch
       boosted_formats.map do |format, boost|
         {
           filter: { term: { format: format } },
-          boost: boost
+          boost_factor: boost
         }
       end
     end
@@ -216,7 +216,9 @@ module Elasticsearch
     def time_boost
       {
         filter: { term: { search_format_types: "announcement" } },
-        script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+        script_score: {
+          script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+        }
       }
     end
   end

--- a/lib/elasticsearch/sitemap.rb
+++ b/lib/elasticsearch/sitemap.rb
@@ -110,6 +110,7 @@ class SitemapGenerator
     builder = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
         chunk.each do |url|
+          url = Array(url).first
           url = URI.join(base_url, url) unless url.start_with?("http")
           xml.url {
             xml.loc url

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -405,9 +405,16 @@ class UnifiedSearchBuilder
     {
       filter: { term: { search_format_types: "announcement" } },
       script_score: {
-        script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+        script: "((0.05 / ((3.16*pow(10,-11)) * abs(now - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)",
+        params: {
+          now: time_in_millis_to_nearest_minute,
+        },
       }
     }
+  end
+
+  def time_in_millis_to_nearest_minute
+    (Time.now.to_i / 60) * 60000
   end
 
   def closed_org_boost

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -242,10 +242,11 @@ class SearchTest < IntegrationTest
       "_index" => "mainstream",
       "_id" => "foo_id",
       "_score" => "1.0",
+      "_type" => "edition",
       "fields" => sample_document_attributes.merge("specialist_sectors" => ["oil-and-gas/licensing"])
     }
 
-    stub_index.stubs(:schema).returns(nil)
+    stub_index.stubs(:schema).returns(sample_schema)
     stub_index.stubs(:mappings).returns(mappings)
     stub_index.expects(:raw_search).returns({"hits" => {"hits" => [document], "total" => 1}})
     stub_index.expects(:index_names).returns(%w{mainstream government detailed})

--- a/test/integration/elasticsearch_closing_test.rb
+++ b/test/integration/elasticsearch_closing_test.rb
@@ -25,7 +25,7 @@ class ElasticsearchClosingTest < IntegrationTest
 
     index = search_server.index_group(@default_index_name).current
     index.close
-    assert_raises *restclient_4xx_errors do
+    assert_raises *(restclient_4xx_errors + [Elasticsearch::BulkIndexFailure]) do
       index.add([sample_document])
     end
 

--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -146,19 +146,4 @@ class ElasticsearchDeletionTest < IntegrationTest
     get "/documents/http:%2F%2Fexample.com%2F"
     assert last_response.not_found?
   end
-
-  def test_should_delete_all_the_things
-    delete "/documents?delete_all=yes"
-    assert last_response.ok?
-
-    ["/an-example-answer", "/another-example-answer"].each do |link|
-      get "/documents/#{CGI.escape(link)}"
-      assert last_response.not_found?
-    end
-
-    ["badger", "benefits"].each do |query|
-      get "/search.json?q=#{query}"
-      assert_no_results
-    end
-  end
 end

--- a/test/integration/specialist_document_search_test.rb
+++ b/test/integration/specialist_document_search_test.rb
@@ -32,6 +32,6 @@ class SpecialistDocumentSearchTest < MultiIndexTest
     first_result = parsed_response["results"].first
 
     assert first_result.has_key? "case_type"
-    assert first_result["case_type"] == [{"label" => "Mergers", "value" => "mergers"}]
+    assert_equal [{"label" => "Mergers", "value" => "mergers"}], first_result["case_type"]
   end
 end

--- a/test/sample_config.rb
+++ b/test/sample_config.rb
@@ -22,4 +22,7 @@ module SampleConfig
     @sample_document_types ||= DocumentTypesParser.new(schema_dir, sample_field_definitions).parse
   end
 
+  def sample_schema
+    @sample_schema ||= SchemaConfig.new(schema_dir)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ require "fixtures/default_mappings"
 require "pp"
 require "shoulda-context"
 require "logging"
+require "timecop"
 
 require "webmock/minitest"
 WebMock.disable_net_connect!
@@ -27,6 +28,10 @@ require "sample_config"
 
 module TestHelpers
   include SampleConfig
+
+  def teardown
+    Timecop.return
+  end
 
   def load_yaml_fixture(filename)
     YAML.load_file(File.expand_path("fixtures/#{filename}", File.dirname(__FILE__)))

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -28,7 +28,7 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def test_keyword_param_is_converted_to_a_boosted_title_and_unboosted_general_query
-    stub_empty_search(:body => "{\"from\":0,\"size\":1,\"query\":{\"custom_filters_score\":{\"query\":{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"happy fun time\",\"fields\":[\"title^3\"],\"default_operator\":\"and\",\"analyzer\":\"default\"}},{\"query_string\":{\"query\":\"happy fun time\",\"analyzer\":\"query_default\"}}]}},\"filters\":[{\"filter\":{\"term\":{\"search_format_types\":\"edition\"}},\"script\":\"((0.15 / ((3.1*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)\"}]}},\"filter\":{}}")
+    stub_empty_search(:body => "{\"from\":0,\"size\":1,\"query\":{\"function_score\":{\"query\":{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"happy fun time\",\"fields\":[\"title^3\"],\"default_operator\":\"and\",\"analyzer\":\"default\"}},{\"query_string\":{\"query\":\"happy fun time\",\"analyzer\":\"query_default\"}}]}},\"functions\":[{\"filter\":{\"term\":{\"search_format_types\":\"edition\"}},\"script_score\":{\"script\":\"((0.15 / ((3.1*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)\"}}]}},\"filter\":{}}")
     @wrapper.advanced_search(default_params.merge('keywords' => 'happy fun time'))
   end
 

--- a/test/unit/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch_index_advanced_search_test.rb
@@ -28,7 +28,7 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def test_keyword_param_is_converted_to_a_boosted_title_and_unboosted_general_query
-    stub_empty_search(:body => "{\"from\":0,\"size\":1,\"query\":{\"function_score\":{\"query\":{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"happy fun time\",\"fields\":[\"title^3\"],\"default_operator\":\"and\",\"analyzer\":\"default\"}},{\"query_string\":{\"query\":\"happy fun time\",\"analyzer\":\"query_default\"}}]}},\"functions\":[{\"filter\":{\"term\":{\"search_format_types\":\"edition\"}},\"script_score\":{\"script\":\"((0.15 / ((3.1*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)\"}}]}},\"filter\":{}}")
+    stub_empty_search(:body => "{\"from\":0,\"size\":1,\"query\":{\"function_score\":{\"query\":{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"happy fun time\",\"fields\":[\"title^3\"],\"default_operator\":\"and\",\"analyzer\":\"default\"}},{\"query_string\":{\"query\":\"happy fun time\",\"analyzer\":\"query_default\"}}]}},\"functions\":[{\"filter\":{\"term\":{\"search_format_types\":\"edition\"}},\"script_score\":{\"script\":\"((0.15 / ((3.1*pow(10,-11)) * abs(now - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.5)\",\"params\":{\"now\":#{(Time.now.to_i / 60) * 60000}}}}]}},\"filter\":{}}")
     @wrapper.advanced_search(default_params.merge('keywords' => 'happy fun time'))
   end
 

--- a/test/unit/elasticsearch_search_query_builder_test.rb
+++ b/test/unit/elasticsearch_search_query_builder_test.rb
@@ -2,6 +2,10 @@ require "test_helper"
 require "elasticsearch/search_query_builder"
 
 class SearchQueryBuilderTest < ShouldaUnitTestCase
+  def setup
+    Timecop.freeze
+    super
+  end
 
   def mappings(properties = {})
     {
@@ -81,7 +85,10 @@ class SearchQueryBuilderTest < ShouldaUnitTestCase
     filters = builder.query_hash[:query][:function_score][:functions]
     expected = {
       filter: { term: { search_format_types: "announcement" } },
-      script_score: { script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)" },
+      script_score: {
+        script: "((0.05 / ((3.16*pow(10,-11)) * abs(now - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)",
+        params: {now: (Time.now.to_i / 60) * 60000},
+      },
     }
     assert_equal expected, filters.last
   end

--- a/test/unit/elasticsearch_search_query_builder_test.rb
+++ b/test/unit/elasticsearch_search_query_builder_test.rb
@@ -13,7 +13,7 @@ class SearchQueryBuilderTest < ShouldaUnitTestCase
   end
 
   def extract_condition_by_type(query_hash, condition_type)
-    must_conditions = query_hash[:query][:custom_filters_score][:query][:bool][:should][0][:bool][:must]
+    must_conditions = query_hash[:query][:function_score][:query][:bool][:should][0][:bool][:must]
     must_conditions.find { |condition| condition.keys == [condition_type] }
   end
 
@@ -36,13 +36,13 @@ class SearchQueryBuilderTest < ShouldaUnitTestCase
   def test_minimum_should_match_has_sensible_default
     builder = Elasticsearch::SearchQueryBuilder.new("one two three", mappings)
 
-    must_conditions = builder.query_hash[:query][:custom_filters_score][:query][:bool][:should][0][:bool][:must]
+    must_conditions = builder.query_hash[:query][:function_score][:query][:bool][:should][0][:bool][:must]
     assert_equal "2<2 3<3 7<50%", must_conditions[0][:match][:_all][:minimum_should_match]
   end
 
   def test_shingle_boosts
     builder = Elasticsearch::SearchQueryBuilder.new("quick brown fox", mappings)
-    shingle_condition = builder.query_hash[:query][:custom_filters_score][:query][:bool][:should][0][:bool][:should].detect do |condition|
+    shingle_condition = builder.query_hash[:query][:function_score][:query][:bool][:should][0][:bool][:should].detect do |condition|
       condition[:multi_match] &&
           condition[:multi_match][:analyzer] == "shingled_query_analyzer"
     end
@@ -60,28 +60,28 @@ class SearchQueryBuilderTest < ShouldaUnitTestCase
 
   def test_format_boosts
     builder = Elasticsearch::SearchQueryBuilder.new("cherokee", mappings)
-    filters = builder.query_hash[:query][:custom_filters_score][:filters]
+    filters = builder.query_hash[:query][:function_score][:functions]
 
     expected = [
-      { filter: { term: { format: "smart-answer" } },      boost: 1.5 },
-      { filter: { term: { format: "transaction" } },       boost: 1.5 },
-      { filter: { term: { format: "topical_event" } },     boost: 1.5 },
-      { filter: { term: { format: "minister" } },          boost: 1.7 },
-      { filter: { term: { format: "organisation" } },      boost: 2.5 },
-      { filter: { term: { format: "topic" } },             boost: 1.5 },
-      { filter: { term: { format: "document_series" } },   boost: 1.3 },
-      { filter: { term: { format: "document_collection" } }, boost: 1.3 },
-      { filter: { term: { format: "operational_field" } }, boost: 1.5 },
+      { filter: { term: { format: "smart-answer" } },      boost_factor: 1.5 },
+      { filter: { term: { format: "transaction" } },       boost_factor: 1.5 },
+      { filter: { term: { format: "topical_event" } },     boost_factor: 1.5 },
+      { filter: { term: { format: "minister" } },          boost_factor: 1.7 },
+      { filter: { term: { format: "organisation" } },      boost_factor: 2.5 },
+      { filter: { term: { format: "topic" } },             boost_factor: 1.5 },
+      { filter: { term: { format: "document_series" } },   boost_factor: 1.3 },
+      { filter: { term: { format: "document_collection" } }, boost_factor: 1.3 },
+      { filter: { term: { format: "operational_field" } }, boost_factor: 1.5 },
     ]
     assert_equal expected, filters[0..-2]
   end
 
   def test_time_boost
     builder = Elasticsearch::SearchQueryBuilder.new("sioux", mappings)
-    filters = builder.query_hash[:query][:custom_filters_score][:filters]
+    filters = builder.query_hash[:query][:function_score][:functions]
     expected = {
       filter: { term: { search_format_types: "announcement" } },
-      script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+      script_score: { script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)" },
     }
     assert_equal expected, filters.last
   end

--- a/test/unit/facet_example_fetcher_test.rb
+++ b/test/unit/facet_example_fetcher_test.rb
@@ -35,9 +35,17 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
     }
   end
 
+  def stub_index(name)
+    schema = stub("schema")
+    schema.stubs(:field_definitions).returns(sample_field_definitions)
+    index = stub("content index")
+    index.stubs(:schema).returns(schema)
+    index
+  end
+
   context "no facet" do
     setup do
-      @index = stub("content index")
+      @index = stub_index("content index")
       @builder = stub("builder")
       @fetcher = FacetExampleFetcher.new(@index, {}, {}, @builder)
     end
@@ -49,7 +57,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
 
   context "one facet with global scope" do
     setup do
-      @index = stub("content index")
+      @index = stub_index("content index")
       @example_fields = %w{link title other_field}
       main_query_response = {"facets" => {
         "sector" => {
@@ -99,7 +107,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
 
   context "one facet with query scope" do
     setup do
-      @index = stub("content index")
+      @index = stub_index("content index")
       @example_fields = %w{link title other_field}
 
       main_query_response = {"facets" => {
@@ -157,7 +165,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
 
   context "one facet but no documents match query" do
     setup do
-      @index = stub("content index")
+      @index = stub_index("content index")
       @example_fields = %w{link title other_field}
       main_query_response = {"facets" => {
         "sector" => {
@@ -186,7 +194,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
 
   context "one facet with 1000 matches" do
     setup do
-      @index = stub("content index")
+      @index = stub_index("content index")
       @example_fields = %w{link title other_field}
 
       main_query_response = {"facets" => {

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -4,6 +4,10 @@ require "unified_searcher"
 require "search_parameter_parser"
 
 class UnifiedSearcherTest < ShouldaUnitTestCase
+  def setup
+    Timecop.freeze
+    super
+  end
 
   def sample_docs
     [{
@@ -118,7 +122,8 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
             {filter: {term: {format: 'operational_field'}}, boost_factor: 1.5},
             {filter: {term: {format: 'contact'}}, boost_factor: 0.3},
             {filter: {term: {search_format_types: 'announcement'}}, script_score: {
-              script: "((0.05 / ((3.16*pow(10,-11)) * abs(time() - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)"
+              script: "((0.05 / ((3.16*pow(10,-11)) * abs(now - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)",
+              params: {now: (Time.now.to_i / 60) * 60000},
             }},
             {filter: {term: {organisation_state: 'closed'}}, boost_factor: 0.3},
             {filter: {term: {organisation_state: 'devolved'}}, boost_factor: 0.3},

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -183,14 +183,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   def make_schema
     schema = stub("schema")
     index_schema = stub("index schema")
-    document_schema = stub("document_schema")
 
     schema.stubs(:schema_for_alias_name).returns(index_schema)
-    index_schema.stubs(:document_type).returns(document_schema)
-    document_schema.stubs(:allowed_values).returns({
-      "cma_case" => cma_case_allowed_values
-    })
-    [schema, document_schema]
+    index_schema.stubs(:document_type).returns(sample_document_types["cma_case"])
+    schema
   end
 
   context "unfiltered, unsorted search" do
@@ -210,7 +206,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:index_names).returns(
         %w{mainstream detailed government}
       )
-      @combined_index.expects(:schema).returns(make_schema[0])
+      @combined_index.expects(:schema).returns(make_schema)
 
       @results = @searcher.search({
         start: 0,
@@ -259,7 +255,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:index_names).returns(
         %w{mainstream detailed government}
       )
-      @combined_index.expects(:schema).returns(make_schema[0])
+      @combined_index.expects(:schema).returns(make_schema)
 
       @results = @searcher.search({
         start: 0,
@@ -304,7 +300,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:index_names).returns(
         %w{mainstream detailed government}
       )
-      @combined_index.expects(:schema).returns(make_schema[0])
+      @combined_index.expects(:schema).returns(make_schema)
 
       @results = @searcher.search({
         start: 0,
@@ -364,7 +360,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index.expects(:index_names).returns(
         %w{mainstream detailed government}
       )
-      @combined_index.expects(:schema).returns(make_schema[0])
+      @combined_index.expects(:schema).returns(make_schema)
 
       @results = @searcher.search({
         start: 0,

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -155,7 +155,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
 
   def mock_best_bets(query)
     @metasearch_index = stub("metasearch index")
-    @metasearch_index.expects(:raw_search).with(
+    @metasearch_index.stubs(:raw_search).with(
       {
         query: {:bool => {:should => [{:match => {:exact_query => query}},
                                       {:match => {:stemmed_query => query}}]}},
@@ -165,7 +165,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       {
         "hits" => {"hits" => [], "total" => [].size}
       })
-    @metasearch_index.expects(:analyzed_best_bet_query).with(query).returns(query)
+    @metasearch_index.stubs(:analyzed_best_bet_query).with(query).returns(query)
   end
 
   def with_base_filters(filter)
@@ -190,6 +190,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     index_schema = stub("index schema")
 
     schema.stubs(:schema_for_alias_name).returns(index_schema)
+    schema.stubs(:field_definitions)
     index_schema.stubs(:document_type).returns(sample_document_types["cma_case"])
     schema
   end
@@ -208,10 +209,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}
       })
-      @combined_index.expects(:index_names).returns(
+      @combined_index.stubs(:index_names).returns(
         %w{mainstream detailed government}
       )
-      @combined_index.expects(:schema).returns(make_schema)
+      @combined_index.stubs(:schema).returns(make_schema)
 
       @results = @searcher.search({
         start: 0,
@@ -248,7 +249,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
       @searcher = make_searcher
-      @combined_index.expects(:raw_search).with({
+      @combined_index.stubs(:raw_search).with({
         from: 0,
         size: 20,
         query: CHEESE_QUERY,
@@ -257,10 +258,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}
       })
-      @combined_index.expects(:index_names).returns(
+      @combined_index.stubs(:index_names).returns(
         %w{mainstream detailed government}
       )
-      @combined_index.expects(:schema).returns(make_schema)
+      @combined_index.stubs(:schema).returns(make_schema)
 
       @results = @searcher.search({
         start: 0,
@@ -293,7 +294,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
       @searcher = make_searcher
-      @combined_index.expects(:raw_search).with({
+      @combined_index.stubs(:raw_search).with({
         from: 0,
         size: 20,
         query: CHEESE_QUERY,
@@ -302,10 +303,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       }).returns({
         "hits" => {"hits" => sample_docs, "total" => 3}
       })
-      @combined_index.expects(:index_names).returns(
+      @combined_index.stubs(:index_names).returns(
         %w{mainstream detailed government}
       )
-      @combined_index.expects(:schema).returns(make_schema)
+      @combined_index.stubs(:schema).returns(make_schema)
 
       @results = @searcher.search({
         start: 0,
@@ -338,7 +339,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       @combined_index = stub("unified index")
       mock_best_bets("cheese")
       @searcher = make_searcher
-      @combined_index.expects(:raw_search).with({
+      @combined_index.stubs(:raw_search).with({
         from: 0,
         size: 20,
         query: CHEESE_QUERY,
@@ -362,10 +363,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
           ]
         }},
       })
-      @combined_index.expects(:index_names).returns(
+      @combined_index.stubs(:index_names).returns(
         %w{mainstream detailed government}
       )
-      @combined_index.expects(:schema).returns(make_schema)
+      @combined_index.stubs(:schema).returns(make_schema)
 
       @results = @searcher.search({
         start: 0,


### PR DESCRIPTION
This contains several more fixes to make rummager work with elasticsearch 1.0+.  It should continue to work as before with elasticsearch 0.90.x

After this commit, there are still a few test failures with elasticsearch 1.x, but almost all problems are fixed.

This is probably best reviewed commit by commit.
