### PR TITLE
Only amend search description when necessary

### DIFF
--- a/lib/snippet.rb
+++ b/lib/snippet.rb
@@ -10,7 +10,7 @@ class Snippet
   end
 
   def text
-    if document['format'] == "organisation" && document["organisation_state"] != "closed"
+    if needs_organsation_prefix?
       description_with_organisation_prefix
     else
       truncated_description
@@ -29,5 +29,11 @@ private
 
   def original_description
     document['description'] || ""
+  end
+
+  def needs_organsation_prefix?
+    document['format'] == "organisation" &&
+      document["organisation_state"] != "closed" &&
+      !document['description'].starts_with?("The home of")
   end
 end

--- a/test/unit/snippet_test.rb
+++ b/test/unit/snippet_test.rb
@@ -34,6 +34,18 @@ class SnippetTest < MiniTest::Unit::TestCase
     assert_equal "The home of Ministry of Magic on GOV.UK. A description.", snippet
   end
 
+  def test_organisation_snippets_should_get_prefixed_when_necessary
+    document = {
+      "title" => "Ministry of Magic",
+      "format" => "organisation", "organisation_state" => "open",
+      "description" => "The home of Ministry of Magic on GOV.UK. A description."
+    }
+
+    snippet = Snippet.new(document).text
+
+    assert_equal "The home of Ministry of Magic on GOV.UK. A description.", snippet
+  end
+
   def test_closed_organisation_snippet_should_not_get_prefixed
     document = { "format" => "organisation", "organisation_state" => "closed", "description" => "A description." }
 


### PR DESCRIPTION
We currently amend the search description for organisations to make the text for organisations read nicely.

For example:

![screen shot 2015-08-10 at 16 26 56](https://cloud.githubusercontent.com/assets/233676/9175257/98f833b6-3f7c-11e5-947a-be95681ef6f1.png)

https://www.gov.uk/search?q=defra

We'd like Whitehall to add the "Home of X on GOV.UK", not rummager. This will allow us to highlight the organisation description correctly.

This commit adds a guard to displaying the prefix, so that when the changes on whitehall are deployed, we don't show the prefix twice. The entire logic can be deleted when we've deployed and fixed whitehall.

Part of https://trello.com/c/z0yi0Qit/227-search-results-add-highlighting-snippets
