### PR TITLE
Limit bulk upload batches to around 256Kb

### DIFF
--- a/lib/bulk_loader.rb
+++ b/lib/bulk_loader.rb
@@ -4,7 +4,7 @@ class BulkLoader
   def initialize(search_config, index_name, options = {})
     @search_config = search_config
     @index_name = index_name
-    @batch_size = options[:batch_size] || 1024 * 1024
+    @batch_size = options[:batch_size] || 256 * 1024
     @logger = options[:logger] || Logger.new(nil)
   end
 


### PR DESCRIPTION
Previously, batches were allowed to be around 1024Kb.  However, this
causes elasticsearch to return an HTTP 400 error; I believe because its
internal index queue gets full (with our current configuration).

Reducing the batch size to 256Kb avoids this problem, and still appears
to perform well, so I suggest just doing this for now and investigating
further if we experience errors during bulk loads.
