### PR TITLE
Fix bug in facet example fetchers

### DIFF
--- a/lib/facet_example_fetcher.rb
+++ b/lib/facet_example_fetcher.rb
@@ -50,6 +50,7 @@ private
     slugs = facet_options.map { |option|
       option["term"]
     }
+
     if slugs.empty?
       {}
     else
@@ -100,14 +101,18 @@ private
                                       example_fields, query, filter)
     responses = @index.msearch(searches)
     response_list = responses["responses"]
+    prepare_response(slugs, response_list)
+  end
+
+  def prepare_response(slugs, response_list)
     result = {}
     slugs.zip(response_list) { |slug, response|
-      hits = response["hits"]
       result[slug] = {
-        total: hits["total"],
-        examples: hits["hits"].map { |hit| apply_multivalued(hit["fields"]) },
+        total: response["hits"]["total"],
+        examples: response["hits"]["hits"].map { |hit| apply_multivalued(hit["fields"] || {}) },
       }
     }
+
     result
   end
 

--- a/test/unit/facet_example_fetcher_test.rb
+++ b/test/unit/facet_example_fetcher_test.rb
@@ -43,6 +43,26 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
     index
   end
 
+  context "#prepare_response" do
+    should "map an empty response" do
+      fetcher = FacetExampleFetcher.new(@index, {}, {}, @builder)
+
+      response = fetcher.send(:prepare_response, [], [])
+
+      assert_equal response, {}
+    end
+
+    should "map a response to facets without fields" do
+      fetcher = FacetExampleFetcher.new(@index, {}, {}, @builder)
+      slugs = ['a-slug-name']
+      response_list = [{ 'hits' => { 'total' => 1, 'hits' => [ { '_id' => 'a-slug-name' }]}}]
+
+      response = fetcher.send(:prepare_response, slugs, response_list)
+
+      assert_equal response, { "a-slug-name" => { total: 1, examples: [{}] } }
+    end
+  end
+
   context "no facet" do
     setup do
       @index = stub_index("content index")


### PR DESCRIPTION
In some cases, elasticsearch's `fields` will be empty. That causes exceptions.

It seems very hard to reproduce this in the tests, so we had to extract a method and test it in isolation. This is not nice, but better than no tests.

cc @rboulton 
