### PR TITLE
Make title sorting case insensitive

### DIFF
--- a/lib/facet_option.rb
+++ b/lib/facet_option.rb
@@ -47,7 +47,7 @@ private
     when :"value.slug"
       value.fetch("slug", "") <=> other.value.fetch("slug", "")
     when :"value.title"
-      value.fetch("title", "") <=> other.value.fetch("title", "")
+      value.fetch("title", "").downcase <=> other.value.fetch("title", "").downcase
     when :"value.link"
       value.fetch("link", "") <=> other.value.fetch("link", "")
     end

--- a/test/unit/facet_option_test.rb
+++ b/test/unit/facet_option_test.rb
@@ -81,6 +81,14 @@ class FacetOptionTest  < MiniTest::Unit::TestCase
     )
   end
 
+  def test_compare_by_title_ignores_case
+    orderings = [[:"value.title", 1]]
+    assert(
+      FacetOption.new({"title" => "a"}, 0, false, orderings) <
+      FacetOption.new({"title" => "Z"}, 0, false, orderings)
+    )
+  end
+
   def test_compare_by_link_ascending
     orderings = [[:"value.link", 1]]
     assert(


### PR DESCRIPTION
Ruby orders by ascii value by default meaning capital letters come
before lowercase letters i.e. Z = 90 comes before a = 97

I've added .downcase to sorting for titles to fix this and added a
test

https://www.pivotaltracker.com/story/show/89405790
