### PR TITLE
Allow faceting by search_format_type

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -35,6 +35,7 @@ class BaseParameterParser
     organisations
     people
     policies
+    search_format_types
     section
     specialist_sectors
   )


### PR DESCRIPTION
The content explorer would like to search with the search_format_type facet.

Trello: https://trello.com/c/TEzydRhA/93-content-explorer-can-we-filter-by-searchable-format

https://github.com/alphagov/govuk-content-explorer/pull/1 depends on this.
