### PR TITLE
Refactor unified searcher tests

### DIFF
--- a/lib/facet_example_fetcher.rb
+++ b/lib/facet_example_fetcher.rb
@@ -5,7 +5,6 @@ class FacetExampleFetcher
     @response_facets = es_response["facets"]
     @params = params
     @search_builder = search_builder
-    @field_definitions = index.schema.field_definitions
   end
 
   # Fetch all requested example facet values
@@ -28,6 +27,11 @@ class FacetExampleFetcher
   end
 
 private
+
+  def field_definitions
+    @index.schema.field_definitions
+  end
+
   def fetch_for_field(field_name, facet_params)
     example_count = facet_params[:examples]
     example_fields = facet_params[:example_fields]
@@ -124,7 +128,7 @@ private
         values = [values]
       end
 
-      if @field_definitions.fetch(field_name).type.multivalued
+      if field_definitions.fetch(field_name).type.multivalued
         result[field_name] = values
       else
         result[field_name] = values.first

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -14,7 +14,7 @@ class UnifiedSearchBuilder
   def initialize(params, metaindex)
     @params = params
     @query = params[:query]
-    if @params[:debug][:disable_best_bets]
+    if @params[:debug] && @params[:debug][:disable_best_bets]
       @best_bets_checker = BestBetsChecker.new(metaindex, nil)
     else
       @best_bets_checker = BestBetsChecker.new(metaindex, @query)

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -126,6 +126,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     {
       requested: requested,
       order: SearchParameterParser::DEFAULT_FACET_SORT,
+      scope: :exclude_field_filter,
     }.merge(options)
   end
 
@@ -301,6 +302,11 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
     should "have correct number of facet values" do
       assert_equal 1, @output[:facets]["organisations"][:options].length
+    end
+
+    should "include requested facet scope" do
+      facet = @output[:facets]["organisations"]
+      assert_equal :exclude_field_filter, facet[:scope]
     end
 
     should "have correct top facet value value" do

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -1,180 +1,20 @@
 require "test_helper"
-require "set"
 require "unified_searcher"
-require "search_parameter_parser"
 
 class UnifiedSearcherTest < ShouldaUnitTestCase
-  EMPTY_ES_RESPONSE = {
-    "hits" => { "hits" => {}, "total" => 0 }
-  }
+  context "#search" do
+    should 'search with the results from the builder and return a presenter' do
+      index = stub('index', :schema)
+      searcher = UnifiedSearcher.new(index, stub, stub, stub)
 
-  def setup
-    Timecop.freeze
-    super
-  end
+      search_payload = stub('payload')
+      UnifiedSearchBuilder.any_instance.expects(:payload).returns(search_payload)
+      index.expects(:raw_search).with(search_payload).returns({})
 
-  def stub_suggester
-    stub('Suggester', suggestions: ['cheese'])
-  end
+      FacetExampleFetcher.any_instance.expects(:fetch).returns(stub('fetch'))
+      UnifiedSearchPresenter.any_instance.expects(:present).returns(stub('presenter'))
 
