### PR TITLE
Allow params in health-check base URL

### DIFF
--- a/lib/health_check/json_search_client.rb
+++ b/lib/health_check/json_search_client.rb
@@ -13,7 +13,15 @@ module HealthCheck
     def search(term, params = {})
       params = { q: term }.merge(params)
       query_string = params.map { |k, v| "#{k}=" + CGI.escape(v.to_s) }.join('&')
-      url = [@base_url, query_string].join('?')
+      url_components = [@base_url, query_string]
+
+      # base_url can be in the form of example.org/search.json?debug=something
+      # or example.org/search.json.
+      url = if @base_url.to_s.include?('?')
+        url_components.join('&')
+      else
+        url_components.join('?')
+      end
 
       request = Net::HTTP::Get.new(url)
       request.basic_auth(*@authentication) if @authentication


### PR DESCRIPTION
Currently health checks are run with:

```
bundle exec bin/health_check --json="https://www.gov.uk/api/search.json"
```

We'd also like to support:

```
bundle exec bin/health_check --json="https://www.gov.uk/api/search.json?debug=new_weighting"
```

This change prevents the URL structure to become malformed with two question marks, eg. `search.json?debug=new_weighting?q=term`.

Trello: https://trello.com/c/8owN56bK/147-add-new-weighting-to-search-healthcheck
