### PR TITLE
Remove use of mappings in parameter parser

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -280,7 +280,7 @@ class Rummager < Sinatra::Application
 
     parser = SearchParameterParser.new(
       parse_query_string(request.query_string),
-      current_index.mappings,
+      unified_index_schema,
     )
 
     unless parser.valid?

--- a/app.rb
+++ b/app.rb
@@ -18,6 +18,7 @@ require "redis"
 require "matcher_set"
 require "search_parameter_parser"
 require "registries"
+require "schema/combined_index_schema"
 
 require_relative "config"
 require_relative "helpers"
@@ -45,6 +46,13 @@ class Rummager < Sinatra::Application
     settings.search_config.govuk_index_names.map do |index_name|
       search_server.index(index_name)
     end
+  end
+
+  def unified_index_schema
+    @unified_index_schema ||= CombinedIndexSchema.new(
+      settings.search_config.govuk_index_names,
+      settings.search_config.schema_config
+    )
   end
 
   def unified_index

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -1,6 +1,7 @@
 {
   "identifier": {
     "description": "An identifier, can be used for exact (case and whitespace sensitive) lookup and facetting",
+    "filter_type": "text",
     "es_config": {
       "type": "string",
       "index": "not_analyzed",
@@ -10,6 +11,7 @@
 
   "identifiers": {
     "description": "Like identifier, but can occur multiple times in a single document",
+    "filter_type": "text",
     "multivalued": true,
     "es_config": {
       "type": "string",
@@ -20,6 +22,7 @@
 
   "searchable_identifier": {
     "description": "Like an identifier, but should also be considered in searches in the _all field",
+    "filter_type": "text",
     "es_config": {
       "type": "string",
       "index": "not_analyzed",
@@ -111,6 +114,7 @@
 
   "date": {
     "description": "A date which can be returned and used for ordering, filtering and facetting",
+    "filter_type": "date",
     "es_config": {
       "type": "date",
       "include_in_all": false

--- a/lib/schema/combined_index_schema.rb
+++ b/lib/schema/combined_index_schema.rb
@@ -1,0 +1,45 @@
+class CombinedIndexSchema
+  def initialize(index_names, schema)
+    @index_names = index_names
+    @schema = schema
+  end
+
+  def document_type(document_type_name)
+    document_types[document_type_name]
+  end
+
+  def document_types
+    @document_types ||= @index_names.inject({}) { |results, index_name|
+      results.merge(@schema.document_types(index_name))
+    }
+  end
+
+  # Get a hash from field_name to FieldDefinition object, for all fields
+  # allowed in any document type in the indexes.
+  #
+  # Since FieldDefinitions can contain an "allowed_values" member, and this
+  # may differ between document types, the definitions returned here will
+  # have combined "allowed_values" fields, containing all the allowed values
+  # for the field across all document types.
+  def field_definitions
+    @field_definitions ||= each_field_with_object({}) { |field_name, field_definition, results|
+      results[field_name] = field_definition.merge(results[field_name])
+    }
+  end
+
+private
+
+  # Call &block for every field defined in any of the document types.
+  # May make repeated calls for a given field.
+  # Passes (field_name, field_definition, obj) to the block each time it is
+  # called.
+  # Returns obj.
+  def each_field_with_object(obj, &block)
+    document_types.values.each do |document_type|
+      document_type.fields.each do |field_name, field_definition|
+        yield field_name, field_definition, obj
+      end
+    end
+    obj
+  end
+end

--- a/lib/schema/combined_index_schema.rb
+++ b/lib/schema/combined_index_schema.rb
@@ -27,6 +27,17 @@ class CombinedIndexSchema
     }
   end
 
+  # Get the names of fields which are allowed to be filtered on.
+  #
+  # This is all fields which have a FieldType for which "filter_type" is defined.
+  def allowed_filter_fields
+    @allowed_filter_fields ||= each_field_with_object(Set.new) { |field_name, field_definition, results|
+      if field_definition.type.filter_type
+        results << field_name
+      end
+    }.to_a
+  end
+
 private
 
   # Call &block for every field defined in any of the document types.

--- a/lib/schema/field_definitions.rb
+++ b/lib/schema/field_definitions.rb
@@ -3,6 +3,25 @@ require "schema/field_types"
 
 FieldDefinition = Struct.new("FieldDefinition", :name, :type, :es_config, :description, :children, :allowed_values)
 
+class FieldDefinition
+  # Merge this field definition with another one.
+  #
+  # Assumes that the definitions are for the same field (but probably for a
+  # different document type).  Therefore, the only thing that can differ is the
+  # allowed_values setting, so we only have to do anything if allowed_values
+  # are set.
+  def merge(other)
+    unless other.nil?
+      if other.allowed_values
+        result = self.clone
+        result.allowed_values = ((result.allowed_values || []) + other.allowed_values).uniq
+        return result
+      end
+    end
+    self
+  end
+end
+
 class FieldDefinitionParser
   def initialize(config_path)
     @config_path = config_path

--- a/lib/schema/field_types.rb
+++ b/lib/schema/field_types.rb
@@ -1,6 +1,6 @@
 require "json"
 
-FieldType = Struct.new("FieldType", :name, :description, :es_config, :multivalued, :children)
+FieldType = Struct.new("FieldType", :name, :filter_type, :description, :es_config, :multivalued, :children)
 
 class FieldTypes
   def initialize(config_path)
@@ -23,6 +23,11 @@ private
         raise %{Missing "es_config" in field type "#{type_name}" in "#{types_file_path}"}
       end
 
+      filter_type = value.delete("filter_type")
+      unless [nil, "text", "date"].include? filter_type
+        raise %{Invalid value for "filter_type" ("#{filter_type}") in field type "#{type_name}" in "#{types_file_path}"}
+      end
+
       children = value.delete("children")
       unless [nil, "named", "dynamic"].include? children
         raise %{Invalid value for "children" ("#{children}") in field type "#{type_name}" in "#{types_file_path}"}
@@ -30,6 +35,7 @@ private
 
       type = FieldType.new(
         type_name,
+        filter_type,
         value.delete("description") || "",
         es_config,
         value.delete("multivalued") || false,

--- a/test/unit/schema/combined_index_schema_test.rb
+++ b/test/unit/schema/combined_index_schema_test.rb
@@ -27,4 +27,9 @@ class CombinedIndexSchemaTest < MiniTest::Unit::TestCase
     assert locations.include?({"label"=>"Afghanistan", "value"=>"afghanistan"})
     assert locations.include?({"label"=>"North East", "value"=>"north-east"})
   end
+
+  def test_allowed_filter_fields
+    refute @combined_schema.allowed_filter_fields.include? "title"
+    assert @combined_schema.allowed_filter_fields.include? "organisations"
+  end
 end

--- a/test/unit/schema/field_definitions_test.rb
+++ b/test/unit/schema/field_definitions_test.rb
@@ -27,6 +27,19 @@ class FieldDefinitionsTest < ShouldaUnitTestCase
     should "know that the `attachments` field has a child of `title` of type searchable_text" do
       assert_equal "searchable_text", @definitions["attachments"].children["title"].type.name
     end
+
+    should "be able to merge two field definitions" do
+      value1 = {"label" => "Value1", "value" => "value1"}
+      value2 = {"label" => "Value2", "value" => "value2"}
+      value3 = {"label" => "Value3", "value" => "value3"}
+      definition1 = FieldDefinition.new("foo", "string", {}, "", nil, [value1, value2])
+      definition2 = FieldDefinition.new("foo", "string", {}, "", nil, [value2, value3])
+      merged = definition2.merge(definition1)
+
+      assert_equal "foo", merged.name
+      assert_equal "string", merged.type
+      assert_equal [value1, value2, value3], merged.allowed_values.sort_by {|item| item["value"]}
+    end
   end
 
 end

--- a/test/unit/schema/field_types_test.rb
+++ b/test/unit/schema/field_types_test.rb
@@ -20,6 +20,10 @@ class FieldTypesTest < ShouldaUnitTestCase
       assert @types.get("identifiers").multivalued
     end
 
+    should "know that the `identifiers` type has a `text` filter type" do
+      assert_equal "text", @types.get("identifiers").filter_type
+    end
+
     should "know that the `identifiers` type does not have children" do
       assert_nil @types.get("identifiers").children
     end
@@ -51,6 +55,16 @@ class FieldTypesTest < ShouldaUnitTestCase
         @types.get("identifier")
       end
       assert_equal %{Missing "es_config" in field type "identifier" in "/config/path/field_types.json"}, exc.message
+    end
+
+    should "fail if a field type has an invalid `filter_type` property" do
+      FieldTypes.any_instance.stubs(:load_json).returns(
+        {"identifier" => {"es_config" => {}, "filter_type" => "bad value"}}
+      )
+      exc = assert_raises(RuntimeError) do
+        @types.get("identifier")
+      end
+      assert_equal %{Invalid value for "filter_type" ("bad value") in field type "identifier" in "/config/path/field_types.json"}, exc.message
     end
 
     should "fail if a field type has an invalid `children` property" do


### PR DESCRIPTION
This is a code cleanup, but also allows slightly more flexibility in the API.

Specifically, this PR removes the `ALLOWED_FILTER_FIELDS` constant in SearchParameterParser, in favour of defining in the schema which fields can be filtered on.  To do this, a new `filter_type` value is supported in the `field_types.json` file.  This may be either set to "text" or "date", and if not present means the field may not be filtered on.

The extra API flexibility is that it is no longer required to filter on document type to make it possible to filter on fields which are defined only for a particular document type.  Performing such filtering will implicitly filter to the document type, anyway (since the field won't be present for any other documents).

This is best reviewed commit by commit.

It would be good to remove the other constants defined in SearchParameterParser in future PRs, but I'd like to merge this one now since it makes a large improvement (by removing the hacks which allowed filtering extra fields when a document_type filter was used), and is self-contained.
