### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "raindrops", "0.11.0"
 gem "sinatra", "1.3.4"
 gem "rake", "0.9.2", :require => false
 gem "rack", "~> 1.6"
-gem "rest-client", "1.6.7"
+gem "rest-client", "1.8.0"
 gem "logging", "1.8.1"
 gem 'nokogiri', "1.5.5"
 gem 'whenever', require: false
@@ -14,7 +14,7 @@ gem "sidekiq", "2.13.0"
 # pin to version that includes security vulnerability fix
 gem "redis-namespace", "1.3.1"
 gem "plek", "1.5.0"
-gem "gds-api-adapters", "7.18.0"
+gem "gds-api-adapters", "20.1.1"
 gem "rack-logstasher", "0.0.3"
 gem 'airbrake', '4.0.0'
 gem "unf", "0.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,17 +21,22 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     docile (1.1.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     ffi (1.9.0)
-    gds-api-adapters (7.18.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
-      rest-client (~> 1.6.3)
+      rack-cache
+      rest-client (~> 1.8.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.6.0)
     json (1.8.1)
     kgio (2.8.0)
-    link_header (0.0.7)
+    link_header (0.0.8)
     listen (1.2.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -45,7 +50,7 @@ GEM
       PriorityQueue (~> 0.1.2)
     metaclass (0.0.1)
     method_source (0.8.2)
-    mime-types (1.19)
+    mime-types (2.6.1)
     minitest (4.6.1)
     mocha (0.13.2)
       metaclass (~> 0.0.1)
@@ -55,6 +60,7 @@ GEM
       rb-inotify (>= 0.8)
       unicorn (>= 4.5)
     multi_json (1.11.0)
+    netrc (0.10.3)
     nokogiri (1.5.5)
     null_logger (0.0.1)
     plek (1.5.0)
@@ -63,6 +69,8 @@ GEM
       method_source (~> 0.8)
       slop (~> 3.4)
     rack (1.6.2)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rack-logstasher (0.0.3)
       logstash-event
       rack
@@ -80,8 +88,10 @@ GEM
     redis (3.0.4)
     redis-namespace (1.3.1)
       redis (~> 3.0.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     safe_yaml (1.0.4)
     shoulda-context (1.1.1)
     sidekiq (2.13.0)
@@ -127,7 +137,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.0.0)
   ci_reporter (= 1.7.1)
-  gds-api-adapters (= 7.18.0)
+  gds-api-adapters (= 20.1.1)
   logging (= 1.8.1)
   minitest (= 4.6.1)
   mocha
@@ -141,7 +151,7 @@ DEPENDENCIES
   raindrops (= 0.11.0)
   rake (= 0.9.2)
   redis-namespace (= 1.3.1)
-  rest-client (= 1.6.7)
+  rest-client (= 1.8.0)
   shoulda-context
   sidekiq (= 2.13.0)
   simplecov (~> 0.10.0)

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -20,7 +20,7 @@ namespace :router do
     ].each do |path, type|
       begin
         puts "Registering #{type} route #{path}"
-        @router_api.add_route path, type, @app_id, :skip_commit => true
+        @router_api.add_route path, type, @app_id
       rescue => e
         puts "Error registering route: #{e.message}"
         raise


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information
