### PR TITLE
Upgrade Webmock gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :test do
   gem "minitest", "4.6.1"
   gem "rack-test"
   gem "mocha", :require => false
-  gem "webmock", "1.9.3", :require => false
+  gem "webmock", "~> 1.21.0", require: false
   gem "timecop", "0.7.3"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     activesupport (3.2.12)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    addressable (2.3.3)
+    addressable (2.3.8)
     airbrake (4.0.0)
       builder
       multi_json
@@ -18,7 +18,8 @@ GEM
       builder (>= 2.1.2)
     coderay (1.1.0)
     connection_pool (1.1.0)
-    crack (0.3.2)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     docile (1.1.5)
     ffi (1.9.0)
     ffi-aspell (0.0.3)
@@ -83,6 +84,7 @@ GEM
       redis (~> 3.0.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
+    safe_yaml (1.0.4)
     shoulda-context (1.1.1)
     sidekiq (2.13.0)
       celluloid (>= 0.14.1)
@@ -114,8 +116,8 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    webmock (1.9.3)
-      addressable (>= 2.2.7)
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
     whenever (0.8.2)
       activesupport (>= 2.3.4)
@@ -153,5 +155,5 @@ DEPENDENCIES
   turn
   unf (= 0.1.3)
   unicorn (= 4.6.2)
-  webmock (= 1.9.3)
+  webmock (~> 1.21.0)
   whenever


### PR DESCRIPTION
Specifically for [WebMock.disable_net_connect! now accepts array of regexps as allow param](https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#1120).
