### PR TITLE
Rename some field types

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -21,7 +21,7 @@
   },
 
   "popularity": {
-    "type": "stored_float"
+    "type": "float"
   },
 
   "organisations": {
@@ -46,15 +46,15 @@
   },
 
   "updated_at": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "last_update": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "public_timestamp": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "latest_change_note": {
@@ -106,7 +106,7 @@
   },
 
   "release_timestamp": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "metadata": {
@@ -176,7 +176,7 @@
   },
 
   "date_of_occurrence": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "registration": {
@@ -208,11 +208,11 @@
   },
 
   "opened_date": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "closed_date": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "contact_group": {
@@ -241,7 +241,7 @@
   },
 
   "first_published_at": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "fund_state": {
@@ -257,7 +257,7 @@
   },
 
   "closing_date": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "manual": {
@@ -293,7 +293,7 @@
   },
 
   "issued_date": {
-    "type": "searchable_date"
+    "type": "date"
   },
 
   "railway_type": {
@@ -342,6 +342,6 @@
 
   "rank_14": {
     "description": "Field used in the page-traffic index to hold the rank of this page in the list of pages on the website when ordered by traffic.  This is a fairly stable value used in ranking calculations.",
-    "type": "stored_float"
+    "type": "float"
   }
 }

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -54,7 +54,7 @@
     }
   },
 
-  "stored_float": {
+  "float": {
     "description": "A floating point number stored such that it can be used in ranking calculations",
     "es_config": {
       "type": "float",
@@ -70,7 +70,7 @@
     }
   },
 
-  "searchable_date": {
+  "date": {
     "description": "A date which can be returned and used for ordering, filtering and facetting",
     "es_config": {
       "type": "date",


### PR DESCRIPTION
Renames the "searchable_date" field type to just "date", and the
"stored_float" field type to just "float".

There are no other types of date or float fields at present, so it's not
particularly helpful to try and be more specific about these names.  If
we need to add separate configuration for only some date fields in
future (probably for performance reasons), we should change the names to
indicate the ways in which the type can be used at that point, but
currently there's no need to add this level of detail.
