### PR TITLE
Fix spelling health checks

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -90,7 +90,7 @@ class HealthCheckCLI
     check_file = open_file(DATA_DIR + "suggestions.csv")
 
     calculator = HealthCheck::SuggestionChecker.new(
-      search_client: search_client_for(nil),
+      search_client: search_client,
       test_data: check_file
     ).run!
 


### PR DESCRIPTION
`search_client_for(nil)` has been removed in ccd29daaad49. This enables
health check for suggestions to run again.
