### PR TITLE
Add small regression test for stemming

### DIFF
--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -7,6 +7,11 @@ class SettingsTest < IntegrationTest
       "It's Mitt’s" => ["it", "mitt"]
   end
 
+  def test_uses_correct_stemming
+    assert_tokenisation :default,
+      "news" => ["news"]
+  end
+
   def test_query_default
     assert_tokenisation :query_default,
       "It's A Small World" => ["it", "small", "world"],


### PR DESCRIPTION
Since PR #447 we're using the `porter2` stemming algorithm. This adds a small regression test for that.
