### PR TITLE
Parallelise bulk loading of a new index.

### DIFF
--- a/bin/bulk_load
+++ b/bin/bulk_load
@@ -26,7 +26,7 @@ load the alias is switched over.
 }
   run do |opts, args|
     if args.size == 1
-      BulkLoader.new(search_config, args.first, logger: Logger.new(STDERR)).load_from($stdin)
+      BulkLoader.new(search_config, args.first).load_from($stdin)
     else
       puts self
     end

--- a/lib/bulk_loader.rb
+++ b/lib/bulk_loader.rb
@@ -4,81 +4,79 @@ class BulkLoader
   def initialize(search_config, index_name, options = {})
     @search_config = search_config
     @index_name = index_name
-    @batch_size = options[:batch_size] || 256 * 1024
+    @iostream_batch_size = options.fetch(:iostream_batch_size, 256 * 1024)
+    @document_batch_size = options.fetch(:document_batch_size, 50)
+    @batch_concurrency = options.fetch(:batch_concurrency, 12)
     @logger = Logging.logger[self]
   end
 
   def load_from(iostream)
-    new_index = index_group.create_index
-    @logger.info "Created index #{new_index.real_name}"
-    old_index = index_group.current_real
-    if old_index.nil?
-      @logger.info "No old index"
-    else
-      @logger.info "Old index #{old_index.real_name}"
-    end
-
-    if old_index
-      old_index.with_lock do
-        do_indexing(new_index, iostream)
-
-        # Switch aliases inside the lock so we avoid a race condition where a
-        # new index exists, but the old index is available for writes
-        index_group.switch_to new_index
-
-        old_index.close
+    build_and_switch_index do |queue|
+      in_even_sized_batches(iostream) do |lines|
+        queue.push(lines.join(""))
       end
-    else
-      index_group.switch_to new_index
-      do_indexing(new_index, iostream)
     end
   end
 
   def load_from_current_index
-    new_index = index_group.create_index
-    old_index = index_group.current_real
-
-    if old_index
-      old_index.with_lock do
-        new_index.populate_from old_index
-
-        # Now bulk inserts fail if any of their operations fail (de47247),
-        # and now we lock the old index to avoid any writes (87a7c60), the
-        # document counts should always match if we get to this point without
-        # throwing an exception, but it's a nice safeguard to have
-        new_count = new_index.all_documents.size
-        old_count = old_index.all_documents.size
-        unless new_count == old_count
-          @logger.error(
-            "Population miscount: new index has #{new_count} documents, " +
-            "while old index has #{old_count}."
-          )
-          raise RuntimeError, "Population count mismatch"
-        end
-
-        # Switch aliases inside the lock so we avoid a race condition where a
-        # new index exists, but the old index is available for writes
-        index_group.switch_to new_index
-
-        old_index.close
+    build_and_switch_index do |queue|
+      index_group.current_real.all_documents(timeout_options).each_slice(@document_batch_size) do |documents|
+        queue.push(documents.map(&:elasticsearch_export))
       end
-    else
-      index_group.switch_to new_index
     end
   end
 
 private
-  def do_indexing(index, iostream)
-    @logger.info "Indexing to #{index.real_name}"
-    total_lines = 0
-    start_time = Time.now
-    in_even_sized_batches(iostream) do |lines|
-      index.bulk_index(lines.join(""), timeout_options)
-      @logger.info "Sent #{lines.size} lines (#{byte_size(lines)} bytes)"
-      total_lines += lines.size
+
+  def build_and_switch_index(&producer_block)
+    new_index = index_group.create_index
+    @logger.info "Created index #{new_index.real_name}"
+    old_index = index_group.current_real
+    if old_index
+      @logger.info "Old index #{old_index.real_name}"
+      old_index.with_lock do
+        populate_index(new_index, &producer_block)
+
+        # Switch aliases inside the lock so we avoid a race condition where a
+        # new index exists, but the old index is available for writes
+        index_group.switch_to(new_index)
+        old_index.close
+      end
+    else
+      @logger.info "No old index"
+      populate_index(new_index, &producer_block)
+      index_group.switch_to(new_index)
     end
-    elapsed_time = Time.now - start_time
-    @logger.info "Indexed %s lines in %.2f seconds (%.2f lines/sec)" % [total_lines, elapsed_time, total_lines / elapsed_time]
+  end
+
+  def populate_index(new_index, &producer_block)
+    @logger.info "Indexing to #{new_index.real_name}"
+    q = Queue.new
+    producer_complete = false
+
+    threads = []
+    @batch_concurrency.times do |n|
+      th = Thread.new do
+        loop do
+          begin
+            documents = q.pop(true)
+          rescue ThreadError => e
+            raise unless e.message == "queue empty"
+            break if producer_complete
+            sleep 0.1
+            retry
+          end
+          new_index.bulk_index(documents, timeout_options)
+        end
+      end
+      threads << th
+    end
+
+    yield q
+    producer_complete = true
+    threads.each {|th| th.join }
+
+    new_index.commit
   end
 
   def timeout_options
