### PR TITLE
Include service manual in unified_search searches

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -7,5 +7,5 @@ document_series_registry_index: "government"
 document_collection_registry_index: "government"
 world_location_registry_index: "government"
 # These indices are passed in this order to GovukSearcher
-govuk_index_names: ["mainstream", "detailed", "government"]
+govuk_index_names: ["mainstream", "detailed", "government", "service-manual"]
 metasearch_index_name: "metasearch"

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -8,6 +8,7 @@ class UnifiedSearchBuilder
   DEFAULT_QUERY_ANALYZER = "query_default"
   DEFAULT_QUERY_ANALYZER_WITHOUT_SYNONYMS = 'default'
   GOVERNMENT_BOOST_FACTOR = 0.4
+  SERVICE_MANUAL_BOOST_FACTOR = 0.1
   POPULARITY_OFFSET = 0.001
 
   def initialize(params, metaindex)
@@ -123,14 +124,25 @@ class UnifiedSearchBuilder
     query = base_query
     {
       indices: {
-        indices: [:government],
+        index: :government,
         query: {
           function_score: {
             query: query,
             boost_factor: GOVERNMENT_BOOST_FACTOR
           }
         },
-        no_match_query: query
+        no_match_query: {
+          indices: {
+            index: :"service-manual",
+            query: {
+              function_score: {
+                query: query,
+                boost_factor: SERVICE_MANUAL_BOOST_FACTOR
+              }
+            },
+            no_match_query: query
+          }
+        }
       }
     }
   end


### PR DESCRIPTION
Note: depends on
https://github.com/alphagov/government-service-design-manual/pull/545
being deployed first, but I'll deploy that in the same deploy slot, so
please merge when ready.

Now that the service manual is (or will be) sending documents to
rummager in the correct format for manuals, include the `service-manual`
index when searching using the `unified_search.json` endpoint.

This will allow the service-manual app to start using the unified_search
endpoint, and thus allow us to deprecate the now-unused old endpoints.

This also allows the service manual and its sections to come up in
search. In order to make sure that they don't come up too high for
unrelated searches, this commit adjusts the weight of anything from the
`service-manual` index downwards considerably. Once the documents are
available in search, we can review whether this down-weighting is
required, or excessive.
