### PR TITLE
Add /content endpoints

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -22,6 +22,8 @@ require "schema/combined_index_schema"
 require_relative "config"
 require_relative "helpers"
 
+require "routes/content"
+
 class Rummager < Sinatra::Application
   def search_server
     settings.search_config.search_server

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,55 @@
+## Rummager API
+
+### `GET /content/?link=/a-link`
+
+Returns information about the search result with the specified link.
+
+### Example reponse
+
+```
+curl -XGET http://rummager.dev.gov.uk/content?link=/vehicle-tax
+```
+
+Currently returns a hash with one element: `raw_source`, which contains the raw elasticsearch document (`_source`).
+
+```json
+{  
+   "raw_source":{  
+      "section":"driving",
+      "subsection":"car-tax-discs",
+      "organisations":[  
+         "department-for-transport",
+         "driver-and-vehicle-licensing-agency"
+      ],
+      "popularity":0.08333333333333333,
+      "public_timestamp":"2014-12-09T16:21:03+00:00",
+      "format":"transaction",
+      "title":"Renew vehicle tax",
+      "description":"Renew your vehicle tax, apply online, by phone or at the Post Office",
+      "link":"/vehicle-tax",
+      "indexable_content":"[..snip..]",
+      "mainstream_browse_pages":[  
+         "driving/car-tax-discs"
+      ],
+      "tags":[  
+         "organisation:department-for-transport",
+         "organisation:driver-and-vehicle-licensing-agency"
+      ],
+      "_type":"edition",
+      "_id":"/vehicle-tax"
+   }
+}
+```
+
+### `DELETE /content/?link=/a-link`
+
+Deletes the search result with the specified link.
+
+
+## Example response
+
+```
+curl -XDELETE http://rummager.dev.gov.uk/content?link=/vehicle-tax
+```
+
+Will return 404 when the link is not found, 204 when it is deleted.

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -72,6 +72,14 @@ module Elasticsearch
       @mappings["edition"]["properties"].keys
     end
 
+    # Translate index names like `mainstream-2015-05-06t09..` into its
+    # proper name, eg. "mainstream", "government" or "service-manual".
+    # The regex takes the string until the first digit. After that, strip any
+    # trailing dash from the string.
+    def self.strip_alias_from_index_name(aliased_index_name)
+      aliased_index_name.match(%r[^\D+]).to_s.chomp('-')
+    end
+
     def real_name
       # If the index exists, it will return something of the form:
       # { real_name => { "aliases" => { alias => {} } } }

--- a/lib/elasticsearch/search_server.rb
+++ b/lib/elasticsearch/search_server.rb
@@ -26,14 +26,14 @@ module Elasticsearch
       )
     end
 
-    def index(prefix)
-      raise NoSuchIndex, prefix unless index_name_valid?(prefix)
-      index_group(prefix).current
+    def index(index_name)
+      validate_index_name!(index_name)
+      index_group(index_name).current
     end
 
     def index_for_search(names)
-      names.each do |name|
-        raise NoSuchIndex, name unless index_name_valid?(name)
+      names.each do |index_name|
+        validate_index_name!(index_name)
       end
       IndexForSearch.new(@base_uri, names, @schema, @search_config)
     end
@@ -45,6 +45,13 @@ module Elasticsearch
     end
 
   private
+    def validate_index_name!(index_name)
+      return if index_name_valid?(index_name)
+
+      raise NoSuchIndex,
+        "Index name #{index_name} is not specified in the elasticsearch settings."
+    end
+
     def index_name_valid?(index_name)
       index_name.split(",").all? do |name|
         @index_names.include?(name)

--- a/lib/result_presenter.rb
+++ b/lib/result_presenter.rb
@@ -71,11 +71,7 @@ private
     # Advanced search only passes through data, not the entire raw result.
     return result unless raw_result["_index"]
 
-    # Translate index names like `mainstream-2015-05-06t09..` into its
-    # proper name, eg. "mainstream", "government" or "service-manual".
-    # The regex takes the string until the first digit. After that, strip any
-    # trailing dash from the string.
-    result[:index] = raw_result["_index"].match(%r[^\D+]).to_s.chomp('-')
+    result[:index] = Elasticsearch::Index.strip_alias_from_index_name(raw_result["_index"])
 
     # Put the elasticsearch score in es_score; this is used in templates when
     # debugging is requested, so it's nicer to be explicit about what score

