### PR TITLE
Hide mainstream browse pages

### DIFF
--- a/lib/query_components/booster.rb
+++ b/lib/query_components/booster.rb
@@ -36,6 +36,9 @@ module QueryComponents
         "document_collection" => 1.3,
         "operational_field" => 1.5,
         "contact"           => 0.3,
+
+        # Hide mainstream browse pages for now.
+        "mainstream_browse_page" => 0,
       }
     end
 


### PR DESCRIPTION
Mainstream browse pages are currently not indexed, but soon will be to allow rummager to deliver content.

We're still unsure if we want to display mainstream browse pages in the search results, and how. By boosting them with zero, they can be hidden from the results.
## Before

![screen shot 2015-07-23 at 17 18 59](https://cloud.githubusercontent.com/assets/233676/8855802/0d0f5ab2-315f-11e5-88f3-46fea6841a37.png)
## After

![screen shot 2015-07-23 at 17 19 14](https://cloud.githubusercontent.com/assets/233676/8855811/11367ce2-315f-11e5-93b0-2f733252c2a5.png)

Trello: https://trello.com/c/6vXKBd5d

PR to index browse pages: https://github.com/alphagov/collections-publisher/pull/127
