### PR TITLE
Actually use the modern English stemmer

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -136,7 +136,7 @@ index:
       filter:
         stemmer_english:
           type: stemmer
-          name: english
+          name: porter2
 
         # Filter used in the analyzer for ".shingle" subfields
         text_shingles:


### PR DESCRIPTION
Elasticsearch 1.3.0 changed the stemmer implementation used when the
"english" stemmer is requested. Instead of using the stemmer as revised
by Martin Porter in 2001/2002 to avoid lots of incorrect over-stemming
and other problems, elasticsearch now defaults to using the algorithm
defined in 1980. This is an entirely inferior algorithm in terms of the
output it produces.

To get the better algorithm back, we now need to request the "porter2"
algorithm.

This has made me grumpy.  The reason that snowball returns the "english"
stemmer instead of the "porter" stemmer when it's asked for a stemmer
for "english" is exactly because the "porter" stemmer is inferior in
every case where it differs from the "english" stemmer. However,
elasticsearch https://github.com/elastic/elasticsearch/pull/6452 changed
the default, apparently because the implementation of the 1980 Porter
stemmer available is faster.

In particular, this change has made a search for "news" on GOV.UK return
anything with the word "new" in it.