-  def text_filter(field_name, values, reject = false)
-    SearchParameterParser::TextFieldFilter.new(field_name, values, reject)
-  end
-
-  def date_filter(field_name, values, reject = false)
-    SearchParameterParser::DateFieldFilter.new(field_name, values, reject)
-  end
-
-  def mock_best_bets(query)
-    @metasearch_index = stub("metasearch index")
-    @metasearch_index.stubs(:raw_search).with(
-      {
-        query: {:bool => {:should => [{:match => {:exact_query => query}},
-                                      {:match => {:stemmed_query => query}}]}},
-        size: 1000,
-        fields: [:details, :stemmed_query_as_term],
-      }, "best_bet").returns(
-      {
-        "hits" => {"hits" => [], "total" => [].size}
-      })
-    @metasearch_index.stubs(:analyzed_best_bet_query).with(query).returns(query)
-  end
-
-  def make_searcher
-    mock_best_bets("cheese")
-    UnifiedSearchBuilder.any_instance.stubs query: 'A SUPER LONG QUERY'
-
-    searcher = UnifiedSearcher.new(@combined_index, @metasearch_index, {}, stub_suggester)
-    @combined_index.stubs(:schema).returns(make_schema)
-    searcher
-  end
-
-  def make_schema
-    schema = stub("schema")
-    index_schema = stub("index schema")
-
-    schema.stubs(:schema_for_alias_name).returns(index_schema)
-    schema.stubs(:field_definitions)
-    index_schema.stubs(:document_type).returns(sample_document_types["cma_case"])
-    schema
-  end
-
-  context "unfiltered, unsorted search" do
-    should 'call raw_search with the results from the builder' do
-      @combined_index = stub("unified index")
-      @searcher = make_searcher
-      @combined_index.expects(:raw_search).with({
-        from: 0,
-        size: 20,
-        query: 'A SUPER LONG QUERY',
-        fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-      }).returns(EMPTY_ES_RESPONSE)
-
-      @results = @searcher.search({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        order: nil,
-        filters: {},
-        return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        debug: {},
-      })
-    end
-  end
-
-  context "unfiltered, sorted search" do
-    should 'call raw_search with the results from the builder' do
-      @combined_index = stub("unified index")
-      @searcher = make_searcher
-      @combined_index.stubs(:raw_search).with({
-        from: 0,
-        size: 20,
-        query: 'A SUPER LONG QUERY',
-        fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        sort: [{"public_timestamp" => {order: "asc", missing: "_last"}}],
-      }).returns(EMPTY_ES_RESPONSE)
-
-      @results = @searcher.search({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        order: ["public_timestamp", "asc"],
-        filters: {},
-        return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        debug: {},
-      })
-    end
-  end
-
-  context "filtered, unsorted search" do
-    should 'call raw_search with the results from the builder' do
-      @combined_index = stub("unified index")
-      @searcher = make_searcher
-      @combined_index.stubs(:raw_search).with({
-        from: 0,
-        size: 20,
-        query: 'A SUPER LONG QUERY',
-        filter: { "terms" => {"organisations" => ["ministry-of-magic"] } },
-        fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-      }).returns(EMPTY_ES_RESPONSE)
-
-      @results = @searcher.search({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        filters: [ text_filter("organisations", ["ministry-of-magic"]) ],
-        return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        facets: nil,
-        debug: {},
-      })
-    end
-  end
-
-  context "faceted, unsorted search" do
-    should 'call raw_search with the results from the builder' do
-      @combined_index = stub("unified index")
-      @searcher = make_searcher
-      @combined_index.stubs(:raw_search).with({
-        from: 0,
-        size: 20,
-        query: 'A SUPER LONG QUERY',
-        facets: {
-          "organisations" => {
-            terms: {
-              field: "organisations",
-              order: "count",
-              size: 100000,
-            },
-          }
-        },
-        fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-      }).returns(EMPTY_ES_RESPONSE.merge(
-        "facets" => {"organisations" => {
-          "missing" => 7,
-          "terms" => [
-            {"term" => "a", "count" => 2,},
-            {"term" => "b", "count" => 1,},
-          ]
-        }},
-      ))
-
-      @results = @searcher.search({
-        start: 0,
-        count: 20,
-        query: "cheese",
-        filters: {},
-        return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-        facets: {
-          "organisations" => {
-            requested: 1,
-            examples: 0,
-            example_fields: [],
-            order: SearchParameterParser::DEFAULT_FACET_SORT,
-            scope: :exclude_field_filter
-          }
-        },
-        debug: {},
-      })
+      searcher.search({})
     end
   end
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -178,7 +178,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   end
 
   context "unfiltered, unsorted search" do
-
     setup do
       @combined_index = stub("unified index")
       @searcher = make_searcher
@@ -202,23 +201,13 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       })
     end
 
-    should "include results from all indexes" do
-      assert_equal(
-        ["government", "mainstream", "detailed"].to_set,
-        @results[:results].map { |result|
-          result[:index]
-        }.to_set
-      )
-    end
-
     should "include suggested queries" do
       assert_equal ['cheese'], @results[:suggested_queries]
     end
   end
 
   context "unfiltered, sorted search" do
