### PR TITLE
Expand 'people' fields into person objects

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -6,6 +6,7 @@ topic_registry_index: "government"
 document_series_registry_index: "government"
 document_collection_registry_index: "government"
 world_location_registry_index: "government"
+people_registry_index: "government"
 # These indices are passed in this order to GovukSearcher
 govuk_index_names: ["mainstream", "detailed", "government", "service-manual"]
 metasearch_index_name: "metasearch"

--- a/lib/registries.rb
+++ b/lib/registries.rb
@@ -13,6 +13,7 @@ class Registries < Struct.new(:search_server, :search_config)
       document_collections: document_collections,
       world_locations: world_locations,
       specialist_sectors: specialist_sectors,
+      people: people,
     }
   end
 
@@ -59,6 +60,14 @@ class Registries < Struct.new(:search_server, :search_config)
   def specialist_sectors
     index_name = settings.search_config.govuk_index_names
     @specialist_sector_registry ||= Registry::SpecialistSector.new(
+      index_for_search(index_name),
+      field_definitions
+    )
+  end
+
+  def people
+    index_name = settings.search_config.people_registry_index
+    @people_registry ||= Registry::Person.new(
       index_for_search(index_name),
       field_definitions
     )

--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -119,4 +119,10 @@ module Registry
       super(index, field_definitions, "world_location")
     end
   end
+
+  class Person < BaseRegistry
+    def initialize(index, field_definitions)
+      super(index, field_definitions, "people")
+    end
+  end
 end

--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -54,6 +54,11 @@ private
         structure_by_slug(specialist_sector_registry, slug)
       end
     end
+    if result['people'] && should_expand_people?
+      result['people'].map! do |slug|
+        structure_by_slug(people_registry, slug)
+      end
+    end
     result
   end
 
@@ -75,6 +80,10 @@ private
 
   def should_expand_world_locations?
     !! world_location_registry
+  end
+
+  def should_expand_people?
+    !! people_registry
   end
 
   def document_series_registry
@@ -99,6 +108,10 @@ private
 
   def specialist_sector_registry
     @context[:specialist_sectors]
+  end
+
+  def people_registry
+    @context[:people]
   end
 
   def structure_by_slug(structure, slug)

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -46,6 +46,10 @@ class SearchConfig
     elasticsearch["organisation_registry_index"]
   end
 
+  def people_registry_index
+    elasticsearch["people_registry_index"]
+  end
+
   def topic_registry_index
     elasticsearch["topic_registry_index"]
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -54,6 +54,7 @@ module ElasticsearchIntegration
       "document_series_registry_index" => @default_index_name,
       "document_collection_registry_index" => @default_index_name,
       "world_location_registry_index" => @default_index_name,
+      "people_registry_index" => @default_index_name,
       "spelling_index_names" => content_index_names,
     })
     app.settings.stubs(:default_index_name).returns(@default_index_name)


### PR DESCRIPTION
Results with a 'people' field were returning an array of string
slugs, compared to fields like 'organisation' where they are
expanded into full objects, with the title/link/etc of the
organisation included.

This adds the appropriate code to expand people fields, so that
the full object representation can be used to display details
about people, eg, in metadata or filter facets in a Finder.

I'm not 100% confident on the `person_registry_index` change,
it's based on what other registries are doing. I think I understand
it, but i'd appreciate someone giving that an extra eye.
