### PR TITLE
Remove special case for Topic snippet

### DIFF
--- a/lib/snippet.rb
+++ b/lib/snippet.rb
@@ -12,8 +12,6 @@ class Snippet
   def text
     if document['format'] == "organisation" && document["organisation_state"] != "closed"
       description_with_organisation_prefix
-    elsif original_description.blank? && document["format"] == "specialist_sector"
-      "List of information about #{document["title"]}."
     else
       truncated_description
     end

--- a/test/unit/snippet_test.rb
+++ b/test/unit/snippet_test.rb
@@ -41,20 +41,4 @@ class SnippetTest < MiniTest::Unit::TestCase
 
     assert_equal "A description.", snippet
   end
-
-  def test_topic_pages_get_a_nice_description_if_they_do_not_have_one
-    document = { "format" => "specialist_sector", "title" => "Muggles" }
-
-    snippet = Snippet.new(document).text
-
-    assert_equal "List of information about Muggles.", snippet
-  end
-
-  def test_topic_pages_keep_description_if_present
-    document = { "format" => "specialist_sector", "description" => "All about Muggles." }
-
-    snippet = Snippet.new(document).text
-
-    assert_equal "All about Muggles.", snippet
-  end
 end


### PR DESCRIPTION
Topics [will soon have descriptions of their own](https://github.com/alphagov/collections-publisher/pull/125), set by the collections publisher. We no longer need to provide it for topics that don't have one.

Trello: https://trello.com/c/AM4LQ2i3
