### PR TITLE
Normalise apostrophes in spelling suggestions

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -26,10 +26,22 @@ index:
           type: custom
           tokenizer: standard
           filter: [standard, lowercase, shingle]
+          char_filter: [normalize_quotes]
         string_for_sorting:
           type: custom
           tokenizer: keyword
           filter: [trim, lowercase]
+
+      char_filter:
+        normalize_quotes:
+          type: "mapping"
+          mappings:
+            - "\u0091=>\u0027"
+            - "\u0092=>\u0027"
+            - "\u2018=>\u0027"
+            - "\u2019=>\u0027"
+            - "\uFF07=>\u0027"
+
       filter:
         stemmer_english:
           type: stemmer

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -1,0 +1,35 @@
+require "integration_test_helper"
+
+class SettingsTest < IntegrationTest
+  def setup
+    enable_test_index_connections
+    refresh_test_index
+  end
+
+  def test_spelling_analyzer_normalizes_and_lowercases_in_bigrams
+    query = "A'pos B’pos"
+    analyzer = "spelling_analyzer"
+
+    tokens = fetch_tokens_for_analyzer(query, analyzer)
+
+    assert_equal ["a'pos", "a'pos b'pos", "b'pos"], tokens
+  end
+
+  private
+
+  def fetch_tokens_for_analyzer(query, analyzer)
+    result = client.post('government-test/_analyze?analyzer=' + analyzer, query)
+    mappings = JSON.parse(result)['tokens']
+    mappings.map { |mapping| mapping['token'] }
+  end
+
+  def refresh_test_index
+    index_name = 'government-test'
+    try_remove_test_index(index_name)
+    create_test_index(index_name)
+  end
+
+  def client
+    @client ||= Elasticsearch::Client.new('http://localhost:9200/')
+  end
+end


### PR DESCRIPTION
Elasticsearch sees words with a "normal" apostrophe as one word, but not words with a curly apostrophe. Before indexing the search suggestions, we normalise all variations on the single quote to the normal apostrophe: U+0027.

This prevents words like "jobseeker's allowance" (normal apostrophe) to be corrected to "jobseeker's allowance" (curly apostrophe).

![screen shot 2015-05-18 at 11 47 26](https://cloud.githubusercontent.com/assets/233676/7679344/ad2fbe28-fd53-11e4-822f-49a7b0371e0d.png)

Trello: https://trello.com/c/vEUfgnuv/117-fix-apostrophe-problem
