### PR TITLE
Add important to editions

### DIFF
--- a/config/schema/document_types/edition.json
+++ b/config/schema/document_types/edition.json
@@ -31,7 +31,8 @@
     "has_act_paper",
     "is_political",
     "is_historic",
-    "government_name"
+    "government_name",
+    "important_to_policy"
   ],
 
   "allowed_values": {

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -394,5 +394,10 @@
   "spelling_text": {
     "description": "Generated field, populated with the same content as sent to the _all field, but tokenised into words, lowercased and shingled, not stemmed, etc",
     "type": "spelling_text"
+  },
+
+  "important_to_policy": {
+    "description": "A flag set by editors to mark a document as being important to policy",
+    "type": "boolean"
   }
 }


### PR DESCRIPTION
This commit adds an important flag to the edition doctype. It will be
used by the Whitehall editor to set documents as being important.
