### PR TITLE
Remove the unused ALLOWED_RETURN_FIELDS constant

### DIFF
--- a/lib/search_parameter_parser.rb
+++ b/lib/search_parameter_parser.rb
@@ -83,41 +83,6 @@ class BaseParameterParser
   #            the query and filters
   ALLOWED_EXAMPLE_SCOPES = [:global, :query]
 
-  # The fields listed here are the only ones that can be returned in search
-  # results.  These are listed and validated explicitly, rather than simply
-  # allowing any field in the schema, to keep the set of such fields as minimal
-  # as possible.  This lets us reorganise the way other fields are stored and
-  # indexed without having to check that we don't break the display of search
-  # results.
-  ALLOWED_RETURN_FIELDS = %w(
-    description
-    detailed_format
-    display_type
-    document_collections
-    document_series
-    format
-    government_name
-    is_historic
-    last_update
-    latest_change_note
-    link
-    mainstream_browse_pages
-    manual
-    organisation_state
-    organisations
-    people
-    policies
-    public_timestamp
-    section
-    slug
-    specialist_sectors
-    subsection
-    subsubsection
-    title
-    topics
-    world_locations
-  )
-
   # The fields which are returned by default for search results.
   DEFAULT_RETURN_FIELDS = %w(
     description


### PR DESCRIPTION
It hasn't been used since f862c694c5a77d227b91692dbcc22f07d478327c,
which changed to use the schema to generate the list of allowed return
fields.
