### PR TITLE
Fix coverage reporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "unf", "0.1.3"
 
 group :test do
   gem "shoulda-context"
-  gem "simplecov"
+  gem "simplecov", "~> 0.10.0"
   gem "simplecov-rcov"
   gem 'turn', require: false # Pretty printed test output
   gem "ci_reporter", "1.7.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     coderay (1.1.0)
     connection_pool (1.1.0)
     crack (0.3.2)
+    docile (1.1.5)
     ffi (1.9.0)
     ffi-aspell (0.0.3)
       ffi (>= 1.0.11)
@@ -54,7 +55,7 @@ GEM
       rb-fsevent (>= 0.9)
       rb-inotify (>= 0.8)
       unicorn (>= 4.5)
-    multi_json (1.3.6)
+    multi_json (1.11.0)
     nokogiri (1.5.5)
     null_logger (0.0.1)
     plek (1.5.0)
@@ -89,10 +90,11 @@ GEM
       json
       redis (>= 3.0)
       redis-namespace
-    simplecov (0.7.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
     sinatra (1.3.4)
@@ -143,7 +145,7 @@ DEPENDENCIES
   rest-client (= 1.6.7)
   shoulda-context
   sidekiq (= 2.13.0)
-  simplecov
+  simplecov (~> 0.10.0)
   simplecov-rcov
   sinatra (= 1.3.4)
   slop (= 3.4.5)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,21 @@
 ENV['RACK_ENV'] = 'test'
 
+# Simplecov should be required before any other code is loaded statement to prevent
+# false negatives.
+if ENV["USE_SIMPLECOV"]
+  require "simplecov"
+  require "simplecov-rcov"
+  SimpleCov.start do
+    add_filter '/test/'
+  end
+
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+end
+
 $LOAD_PATH << File.expand_path('../../', __FILE__)
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
+
+require 'app'
 
 require "bundler/setup"
 require "minitest/autorun"
@@ -16,13 +30,6 @@ require "timecop"
 
 require "webmock/minitest"
 WebMock.disable_net_connect!
-
-if ENV["USE_SIMPLECOV"]
-  require "simplecov"
-  require "simplecov-rcov"
-  SimpleCov.start
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-end
 
 require "sample_config"
 


### PR DESCRIPTION
Simplecov should be required before any other code is loaded to prevent
false negatives.

Simplecov now reports a nice 96.63% code coverage on this repo. :+1: 
