### PR TITLE
Calculate snippet for search results

### DIFF
--- a/lib/result_set_presenter.rb
+++ b/lib/result_set_presenter.rb
@@ -1,5 +1,6 @@
 require "active_support/inflector"
 require "entity_expander"
+require "snippet"
 
 class ResultSetPresenter
 
@@ -25,6 +26,7 @@ private
   def build_result(document)
     result = expand_metadata(document.to_hash)
     result = EntityExpander.new(@context).new_result(result)
+    result[:snippet] = Snippet.new(result).text
     result
   end
 

--- a/lib/snippet.rb
+++ b/lib/snippet.rb
@@ -1,0 +1,35 @@
+require "active_support/core_ext/string"
+
+# Calculates the snippet for a search result. This will be the place to add
+# highlighting and fragments.
+class Snippet
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def text
+    if document['format'] == "organisation" && document["organisation_state"] != "closed"
+      description_with_organisation_prefix
+    elsif original_description.blank? && document["format"] == "specialist_sector"
+      "List of information about #{document["title"]}."
+    else
+      truncated_description
+    end
+  end
+
+private
+
+  def description_with_organisation_prefix
+    "The home of #{document["title"]} on GOV.UK. #{truncated_description}"
+  end
+
+  def truncated_description
+    original_description.truncate(215, separator: " ", omission: '…')
+  end
+
+  def original_description
+    document['description'] || ""
+  end
+end

--- a/test/functional/advanced_search_test.rb
+++ b/test/functional/advanced_search_test.rb
@@ -24,11 +24,10 @@ class AdvancedSearchTest < IntegrationTest
       .returns(stub(total: 1, results: [sample_document]))
 
     get "/mainstream_test/advanced_search.json", {per_page: '1', page: '1', keywords: 'meh'}
-    expected_result = {'total' => 1, 'results' => [sample_document_attributes], 'spelling_suggestions' => []}
+    result = JSON.parse(last_response.body)
 
     assert last_response.ok?, "Bad status: #{last_response.status}"
     assert_match /application\/json/, last_response.headers["Content-Type"]
-    result = JSON.parse(last_response.body)
-    assert_equal expected_result, result
+    assert_equal sample_document.title, result['results'].first['title']
   end
 end

--- a/test/unit/snippet_test.rb
+++ b/test/unit/snippet_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+require "snippet"
+
+class SnippetTest < MiniTest::Unit::TestCase
+  def test_snippet_by_default
+    document = { "description" => "Some short description." }
+
+    snippet = Snippet.new(document).text
+
+    assert_equal "Some short description.", snippet
+  end
+
+  def test_nil_snippet_is_empty
+    document = { "description" => nil }
+
+    snippet = Snippet.new(document).text
+
+    assert_equal "", snippet
+  end
+
+  def test_snippet_should_be_truncated
+    document = { "description" => "Some looong description." * 20 }
+
+    snippet = Snippet.new(document).text
+
+    assert snippet.size < 215
+  end
+
+  def test_organisation_snippet_should_get_prefixed
+    document = { "title" => "Ministry of Magic", "format" => "organisation", "organisation_state" => "open", "description" => "A description." }
+
+    snippet = Snippet.new(document).text
+
+    assert_equal "The home of Ministry of Magic on GOV.UK. A description.", snippet
+  end
+
+  def test_closed_organisation_snippet_should_not_get_prefixed
+    document = { "format" => "organisation", "organisation_state" => "closed", "description" => "A description." }
+
+    snippet = Snippet.new(document).text
+
+    assert_equal "A description.", snippet
+  end
+
+  def test_topic_pages_get_a_nice_description_if_they_do_not_have_one
+    document = { "format" => "specialist_sector", "title" => "Muggles" }
+
+    snippet = Snippet.new(document).text
+
+    assert_equal "List of information about Muggles.", snippet
+  end
+
+  def test_topic_pages_keep_description_if_present
+    document = { "format" => "specialist_sector", "description" => "All about Muggles." }
+
+    snippet = Snippet.new(document).text
+
+    assert_equal "All about Muggles.", snippet
+  end
+end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -218,7 +218,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
     end
 
     should 'return only basic metadata of fields' do
-      expected_keys = [:index, :es_score, :_id, :document_type]
+      expected_keys = [:snippet, :index, :es_score, :_id, :document_type]
 
       assert_equal expected_keys, @output[:results].first.keys
     end


### PR DESCRIPTION
Currently, the [frontend application does a lot of work to generate descriptions](https://github.com/alphagov/frontend/blob/2b64f4989fcb7089d8e2c7255c78170ee7c624da/app/presenters/search_result.rb#L59) for the search results. For example by adding missing descriptions for topic pages. This commit adds a Snippet class which replicates the current behaviour of frontend.

Having the behaviour here will allow us to add highlighting, show fragments (parts of the content) and to serve the same snippet to other users of rummager.

Trello: https://trello.com/c/z0yi0Qit/227-search-results-add-highlighting-snippets & https://trello.com/c/AM4LQ2i3