@@ -95,7 +93,7 @@ private
   # Breaks the given input stream into batches of line pairs of at least
   # `batch_size` bytes (including newlines). Always keeps line pairs together.
   # Yields each batch of lines.
-  def in_even_sized_batches(iostream, batch_size=@batch_size, &block)
+  def in_even_sized_batches(iostream, batch_size=@iostream_batch_size, &block)
     chunk = []
     iostream.each_line.each_slice(2) do |command, document|
       chunk << command

--- a/lib/bulk_loader.rb
+++ b/lib/bulk_loader.rb
@@ -20,8 +20,11 @@ class BulkLoader
 
   def load_from_current_index
     build_and_switch_index do |queue|
-      index_group.current_real.all_documents(timeout_options).each_slice(@document_batch_size) do |documents|
-        queue.push(documents.map(&:elasticsearch_export))
+      current_index = index_group.current_real
+      if current_index
+        current_index.all_documents(timeout_options).each_slice(@document_batch_size) do |documents|
+          queue.push(documents.map(&:elasticsearch_export))
+        end
       end
     end
   end

--- a/lib/bulk_loader.rb
+++ b/lib/bulk_loader.rb
@@ -5,7 +5,7 @@ class BulkLoader
     @search_config = search_config
     @index_name = index_name
     @batch_size = options[:batch_size] || 256 * 1024
-    @logger = options[:logger] || Logger.new(nil)
+    @logger = Logging.logger[self]
   end
 
   def load_from(iostream)

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -34,39 +34,10 @@ You should run this task if the index schema has changed.
 
 "
   task :migrate_index do
+    require 'bulk_loader'
+
     index_names.each do |index_name|
-      index_group = search_server.index_group(index_name)
-
-      new_index = index_group.create_index
-      old_index = index_group.current_real
-
-      if old_index
-        old_index.with_lock do
-          new_index.populate_from old_index
-
-          # Now bulk inserts fail if any of their operations fail (de47247),
-          # and now we lock the old index to avoid any writes (87a7c60), the
-          # document counts should always match if we get to this point without
-          # throwing an exception, but it's a nice safeguard to have
-          new_count = new_index.all_documents.size
-          old_count = old_index.all_documents.size
-          unless new_count == old_count
-            logger.error(
-              "Population miscount: new index has #{new_count} documents, " +
-              "while old index has #{old_count}."
-            )
-            raise RuntimeError, "Population count mismatch"
-          end
-
-          # Switch aliases inside the lock so we avoid a race condition where a
-          # new index exists, but the old index is available for writes
-          index_group.switch_to new_index
-
-          old_index.close
-        end
-      else
-        index_group.switch_to new_index
-      end
+      BulkLoader.new(search_config, index_name, :logger => logger).load_from_current_index
     end
   end
 

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -56,30 +56,10 @@ You should run this task if the index schema has changed.
     # WARNING: this is potentially dangerous, and will leave the search
     # unavailable for a very short (sub-second) period of time
 
+    require 'bulk_loader'
+
     index_names.each do |index_name|
-      index_group = search_server.index_group(index_name)
-
-      real_index_name = index_group.current.real_name
-      unless real_index_name == index_name
-        # This task only makes sense if we're migrating from an unaliased index
-        raise "Expecting index name #{index_name.inspect}; found #{real_index_name.inspect}"
-      end
-
-      logger.info "Creating new #{index_name} index..."
-      new_index = index_group.create_index
-      logger.info "...index '#{new_index.real_name}' created"
-
-      logger.info "Populating new #{index_name} index..."
-      new_index.populate_from index_group.current
-      logger.info "...index populated."
-
-      logger.info "Deleting #{index_name} index..."
-      index_group.send :delete, CGI.escape(index_name)
-      logger.info "...deleted."
-
-      logger.info "Switching #{index_name}..."
-      index_group.switch_to new_index
-      logger.info "...switched"
+      BulkLoader.new(search_config, index_name).load_from_current_unaliased_index
     end
   end
 

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -37,7 +37,7 @@ You should run this task if the index schema has changed.
     require 'bulk_loader'
 
     index_names.each do |index_name|
-      BulkLoader.new(search_config, index_name, :logger => logger).load_from_current_index
+      BulkLoader.new(search_config, index_name).load_from_current_index
     end
   end
 

--- a/test/integration/elasticsearch_migration_test.rb
+++ b/test/integration/elasticsearch_migration_test.rb
@@ -1,5 +1,6 @@
 require "integration_test_helper"
 require "rack/logger"
+require "bulk_loader"
 
 class ElasticsearchMigrationTest < IntegrationTest
 
@@ -15,7 +16,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     @stemmer["rules"] = ["fish => fish"]
 
     create_test_indexes
-    add_sample_documents
+    add_documents(sample_document_attributes)
     commit_index
   end
 
@@ -38,9 +39,9 @@ class ElasticsearchMigrationTest < IntegrationTest
     ]
   end
 
-  def add_sample_documents
-    sample_document_attributes.each do |sample_document|
-      post "/documents", sample_document.to_json
+  def add_documents(documents)
+    documents.each do |document|
+      post "/documents", document.to_json
       assert last_response.ok?
     end
   end
