### PR TITLE
Fix snippet for organisations without description

### DIFF
--- a/lib/snippet.rb
+++ b/lib/snippet.rb
@@ -20,7 +20,7 @@ class Snippet
 private
 
   def description_with_organisation_prefix
-    "The home of #{document["title"]} on GOV.UK. #{truncated_description}"
+    "The home of #{document["title"]} on GOV.UK. #{truncated_description}".chomp(' ')
   end
 
   def truncated_description
@@ -34,6 +34,6 @@ private
   def needs_organsation_prefix?
     document['format'] == "organisation" &&
       document["organisation_state"] != "closed" &&
-      !document['description'].starts_with?("The home of")
+      !document['description'].to_s.starts_with?("The home of")
   end
 end

--- a/test/unit/snippet_test.rb
+++ b/test/unit/snippet_test.rb
@@ -46,6 +46,19 @@ class SnippetTest < MiniTest::Unit::TestCase
     assert_equal "The home of Ministry of Magic on GOV.UK. A description.", snippet
   end
 
+  def test_organisation_without_description
+    document = {
+      "title" => "Ministry of Magic",
+      "format" => "organisation",
+      "organisation_state" => "open",
+      "description" => nil
+    }
+
+    snippet = Snippet.new(document).text
+
+    assert_equal "The home of Ministry of Magic on GOV.UK.", snippet
+  end
+
   def test_closed_organisation_snippet_should_not_get_prefixed
     document = { "format" => "organisation", "organisation_state" => "closed", "description" => "A description." }
 


### PR DESCRIPTION
Sometimes organisations don't have a description at all, causing the `#needs_organsation_prefix?` to raise an error.

This commit allows `description` to be nil, and formats the snippet correctly for those results.
