### PR TITLE
Make attachment metadata searchable in _all field

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -86,10 +86,10 @@
     "children": {
       "content": { "type": "searchable_text" },
       "title": { "type": "searchable_text" },
-      "isbn": { "type": "identifier" },
-      "unique_reference": { "type": "identifier" },
-      "command_paper_number": { "type": "identifier" },
-      "hoc_paper_number": { "type": "identifier" }
+      "isbn": { "type": "searchable_identifier" },
+      "unique_reference": { "type": "searchable_identifier" },
+      "command_paper_number": { "type": "searchable_identifier" },
+      "hoc_paper_number": { "type": "searchable_identifier" }
     }
   },
 

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -18,6 +18,15 @@
     }
   },
 
+  "searchable_identifier": {
+    "description": "Like an identifier, but should also be considered in searches in the _all field",
+    "es_config": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": true
+    }
+  },
+
   "searchable_text": {
     "description": "A piece of plain text that should be split into words and considered in searches",
     "es_config": {


### PR DESCRIPTION
Editors have been associating metadata with attachments which helps
users to find those attachments.  These are identifiers, so shouldn't be
analysed as free text, but should be considered if a user performs a
free text search.

I've implemented this by adding a "searchable_identifier" type, and
using that for these types.  There may be some other fields which would
benefit from this type, but since this is a strict improvement that
fixes a problem we've had complaints about, I'd like to get this merged
and deployed quickly, rather than do a full audit.

We'll be continually reviewing the schema definitions in future, anyway,
to see how we can improve our overall ranking schemes.
