### PR TITLE
Make title ordering case and whitespace insensitive

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -26,6 +26,10 @@ index:
           type: custom
           tokenizer: standard
           filter: [standard, lowercase, shingle]
+        string_for_sorting:
+          type: custom
+          tokenizer: keyword
+          filter: [trim, lowercase]
       filter:
         stemmer_english:
           type: stemmer

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -48,7 +48,8 @@
       "fields": {
         "sort": {
           "type": "string",
-          "index": "not_analyzed",
+          "index": "analyzed",
+          "analyzer": "string_for_sorting",
           "include_in_all": false
         }
       }

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -41,8 +41,12 @@ class MultiIndexTest < IntegrationTest
   def sample_document_attributes(index_name, count)
     short_index_name = index_name.sub("_test", "")
     (1..count).map do |i|
+      title = "Sample #{short_index_name} document #{i}"
+      if i % 2 == 1
+        title = title.downcase
+      end
       fields = {
-        "title" => "Sample #{short_index_name} document #{i}",
+        "title" => title,
         "link" => "/#{short_index_name}-#{i}",
         "indexable_content" => "Something something important content",
       }

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -60,6 +60,18 @@ class UnifiedSearchTest < MultiIndexTest
     assert_equal ["/detailed-1", "/detailed-2", "/mainstream-1", "/mainstream-2"], links.slice(2, 6).sort
   end
 
+  def test_sort_by_title_ascending
+    get "/unified_search?order=title"
+    titles = parsed_response["results"].map do |result|
+      result["title"]
+    end
+
+    lowercase_titles = titles.map(&:downcase)
+
+    assert_equal lowercase_titles, lowercase_titles.sort
+  end
+
+
   def test_filter_by_section
     get "/unified_search?filter_section=1"
     assert last_response.ok?
@@ -200,9 +212,9 @@ class UnifiedSearchTest < MultiIndexTest
         "example_info" => {
           "total" => 3,
           "examples" => [
-            {"section" => "1", "title" => "Sample mainstream document 1", "link" => "/mainstream-1"},
-            {"section" => "1", "title" => "Sample detailed document 1", "link" => "/detailed-1"},
-            {"section" => "1", "title" => "Sample government document 1", "link" => "/government-1"},
+            {"section" => "1", "title" => "sample mainstream document 1", "link" => "/mainstream-1"},
+            {"section" => "1", "title" => "sample detailed document 1", "link" => "/detailed-1"},
+            {"section" => "1", "title" => "sample government document 1", "link" => "/government-1"},
           ]
         }
       },


### PR DESCRIPTION
Instead of not analyzing the title.sort field at all, strip leading and
trailing whitespace and lowercase it.  This will make the sort case
insensitive, and not dependent on whitespace, which is what is usually
meant when people sort by alphabetical order.

Also, add an integration test for this sorting.

This commit introduces a new filter for the processing we want for
sorting: `string_for_sorting`.  This is actually identical currently to
the existing `exact_match` analyzer, but it's good to have analyzers
named by function, so that we can improve them in future without having
to work out what things are using them.

Also, in order to test the case insensitivity, downcase the word
"Sample" in the title of some of the sample documents.

FAO @tommyp 
