### PR TITLE
Normalize and strip apostrophes when indexing/searching

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -6,10 +6,12 @@ index:
           type: custom
           tokenizer: standard
           filter: [standard, lowercase, stop, stemmer_override, stemmer_english]
+          char_filter: [normalize_quotes, strip_quotes]
         query_default:
           type: custom
           tokenizer: standard
           filter: [standard, lowercase, synonym, stop, stemmer_override, stemmer_english]
+          char_filter: [normalize_quotes, strip_quotes]
         shingled_query_analyzer:
           type: custom
           tokenizer: standard
@@ -18,21 +20,29 @@ index:
           type: custom
           tokenizer: keyword
           filter: [trim, lowercase]
+          char_filter: [normalize_quotes]
         best_bet_stemmed_match:
           type: custom
           tokenizer: standard
           filter: [standard, lowercase, stemmer_override, stemmer_english]
+          char_filter: [normalize_quotes, strip_quotes]
         spelling_analyzer:
           type: custom
           tokenizer: standard
           filter: [standard, lowercase, shingle]
-          char_filter: [normalize_quotes]
+          char_filter: [normalize_quotes, strip_quotes]
         string_for_sorting:
           type: custom
           tokenizer: keyword
           filter: [trim, lowercase]
+          char_filter: [normalize_quotes, strip_quotes]
 
       char_filter:
+        strip_quotes:
+          type: "pattern_replace"
+          pattern: "\'"
+          replacement: ""
+
         normalize_quotes:
           type: "mapping"
           mappings:

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -3,37 +3,40 @@ require "integration_test_helper"
 class SettingsTest < IntegrationTest
   def test_default
     assert_tokenisation :default,
-      "It's A Small World" => ["it'", "small", "world"]
+      "It's A Small’s World" => ["it", "small", "world"],
+      "It's Mitt’s" => ["it", "mitt"]
   end
 
   def test_query_default
     assert_tokenisation :query_default,
-      "It's A Small World" => ["it'", "small", "world"]
+      "It's A Small World" => ["it", "small", "world"],
+      "It's, It’s Mr. O'Neill" => ["it", "it", "mr", "oneil"]
   end
 
   def test_shingled_query_analyzer
     assert_tokenisation :shingled_query_analyzer,
-      "Hello Hallo" => ["hello", "hello hallo", "hallo"]
+      "Hello Hallo" => ["hello", "hello hallo", "hallo"],
+      "H'lo ’Hallo" => ["h'lo", "h'lo hallo", "hallo"]
   end
 
   def test_exact_match
     assert_tokenisation :exact_match,
-      "It's A Small World" => ["it's a small world"]
+      "It’s A Small W'rld" => ["it's a small w'rld"]
   end
 
   def test_best_bet_stemmed_match
     assert_tokenisation :best_bet_stemmed_match,
-      "It's A Small World" => ["it'", "a", "small", "world"]
+      "It’s A Small W'rld" => ["it", "a", "small", "wrld"]
   end
 
   def test_spelling_analyzer
     assert_tokenisation :spelling_analyzer,
-      "Bi Grammed" => ["bi", "bi grammed", "grammed"]
+      "It’s Grammed" => ["its", "its grammed", "grammed"]
   end
 
   def test_string_for_sorting
     assert_tokenisation :string_for_sorting,
-      "It's A Small World" => ["it's a small world"]
+      "It's A Small W’rld" => ["its a small wrld"]
   end
 
   private

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -1,24 +1,57 @@
 require "integration_test_helper"
 
 class SettingsTest < IntegrationTest
-  def setup
-    enable_test_index_connections
-    refresh_test_index
+  def test_default
+    assert_tokenisation :default,
+      "It's A Small World" => ["it'", "small", "world"]
   end
 
-  def test_spelling_analyzer_normalizes_and_lowercases_in_bigrams
-    query = "A'pos B’pos"
-    analyzer = "spelling_analyzer"
+  def test_query_default
+    assert_tokenisation :query_default,
+      "It's A Small World" => ["it'", "small", "world"]
+  end
 
-    tokens = fetch_tokens_for_analyzer(query, analyzer)
+  def test_shingled_query_analyzer
+    assert_tokenisation :shingled_query_analyzer,
+      "Hello Hallo" => ["hello", "hello hallo", "hallo"]
+  end
 
-    assert_equal ["a'pos", "a'pos b'pos", "b'pos"], tokens
+  def test_exact_match
+    assert_tokenisation :exact_match,
+      "It's A Small World" => ["it's a small world"]
+  end
+
+  def test_best_bet_stemmed_match
+    assert_tokenisation :best_bet_stemmed_match,
+      "It's A Small World" => ["it'", "a", "small", "world"]
+  end
+
+  def test_spelling_analyzer
+    assert_tokenisation :spelling_analyzer,
+      "Bi Grammed" => ["bi", "bi grammed", "grammed"]
+  end
+
+  def test_string_for_sorting
+    assert_tokenisation :string_for_sorting,
+      "It's A Small World" => ["it's a small world"]
   end
 
   private
 
+  # Verifies that certain input will be tokenised as expected by the specified
+  # analyzer. 
+  def assert_tokenisation(analyzer, assertions)
+    enable_test_index_connections
+    refresh_test_index
+
+    assertions.each do |query, expected_output|
+      tokens = fetch_tokens_for_analyzer(query, analyzer)
+      assert_equal expected_output, tokens
+    end
+  end
+
   def fetch_tokens_for_analyzer(query, analyzer)
-    result = client.post('government-test/_analyze?analyzer=' + analyzer, query)
+    result = client.post('government-test/_analyze?analyzer=' + analyzer.to_s, query)
     mappings = JSON.parse(result)['tokens']
     mappings.map { |mapping| mapping['token'] }
   end


### PR DESCRIPTION
Currently, words with curly apostrophes (copy-pasted from a word document for example) are tokenised differently from words with "normal" apostrophes. This causes different documents to turn up depending on the type of apostrophe is used.

This commit adds character filters to the analysers that first normalise the apostrophe and then remove it altogether in certain situations.

Trello: https://trello.com/c/hAjYAydH/119-fix-apostrophes-and-quotes-in-search
