### PR TITLE
Preserve the "_id" field when migrating an index

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -248,7 +248,7 @@ module Elasticsearch
       search_body = {query: {match_all: {}}}
       batch_size = self.class.scroll_batch_size
       ScrollEnumerator.new(client, search_body, batch_size) do |hit|
-        document_from_hash(hit["_source"])
+        document_from_hash(hit["_source"].merge("_id" => hit["_id"]))
       end
     end
 


### PR DESCRIPTION
Currently, when an index is migrated, Document objects are created from
the _source object for each document in the index.  Unfortunately, the
_source object doesn't contain the "_id" field, which the Document
constructor looks for to assign an _id field.  For most indexes, this
doesn't matter because if the Document constructor can't find an "_id"
field, it uses the "link" field instead.  However, for the
"page_traffic" and "metasearch" indexes, there isn't a link field.

This means currently that migrating these indexes changes all the
document IDs to ones randomly assigned by Elasticsearch.  This commit
changes this so that document IDs are preserved when migrating these
indexes.