-
-    setup do
+    should 'call raw_search with the results from the builder' do
       @combined_index = stub("unified index")
       @searcher = make_searcher
       @combined_index.stubs(:raw_search).with({
@@ -241,20 +230,10 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         debug: {},
       })
     end
-
-    should "include results from all indexes" do
-      assert_equal(
-        ["government", "mainstream", "detailed"].to_set,
-        @results[:results].map do |result|
-          result[:index]
-        end.to_set
-      )
-    end
   end
 
   context "filtered, unsorted search" do
-
-    setup do
+    should 'call raw_search with the results from the builder' do
       @combined_index = stub("unified index")
       @searcher = make_searcher
       @combined_index.stubs(:raw_search).with({
@@ -277,19 +256,9 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         debug: {},
       })
     end
-
-    should "include results from all indexes" do
-      assert_equal(
-        ["government", "mainstream", "detailed"].to_set,
-        @results[:results].map do |result|
-          result[:index]
-        end.to_set
-      )
-    end
   end
 
   context "faceted, unsorted search" do
-
     setup do
       @combined_index = stub("unified index")
       @searcher = make_searcher
@@ -337,15 +306,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       })
     end
 
-    should "include results from all indexes" do
-      assert_equal(
-        ["government", "mainstream", "detailed"].to_set,
-        @results[:results].map do |result|
-          result[:index]
-        end.to_set
-      )
-    end
-
     should "include requested number of facet options" do
       facet = @results[:facets]["organisations"]
       assert_equal(1, facet[:options].length)
@@ -372,5 +332,4 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       assert_equal(:exclude_field_filter, facet[:scope])
     end
   end
-
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -4,43 +4,13 @@ require "unified_searcher"
 require "search_parameter_parser"
 
 class UnifiedSearcherTest < ShouldaUnitTestCase
+  EMPTY_ES_RESPONSE = {
+    "hits" => { "hits" => {}, "total" => 0 }
+  }
+
   def setup
     Timecop.freeze
     super
-  end
-
-  def sample_docs
-    [{
-      "_index" => "government-2014-03-19t14:35:28z-a05cfc73-933a-41c7-adc0-309a715baf09",
-      _type: "edition",
-      _id: "/government/publications/staffordshire-cheese",
-      _score: 3.0514863,
-      "fields" => {
-        "description" => "Staffordshire Cheese Product of Designated Origin (PDO) and Staffordshire Organic Cheese.",
-        "title" => "Staffordshire Cheese",
-        "link" => "/government/publications/staffordshire-cheese",
-      },
-    }, {
-      "_index" => "mainstream-2014-03-19t14:35:28z-6472f975-dc38-49a5-98eb-c498e619650c",
-      _type: "edition",
-      _id: "/duty-relief-for-imports-and-exports",
-      _score: 0.49672604,
-      "fields" => {
-        "description" => "Schemes that offer reduced or zero rate duty and VAT for imports and exports",
-        "title" => "Duty relief for imports and exports",
-        "link" => "/duty-relief-for-imports-and-exports",
-      },
-    }, {
-      "_index" => "detailed-2014-03-19t14:35:27z-27e2831f-bd14-47d8-9c7a-3017e213efe3",
-      _type: "edition",
-      _id: "/dairy-farming-and-schemes",
-      _score: 0.34655035,
-      "fields" => {
-        "description" => "Information on hygiene standards and milking practices for UK dairy farmers, with a guide to EU schemes for dairy farmers and producers",
-        "title" => "Dairy farming and schemes",
-        "link" => "/dairy-farming-and-schemes",
-      },
-    }]
   end
 
   def stub_suggester
