### PR TITLE
Add support for "reject"-style filters

### DIFF
--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -55,6 +55,16 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal links, ["/detailed-1", "/government-1", "/mainstream-1"], links
   end
 
+  def test_reject_by_section
+    get "/unified_search?reject_section=1"
+    assert last_response.ok?
+    links = parsed_response["results"].map do |result|
+      result["link"]
+    end
+    links.sort!
+    assert_equal links, ["/detailed-2", "/government-2", "/mainstream-2"], links
+  end
+
   def test_can_filter_for_missing_section_field
     get "/unified_search?filter_specialist_sectors=_MISSING"
     assert last_response.ok?
@@ -76,6 +86,20 @@ class UnifiedSearchTest < MultiIndexTest
       "/detailed-1", "/detailed-2",
       "/government-1", "/government-2",
       "/mainstream-1", "/mainstream-2",
+    ], links
+  end
+
+  def test_can_filter_and_reject
+    get "/unified_search?reject_section=1&filter_specialist_sectors[]=farming"
+    assert last_response.ok?
+    links = parsed_response["results"].map do |result|
+      result["link"]
+    end
+    links.sort!
+    assert_equal [
+      "/detailed-2",
+      "/government-2",
+      "/mainstream-2",
     ], links
   end
 

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -698,7 +698,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     end
   end
 
-  def text_filter(field_name, values)
-    SearchParameterParser::TextFieldFilter.new(field_name, values)
+  def text_filter(field_name, values, reject = false)
+    SearchParameterParser::TextFieldFilter.new(field_name, values, reject)
   end
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -62,15 +62,12 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
     stub('Suggester', suggestions: ['cheese'])
   end
 
-  def text_filter(field_name, values)
-    SearchParameterParser::TextFieldFilter.new(field_name, values)
+  def text_filter(field_name, values, reject = false)
+    SearchParameterParser::TextFieldFilter.new(field_name, values, reject)
   end
 
-  def date_filter(field_name, values)
-    SearchParameterParser::DateFieldFilter.new(
-      field_name,
-      values,
-    )
+  def date_filter(field_name, values, reject = false)
+    SearchParameterParser::DateFieldFilter.new(field_name, values, reject)
   end
 
   BASE_CHEESE_QUERY = {


### PR DESCRIPTION
For example:

  /unified_search.json?reject_organisations=hm-revenue-customs

would return all documents, except for those tagged with the
`hm-revenue-customs` organisation.  This is wanted for the new search
interface for manuals, where the results filtered to the manual are
to be shown in one area, and all the other results in a separate area.

This is implemented by adding a "reject" parameter to the Filter object,
which tracks whether the filter is a rejection filter or not.

If a user supplies both "reject_organisations" and
"filter_organisations", both the filters need to match.  This will
usually not be intended behaviour, but it might be convenient to write a
frontend application this way, so I haven't made it into a validation
failure.
