### PR TITLE
Move schedule file to alphagov-deployment.

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,9 +1,1 @@
-set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
-job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv rummager bundle exec rake :task :output'
-
-# Sitemap filenames are generated based on the current day and hour. Putting
-# this at 10 past gets around any problems that might arise from running just
-# before the hour.
-every 1.day, :at => '1.10am' do
-  rake 'sitemap:generate_and_replace'
-end
+# This file is overwritten on deploy


### PR DESCRIPTION
This is to allow it to be different per environment.

Do not deploy until https://github.gds/gds/alphagov-deployment/pull/1028 is merged.
