### PR TITLE
Clean up Registries code

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -47,13 +47,13 @@ class Rummager < Sinatra::Application
 
   def unified_index_schema
     @unified_index_schema ||= CombinedIndexSchema.new(
-      settings.search_config.govuk_index_names,
+      settings.search_config.content_index_names,
       settings.search_config.schema_config
     )
   end
 
   def unified_index
-    search_server.index_for_search(settings.search_config.govuk_index_names)
+    search_server.index_for_search(settings.search_config.content_index_names)
   end
 
   def text_error(content)
@@ -152,7 +152,7 @@ class Rummager < Sinatra::Application
   get "/organisations.?:request_format?" do
     json_only
 
-    organisations = registries.organisations.all
+    organisations = registries[:organisations].all
     OrganisationSetPresenter.new(organisations).present.to_json
   end
 

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,14 +1,7 @@
 base_uri: "http://localhost:9200"
 content_index_names: ["mainstream", "detailed", "government", "service-manual"]
 auxiliary_index_names: ["page-traffic", "metasearch"]
-organisation_registry_index: "government"
-topic_registry_index: "government"
-document_series_registry_index: "government"
-document_collection_registry_index: "government"
-world_location_registry_index: "government"
-people_registry_index: "government"
-# These indices are passed in this order to GovukSearcher
-govuk_index_names: ["mainstream", "detailed", "government", "service-manual"]
+registry_index: "government"
 metasearch_index_name: "metasearch"
 popularity_rank_offset: 10
 

--- a/lib/registries.rb
+++ b/lib/registries.rb
@@ -8,77 +8,35 @@ class Registries < Struct.new(:search_server, :search_config)
   def as_hash
     @registries ||= {
       organisations: organisations,
-      topics: topics,
-      document_series: document_series,
-      document_collections: document_collections,
-      world_locations: world_locations,
       specialist_sectors: specialist_sectors,
-      people: people,
+      topics: registry_for_document_format('topic'),
+      document_series: registry_for_document_format('document_series'),
+      document_collections: registry_for_document_format('document_collection'),
+      world_locations: registry_for_document_format('world_location'),
+      people: registry_for_document_format('person'),
     }
   end
 
+private
+
   def organisations
-    index_name = search_config.organisation_registry_index
-    @organisations ||= Registry::Organisation.new(
-      index_for_search(index_name),
-      field_definitions
-    ) if index_name
-  end
-
-  def topics
-    index_name = search_config.topic_registry_index
-    @topics ||= Registry::Topic.new(
-      index_for_search(index_name),
-      field_definitions
-    ) if index_name
-  end
-
-  def document_series
-    index_name = search_config.document_series_registry_index
-    @document_series ||= Registry::DocumentSeries.new(
-      index_for_search(index_name),
-      field_definitions
-    ) if index_name
-  end
-
-  def document_collections
-    index_name = search_config.document_collection_registry_index
-    @document_collections ||= Registry::DocumentCollection.new(
-      index_for_search(index_name),
-      field_definitions
-    ) if index_name
-  end
-
-  def world_locations
-    index_name = search_config.world_location_registry_index
-    @world_locations ||= Registry::WorldLocation.new(
-      index_for_search(index_name),
-      field_definitions
-    ) if index_name
+    Registry::Organisation.new(index, field_definitions)
   end
 
   def specialist_sectors