--- a/lib/routes/content.rb
+++ b/lib/routes/content.rb
@@ -1,0 +1,31 @@
+class Rummager < Sinatra::Application
+  get '/content' do
+    raw_result = find_result_by_link(params["link"])
+    { raw_source: raw_result['_source'] }.to_json
+  end
+
+  delete '/content' do
+    raw_result = find_result_by_link(params["link"])
+    delete_result_from_index(raw_result)
+    json_result 204, "Deleted the link from search index"
+  end
+
+private
+
+  def find_result_by_link(link)
+    results = unified_index.raw_search(query: { term: { link: link }}, size: 1)
+    raw_result = results['hits']['hits'].first
+
+    unless raw_result
+      halt 404, "No document found with link #{link}."
+    end
+
+    raw_result
+  end
+
+  def delete_result_from_index(raw_result)
+    index_name = Elasticsearch::Index.strip_alias_from_index_name(raw_result['_index'])
+    index = search_server.index(index_name)
+    index.delete(raw_result['_type'], raw_result['_id'])
+  end
+end

--- a/lib/routes/content.rb
+++ b/lib/routes/content.rb
@@ -1,7 +1,10 @@
 class Rummager < Sinatra::Application
   get '/content' do
     raw_result = find_result_by_link(params["link"])
-    { raw_source: raw_result['_source'] }.to_json
+    {
+      index: Elasticsearch::Index.strip_alias_from_index_name(raw_result['_index']),
+      raw_source: raw_result['_source']
+    }.to_json
   end
 
   delete '/content' do

--- a/lib/routes/content.rb
+++ b/lib/routes/content.rb
@@ -8,9 +8,13 @@ class Rummager < Sinatra::Application
   end
 
   delete '/content' do
-    raw_result = find_result_by_link(params["link"])
-    delete_result_from_index(raw_result)
-    json_result 204, "Deleted the link from search index"
+    begin
+      raw_result = find_result_by_link(params["link"])
+      delete_result_from_index(raw_result)
+      json_result 204, "Deleted the link from search index"
+    rescue Elasticsearch::IndexLocked
+      json_result 423, "The index is locked. Please try again later."
+    end
   end
 
 private

--- a/test/functional/content_endpoints_test.rb
+++ b/test/functional/content_endpoints_test.rb
@@ -1,0 +1,71 @@
+require "integration_test_helper"
+
+class ContentEndpointsTest < IntegrationTest
+  def setup
+    stub_elasticsearch_settings
+  end
+
+  def test_content_document_not_found
+    result = { "hits" => { "hits" => [] } }
+
+    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+      to_return(status: 200, body: JSON.dump(result))
+
+    get "/content?link=/a-document/that-does-not-exist"
+
+    assert last_response.not_found?
+  end
+
+  def test_that_getting_a_document_returns_the_document
+    result = {
+       "hits"=>
+        {"hits"=>
+          [{"_index"=>
+             "mainstream-2015-07-14t12:15:23z-00000000-0000-0000-0000-000000000000",
+            "_type"=>"edition",
+            "_id"=>"/vehicle-tax",
+            "_score"=>1.0,
+            "_source"=> 'THE_RAW_SOURCE' }]}}
+
+    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+      to_return(status: 200, body: JSON.dump(result))
+
+    get "/content?link=a-document/in-search"
+
+    assert last_response.ok?
+    assert_equal 'THE_RAW_SOURCE', parsed_response['raw_source']
+  end
+
+  def test_deleting_a_document
+    result = {
+       "hits"=>
+        {"hits"=>
+          [{"_index"=>
+             "mainstream_test",
+            "_type"=>"edition",
+            "_id"=>"/vehicle-tax",
+            "_score"=>1.0,
+            "_source"=> 'THE_RAW_SOURCE' }]}}
+
+    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+      to_return(status: 200, body: JSON.dump(result))
+
+    stub_request(:delete, "http://localhost:9200/mainstream_test/edition/%2Fvehicle-tax").
+      to_return(status: 200, body: "{}")
+
+    delete "/content?link=a-document/in-search"
+
+    assert_equal 204, last_response.status
+  end
+
+  def test_deleting_a_document_that_doesnt_exist
+    result = { "hits" => { "hits" => [] } }
+
+    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+      to_return(status: 200, body: JSON.dump(result))
+
+    delete "/content?link=a-document/in-search"
+
+    assert last_response.not_found?
+  end
+end