@@ -64,15 +65,53 @@ class ElasticsearchMigrationTest < IntegrationTest
     @stemmer["rules"] = ["directive => directive"]
 
     index_group = search_server.index_group("mainstream_test")
-    new_index = index_group.create_index
-    new_index.populate_from index_group.current
+    original_index_name = index_group.current_real.real_name
 
-    index_group.switch_to new_index
+    BulkLoader.new(search_config, "mainstream_test").load_from_current_index
+
+    # Ensure the indexes have actually been switched.
+    refute_equal original_index_name, index_group.current_real.real_name
 
     get "/unified_search?q=directive"
     assert_result_links "/important"
 
     get "/unified_search?q=direct"
     assert_result_links "/aliens"
+  end
+
+  def test_full_reindex_multiple_batches
+    index_group = search_server.index_group("mainstream_test")
+    extra_documents = (Elasticsearch::Index.populate_batch_size + 5).times.map do |n|
+      {
+        "_type" => "edition",
+        "title" => "Document #{n}",
+        "format" => "answer",
+        "link" => "/doc-#{n}",
+      }
+    end
+    index_group.current_real.bulk_index(extra_documents)
+    commit_index
+
+    get "/unified_search?q=directive"
+    assert_equal 2, JSON.parse(last_response.body)["results"].length
+
+    @stemmer["rules"] = ["directive => directive"]
+
+    index_group = search_server.index_group("mainstream_test")
+    original_index_name = index_group.current_real.real_name
+
+    BulkLoader.new(search_config, "mainstream_test").load_from_current_index
+
+    # Ensure the indexes have actually been switched.
+    refute_equal original_index_name, index_group.current_real.real_name
+
+    get "/unified_search?q=directive"
+    assert_result_links "/important"
+
+    get "/unified_search?q=direct"
+    assert_result_links "/aliens"
+
+    get "/unified_search?q=Document&count=100"
+    assert_equal Elasticsearch::Index.populate_batch_size + 5, JSON.parse(last_response.body)["results"].length
   end
 end

--- a/test/integration/elasticsearch_migration_test.rb
+++ b/test/integration/elasticsearch_migration_test.rb
@@ -139,4 +139,20 @@ class ElasticsearchMigrationTest < IntegrationTest
     get "/unified_search?q=directive"
     assert_equal 2, JSON.parse(last_response.body)["results"].length
   end
+
+  def test_reindex_with_no_existing_index
+    # Test that a reindex will still create the index and alias with no
+    # existing index
+
+    try_remove_test_index
+
+    BulkLoader.new(search_config, "mainstream_test").load_from_current_index
+
+    index_group = search_server.index_group("mainstream_test")
+    new_index = index_group.current_real
+    refute_nil new_index
+
+    # Ensure it's an aliased index
+    refute_equal "mainstream_test", new_index.real_name
+  end
 end

--- a/test/support/elasticsearch_integration_helpers.rb
+++ b/test/support/elasticsearch_integration_helpers.rb
@@ -43,8 +43,12 @@ module ElasticsearchIntegrationHelpers
     WebMock.disable_net_connect!(allow: only_test_databases)
   end
 
+  def search_config
+    app.settings.search_config
+  end
+
   def search_server
-    app.settings.search_config.search_server
+    search_config.search_server
   end
 
   def create_test_index(group_name = DEFAULT_INDEX_NAME)

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -649,21 +649,6 @@ EOS
     @wrapper.all_documents(timeout: 20, open_timeout: 25)
   end
 
-  def test_should_specify_longer_timeouts_on_population
-    timeout_params = {
-      timeout: Elasticsearch::Index::LONG_TIMEOUT_SECONDS,
-      open_timeout: Elasticsearch::Index::LONG_OPEN_TIMEOUT_SECONDS
-    }
-    stub_doc = stub("document")
-    old_index = mock("old index")
-    old_index.stubs(:index_name).returns("Old index")
-    old_index.expects(:all_documents).with(has_entries(timeout_params)).returns([stub_doc])
-    @wrapper.expects(:add).with([stub_doc], has_entries(timeout_params))
-    @wrapper.expects(:commit).at_most_once  # Not central to this test
-
-    @wrapper.populate_from(old_index)
-  end
-
   def scroll_uri(scroll_id)
      "http://example.com:9200/_search/scroll?scroll=60m&scroll_id=#{scroll_id}"
   end


### PR DESCRIPTION
This may be easier to review commit-by-commit.

We can get much more performance while bulk loading a new index (either
migrating an indes, or loading an index from an external dump), by
processing batches of records in parallel.  This is because it allows
elastisearch to use all the resources available to it.  See 
https://www.elastic.co/blog/performance-considerations-elasticsearch-indexing
for more details.

I've picked a default concurrency level of 12 to match our
infrastructure.  Elasticsearch defaults to using an indexing thread pool
size that matches the number of CPU cores available.  Our
api-elasticsearch machines have 4 cores, and we run a 3-node cluster,
hence a value of 12 makes sense. This may need to be tuned after
benchmarking etc.

This change halved the indexing time on my dev VM.
