### PR TITLE
Refactor UnifiedSearchPresenter

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -190,11 +190,11 @@ class Rummager < Sinatra::Application
     result_streams = searcher.search(@query, organisation, params["sort"])
 
     result_context = {
-      organisation_registry: organisation_registry,
-      topic_registry: topic_registry,
-      document_series_registry: document_series_registry,
-      document_collection_registry: document_collection_registry,
-      world_location_registry: world_location_registry
+      organisations: organisation_registry,
+      topics: topic_registry,
+      document_series: document_series_registry,
+      document_collections: document_collection_registry,
+      world_locations: world_location_registry
     }
 
     output = GovukSearchPresenter.new(result_streams, result_context).present
@@ -241,7 +241,7 @@ class Rummager < Sinatra::Application
   #     - link: the link in the facet value
   #     - title: the title in the facet value
   #     - filtered: whether the value is used in an active filter
-  #     
+  #
   #     Each ordering may be preceded by a "-" to sort in descending order.
   #     Multiple orderings can be specified, in priority order, separated by a
   #     colon.  The default ordering is "filtered:-count:slug".
@@ -331,14 +331,6 @@ class Rummager < Sinatra::Application
     json_only
 
     registries = {
-      organisation_registry: organisation_registry,
-      topic_registry: topic_registry,
-      document_series_registry: document_series_registry,
-      document_collection_registry: document_collection_registry,
-      world_location_registry: world_location_registry,
-      specialist_sector_registry: specialist_sector_registry,
-    }
-    registry_by_field = {
       organisations: organisation_registry,
       topics: topic_registry,
       document_series: document_series_registry,
@@ -357,7 +349,7 @@ class Rummager < Sinatra::Application
       return { error: parser.error }.to_json
     end
 
-    searcher = UnifiedSearcher.new(unified_index, metasearch_index, registries, registry_by_field, suggester)
+    searcher = UnifiedSearcher.new(unified_index, metasearch_index, registries, suggester)
     searcher.search(parser.parsed_params).to_json
   end
 
@@ -388,18 +380,21 @@ class Rummager < Sinatra::Application
     json_only
 
     organisation = params["organisation_slug"] == "" ? nil : params["organisation_slug"]
+
     result_set = current_index.search(@query,
       organisation: organisation,
       sort: params["sort"],
       order: params["order"])
+
     presenter_context = {
-      organisation_registry: organisation_registry,
-      topic_registry: topic_registry,
-      document_series_registry: document_series_registry,
-      document_collection_registry: document_collection_registry,
-      world_location_registry: world_location_registry,
+      organisations: organisation_registry,
+      topics: topic_registry,
+      document_series: document_series_registry,
+      document_collections: document_collection_registry,
+      world_locations: world_location_registry,
       spelling_suggestions: suggester.suggestions(@query)
     }
+
     presenter = ResultSetPresenter.new(result_set, presenter_context)
     presenter.present.to_json
   end

--- a/lib/govuk_search_presenter.rb
+++ b/lib/govuk_search_presenter.rb
@@ -15,7 +15,7 @@ class GovukSearchPresenter
   # `presenter_context` should be a map from registry names to registries,
   # which gets passed to the ResultSetPresenter class. For example:
   #
-  #     { organisation_registry: OrganisationRegistry.new(...) }
+  #     { organisations: OrganisationRegistry.new(...) }
   def initialize(result_sets, presenter_context = {})
     unknown_keys = result_sets.keys - STREAM_TITLES.keys
     if unknown_keys.any?

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -81,27 +81,27 @@ private
   end
 
   def document_series_registry
-    @context[:document_series_registry]
+    @context[:document_series]
   end
 
   def document_collection_registry
-    @context[:document_collection_registry]
+    @context[:document_collections]
   end
 
   def organisation_registry
-    @context[:organisation_registry]
+    @context[:organisations]
   end
 
   def topic_registry
-    @context[:topic_registry]
+    @context[:topics]
   end
 
   def world_location_registry
-    @context[:world_location_registry]
+    @context[:world_locations]
   end
 
   def specialist_sector_registry
-    @context[:specialist_sector_registry]
+    @context[:specialist_sectors]
   end
 
   def spelling_suggestions

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -16,17 +16,14 @@ class UnifiedSearchPresenter
   # values containing example information for the value.
   def initialize(search_params,
                  es_response,
-                 start,
                  index_names,
-                 applied_filters = {},
-                 facet_fields = {},
                  registries = {},
                  registry_by_field = {},
                  suggestions = [],
                  facet_examples = {},
                  schema = nil)
 
-    @start = start
+    @start = search_params[:start]
     @results = es_response["hits"]["hits"].map do |result|
       doc = result.delete("fields") || {}
       doc[:_metadata] = result
@@ -35,8 +32,10 @@ class UnifiedSearchPresenter
     @facets = es_response["facets"]
     @total = es_response["hits"]["total"]
     @index_names = index_names
-    @applied_filters = applied_filters
-    @facet_fields = facet_fields
+
+    @applied_filters = search_params[:filters] || []
+    @facet_fields = search_params[:facets] || {}
+
     @registries = registries
     @registry_by_field = registry_by_field
     @suggestions = suggestions

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -5,6 +5,7 @@ require "result_set_presenter"
 
 # Presents a combined set of results for a GOV.UK site search
 class UnifiedSearchPresenter
+  attr_reader :es_response, :search_params
 
   # `registries` should be a map from registry names to registries,
   # which gets passed to the ResultSetPresenter class. For example:
@@ -23,19 +24,14 @@ class UnifiedSearchPresenter
                  facet_examples = {},
                  schema = nil)
 