--- a/test/integration/bulk_loader_test.rb
+++ b/test/integration/bulk_loader_test.rb
@@ -26,7 +26,7 @@ class BulkLoaderTest < IntegrationTest
 
   def retrieve_document_from_rummager(link)
     get "/documents/#{CGI::escape(link)}"
-    JSON.parse(last_response.body)
+    parsed_response
   end
 
   def assert_document_is_in_rummager(document, skip_keys=["popularity"])

--- a/test/integration/elasticsearch_advanced_search_test.rb
+++ b/test/integration/elasticsearch_advanced_search_test.rb
@@ -88,7 +88,6 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
       hash = links.pop
       order = hash[:order]
     end
-    parsed_response = JSON.parse(last_response.body)
     parsed_links = parsed_response['results'].map { |r| r["link"] }
     if order
       assert_equal links, parsed_links
@@ -98,7 +97,6 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
   end
 
   def assert_result_total(total)
-    parsed_response = JSON.parse(last_response.body)
     assert_equal total, parsed_response['total']
   end
 
@@ -195,7 +193,6 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
 
     assert last_response.ok?
     assert_result_total 1
-    parsed_response = JSON.parse(last_response.body)
     assert_equal ["ministry-of-cheese"], parsed_response["results"][0]["organisations"]
   end
 

--- a/test/integration/elasticsearch_amendment_test.rb
+++ b/test/integration/elasticsearch_amendment_test.rb
@@ -34,7 +34,6 @@ class ElasticsearchAmendmentTest < IntegrationTest
   def test_should_get_a_document_through_elasticsearch
     get "/documents/%2Fan-example-answer"
     assert last_response.ok?
-    parsed_response = JSON.parse(last_response.body)
 
     sample_document_attributes.each do |key, value|
       assert_equal value, parsed_response[key]
@@ -54,7 +53,6 @@ class ElasticsearchAmendmentTest < IntegrationTest
 
     get "/documents/%2Fan-example-answer"
     assert last_response.ok?
-    parsed_response = JSON.parse(last_response.body)
 
     updates = {"title" => "A new title"}
     sample_document_attributes.merge(updates).each do |key, value|
@@ -69,7 +67,6 @@ class ElasticsearchAmendmentTest < IntegrationTest
 
     get "/documents/%2Fan-example-answer"
     assert last_response.ok?
