### PR TITLE
Add detailed_format to edition

### DIFF
--- a/config/schema/document_types/edition.json
+++ b/config/schema/document_types/edition.json
@@ -6,6 +6,7 @@
     "id",
     "acronym",
     "attachments",
+    "detailed_format",
     "display_type",
     "document_collections",
     "document_series",
@@ -31,5 +32,174 @@
     "is_political",
     "is_historic",
     "government_name"
-  ]
+  ],
+
+  "allowed_values": {
+    "detailed_format": [
+      {
+        "label": "Announcement",
+        "value": "announcement"
+      },
+      {
+        "label": "Case study",
+        "value": "case-study"
+      },
+      {
+        "label": "Closed consultation",
+        "value": "closed-consultation"
+      },
+      {
+        "label": "Collection",
+        "value": "collection"
+      },
+      {
+        "label": "Consultation",
+        "value": "consultation"
+      },
+      {
+        "label": "Consultation outcome",
+        "value": "consultation-outcome"
+      },
+      {
+        "label": "Corporate information",
+        "value": "corporate-information"
+      },
+      {
+        "label": "Corporate report",
+        "value": "corporate-report"
+      },
+      {
+        "label": "Correspondence",
+        "value": "correspondence"
+      },
+      {
+        "label": "Decision",
+        "value": "decision"
+      },
+      {
+        "label": "Detailed guide",
+        "value": "detailed-guide"
+      },
+      {
+        "label": "Fatality notice",
+        "value": "fatality-notice"
+      },
+      {
+        "label": "FOI release",
+        "value": "foi-release"
+      },
+      {
+        "label": "Form",
+        "value": "form"
+      },
+      {
+        "label": "Government response",
+        "value": "government-response"
+      },
+      {
+        "label": "Guidance",
+        "value": "guidance"
+      },
+      {
+        "label": "Impact assessment",
+        "value": "impact-assessment"
+      },
+      {
+        "label": "Imported - awaiting type",
+        "value": "imported-awaiting-type"
+      },
+      {
+        "label": "Independent report",
+        "value": "independent-report"
+      },
+      {
+        "label": "International treaty",
+        "value": "international-treaty"
+      },
+      {
+        "label": "Map",
+        "value": "map"
+      },
+      {
+        "label": "News story",
+        "value": "news-story"
+      },
+      {
+        "label": "Notice",
+        "value": "notice"
+      },
+      {
+        "label": "Open consultation",
+        "value": "open-consultation"
+      },
+      {
+        "label": "Policy",
+        "value": "policy"
+      },
+      {
+        "label": "Policy paper",
+        "value": "policy-paper"
+      },
+      {
+        "label": "Press release",
+        "value": "press-release"
+      },
+      {
+        "label": "Promotional material",
+        "value": "promotional-material"
+      },
+      {
+        "label": "Publication",
+        "value": "publication"
+      },
+      {
+        "label": "Regulation",
+        "value": "regulation"
+      },
+      {
+        "label": "Research and analysis",
+        "value": "research-and-analysis"
+      },
+      {
+        "label": "Speech",
+        "value": "speech"
+      },
+      {
+        "label": "Statement to Parliament",
+        "value": "statement-to-parliament"
+      },
+      {
+        "label": "Statistical data set",
+        "value": "statistical-data-set"
+      },
+      {
+        "label": "Statistics",
+        "value": "statistics"
+      },
+      {
+        "label": "Statistics - national statistics",
+        "value": "statistics-national-statistics"
+      },
+      {
+        "label": "Statutory guidance",
+        "value": "statutory-guidance"
+      },
+      {
+        "label": "Supporting page",
+        "value": "supporting-page"
+      },
+      {
+        "label": "Transparency data",
+        "value": "transparency-data"
+      },
+      {
+        "label": "World location news article",
+        "value": "world-location-news-article"
+      },
+      {
+        "label": "Worldwide priority",
+        "value": "worldwide-priority"
+      }
+    ]
+  }
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -98,6 +98,11 @@
     }
   },
 
+  "detailed_format": {
+    "description": "A slugified version of the display_type field",
+    "type": "identifier"
+  },
+
   "display_type": {
     "type": "identifier"
   },

--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -27,7 +27,7 @@ class BaseParameterParser
   # The fields listed here are the only ones which can be used to calculated
   # facets for.  This should be a subset of allowed_filter_fields
   ALLOWED_FACET_FIELDS = %w(
-    display_type
+    detailed_format
     document_collections
     format
     mainstream_browse_pages
@@ -89,6 +89,7 @@ class BaseParameterParser
   # results.
   ALLOWED_RETURN_FIELDS = %w(
     description
+    detailed_format
     display_type
     document_collections
     document_series


### PR DESCRIPTION
As we need to get back a slug version of `display_type` I added a new
field to edition and gave it all the possible values of display type to
the `allowed_values` field in the edition doctype.

The need for this comes from the fact that `display_type` is sent to
rummager as a title case string `News story` instead of `news-story`.

Ticket:
https://trello.com/c/TAuAS4wp/174-8-add-more-filter-options-to-policy-pages
