### PR TITLE
Allow sorting of facets by value

### DIFF
--- a/lib/facet_option.rb
+++ b/lib/facet_option.rb
@@ -44,6 +44,12 @@ private
       )
     when :count
       count <=> other.count
+    when :value
+      if value.is_a?(String)
+        value.downcase <=> other.value.downcase
+      else
+        value.fetch("title", "").downcase <=> other.value.fetch("title", "").downcase
+      end
     when :"value.slug"
       value.fetch("slug", "") <=> other.value.fetch("slug", "")
     when :"value.title"

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -61,6 +61,7 @@ class BaseParameterParser
   # preceded with a "-" to sort in descending order.
   #  - filtered: sort fields which have filters applied to them first.
   #  - count: sort values by number of matching documents.
+  #  - value: sort by value if string, sort by title if not a string
   #  - value.slug: sort values by the slug part of the value.
   #  - value.title: sort values by the title of the value.
   #  - value.link: sort values by the link of the value.
@@ -68,6 +69,7 @@ class BaseParameterParser
   ALLOWED_FACET_SORT_OPTIONS = %w(
     filtered
     count
+    value
     value.slug
     value.title
     value.link

--- a/test/unit/facet_option_test.rb
+++ b/test/unit/facet_option_test.rb
@@ -105,6 +105,22 @@ class FacetOptionTest  < MiniTest::Unit::TestCase
     )
   end
 
+  def test_compare_by_value
+    orderings = [[:value, 1]]
+    assert(
+      FacetOption.new("a", 0, false, orderings) <
+      FacetOption.new("b", 0, false, orderings)
+    )
+  end
+
+  def test_compare_by_value_with_title
+    orderings = [[:value, 1]]
+    assert(
+      FacetOption.new({"title" => "a"}, 0, false, orderings) <
+      FacetOption.new({"title" => "b"}, 0, false, orderings)
+    )
+  end
+
   def test_fall_back_to_slug_ordering
     orderings = [[:count, 1]]
     assert(


### PR DESCRIPTION
This commit modifies the `SearchParameterParser` and the `FacetOption`
to allow facet options to be sorted by the value returned if the value
is just a string. If the value is an object it will be fall back to
sorting it by title.