-    parsed_response = JSON.parse(last_response.body)
 
     updates = {
       "tags" => ["organisation:hm-magic", "sector:oil-and-gas/licensing"],

--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -81,7 +81,7 @@ class ElasticsearchDeletionTest < IntegrationTest
   end
 
   def assert_no_results
-    assert_equal [], JSON.parse(last_response.body)["results"]
+    assert_equal [], parsed_response["results"]
   end
 
   def test_should_404_on_deleted_content

--- a/test/integration/elasticsearch_indexing_test.rb
+++ b/test/integration/elasticsearch_indexing_test.rb
@@ -23,7 +23,7 @@ class ElasticsearchIndexingTest < IntegrationTest
 
   def retrieve_document_from_rummager(link)
     get "/documents/#{CGI::escape(link)}"
-    JSON.parse(last_response.body)
+    parsed_response
   end
 
   def assert_document_is_in_rummager(document)

--- a/test/integration/elasticsearch_migration_test.rb
+++ b/test/integration/elasticsearch_migration_test.rb
@@ -51,7 +51,6 @@ class ElasticsearchMigrationTest < IntegrationTest
   end
 
   def assert_result_links(*links)
-    parsed_response = JSON.parse(last_response.body)
     assert_equal links, parsed_response["results"].map { |r| r["link"] }
   end
 
@@ -60,7 +59,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     # stemming settings
 
     get "/unified_search?q=directive"
-    assert_equal 2, JSON.parse(last_response.body)["results"].length
+    assert_equal 2, parsed_response["results"].length
 
     @stemmer["rules"] = ["directive => directive"]
 
@@ -94,7 +93,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     commit_index
 
     get "/unified_search?q=directive"
-    assert_equal 2, JSON.parse(last_response.body)["results"].length
+    assert_equal 2, parsed_response["results"].length
 
     @stemmer["rules"] = ["directive => directive"]
 
@@ -113,7 +112,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     assert_result_links "/aliens"
 
     get "/unified_search?q=Document&count=100"
-    assert_equal test_batch_size + 5, JSON.parse(last_response.body)["results"].length
+    assert_equal test_batch_size + 5, parsed_response["results"].length
   end
 
   def test_handles_errors_correctly
@@ -122,7 +121,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     Elasticsearch::Index.any_instance.stubs(:bulk_index).raises(Elasticsearch::IndexLocked)
 
     get "/unified_search?q=directive"
-    assert_equal 2, JSON.parse(last_response.body)["results"].length
+    assert_equal 2, parsed_response["results"].length
 
     @stemmer["rules"] = ["directive => directive"]
 
@@ -137,7 +136,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     assert_equal original_index_name, index_group.current_real.real_name
 
     get "/unified_search?q=directive"
-    assert_equal 2, JSON.parse(last_response.body)["results"].length
+    assert_equal 2, parsed_response["results"].length
   end
 
   def test_reindex_with_no_existing_index

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -87,10 +87,6 @@ class MultiIndexTest < IntegrationTest
     post "/#{index_name}/commit", nil
   end
 
-  def parsed_response
-    JSON.parse(last_response.body)
-  end
-
   private
 
   def populate_content_indexes(params)

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -14,6 +14,10 @@ class IntegrationTest < MiniTest::Unit::TestCase
     Rummager
   end
 
+  def parsed_response
+    JSON.parse(last_response.body)
+  end
+
 private
 
   def deep_copy(hash)


### PR DESCRIPTION
This PR adds two new API endpoints.

`GET /content?link=/vehicle-tax`

Will return the search result from our content indexes with the specified link.

`DELETE /content?link=/vehicle-tax`

Will delete the search result from the index.

These endpoints are meant to be used by [search-admin](https://github.com/alphagov/search-admin) first, to: 
1. Display the data for a link in elasticsearch, usefull to debug what is in `indexable_content` 
2. Manually delete search results from the indices. Removal of search results is currently done manually, which is taking up developer time.

Notes:
- There is already a `get "/?:index?/documents/*"` route to fetch the document from elasticsearch. However, this endpoint does not support multiple indexes. The difference between our four "content" indexes (mainstream, government, detailed, service-manual) is no longer relevant and users may not even know in which index the document lives. The new `GET` route works on all content indexes.
- `get "/?:index?/documents/*"` doesn't work for some document formats because of the way it calculates the document type when searching (see [this](https://github.com/alphagov/rummager/blob/9b2a1e1748808bdedbc7cbf974c32c1159582e1a/lib/elasticsearch/index.rb#L334) for details). The new endpoint works for all documents that can turn up in the results.
- `delete "/?:index?/documents/*"` needs the `type` and `index` of the result to delete. This is difficult to find, especially since `get "/?:index?/documents/*"` doesn't work. Our new endpoint doesn't need the type.
- A third endpoint `delete "/?:index?/documents"` can also be deprecated.

Notes about implementation:
- We chose to add a new file in `lib/routes` for these endpoints, to keep `app.rb` from growing even bigger.
- The URL would be nicer in the form of `GET /content/:id`. But this would be confusing because of the double slash the URL would contain (a problem with the endpoints mentioned above).
- Added documentation to `/docs/api.md`.
## Trello

https://trello.com/c/dvzAnQ80/272-remove-passport-extension-page-from-search
https://trello.com/c/0Jybv3yh/276-remove-item-from-search-index

Paired with @jackscotti on this one :+1: 