-    @start = search_params[:start]
-    @results = es_response["hits"]["hits"].map do |result|
-      doc = result.delete("fields") || {}
-      doc[:_metadata] = result
-      doc
-    end
+    @es_response = es_response
     @facets = es_response["facets"]
-    @total = es_response["hits"]["total"]
-    @index_names = index_names
 
+    @search_params = search_params
     @applied_filters = search_params[:filters] || []
     @facet_fields = search_params[:facets] || {}
 
+    @index_names = index_names
     @registries = registries
     @registry_by_field = registry_by_field
     @suggestions = suggestions
@@ -46,8 +42,8 @@ class UnifiedSearchPresenter
   def present
     {
       results: presented_results,
-      total: @total,
-      start: @start,
+      total: es_response["hits"]["total"],
+      start: search_params[:start],
       facets: presented_facets,
       suggested_queries: @suggestions
     }
@@ -62,7 +58,7 @@ private
     # organisations and topics.  It then makes a few further changes to tidy up
     # the output in other ways.
 
-    result_set = ResultSet.new(@results, nil)
+    result_set = ResultSet.new(search_results, nil)
     ResultSetPresenter.new(result_set, registries, schema).present["results"].each do |fields|
       metadata = fields.delete(:_metadata)
 
@@ -91,6 +87,14 @@ private
 
   def field_presenter
     @field_presenter ||= FieldPresenter.new(registry_by_field)
+  end
+
+  def search_results
+    es_response["hits"]["hits"].map do |result|
+      doc = result.delete("fields") || {}
+      doc[:_metadata] = result
+      doc
+    end
   end
 
   def facet_option_fields(field, slug)

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -10,7 +10,7 @@ class UnifiedSearchPresenter
   # `registries` should be a map from registry names to registries,
   # which gets passed to the ResultSetPresenter class. For example:
   #
-  #     { organisation_registry: OrganisationRegistry.new(...) }
+  #     { organisations: OrganisationRegistry.new(...) }
   #
   # `facet_examples` is {field_name => {facet_value => {total: count, examples: [{field: value}, ...]}}}
   # ie: a hash keyed by field name, containing hashes keyed by facet value with
