### PR TITLE
Reduce effect of popularity for very popular pages

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -10,6 +10,7 @@ people_registry_index: "government"
 # These indices are passed in this order to GovukSearcher
 govuk_index_names: ["mainstream", "detailed", "government", "service-manual"]
 metasearch_index_name: "metasearch"
+popularity_rank_offset: 10
 
 # When doing spell checking, which indices to use?
 spelling_index_names:

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -573,7 +573,11 @@ module Elasticsearch
       end
 
       Hash[links.map { |link|
-        popularity_score = (ranks[link] == 0) ? 0 : (1.0 / ranks[link])
+        popularity_score = if ranks[link] == 0
+          0
+        else
+          1.0 / (ranks[link] + @search_config.popularity_rank_offset)
+        end
         [link, popularity_score]
       }]
     end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -66,6 +66,10 @@ class SearchConfig
     elasticsearch["metasearch_index_name"]
   end
 
+  def popularity_rank_offset
+    elasticsearch["popularity_rank_offset"]
+  end
+
 private
   def config_path
     File.expand_path("../config/schema", File.dirname(__FILE__))

--- a/test/integration/bulk_loader_test.rb
+++ b/test/integration/bulk_loader_test.rb
@@ -82,11 +82,13 @@ class BulkLoaderTest < IntegrationTest
 
   def test_adds_extra_fields
     # We have to insert at least two popularity documents to get a popularity
-    # score other than 1.0, because the popularity is based on the rank of the
+    # score other than the maximum, because the popularity is based on the rank of the
     # document when ordered by traffic, and the rank is capped at the number of
     # documents in the popularity index.  The actual value we insert here is a
     # rank of 10, but because there are two documents the popularity value we
-    # get returned is 1/2.
+    # get returned is 1/(2 + popularity_rank_offset), where
+    # popularity_rank_offset is a configuration value which is set to 10 by
+    # default.
     insert_stub_popularity_data(@sample_document["link"])
     insert_stub_popularity_data("/another-example")
 
@@ -94,7 +96,7 @@ class BulkLoaderTest < IntegrationTest
     bulk_loader.load_from(StringIO.new(index_payload(@sample_document)))
 
     assert_document_is_in_rummager(
-      @sample_document.merge("popularity" => 0.5), []
+      @sample_document.merge("popularity" => 1.0/12), []
     )
   end
 end

--- a/test/support/elasticsearch_integration_helpers.rb
+++ b/test/support/elasticsearch_integration_helpers.rb
@@ -31,6 +31,7 @@ module ElasticsearchIntegrationHelpers
       "world_location_registry_index" => REGISTRY_INDEX,
       "people_registry_index" => REGISTRY_INDEX,
       "spelling_index_names" => INDEX_NAMES,
