### PR TITLE
Support filtering by public timestamp

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -23,6 +23,7 @@ class BaseParameterParser
     manual
     organisations
     policies
+    public_timestamp
     section
     specialist_sectors
   )

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -386,6 +386,13 @@ private
   end
 
   def schema_get_field_type(field_name)
+    # Short term hack to recognise `public_timstamp` as date-field for filtering
+    # Without a `document_type` a schema can't be matched (see `schema`) and a
+    # type can't be found, defaulting to string.
+    if field_name == 'public_timestamp'
+      return 'date'
+    end
+
     schema
       .fetch("properties", {})
       .fetch(field_name, {})


### PR DESCRIPTION
This will be used by policy finders, see: https://github.com/alphagov/policy-publisher/pull/54
### Changes

**The clean bit:** Add `public_timestamp` to allowed filterable fields.

**The nasty bit:** Short-term hack to treat public_timestamp as a date
This will force `public_timstamp` to be a date-field for filtering.
Without a `document_type` a schema can't be matched (see `schema`) and a
type can't be found, defaulting to string, and causing an elastic search
error.

Date filtering is required for the new policy finders, which will need it
as part of the election work, so is required quite soon.

There is larger refactoring work in-progress by @rboulton to fix this
properly, but for now this unblocks the election team for now. It's
expected the larger refactor work will be done before the election, but
this short term hack will allow the election team to test this on
preview, and build other features on top of it, in the mean time.
