### PR TITLE
Link to the API docs from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,58 +63,13 @@ After changing the schema, you'll need to migrate the index.
 
     RUMMAGER_INDEX=all bundle exec rake rummager:migrate_index
 
-### Example API output
+### API documentation
 
-The simplest query:
+For the most up to date query syntax and API output:
 
-    curl 'http://rummager.dev.gov.uk/unified_search.json?q=taxes'
-
-For the most up to date query syntax and API output, check the documentation for individual endpoints in [app.rb](app.rb).
-
-```json
-{  
-   "results":[  
-      {  
-         "title":"Renew vehicle tax",
-         "subsection":"car-tax-discs",
-         "description":"Get vehicle tax from the DVLA for your car, motorbike, lorry, bus or other vehicle - online, by phone or at the Post Office",
-         "link":"/vehicle-tax",
-         "format":"transaction",
-         "organisations":[  
-            {  
-               "slug":"department-for-transport",
-               "link":"/government/organisations/department-for-transport",
-               "title":"Department for Transport",
-               "acronym":"DFT",
-               "organisation_type":"Ministerial department",
-               "organisation_state":"live"
-            },
-            {  
-               "slug":"driver-and-vehicle-licensing-agency",
-               "link":"/government/organisations/driver-and-vehicle-licensing-agency",
-               "title":"Driver and Vehicle Licensing Agency",
-               "acronym":"DVLA",
-               "organisation_state":"live"
-            }
-         ],
-         "public_timestamp":"2014-12-09T16:21:03+00:00",
-         "section":"driving",
-         "index":"mainstream",
-         "es_score":0.29372323,
-         "_id":"/vehicle-tax",
-         "document_type":"edition"
-      },
-      { ... }
-      ],
-   "total":11876,
-   "start":0,
-   "facets":{  
-
-   },
-   "suggested_queries":[]
-}
-```
-
+- [docs/unified-search-api.md](docs/unified-search-api.md) for the unified search
+  endpoint (`/unified-search.json`).
+- [docs/content-api.md](docs/content-api.md) for the `/content/*` endpoint.
 
 ### Additional Docs
 

--- a/docs/content-api.md
+++ b/docs/content-api.md
@@ -1,4 +1,4 @@
-## Rummager API
+## Rummager Content API
 
 ### `GET /content/?link=/a-link`
 

--- a/docs/unified-search-api.md
+++ b/docs/unified-search-api.md
@@ -184,26 +184,28 @@ For example:
 
 Returns something like:
 
-    {
-      "results": [
-        {...},
-        {...}
-      ],
-      "total": 19,
-      "offset": 0,
-      "spelling_suggestions": [
-        ...
-      ],
-      "facets": {
-        "organisations": {
-          "options": [
-            {
-              "value": "department-for-business-innovation-skills",
-              "documents": 788
-            }, ...],
-          "documents_with_no_value": 1610,
-          "total_options": 94,
-          "missing_options": 84
-        }
-      }
+```json
+{
+  "results": [
+    {...},
+    {...}
+  ],
+  "total": 19,
+  "offset": 0,
+  "spelling_suggestions": [
+    ...
+  ],
+  "facets": {
+    "organisations": {
+      "options": [
+        {
+          "value": "department-for-business-innovation-skills",
+          "documents": 788
+        }, ...],
+      "documents_with_no_value": 1610,
+      "total_options": 94,
+      "missing_options": 84
     }
+  }
+}
+```


### PR DESCRIPTION
The new API docs are actually useful, so we should link to them.