@@ -18,7 +18,6 @@ class UnifiedSearchPresenter
   def initialize(search_params,
                  es_response,
                  registries = {},
-                 registry_by_field = {},
                  suggestions = [],
                  facet_examples = {},
                  schema = nil)
@@ -30,7 +29,6 @@ class UnifiedSearchPresenter
     @facet_fields = search_params[:facets] || {}
 
     @registries = registries
-    @registry_by_field = registry_by_field
     @suggestions = suggestions
     @facet_examples = facet_examples
     @schema = schema
@@ -48,7 +46,7 @@ class UnifiedSearchPresenter
 
 private
 
-  attr_reader :registries, :registry_by_field, :schema
+  attr_reader :registries, :schema
 
   def presented_results
     # This uses the "standard" ResultSetPresenter to expand fields like
@@ -81,7 +79,7 @@ private
   end
 
   def field_presenter
-    @field_presenter ||= FieldPresenter.new(registry_by_field)
+    @field_presenter ||= FieldPresenter.new(registries)
   end
 
   def search_results

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -14,10 +14,18 @@ class UnifiedSearchPresenter
   # `facet_examples` is {field_name => {facet_value => {total: count, examples: [{field: value}, ...]}}}
   # ie: a hash keyed by field name, containing hashes keyed by facet value with
   # values containing example information for the value.
-  def initialize(es_response, start, index_names, applied_filters = {},
-                 facet_fields = {}, registries = {},
-                 registry_by_field = {}, suggestions = [],
-                 facet_examples={}, schema=nil)
+  def initialize(search_params,
+                 es_response,
+                 start,
+                 index_names,
+                 applied_filters = {},
+                 facet_fields = {},
+                 registries = {},
+                 registry_by_field = {},
+                 suggestions = [],
+                 facet_examples = {},
+                 schema = nil)
+
     @start = start
     @results = es_response["hits"]["hits"].map do |result|
       doc = result.delete("fields") || {}
@@ -128,7 +136,7 @@ private
   # Get the facet options, sorted according to the "order" option.
   #
   # Returns the requested number of options, but will additionally return any
