### PR TITLE
Run suggestions & results health checks separately

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -43,6 +43,7 @@ class HealthCheckCLI
       on 'a', 'auth=', "Basic auth credentials (of the form 'user:pass'", as: HealthCheck::BasicAuthCredentials
       on 'j', 'json=', "Connect to a Rummager unified search endpoint at the the given url (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
       on 'v', 'verbose', "Show verbose logging output"
+      on 'type=', "Which tests to run. 'suggestions' or 'results' (default)"
       run(health_checker)
     end
   end
@@ -66,8 +67,11 @@ class HealthCheckCLI
     elsif opts.help?
       usage(opts)
     else
-      run_suggestions_test if opts.json?
-      run_search_result_tests(args)
+      if opts["type"] == "suggestions"
+        run_suggestions_test
+      else
+        run_search_result_tests(args)
+      end
     end
   end
 


### PR DESCRIPTION
Currently the suggestions and results health checks are run at the same time. This causes the CI to only report the first (spelling) score.

Splitting them up also makes it possible to run the results health checks more often than the spelling checks, which should change less often.

Trello: https://trello.com/c/3UVjZFEb/164-bug-search-health-check-overall-score-is-only-for-spelling-suggestions

CI job `govuk_search_health_check_production_suggestions` needs to be enabled after this is merged into master.