-    index_name = settings.search_config.govuk_index_names
-    @specialist_sector_registry ||= Registry::SpecialistSector.new(
-      index_for_search(index_name),
-      field_definitions
+    Registry::BaseRegistry.new(
+      search_server.index_for_search(settings.search_config.content_index_names),
+      field_definitions,
+      "specialist_sector"
     )
   end
 
-  def people
-    index_name = settings.search_config.people_registry_index
-    @people_registry ||= Registry::Person.new(
-      index_for_search(index_name),
-      field_definitions
-    )
+  def registry_for_document_format(format)
+    Registry::BaseRegistry.new(index, field_definitions, format)
   end
 
-  private
-
-  def index_for_search(index_name)
-    search_server.index_for_search(
-      index_name.is_a?(Array) ? index_name : [index_name]
-    )
+  def index
+    search_server.index_for_search([settings.search_config.registry_index])
   end
 
   def field_definitions

--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -34,18 +34,6 @@ module Registry
     end
   end
 
-  class DocumentCollection < BaseRegistry
-    def initialize(index, field_definitions)
-      super(index, field_definitions, "document_collection")
-    end
-  end
-
-  class DocumentSeries < BaseRegistry
-    def initialize(index, field_definitions)
-      super(index, field_definitions, "document_series")
-    end
-  end
-
   class Organisation < BaseRegistry
     def self.load_ministerial_departments
       file_path = File.join(File.dirname(__FILE__), "..", "config", "ministerial_departments.txt")
@@ -76,30 +64,6 @@ module Registry
       end
 
       organisation
-    end
-  end
-
-  class SpecialistSector < BaseRegistry
-    def initialize(index, field_definitions)
-      super(index, field_definitions, "specialist_sector")
-    end
-  end
-
-  class Topic < BaseRegistry
-    def initialize(index, field_definitions)
-      super(index, field_definitions, "topic")
-    end
-  end
-
-  class WorldLocation < BaseRegistry
-    def initialize(index, field_definitions)
-      super(index, field_definitions, "world_location")
-    end
-  end
-
-  class Person < BaseRegistry
-    def initialize(index, field_definitions)
-      super(index, field_definitions, "person")
     end
   end
 end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -4,6 +4,19 @@ require "schema_config"
 require "plek"
 
 class SearchConfig
+  %w[
+    registry_index
+    metasearch_index_name
+    popularity_rank_offset
+    auxiliary_index_names
+    content_index_names
+    spelling_index_names
+  ].each do |config_method|
+    define_method config_method do
+      elasticsearch.fetch(config_method)
+    end
+  end
+
   def search_server
     @server ||= Elasticsearch::SearchServer.new(
       elasticsearch["base_uri"],
@@ -22,61 +35,14 @@ class SearchConfig
     content_index_names + auxiliary_index_names
   end
 
-  def content_index_names
-    elasticsearch["content_index_names"] || []
-  end
-
-  def auxiliary_index_names
-    elasticsearch["auxiliary_index_names"] || []
-  end
+private
 
   def elasticsearch
     @elasticsearch ||= config_for("elasticsearch")
   end
 
-  def document_series_registry_index
-    elasticsearch["document_series_registry_index"]
-  end
-
-  def document_collection_registry_index
-    elasticsearch["document_collection_registry_index"]
-  end
-
-  def organisation_registry_index
-    elasticsearch["organisation_registry_index"]
-  end
-
-  def people_registry_index
-    elasticsearch["people_registry_index"]
-  end
-
-  def topic_registry_index
-    elasticsearch["topic_registry_index"]
-  end
-
-  def world_location_registry_index
-    elasticsearch["world_location_registry_index"]
-  end
-
-  def govuk_index_names
-    elasticsearch["govuk_index_names"]
-  end
-
-  def metasearch_index_name
-    elasticsearch["metasearch_index_name"]
-  end
-
-  def popularity_rank_offset
-    elasticsearch["popularity_rank_offset"]
-  end
-
-private
   def config_path
     File.expand_path("../config/schema", File.dirname(__FILE__))
-  end
-
-  def in_development_environment?
-    %w{development test}.include?(ENV['RACK_ENV'])
   end
 
   def config_for(kind)

--- a/lib/unified_search/spell_check_fetcher.rb
+++ b/lib/unified_search/spell_check_fetcher.rb
@@ -40,7 +40,7 @@ module UnifiedSearch
     end
 
     def spelling_index_names
-      Rummager.search_config.elasticsearch.fetch('spelling_index_names')
+      Rummager.search_config.spelling_index_names
     end
   end
 end

--- a/lib/unified_search/suggestion_blacklist.rb
+++ b/lib/unified_search/suggestion_blacklist.rb
@@ -30,7 +30,7 @@ module UnifiedSearch
     # Organisation acronyms like `dvla` and 'gds' are sometimes considered
     # spelling errors. We use the organisation index to ignore all acronyms.
     def organisation_acronyms
-      organisation_registry = registries.organisations
+      organisation_registry = registries[:organisations]
       organisation_registry.all.map(&:acronym).compact.map(&:downcase)
     end
   end

--- a/test/support/elasticsearch_integration_helpers.rb
+++ b/test/support/elasticsearch_integration_helpers.rb
@@ -2,7 +2,6 @@ module ElasticsearchIntegrationHelpers
   AUXILIARY_INDEX_NAMES = ["page-traffic_test", "metasearch_test"]
   INDEX_NAMES = ["mainstream_test", "detailed_test", "government_test"]
   DEFAULT_INDEX_NAME = INDEX_NAMES.first
-  REGISTRY_INDEX = "government_test"
 
   def check_index_name!(index_name)
     unless /^[a-z_-]+(_|-)test($|-)/.match(index_name)
@@ -19,20 +18,13 @@ module ElasticsearchIntegrationHelpers
       "base_uri" => "http://localhost:9200",
       "content_index_names" => INDEX_NAMES,
       "auxiliary_index_names" => AUXILIARY_INDEX_NAMES,
-      "govuk_index_names" => INDEX_NAMES,
       "metasearch_index_name" => "metasearch_test",
-      "organisation_registry_index" => REGISTRY_INDEX,
-      "topic_registry_index" => REGISTRY_INDEX,
-      "document_series_registry_index" => REGISTRY_INDEX,
-      "document_collection_registry_index" => REGISTRY_INDEX,
-      "world_location_registry_index" => REGISTRY_INDEX,
-      "people_registry_index" => REGISTRY_INDEX,
+      "registry_index" => "government_test",
       "spelling_index_names" => INDEX_NAMES,
       "popularity_rank_offset" => 10,
     })
     app.settings.stubs(:default_index_name).returns(DEFAULT_INDEX_NAME)
     app.settings.stubs(:enable_queue).returns(false)
