### PR TITLE
Add a `spelling_text` field for suggestions

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -14,6 +14,7 @@
     "updated_at",
     "last_update",
     "public_timestamp",
-    "latest_change_note"
+    "latest_change_note",
+    "spelling_text"
   ]
 }

--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -22,6 +22,10 @@ index:
           type: custom
           tokenizer: standard
           filter: [standard, lowercase, stemmer_override, stemmer_english]
+        spelling_analyzer:
+          type: custom
+          tokenizer: standard
+          filter: [standard, lowercase, shingle]
       filter:
         stemmer_english:
           type: stemmer

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -343,5 +343,10 @@
   "rank_14": {
     "description": "Field used in the page-traffic index to hold the rank of this page in the list of pages on the website when ordered by traffic.  This is a fairly stable value used in ranking calculations.",
     "type": "float"
+  },
+
+  "spelling_text": {
+    "description": "Generated field, populated with the same content as sent to the _all field, but tokenised into words, lowercased and shingled, not stemmed, etc",
+    "type": "spelling_text"
   }
 }

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -23,7 +23,8 @@
     "es_config": {
       "type": "string",
       "index": "not_analyzed",
-      "include_in_all": true
+      "include_in_all": true,
+      "copy_to": ["spelling_text"]
     }
   },
 
@@ -32,7 +33,8 @@
     "es_config": {
       "type": "string",
       "index": "analyzed",
-      "include_in_all": true
+      "include_in_all": true,
+      "copy_to": ["spelling_text"]
     }
   },
 
@@ -41,6 +43,16 @@
     "es_config": {
       "type": "string",
       "index": "no",
+      "include_in_all": false
+    }
+  },
+
+  "spelling_text": {
+    "description": "Text which is tokenised into words and lowercased, but not stemmed, stopworded, etc. This can be used for spelling correction, or exact word matching",
+    "es_config": {
+      "type": "string",
+      "index": "analyzed",
+      "analyzer": "spelling_analyzer",
       "include_in_all": false
     }
   },


### PR DESCRIPTION
This field contains a copy of all the text that's used for searching, tokenised only by splitting it into words and groups of words ("shingles") and lowercasing.

Stemming, stopwording, etc, are not applied. This is to support spelling correction, which otherwise will try to correct words to their stemmed forms.  eg "prisioner" would be corrected to "prison" if corrected using the `_all` field.  Using the `spelling_text` field, it is corrected to "prisoner".

Lowercasing is needed so that words which are consistently capitalised in our documents (such as "PAYE"), but are not consistently capitalised in searches, are still corrected to useful variants.  It would be nice to avoid having to lowercase, so that we could, for example, suggest proper nouns with the appropriate capitalisation, but that is less important than making basic corrections work at present.

The shingles filter adds "shingles" (token n-grams) to the field to allow corrections like "driving liecence" to "driving licence". [From the docs](http://www.elastic.co/guide/en/elasticsearch/reference/1.5/analysis-shingle-tokenfilter.html):

> 'For example, the sentence "please divide this sentence into shingles" might be tokenized into shingles "please divide", "divide this", "this sentence", "sentence into", and "into shingles".'

The field is generated by elasticsearch at index time by copying any `searchable_text` or `searchable_identifier` fields.  It therefore won't appear in the _source field when fetching documents, or be shown.

However, it is possible to search on it, and use it as the target field for a TermSuggester for spelling corrections, etc.

Original commit by @rboulton
## Testing

Reindex rummager by running:

```
bundle exec rake rummager:migrate_index RUMMAGER_INDEX=all
```
