### PR TITLE
More downweighting for closed organisations

### DIFF
--- a/lib/query_components/booster.rb
+++ b/lib/query_components/booster.rb
@@ -74,7 +74,7 @@ module QueryComponents
     def closed_org_boost
       {
         filter: { term: { organisation_state: "closed" } },
-        boost_factor: 0.3,
+        boost_factor: 0.2,
       }
     end
 


### PR DESCRIPTION
Closed organisations can currently rank higher than normal organisations. By decreasing the boost ever further we prevent that.

Example: search for "uk border" should not bring up the closed UK Border Agency as high as it does now.

https://www.gov.uk/search?q=uk+border 
## Before

![screen shot 2015-08-03 at 10 56 12](https://cloud.githubusercontent.com/assets/233676/9035372/28403bf8-39cf-11e5-8bac-95c15db8eb50.png)
## After

![screen shot 2015-08-03 at 10 56 24](https://cloud.githubusercontent.com/assets/233676/9035371/283c2590-39cf-11e5-8f33-4b5c55b9be09.png)

(Descriptions removed to fit it all on one page).