+      "popularity_rank_offset" => 10,
     })
     app.settings.stubs(:default_index_name).returns(DEFAULT_INDEX_NAME)
     app.settings.stubs(:enable_queue).returns(false)

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -144,7 +144,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":1.0,"tags":[],"format":"edition"}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0.09090909090909091,"tags":[],"format":"edition"}
     eos
     response = <<-eos
 {"took":5,"items":[
@@ -172,7 +172,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"not_an_edition","_id":"some_id"}}
-{"_type":"not_an_edition","_id":"some_id","title":"TITLE ONE","link":"/a/link","popularity":1.0,"tags":[],"format":"not_an_edition"}
+{"_type":"not_an_edition","_id":"some_id","title":"TITLE ONE","link":"/a/link","popularity":0.09090909090909091,"tags":[],"format":"not_an_edition"}
   eos
     response = <<-eos
 {"took":5,"items":[
@@ -193,7 +193,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":1.0,"tags":[],"format":"edition"}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0.09090909090909091,"tags":[],"format":"edition"}
     eos
     stub_request(:post, "http://example.com:9200/mainstream_test/_bulk").with(
         body: payload,
@@ -207,8 +207,8 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     stub_popularity_index_requests(["/foo/bar", "/foo/baz"], 1.0, 20)
 
     json_documents = [
-      { "_type" => "edition", "link" => "/foo/bar", "title" => "TITLE ONE", "popularity" => "1.0" },
-      { "_type" => "edition", "link" => "/foo/baz", "title" => "TITLE TWO", "popularity" => "1.0" }
+      { "_type" => "edition", "link" => "/foo/bar", "title" => "TITLE ONE", "popularity" => "0.09090909090909091" },
+      { "_type" => "edition", "link" => "/foo/baz", "title" => "TITLE TWO", "popularity" => "0.09090909090909091" }
     ]
     documents = json_documents.map do |json_document|
       stub("document", elasticsearch_export: json_document)
@@ -275,7 +275,7 @@ eos
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","specialist_sectors":["oil-and-gas/licensing","oil-and-gas/onshore-oil-and-gas"],"organisations":["hm-magic"],"popularity":1.0,"tags":["organisation:hm-magic","sector:oil-and-gas/licensing","sector:oil-and-gas/onshore-oil-and-gas"],"format":"edition"}
+{"_type":"edition","link":"/foo/bar","specialist_sectors":["oil-and-gas/licensing","oil-and-gas/onshore-oil-and-gas"],"organisations":["hm-magic"],"popularity":0.09090909090909091,"tags":["organisation:hm-magic","sector:oil-and-gas/licensing","sector:oil-and-gas/onshore-oil-and-gas"],"format":"edition"}
     eos
     response = <<-eos
 {"took":5,"items":[
@@ -304,7 +304,7 @@ eos
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","section":"benefits","subsection":"entitlement","popularity":1.0,"mainstream_browse_pages":["benefits/entitlement"],"tags":[],"format":"edition"}
+{"_type":"edition","link":"/foo/bar","section":"benefits","subsection":"entitlement","popularity":0.09090909090909091,"mainstream_browse_pages":["benefits/entitlement"],"tags":[],"format":"edition"}
     eos
     response = <<-eos
 {"took":5,"items":[
@@ -335,7 +335,7 @@ eos
 
     payload = <<-EOS
 {"index":{"_type":"edition","_id":"/document/thing"}}
-{"_type":"edition","link":"/document/thing","last_update":"2015-03-26T10:300:00.006+00:00","popularity":1.0,"tags":[],"format":"edition","public_timestamp":"2015-03-26T10:300:00.006+00:00"}
+{"_type":"edition","link":"/document/thing","last_update":"2015-03-26T10:300:00.006+00:00","popularity":0.09090909090909091,"tags":[],"format":"edition","public_timestamp":"2015-03-26T10:300:00.006+00:00"}
     EOS
 
   response = <<-EOS


### PR DESCRIPTION
Currently, the popularity ranking formula is to multiply the score by:

```
(1 / rank_of_document) + 0.001
```

This commit changes it to:

```
(1 / (rank_of_document + 10)) + 0.001
```

What we're actually aiming to do is to roughly multiply the score of a
page by the amount of traffic it gets.  However, if we used the actual
figure for the amount of traffic directly, it would be quite unstable;
all the rankings could vary wildly if there was a particular event
happening causing some pages to get much more traffic than normal.

Instead of using the figures directly, therefore, we use the inverse
rank of the page.  Ie, the top page has a rank of 1, the next page has a
rank of 2, etc.  This is a good (but relatively robust to traffic
bursts) approximation to the traffic a page gets, because the amount of
traffic pages on our site get follows a Zipf distribution
(http://en.wikipedia.org/wiki/Zipf%27s_law).

The "0.001" part of this has two purposes.  Firstly, for brand-new pages
there is no "rank", so we give that part of the formula a value of 0.
This would mean that brand-new pages always got a score of 0, so we add
a small constant to formula.  Secondly, for existing but rarely visited
pages, the exact rank becomes a sensitive to small fluctuations in
traffic, so adding a small constant "buffers" this effect.

This formula has worked reasonably well for some time, but we often see
high traffic pages swamping the results a bit too much.  For example,
the HMRC page (currently at rank 3) is often ranked highly for tax
related searches, over the more-specific content that matches the
search.  This commit adds a mitigation for high traffic pages, by adding
a constant to the `rank_of_document` part of the formula.  To start
with, I'm setting this constant to `10`, which means, eg, that instead of the
page at rank 3 getting 30 times the multipler of something at rank 100,
it would only get around 7.7 times the multiplier.  For lower ranked
documents, this adjustment will have very little effect.

Experimenting locally, this seems to improve quite a few searches, but
still return high-ranked pages highly.
