### PR TITLE
Add organisations and people to policy schema.

### DIFF
--- a/config/schema/document_types/policy.json
+++ b/config/schema/document_types/policy.json
@@ -1,5 +1,7 @@
 {
   "fields": [
-    "slug"
+    "slug",
+    "organisations",
+    "people"
   ]
 }


### PR DESCRIPTION
Both fields are already defined in `field_definitions.json` as they're used by the edition schema.
