### PR TITLE
Add the closing_date attribute to the ALLOWED_SORT_FIELDS list

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -11,6 +11,7 @@ class BaseParameterParser
   ALLOWED_SORT_FIELDS = %w(
     last_update
     public_timestamp
+    closing_date
     title
   )
 


### PR DESCRIPTION
- This is needed for
  https://github.com/alphagov/specialist-publisher/pull/504.
