### PR TITLE
Add policy groups to policies.

### DIFF
--- a/config/schema/document_types/policy.json
+++ b/config/schema/document_types/policy.json
@@ -1,6 +1,7 @@
 {
   "fields": [
     "slug",
-    "people"
+    "people",
+    "policy_groups"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -130,6 +130,10 @@
     "type": "identifiers"
   },
 
+  "policy_groups": {
+    "type": "identifiers"
+  },
+
   "relevant_to_local_government": {
     "type": "boolean"
   },


### PR DESCRIPTION
Required to show new-world policies on groups in
whitehall for: https://trello.com/c/pV7ExOoE/203-5-associate-policy-to-a-group
