### PR TITLE
Make sorting by title work.

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -4,7 +4,7 @@
   },
 
   "title": {
-    "type": "searchable_text"
+    "type": "searchable_sortable_text"
   },
 
   "description": {

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -38,6 +38,23 @@
     }
   },
 
+  "searchable_sortable_text": {
+    "description": "A piece of plain text that should be split into words and considered in searches, but can also be sorted on",
+    "es_config": {
+      "type": "string",
+      "index": "analyzed",
+      "include_in_all": true,
+      "copy_to": ["spelling_text"],
+      "fields": {
+        "sort": {
+          "type": "string",
+          "index": "not_analyzed",
+          "include_in_all": false
+        }
+      }
+    }
+  },
+
   "unsearchable_text": {
     "description": "A piece of text which can be returned, but which is not searchable",
     "es_config": {

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -14,6 +14,10 @@ class BaseParameterParser
     title
   )
 
+  SORT_MAPPINGS = {
+    "title" => "title.sort"
+  }
+
   # The fields listed here are the only ones which can be used to filter by.
   ALLOWED_FILTER_FIELDS = %w(
     display_type
@@ -309,7 +313,7 @@ private
       @errors << %{"#{field}" is not a valid sort field}
       return nil
     end
-    return [field, dir]
+    return [SORT_MAPPINGS.fetch(field, field), dir]
   end
 
   # Get a list of the fields to request in results from elasticsearch


### PR DESCRIPTION
This is implemented by also indexing "title" to a non-analyzed sub-field
called "title.sort", and making a sort on title use this.

(Depends on elasticsearch 1.0+'s "fields" feature.)

This probably actually wants to have the title lowercased, etc, so that sorting is case insensitive.

The index will need to be migrated first, for this to work.

FAO: @tommyp 
