### PR TITLE
Add Upper Tribunal Immigration and Asylum Chamber decisions

### DIFF
--- a/config/schema/document_types/utiac_decision.json
+++ b/config/schema/document_types/utiac_decision.json
@@ -1,0 +1,9 @@
+{
+  "fields": [
+    "country",
+    "country_guidance",
+    "decision_reported",
+    "judges",
+    "promulgation_date"
+  ]
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -399,5 +399,21 @@
   "important_to_policy": {
     "description": "A flag set by editors to mark a document as being important to policy",
     "type": "boolean"
+  },
+
+  "country": {
+    "type": "identifier"
+  },
+  "country_guidance": {
+    "type": "identifier"
+  },
+  "decision_reported": {
+    "type": "identifier"
+  },
+  "judges": {
+    "type": "searchable_identifiers"
+  },
+  "promulgation_date": {
+    "type": "date"
   }
 }

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -31,6 +31,18 @@
     }
   },
 
+  "searchable_identifiers": {
+    "description": "Like identifier, but can occur multiple times in a single document and be considered in non-field-specific text searches.",
+    "filter_type": "text",
+    "multivalued": true,
+    "es_config": {
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": true,
+      "copy_to": ["spelling_text", "all_searchable_text"]
+    }
+  },
+
   "searchable_text": {
     "description": "A piece of plain text that should be split into words and considered in searches",
     "es_config": {

--- a/config/schema/indexes/mainstream.json
+++ b/config/schema/indexes/mainstream.json
@@ -16,6 +16,7 @@
     "medical_safety_alert",
     "policy",
     "raib_report",
+    "utiac_decision",
     "vehicle_recalls_and_faults_alert"
   ]
 }


### PR DESCRIPTION
- Add `utiac_decision` document type and field definitions for Upper Tribunal Immigration and Asylum Chamber decisions.
- Add new `searchable_identifiers` field type that allows identifiers that occur multiple times in a single document to be considered in non-field-specific text searches.