-    app.settings.search_config.stubs(:govuk_index_names).returns(INDEX_NAMES)
   end
 
   def search_config

--- a/test/unit/specialist_sector_registry_test.rb
+++ b/test/unit/specialist_sector_registry_test.rb
@@ -6,7 +6,7 @@ require "schema/field_definitions"
 class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
   def setup
     @index = stub("elasticsearch index")
-    @specialist_sector_registry = Registry::SpecialistSector.new(@index, sample_field_definitions)
+    @specialist_sector_registry = Registry::BaseRegistry.new(@index, sample_field_definitions, "specialist_sector")
   end
 
   def oil_and_gas
@@ -45,6 +45,6 @@ class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
   def test_uses_300_second_cache_lifetime
     TimedCache.expects(:new).with(300, anything)
 
-    Registry::SpecialistSector.new(@index, sample_field_definitions)
+    Registry::BaseRegistry.new(@index, sample_field_definitions, "specialist_sector")
   end
 end

--- a/test/unit/unified_search/suggestion_blacklist_test.rb
+++ b/test/unit/unified_search/suggestion_blacklist_test.rb
@@ -21,7 +21,7 @@ class UnifiedSearch::SuggestionBlacklistTest < ShouldaUnitTestCase
 
     def blacklist
       UnifiedSearch::SuggestionBlacklist.new(
-        stub(organisations: stubbed_organisation_registry)
+        { organisations: stubbed_organisation_registry }
       )
     end
 


### PR DESCRIPTION
This PR makes the following changes:
- Specify one `registry_index`, not for each type (special cases like `specialist_sectors` can be handled in the `Registries` class.
- By using `Registry::BaseRegistry` directly we can save a lot of code and limit inheritance.
- Only allow hash-style access to registries to cut down on public methods on that class.
- Replaces the `govuk_index_names` setting with `content_index_names`, which is identical.
- Refactors `search_config` to be cleaner.

No change in functionality intended.