@@ -186,9 +156,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         size: 20,
         query: CHEESE_QUERY,
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-      }).returns({
-        "hits" => {"hits" => sample_docs, "total" => 3}
-      })
+      }).returns(EMPTY_ES_RESPONSE)
 
       @results = @searcher.search({
         start: 0,
@@ -212,9 +180,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         query: CHEESE_QUERY,
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
         sort: [{"public_timestamp" => {order: "asc", missing: "_last"}}],
-      }).returns({
-        "hits" => {"hits" => sample_docs, "total" => 3}
-      })
+      }).returns(EMPTY_ES_RESPONSE)
 
       @results = @searcher.search({
         start: 0,
@@ -238,9 +204,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         query: CHEESE_QUERY,
         filter: { "terms" => {"organisations" => ["ministry-of-magic"] } },
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-      }).returns({
-        "hits" => {"hits" => sample_docs, "total" => 3}
-      })
+      }).returns(EMPTY_ES_RESPONSE)
 
       @results = @searcher.search({
         start: 0,
@@ -272,8 +236,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
           }
         },
         fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
-      }).returns({
-        "hits" => {"hits" => sample_docs, "total" => 3},
+      }).returns(EMPTY_ES_RESPONSE.merge(
         "facets" => {"organisations" => {
           "missing" => 7,
           "terms" => [
@@ -281,7 +244,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
             {"term" => "b", "count" => 1,},
           ]
         }},
-      })
+      ))
 
       @results = @searcher.search({
         start: 0,

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -131,7 +131,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   end
 
   context "faceted, unsorted search" do
-    setup do
+    should 'call raw_search with the results from the builder' do
       @combined_index = stub("unified index")
       @searcher = make_searcher
       @combined_index.stubs(:raw_search).with({
@@ -175,32 +175,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         },
         debug: {},
       })
-    end
-
-    should "include requested number of facet options" do
-      facet = @results[:facets]["organisations"]
-      assert_equal(1, facet[:options].length)
-    end
-
-    should "have correct top facet option" do
-      facet = @results[:facets]["organisations"]
-      assert_equal({value: {"slug" => "a"}, documents: 2}, facet[:options][0])
-    end
-
-    should "include requested number of facets" do
-      facet = @results[:facets]["organisations"]
-      assert_equal(2, facet[:total_options])
-      assert_equal(1, facet[:missing_options])
-    end
-
-    should "include number of documents with no value" do
-      facet = @results[:facets]["organisations"]
-      assert_equal(7, facet[:documents_with_no_value])
-    end
-
-    should "include requested facet scope" do
-      facet = @results[:facets]["organisations"]
-      assert_equal(:exclude_field_filter, facet[:scope])
     end
   end
 end

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -178,7 +178,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   end
 
   context "unfiltered, unsorted search" do
-    setup do
+    should 'call raw_search with the results from the builder' do
       @combined_index = stub("unified index")
       @searcher = make_searcher
       @combined_index.expects(:raw_search).with({
@@ -199,10 +199,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         return_fields: SearchParameterParser::ALLOWED_RETURN_FIELDS,
         debug: {},
       })
-    end
-
-    should "include suggested queries" do
-      assert_equal ['cheese'], @results[:suggested_queries]
     end
   end
 

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -211,10 +211,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       )
     end
 
-    should "include total result count" do
-      assert_equal(3, @results[:total])
-    end
-
     should "include suggested queries" do
       assert_equal ['cheese'], @results[:suggested_queries]
     end
@@ -254,10 +250,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
         end.to_set
       )
     end
-
-    should "include total result count" do
-      assert_equal(3, @results[:total])
-    end
   end
 
   context "filtered, unsorted search" do
@@ -293,10 +285,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
           result[:index]
         end.to_set
       )
-    end
-
-    should "include total result count" do
-      assert_equal(3, @results[:total])
     end
   end
 
@@ -356,10 +344,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
           result[:index]
         end.to_set
       )
-    end
-
-    should "include total result count" do
-      assert_equal(3, @results[:total])
     end
 
     should "include requested number of facet options" do


### PR DESCRIPTION
While refactoring `unified_searcher_test.rb`, it became increasingly apparent that almost all tests there duplicate other tests.

The first commits in this PR strip away tests and code from `unified_searcher_test.rb`, the last commit (e8f916e) finally replaces the tests with a simpler version. 

UnifiedSearcher is a very simple class. It receives an arguments object, sends that to a query builder, executes the query in elasticsearch and returns the results in a presenter. A test for this class should test that the right methods are being called with the correct arguments.

With these changes, code coverage (as reported by simplecov) increases slightly from 96.63% to 96.64%.