-  # options which are part of a filter. 
+  # options which are part of a filter.
   def facet_options(field, calculated_options, facet_parameters)
     applied_options = filter_values_for_field(field)
 

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -24,6 +24,7 @@ class UnifiedSearcher
                                               builder)
     facet_examples = example_fetcher.fetch
     UnifiedSearchPresenter.new(
+      params,
       es_response,
       params[:start],
       index.index_names,

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -26,12 +26,11 @@ class UnifiedSearcher
     UnifiedSearchPresenter.new(
       params,
       es_response,
-      index.index_names,
       registries,
       registry_by_field,
       suggested_queries(params[:query]),
       facet_examples,
-      index.schema,
+      index.schema
     ).present
   end
 

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -6,13 +6,12 @@ require "unified_search_presenter"
 
 class UnifiedSearcher
 
-  attr_reader :index, :registries, :registry_by_field, :suggester
+  attr_reader :index, :registries, :suggester
 
-  def initialize(index, metaindex, registries, registry_by_field, suggester)
+  def initialize(index, metaindex, registries, suggester)
     @index = index
     @metaindex = metaindex
     @registries = registries
-    @registry_by_field = registry_by_field
     @suggester = suggester
   end
 
@@ -27,7 +26,6 @@ class UnifiedSearcher
       params,
       es_response,
       registries,
-      registry_by_field,
       suggested_queries(params[:query]),
       facet_examples,
       index.schema

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -26,10 +26,7 @@ class UnifiedSearcher
     UnifiedSearchPresenter.new(
       params,
       es_response,
-      params[:start],
       index.index_names,
-      params[:filters],
-      params[:facets],
       registries,
       registry_by_field,
       suggested_queries(params[:query]),

--- a/test/functional/search_test.rb
+++ b/test/functional/search_test.rb
@@ -249,7 +249,6 @@ class SearchTest < IntegrationTest
     stub_index.stubs(:schema).returns(sample_schema)
     stub_index.stubs(:mappings).returns(mappings)
     stub_index.expects(:raw_search).returns({"hits" => {"hits" => [document], "total" => 1}})
-    stub_index.expects(:index_names).returns(%w{mainstream government detailed})
     stub_metasearch_index.expects(:analyzed_best_bet_query).with("bob").returns("bob")
     stub_metasearch_index.expects(:raw_search).returns({"hits" => {"hits" => []}})
     Registry::SpecialistSector.any_instance.expects(:[])

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -113,7 +113,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
     presenter = ResultSetPresenter.new(
       single_result_with_document_series("rail-statistics"),
-      document_series_registry: document_series_registry
+      document_series: document_series_registry
     )
 
     output = presenter.present
@@ -138,7 +138,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
     presenter = ResultSetPresenter.new(
       single_result_with_document_collection("rail-statistics"),
-      document_collection_registry: document_collection_registry
+      document_collections: document_collection_registry
     )
 
     output = presenter.present
@@ -163,7 +163,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
     presenter = ResultSetPresenter.new(
       single_result_with_organisations("ministry-of-defence"),
-      organisation_registry: organisation_registry
+      organisations: organisation_registry
     )
 
     output = presenter.present
@@ -187,7 +187,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
     presenter = ResultSetPresenter.new(
       single_result_with_topics("housing"),
-      topic_registry: topic_registry
+      topics: topic_registry
     )
 
     output = presenter.present
@@ -211,7 +211,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
     presenter = ResultSetPresenter.new(
       single_result_with_world_locations("angola"),
-      world_location_registry: world_location_registry
+      world_locations: world_location_registry
     )
 
     output = presenter.present
@@ -235,7 +235,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
     presenter = ResultSetPresenter.new(
       single_result_with_sectors("oil-and-gas/licensing"),
-      specialist_sector_registry: specialist_sector_registry,
+      specialist_sectors: specialist_sector_registry,
     )
 
     output = presenter.present
@@ -253,7 +253,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
     presenter = ResultSetPresenter.new(
       single_result_with_organisations("ministry-of-silly-walks"),
-      organisation_registry: organisation_registry
+      organisations: organisation_registry
     )
 
     output = presenter.present
@@ -267,7 +267,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
   def test_organisations_not_modified_if_no_registry_available
     presenter = ResultSetPresenter.new(
       single_result_with_organisations("ministry-of-silly-walks"),
-      organisation_registry: nil
+      organisations: nil
     )
 
     output = presenter.present

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -134,6 +134,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   def search_presenter(options)
     org_registry = options[:org_registry]
     UnifiedSearchPresenter.new(
+      { start: options.fetch(:start, 0) },
       sample_es_response(options.fetch(:es_response, {})),
       options.fetch(:start, 0),
       INDEX_NAMES,
@@ -155,7 +156,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           "total" => 0
         }
       }
-      @output = UnifiedSearchPresenter.new(results, 0, INDEX_NAMES).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, results, 0, INDEX_NAMES).present
     end
 
     should "present empty list of results" do
@@ -173,7 +174,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
   context "results with no registries" do
     setup do
-      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, 0, INDEX_NAMES).present
     end
 
     should "have correct total" do
@@ -216,7 +217,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         response['hits']['hits'] = [ @empty_result ]
       }
 
-      @output = UnifiedSearchPresenter.new(response, 0, INDEX_NAMES).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, response, 0, INDEX_NAMES).present
     end
 
     should 'return only basic metadata of fields' do
