### PR TITLE
Downweight historic WH content

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -80,7 +80,7 @@ class UnifiedSearchBuilder
   end
 
   def boost_filters
-    (format_boosts + [time_boost, closed_org_boost, devolved_org_boost]).compact
+    (format_boosts + [time_boost, closed_org_boost, devolved_org_boost, historic_edition_boost]).compact
   end
 
   def best_bets
@@ -461,6 +461,13 @@ class UnifiedSearchBuilder
     {
       filter: { term: { organisation_state: "devolved" } },
       boost_factor: 0.3,
+    }
+  end
+
+  def historic_edition_boost
+    {
+      filter: { term: { is_historic: true } },
+      boost_factor: 0.5,
     }
   end
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -124,6 +124,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
             }},
             {filter: {term: {organisation_state: 'closed'}}, boost_factor: 0.3},
             {filter: {term: {organisation_state: 'devolved'}}, boost_factor: 0.3},
+            {filter: {term: {is_historic: true}}, boost_factor: 0.5},
           ],
           score_mode: 'multiply',
         }


### PR DESCRIPTION
We want to downweight historic content so users are less likely
to be shown historic content when using a broad search term. When
searching specifically for historic content it should still rank
highly. Eg, when searching for something like "tax" historic
content should be less visible, but when searching for the title
of a specific historic tax document it should still be top.

(Historic means that the content is political and published under
a prior government, eg, not reflecting the political stance of
the current government)

Non political content will be unaffected.

This is an initial weighting, which needs some testing and
analysis before deciding.

This PR for discussion while we agree an initial value and analysis approach, it probably shouldn't be merged yet.
- [x] Agree initial down weighting value
