### PR TITLE
Temporarily fix leading slashes in links

### DIFF
--- a/lib/result_presenter.rb
+++ b/lib/result_presenter.rb
@@ -21,6 +21,7 @@ class ResultPresenter
     result = expand_entities(result)
     result = add_calculated_fields(result)
     result = add_debug_values(result)
+    result = temporarily_fix_link_field(result)
     result
   end
 
@@ -89,6 +90,15 @@ private
 
   def add_calculated_fields(result)
     result[:snippet] = Snippet.new(result).text
+    result
+  end
+
+  def temporarily_fix_link_field(result)
+    return result if result['link'].nil? ||
+      result['link'].starts_with?('http') ||
+      result['link'].starts_with?('/')
+
+    result['link'] = '/' + result['link']
     result
   end
 end

--- a/test/unit/temporary_link_fix_test.rb
+++ b/test/unit/temporary_link_fix_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+require "result_presenter"
+
+class TemporaryLinkFixTest < MiniTest::Unit::TestCase
+  def test_appending_a_slash_to_the_link_field
+    document = {
+      '_type' => 'raib_report',
+      '_index' => 'mainstream_test',
+      'fields' => { 'link' => ['some/link'] }
+    }
+
+    result = ResultPresenter.new(document, nil, sample_schema).present
+
+    assert_equal "/some/link", result["link"]
+  end
+
+  def test_keep_http_links_intact
+    document = {
+      '_type' => 'raib_report',
+      '_index' => 'mainstream_test',
+      'fields' => { 'link' => ['http://example.org/some-link'] }
+    }
+
+    result = ResultPresenter.new(document, nil, sample_schema).present
+
+    assert_equal "http://example.org/some-link", result["link"]
+  end
+
+  def test_keep_correct_links_intact
+    document = {
+      '_type' => 'raib_report',
+      '_index' => 'mainstream_test',
+      'fields' => { 'link' => ['/some-link'] }
+    }
+
+    result = ResultPresenter.new(document, nil, sample_schema).present
+
+    assert_equal "/some-link", result["link"]
+  end
+end


### PR DESCRIPTION
The link field should contain either a full URL or a relative URL with leading slash for the frontend to work. Manuals and specialist documents currently send links without leading slash to rummager,
causing problems in search and collections.

This temporarily adds the leading slash. This functionality should be removed once all documents are indexed correctly. For this reason the tests have been isolated in a separate file.