@@ -239,6 +240,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         .returns(farming_topic_document)
 
       @output = UnifiedSearchPresenter.new(
+        { start: 0 },
         sample_es_response,
         0,
         INDEX_NAMES,
@@ -292,6 +294,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   context "results with facets" do
     setup do
       @output = UnifiedSearchPresenter.new(
+        { start: 0 },
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
@@ -335,6 +338,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   context "results with facets and a filter applied" do
     setup do
       @output = UnifiedSearchPresenter.new(
+        { start: 0 },
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
@@ -385,6 +389,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   context "results with facets and a filter which matches nothing applied" do
     setup do
       @output = UnifiedSearchPresenter.new(
+        { start: 0 },
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
@@ -435,6 +440,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   context "results with facet counting only" do
     setup do
       @output = UnifiedSearchPresenter.new(
+        { start: 0 },
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
@@ -559,6 +565,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       org_registry = sample_org_registry
 
       @output = UnifiedSearchPresenter.new(
+        { start: 0 },
         sample_es_response("facets" => sample_facet_data_with_topics),
         0,
         INDEX_NAMES,
@@ -621,6 +628,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       org_registry = sample_org_registry
 
       @output = UnifiedSearchPresenter.new(
+        { start: 0 },
         sample_es_response("facets" => sample_facet_data),
         0,
         INDEX_NAMES,
@@ -686,13 +694,13 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         "self assessment",
         "tax returns"
       ]
-      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES, [], {}, {}, {}, @suggestions).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, 0, INDEX_NAMES, [], {}, {}, {}, @suggestions).present
 
       assert_equal ["self assessment", "tax returns"], @output[:suggested_queries]
     end
 
     should "default to an empty array when not present" do
-      @output = UnifiedSearchPresenter.new(sample_es_response, 0, INDEX_NAMES, [], {}, {}, {}).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, 0, INDEX_NAMES, [], {}, {}, {}).present
 
       assert_equal [], @output[:suggested_queries]
     end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -129,8 +129,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     }.merge(options)
   end
 
-  INDEX_NAMES = %w(mainstream government detailed)
-
   def search_presenter(options)
     org_registry = options[:org_registry]
     UnifiedSearchPresenter.new(
@@ -140,7 +138,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         facets: options.fetch(:facets, {}),
       },
       sample_es_response(options.fetch(:es_response, {})),
-      INDEX_NAMES,
       org_registry.nil? ? {} : {organisation_registry: org_registry},
       org_registry.nil? ? {} : {organisations: org_registry},
       options.fetch(:suggestions, []),
@@ -157,7 +154,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           "total" => 0
         }
       }
-      @output = UnifiedSearchPresenter.new({ start: 0 }, results, INDEX_NAMES).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, results).present
     end
 
     should "present empty list of results" do
@@ -175,7 +172,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
   context "results with no registries" do
     setup do
-      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, INDEX_NAMES).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response).present
     end
 
     should "have correct total" do
@@ -188,7 +185,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
     should "have short index names" do
       @output[:results].each do |result|
-        assert_contains INDEX_NAMES, result[:index]
+        assert_contains %w[mainstream detailed government service-manual], result[:index]
       end
     end
 
@@ -218,7 +215,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         response['hits']['hits'] = [ @empty_result ]
       }
 
-      @output = UnifiedSearchPresenter.new({ start: 0 }, response, INDEX_NAMES).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, response).present
     end
 
     should 'return only basic metadata of fields' do
@@ -243,7 +240,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       @output = UnifiedSearchPresenter.new(
         { start: 0 },
         sample_es_response,
-        INDEX_NAMES,
         {topic_registry: topic_registry},
         {topics: topic_registry},
       ).present
@@ -259,7 +255,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
     should "have short index names" do
       @output[:results].each do |result|
-        assert_contains INDEX_NAMES, result[:index]
+        assert_contains %w[mainstream detailed government service-manual], result[:index]
       end
     end
 
@@ -294,7 +290,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       @output = UnifiedSearchPresenter.new(
         { start: 0, facets: { "organisations" => facet_params(1) } },
         sample_es_response("facets" => sample_facet_data),
-        INDEX_NAMES
       ).present
     end
 
