### PR TITLE
Reduce cache lifetime for registries

### DIFF
--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -2,7 +2,7 @@ require "timed_cache"
 
 module Registry
   class BaseRegistry
-    CACHE_LIFETIME = 12 * 3600  # 12 hours
+    CACHE_LIFETIME = 300 # 5 minutes
 
     def initialize(index, field_definitions, format, fields = %w{slug link title}, clock = Time)
       @cache = TimedCache.new(self.class::CACHE_LIFETIME, clock) { fetch }
@@ -80,8 +80,6 @@ module Registry
   end
 
   class SpecialistSector < BaseRegistry
-    CACHE_LIFETIME = 300
-
     def initialize(index, field_definitions)
       super(index, field_definitions, "specialist_sector", %w{link title})
     end


### PR DESCRIPTION
The cache lifetime is currently set to a very high value (12 hours).
This means that, for example, when a new organisation is created,
documents which are assigned to that organisation won't appear with the
correct details in their "organisation" field for up to 12 hours.

This is a particular concern because when a new government is being
formed, there are likely to be several newly created organisations,
which may have considerable interest in them.

This PR changes the timeout to 5 minutes.  There is a risk that this may
increase load an unacceptable amount, but I expect it to be within
reasonable limits; on my dev VM building all the registries takes under
200ms, and I'd expect it to be faster with an elasticsearch cluster with
a hot cache.  However, to be careful, I plan to deploy this to staging
and watch load for a while (at least 15 minutes) before moving to
master.
