### PR TITLE
Prepare to put service-manual in unified_search

### DIFF
--- a/config/schema/indexes/service-manual.json
+++ b/config/schema/indexes/service-manual.json
@@ -1,5 +1,7 @@
 {
   "document_types": [
-    "edition"
+    "edition",
+    "manual",
+    "manual_section"
   ]
 }


### PR DESCRIPTION
Currently, the service-manual is a special case for our search system:
it has its own index, its own frontend, and is the only thing still
using the old rummager `/<index name>/search` endpoint.

We'd like to fix all of these special cases, but the most important is
to stop it using the old endpoint in favour of using the main
`unified_search` endpoint, so that we can delete all the supporting code
for that endpoint.

In order to make this possible, we'll change the format of the documents
sent from the service-manual indexing code so that they match an
existing format on GOV.UK, and include something to allow the results
returned to be restricted to those in the service manual.  The obvious
way to do this is to use the same format that our other manuals use.

This commit is the first step in this process, to permit the `manual`
and `manual_section` formats in the `service-manual` index.
