### PR TITLE
Fix expansion of specialist_sectors.

### DIFF
--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -81,30 +81,7 @@ module Registry
 
   class SpecialistSector < BaseRegistry
     def initialize(index, field_definitions)
-      super(index, field_definitions, "specialist_sector", %w{link title})
-    end
-
-    def [](slug)
-      all[slug]
-    end
-
-  private
-    def fetch
-      Hash[find_documents_by_format.map { |document|
-        # Specialist sector documents don't come from whitehall and so they don't
-        # have a slug in search.  Panopticon constructs the link field from the
-        # slug (held in panopticon) by adding a '/' prefix, so rather than do the
-        # work now to add a slug and reindex the sectors, we construct a slug
-        # field for the cached sector results in SpecialistSectorRegistry by
-        # removing this '/'.
-        #
-        # This can be removed if the slug is ever actually added to
-        # specialist_sector documents.
-        fields = document.to_hash
-        slug = fields["link"][1..-1]
-        fields["slug"] = slug
-        [slug, fields]
-      }]
+      super(index, field_definitions, "specialist_sector")
     end
   end
 

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -140,7 +140,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
 
   def test_expands_sectors
     oil_gas_sector_fields = {
-      "link" => "/oil-and-gas/licensing",
+      "link" => "/topic/oil-and-gas/licensing",
       "title" => "Licensing",
       "slug" => "oil-and-gas/licensing",
     }
@@ -158,7 +158,7 @@ class ResultSetPresenterTest < MiniTest::Unit::TestCase
     assert_equal 1, output["results"][0]["specialist_sectors"].size
     assert_instance_of Hash, output["results"][0]["specialist_sectors"][0]
     assert_equal "Licensing", output["results"][0]["specialist_sectors"][0]["title"]
-    assert_equal "/oil-and-gas/licensing", output["results"][0]["specialist_sectors"][0]["link"]
+    assert_equal "/topic/oil-and-gas/licensing", output["results"][0]["specialist_sectors"][0]["link"]
     assert_equal "oil-and-gas/licensing", output["results"][0]["specialist_sectors"][0]["slug"]
   end
 

--- a/test/unit/specialist_sector_registry_test.rb
+++ b/test/unit/specialist_sector_registry_test.rb
@@ -11,8 +11,9 @@ class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
 
   def oil_and_gas
     Document.new(
-      sample_field_definitions(%w{link title}),
-      link: "/oil-and-gas/licensing",
+      sample_field_definitions(%w{link slug title}),
+      link: "/topic/oil-and-gas/licensing",
+      slug: "oil-and-gas/licensing",
       title: "Licensing"
     )
   end
@@ -22,13 +23,13 @@ class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
       .with("specialist_sector", anything)
       .returns([oil_and_gas])
     sector = @specialist_sector_registry["oil-and-gas/licensing"]
-    assert_equal oil_and_gas.link, sector["link"]
-    assert_equal oil_and_gas.title, sector["title"]
+    assert_equal oil_and_gas.link, sector.link
+    assert_equal oil_and_gas.title, sector.title
   end
 
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
-      .with("specialist_sector", sample_field_definitions(%w{link title}))
+      .with("specialist_sector", sample_field_definitions(%w{link slug title}))
       .returns([])
     @specialist_sector_registry["oil-and-gas/licensing"]
   end
@@ -39,18 +40,6 @@ class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
       .returns([oil_and_gas])
     sector = @specialist_sector_registry["foo"]
     assert_nil sector
-  end
-
-  def test_document_enumerator_is_traversed_only_once
-    document_enumerator = stub("enumerator")
-    document_enumerator.expects(:map).returns([
-      ["oil-and-gas/licensing", oil_and_gas],
-    ]).once
-    @index.stubs(:documents_by_format)
-      .with("specialist_sector", anything)
-      .returns(document_enumerator)
-      .once
-    assert @specialist_sector_registry["oil-and-gas/licensing"]
   end
 
   def test_uses_300_second_cache_lifetime


### PR DESCRIPTION
They've been moved to the /topic namespace, so the code that inferred
the slug from the link field was no longer working. Instead we now send
the slug to rummager (alphagov/collections-publisher#112), so this
inferrence is no longer necessary.
