### PR TITLE
Fix sitemap generation cron command

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,5 @@
 set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
-job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv search bundle exec rake :task :output'
+job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv rummager bundle exec rake :task :output'
 
 # Sitemap filenames are generated based on the current day and hour. Putting
 # this at 10 past gets around any problems that might arise from running just


### PR DESCRIPTION
Rummager is now using the name "rummager" in production, rather than
search.  This is encoded in the command which is scheduled to run
nightly to generate sitemaps.  For now, just update this.

Later, this should be specified by an environment variable, or other
configuration outside the app.
