### PR TITLE
Add 'people' to list of returnable fields

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -112,6 +112,7 @@ class BaseParameterParser
     manual
     organisation_state
     organisations
+    people
     policies
     public_timestamp
     section


### PR DESCRIPTION
'people' was added to facetable/filterable fields in #420, but was
missed in the returnable fields list, so filtering won't work
without it.
