### PR TITLE
Add script to cleanup old sitemaps

### DIFF
--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -14,5 +14,7 @@ namespace :sitemap do
 
     `ln -sf #{sitemap_index_path} #{sitemap_link_path}`
     fail("Symlinking failed") unless $?.success?
+
+    sitemap.cleanup
   end
 end

--- a/test/unit/sitemap_cleanup_test.rb
+++ b/test/unit/sitemap_cleanup_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+require "elasticsearch/sitemap"
+
+class SitemapCleanupTest < MiniTest::Unit::TestCase
+  def test_should_delete_old_sitemaps
+    Dir.stubs(:glob).returns(%w{
+      sitemap_2015-03-05T01.xml
+      sitemap_1_2015-03-05T01.xml
+
+      sitemap_2015-03-06T01.xml
+      sitemap_1_2015-03-06T01.xml
+
+      sitemap_2015-03-07T01.xml
+      sitemap_1_2015-03-07T01.xml
+
+      sitemap_2015-03-08T01.xml
+      sitemap_1_2015-03-08T01.xml
+
+      sitemap_2015-03-04T01.xml
+      sitemap_1_2015-03-04T01.xml
+    })
+
+    FileUtils.expects(:rm).with("sitemap_2015-03-04T01.xml")
+    FileUtils.expects(:rm).with("sitemap_1_2015-03-04T01.xml")
+
+    cleanup = SitemapCleanup.new('public')
+    cleanup.delete_excess_sitemaps
+  end
+
+  def test_should_delete_old_sitemaps_with_a_gap_in_days
+    Dir.stubs(:glob).returns(%w{
+      sitemap_2015-03-05T01.xml
+      sitemap_1_2015-03-05T01.xml
+
+      sitemap_2015-03-07T01.xml
+      sitemap_1_2015-03-07T01.xml
+
+      sitemap_2015-03-09T01.xml
+      sitemap_1_2015-03-09T01.xml
+
+      sitemap_2015-03-11T01.xml
+      sitemap_1_2015-03-11T01.xml
+
+      sitemap_2015-03-03T01.xml
+      sitemap_1_2015-03-03T01.xml
+    })
+
+    FileUtils.expects(:rm).with("sitemap_2015-03-03T01.xml")
+    FileUtils.expects(:rm).with("sitemap_1_2015-03-03T01.xml")
+
+    cleanup = SitemapCleanup.new('public')
+    cleanup.delete_excess_sitemaps
+  end
+end


### PR DESCRIPTION
Currently we are keeping all sitemaps ever created. It would be good to
clean then up after a couple of days so that we don't have hundreds of
them saved on disk.

This lets you set a number of days to clean up and then deletes all
sitemaps which aren't the number of days most recent. If the sitemaps
are not created on a particular day this will still maintain at least
the right number of days worth of sitemaps not just the last number of
calendar days worth.

https://www.pivotaltracker.com/story/show/90087288
