### PR TITLE
Fix lookup of people for expansion

### DIFF
--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -122,7 +122,7 @@ module Registry
 
   class Person < BaseRegistry
     def initialize(index, field_definitions)
-      super(index, field_definitions, "people")
+      super(index, field_definitions, "person")
     end
   end
 end


### PR DESCRIPTION
The format of a document about a person is `person`, not `people`.
Change the lookup performed by the Person registry to look for documents
with this format, so that expansion works.
