### PR TITLE
Make the pattern for index names more forgiving

### DIFF
--- a/lib/elasticsearch/index_group.rb
+++ b/lib/elasticsearch/index_group.rb
@@ -145,7 +145,7 @@ module Elasticsearch
         \d{2}:\d{2}:\d{2}  # Time
         z
         -
-        \h{8}-\h{4}-\h{4}-\h{4}-\h{12}  # UUID
+        \h[-\h]*  # UUID
         \Z
       }x
     end


### PR DESCRIPTION
Currently, staging and preview servers, and dev vms which have synced
recently, will have old indexes lying around which rummager won't
delete (ie, the `rummager:clean` rake task won't delete them). This is
because there was a bug in the sync script which produced indexes which
had an invalid "UUID" part of the index name.

To clean these up, this change makes the UUID pattern much more
forgiving: it just needs to contain a digit followed by some digits or
hyphens.

The pattern which matches indexes is still pretty specific, so I don't
think there's a significant risk of this overmatching.