@@ -339,7 +334,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           facets: {"organisations" => facet_params(2)},
         },
         sample_es_response("facets" => sample_facet_data),
-        INDEX_NAMES
       ).present
     end
 
@@ -391,7 +385,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           facets: {"organisations" => facet_params(1)},
         },
         sample_es_response("facets" => sample_facet_data),
-        INDEX_NAMES
       ).present
     end
 
@@ -442,7 +435,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           facets: { "organisations" => facet_params(0) },
         },
         sample_es_response("facets" => sample_facet_data),
-        INDEX_NAMES
       ).present
     end
 
@@ -567,9 +559,8 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           facets: {"organisations" => facet_params(1), "topics" => facet_params(1)},
         },
         sample_es_response("facets" => sample_facet_data_with_topics),
-        INDEX_NAMES,
-        {organisation_registry: org_registry},
-        {organisations: org_registry},
+        { organisation_registry: org_registry },
+        { organisations: org_registry },
       ).present
     end
 
@@ -630,7 +621,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           facets: { "organisations" => facet_params(1) }
         },
         sample_es_response("facets" => sample_facet_data),
-        INDEX_NAMES,
         {organisation_registry: org_registry},
         {organisations: org_registry},
         [],
@@ -691,13 +681,13 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         "self assessment",
         "tax returns"
       ]
-      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, INDEX_NAMES, {}, {}, @suggestions).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, {}, {}, @suggestions).present
 
       assert_equal ["self assessment", "tax returns"], @output[:suggested_queries]
     end
 
     should "default to an empty array when not present" do
-      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, INDEX_NAMES).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response).present
 
       assert_equal [], @output[:suggested_queries]
     end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -138,8 +138,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         facets: options.fetch(:facets, {}),
       },
       sample_es_response(options.fetch(:es_response, {})),
-      org_registry.nil? ? {} : {organisation_registry: org_registry},
-      org_registry.nil? ? {} : {organisations: org_registry},
+      org_registry.nil? ? {} : { organisations: org_registry },
       options.fetch(:suggestions, []),
       options.fetch(:facet_examples, {}),
       options.fetch(:schema, nil)
@@ -240,8 +239,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       @output = UnifiedSearchPresenter.new(
         { start: 0 },
         sample_es_response,
-        {topic_registry: topic_registry},
-        {topics: topic_registry},
+        { topics: topic_registry },
       ).present
     end
 
@@ -559,7 +557,6 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           facets: {"organisations" => facet_params(1), "topics" => facet_params(1)},
         },
         sample_es_response("facets" => sample_facet_data_with_topics),
-        { organisation_registry: org_registry },
         { organisations: org_registry },
       ).present
     end
@@ -621,8 +618,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           facets: { "organisations" => facet_params(1) }
         },
         sample_es_response("facets" => sample_facet_data),
-        {organisation_registry: org_registry},
-        {organisations: org_registry},
+        { organisations: org_registry },
         [],
         {"organisations" => {
           "hm-magic" => {
@@ -681,7 +677,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         "self assessment",
         "tax returns"
       ]
-      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, {}, {}, @suggestions).present
+      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response, {}, @suggestions).present
 
       assert_equal ["self assessment", "tax returns"], @output[:suggested_queries]
     end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -191,7 +191,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   end
 
   def make_searcher
-    UnifiedSearcher.new(@combined_index, @metasearch_index, {}, {}, stub_suggester)
+    UnifiedSearcher.new(@combined_index, @metasearch_index, {}, stub_suggester)
   end
 
   def make_schema


### PR DESCRIPTION
These commits refactor the UnifiedSearchPresenter class and associated tests. By consolidating arguments it brings down the arity of `UnifiedSearchPresenter.new` from 10 to 6 and improves readability of the tests. 

Immediate win is that it's no longer necessary to add new parameters for an upcoming change relating to the spelling suggester.

Best reviewed per-commit in chronological order (start at 97ec7e6).
