### PR TITLE
Update Access to work label for filter

### DIFF
--- a/config/schema/document_types/european_structural_investment_fund.json
+++ b/config/schema/document_types/european_structural_investment_fund.json
@@ -26,7 +26,7 @@
 
     "fund_type": [
       {
-        "label": "Access to work",
+        "label": "Access to employment",
         "value": "access-to-work"
       },
       {


### PR DESCRIPTION
To prevent misleading users from thinking this is related or similar
to a former name of an existing Government programme for disabled
people I have updated the label to read 'Access to employment'

https://www.pivotaltracker.com/story/show/92349076
