### PR TITLE
Allow FacetExampleFetcher to use builder `query` & `filter`

### DIFF
--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -32,8 +32,6 @@ class UnifiedSearchBuilder
     )
   end
 
-  private
-
   def query
     QueryComponents::Query.new(params).payload
   end
@@ -41,6 +39,8 @@ class UnifiedSearchBuilder
   def filter
     QueryComponents::Filter.new(params).payload
   end
+
+  private
 
   def sort
     QueryComponents::Sort.new(params).payload

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -222,6 +222,28 @@ class UnifiedSearchTest < MultiIndexTest
     }, facets.fetch("section").fetch("options").fetch(0))
   end
 
+  def test_facet_examples_with_example_scope_query
+    get "/unified_search?q=important&facet_section=1,examples:5,example_scope:query,example_fields:link:title:section"
+
+    assert_equal 6, parsed_response["total"]
+
+    facets = parsed_response["facets"]
+    assert_equal({
+      "value" => {
+        "slug" => "1",
+        "example_info" => {
+          "total" => 3,
+          "examples" => [
+            {"section" => "1", "title" => "sample mainstream document 1", "link" => "/mainstream-1"},
+            {"section" => "1", "title" => "sample detailed document 1", "link" => "/detailed-1"},
+            {"section" => "1", "title" => "sample government document 1", "link" => "/government-1"},
+          ]
+        }
+      },
+      "documents" => 3,
+    }, facets.fetch("section").fetch("options").fetch(0))
+  end
+
   def test_validates_integer_params
     get "/unified_search?start=a"
     assert_equal last_response.status, 422


### PR DESCRIPTION
FacetExampleFetcher needs the query and the filter to request facets. These methods are currently not public, causing bugs.

Adds a test for this specific case.
