### PR TITLE
Add title to sort fields

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -11,6 +11,7 @@ class BaseParameterParser
   ALLOWED_SORT_FIELDS = %w(
     last_update
     public_timestamp
+    title
   )
 
   # The fields listed here are the only ones which can be used to filter by.


### PR DESCRIPTION
For the Policy finder (https://www.gov.uk/government/policies) sorting
by `public_timestamp` is meaningless as content changes don't bubble up
to the Policy. Until we can do that, it makes more sense to sort the
Policies by title. This commit adds title to the `ALLOWED_SORT_FIELDS`.
