### PR TITLE
Revert outcome_type to being of type identifier

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -204,7 +204,7 @@
   },
 
   "outcome_type": {
-    "type": "identifiers"
+    "type": "identifier"
   },
 
   "opened_date": {


### PR DESCRIPTION
Specialist Publisher is sending a value of `[""]` for this field when the document doesn't have an `outcome_type`. When this field was an `identifier` (singular), Rummager did not index a value for this field. Now this field is `identifiers` (plural), Rummager is indexing the value as is. This causes Rummager to return `[null]` when Finder Frontend requests the results, which causes Finder Frontend to error.

This issue should be addressed independently in all three applications, as they're all acting in slightly surprising ways, but to give us time to sort that out let's revert back to config that Just Works.
