### PR TITLE
Encapsulate search parameters in value object

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -18,6 +18,7 @@ require "redis"
 require "matcher_set"
 require "parameter_parser/search_parameter_parser"
 require "parameter_parser/facet_parameter_parser"
+require "search_parameters"
 require "registries"
 require "schema/combined_index_schema"
 
@@ -107,8 +108,9 @@ class Rummager < Sinatra::Application
       return { error: parser.error }.to_json
     end
 
+    search_params = SearchParameters.new(parser.parsed_params)
     searcher = UnifiedSearcher.new(unified_index, registries)
-    searcher.search(parser.parsed_params).to_json
+    searcher.search(search_params).to_json
   end
 
   # Perform an advanced search. Supports filters and pagination.

--- a/lib/facet_example_fetcher.rb
+++ b/lib/facet_example_fetcher.rb
@@ -1,5 +1,7 @@
 # Fetch example values for facets
 class FacetExampleFetcher
+  attr_reader :search_params
+
   def initialize(index, es_response, search_params, search_builder)
     @index = index
     @response_facets = es_response["facets"]
@@ -7,26 +9,19 @@ class FacetExampleFetcher
     @search_builder = search_builder
   end
 
-  def facets
-    @search_params.facets
-  end
-
   # Fetch all requested example facet values
   # Returns {field_name => {facet_value => {total: count, examples: [{field: value}, ...]}}}
   # ie: a hash keyed by field name, containing hashes keyed by facet value with
   # values containing example information for the value.
   def fetch
-    if facets.nil? || @response_facets.nil?
-      return {}
-    end
-    result = {}
-    facets.each do |field_name, facet_params|
-      examples = facet_params[:examples]
-      if examples > 0
+    return {} if @response_facets.nil?
+
+    search_params.facets.reduce({}) do |result, (field_name, facet_params)|
+      if facet_params[:examples] > 0
         result[field_name] = fetch_for_field(field_name, facet_params)
       end
+      result
     end
-    result
   end
 
 private

--- a/lib/facet_example_fetcher.rb
+++ b/lib/facet_example_fetcher.rb
@@ -1,10 +1,14 @@
 # Fetch example values for facets
 class FacetExampleFetcher
-  def initialize(index, es_response, params, search_builder)
+  def initialize(index, es_response, search_params, search_builder)
     @index = index
     @response_facets = es_response["facets"]
-    @params = params
+    @search_params = search_params
     @search_builder = search_builder
+  end
+
+  def facets
+    @search_params.facets
   end
 
   # Fetch all requested example facet values
@@ -12,7 +16,6 @@ class FacetExampleFetcher
   # ie: a hash keyed by field name, containing hashes keyed by facet value with
   # values containing example information for the value.
   def fetch
-    facets = @params[:facets]
     if facets.nil? || @response_facets.nil?
       return {}
     end

--- a/lib/facet_result_presenter.rb
+++ b/lib/facet_result_presenter.rb
@@ -16,7 +16,7 @@ class FacetResultPresenter
 
     result = {}
     facets.each do |field, facet_info|
-      facet_parameters = facet_fields[field]
+      facet_parameters = search_params.facets[field]
 
       options = facet_info["terms"]
       result[field] = {
@@ -32,14 +32,6 @@ class FacetResultPresenter
   end
 
 private
-
-  def applied_filters
-    search_params[:filters] || []
-  end
-
-  def facet_fields
-    search_params[:facets] || {}
-  end
 
   # Get the facet options, sorted according to the "order" option.
   #
@@ -69,7 +61,7 @@ private
   end
 
   def filter_values_for_field(field)
-    filter = applied_filters.find { |applied_filter| applied_filter.field_name == field }
+    filter = search_params.filters.find { |applied_filter| applied_filter.field_name == field }
     filter ? filter.values : []
   end
 

--- a/lib/query_components/base_component.rb
+++ b/lib/query_components/base_component.rb
@@ -3,7 +3,6 @@ module QueryComponents
     include Elasticsearch::Escaping
 
     attr_reader :search_params
-    delegate :debug, to: :search_params
 
     def initialize(search_params = SearchParameters.new)
       @search_params = search_params

--- a/lib/query_components/base_component.rb
+++ b/lib/query_components/base_component.rb
@@ -2,20 +2,15 @@ module QueryComponents
   class BaseComponent
     include Elasticsearch::Escaping
 
-    attr_reader :params
+    attr_reader :search_params
+    delegate :debug, to: :search_params
 
-    def initialize(params = {})
-      @params = params
+    def initialize(search_params = SearchParameters.new)
+      @search_params = search_params
     end
-
-  protected
 
     def search_term
-      params[:query]
-    end
-
-    def debug
-      params[:debug] || {}
+      search_params.query
     end
   end
 end

--- a/lib/query_components/best_bets.rb
+++ b/lib/query_components/best_bets.rb
@@ -1,7 +1,7 @@
 module QueryComponents
   class BestBets < BaseComponent
     def wrap(original_query)
-      return original_query if debug[:disable_best_bets] || no_bets?
+      return original_query if search_params.disable_best_bets? || no_bets?
 
       result = {
         bool: {

--- a/lib/query_components/core_query.rb
+++ b/lib/query_components/core_query.rb
@@ -105,7 +105,7 @@ module QueryComponents
     end
 
     def query_analyzer
-      if debug[:disable_synonyms]
+      if search_params.disable_synonyms?
         DEFAULT_QUERY_ANALYZER_WITHOUT_SYNONYMS
       else
         DEFAULT_QUERY_ANALYZER

--- a/lib/query_components/facets.rb
+++ b/lib/query_components/facets.rb
@@ -1,9 +1,9 @@
 module QueryComponents
   class Facets < BaseComponent
     def payload
-      return if facets.nil?
+      return if search_params.facets.nil?
 
-      facets.reduce({}) do |result, (field_name, options)|
+      search_params.facets.reduce({}) do |result, (field_name, options)|
         result[field_name] = facet_hash_for_facet(field_name, options)
         result
       end
@@ -49,11 +49,7 @@ module QueryComponents
 
     # Possible duplication.
     def filters_hash(excluding)
-      QueryComponents::Filter.new(@params).payload(excluding)
-    end
-
-    def facets
-      params[:facets]
+      QueryComponents::Filter.new(search_params).payload(excluding)
     end
   end
 end

--- a/lib/query_components/facets.rb
+++ b/lib/query_components/facets.rb
@@ -1,8 +1,6 @@
 module QueryComponents
   class Facets < BaseComponent
     def payload
-      return if search_params.facets.nil?
-
       search_params.facets.reduce({}) do |result, (field_name, options)|
         result[field_name] = facet_hash_for_facet(field_name, options)
         result

--- a/lib/query_components/filter.rb
+++ b/lib/query_components/filter.rb
@@ -4,7 +4,7 @@ module QueryComponents
       rejects = []
       filters = []
 
-      param_filters = params.fetch(:filters).reject do |filter|
+      param_filters = search_params.filters.reject do |filter|
         excluding.include?(filter.field_name)
       end
 

--- a/lib/query_components/popularity.rb
+++ b/lib/query_components/popularity.rb
@@ -3,7 +3,7 @@ module QueryComponents
     POPULARITY_OFFSET = 0.001
 
     def wrap(boosted_query)
-      return boosted_query if debug[:disable_popularity]
+      return boosted_query if search_params.disable_popularity?
 
       {
         function_score: {

--- a/lib/query_components/query.rb
+++ b/lib/query_components/query.rb
@@ -43,7 +43,7 @@ module QueryComponents
         return { match_all: {} }
       end
 
-      if debug[:new_weighting]
+      if search_params.enable_new_weighting?
         core_query = QueryComponents::TextQuery.new(search_params).payload
       else
         core_query = QueryComponents::CoreQuery.new(search_params).payload

--- a/lib/query_components/query.rb
+++ b/lib/query_components/query.rb
@@ -7,7 +7,7 @@ module QueryComponents
     SERVICE_MANUAL_BOOST_FACTOR = 0.1
 
     def payload
-      QueryComponents::BestBets.new(params).wrap(query_hash)
+      QueryComponents::BestBets.new(search_params).wrap(query_hash)
     end
 
     private
@@ -44,12 +44,12 @@ module QueryComponents
       end
 
       if debug[:new_weighting]
-        core_query = QueryComponents::TextQuery.new(params).payload
+        core_query = QueryComponents::TextQuery.new(search_params).payload
       else
-        core_query = QueryComponents::CoreQuery.new(params).payload
+        core_query = QueryComponents::CoreQuery.new(search_params).payload
       end
-      boosted_query = QueryComponents::Booster.new(params).wrap(core_query)
-      QueryComponents::Popularity.new(params).wrap(boosted_query)
+      boosted_query = QueryComponents::Booster.new(search_params).wrap(core_query)
+      QueryComponents::Popularity.new(search_params).wrap(boosted_query)
     end
   end
 end

--- a/lib/query_components/sort.rb
+++ b/lib/query_components/sort.rb
@@ -5,7 +5,7 @@ module QueryComponents
       if search_params.order.nil?
         # Sort by popularity when there's no explicit ordering, and there's no
         # query (so there's no relevance scores).
-        if search_term.nil? && !(debug[:disable_popularity])
+        if search_term.nil? && !search_params.disable_popularity?
           return [{ "popularity" => { order: "desc" } }]
         else
           return nil

--- a/lib/query_components/sort.rb
+++ b/lib/query_components/sort.rb
@@ -2,7 +2,7 @@ module QueryComponents
   class Sort < BaseComponent
     # Get a list describing the sort order (or nil)
     def payload
-      if params[:order].nil?
+      if search_params.order.nil?
         # Sort by popularity when there's no explicit ordering, and there's no
         # query (so there's no relevance scores).
         if search_term.nil? && !(debug[:disable_popularity])
@@ -12,7 +12,7 @@ module QueryComponents
         end
       end
 
-      field, order = params[:order]
+      field, order = search_params.order
 
       [{field => {order: order, missing: "_last"}}]
     end

--- a/lib/query_components/text_query.rb
+++ b/lib/query_components/text_query.rb
@@ -42,7 +42,11 @@ module QueryComponents
       # multiple of these ways).
       queries = []
       queries << match_query(:all_searchable_text, search_term)
-      queries << match_query(:"all_searchable_text.synonym", search_term) unless debug[:disable_synonyms]
+
+      unless search_params.disable_synonyms?
+        queries << match_query(:"all_searchable_text.synonym", search_term)
+      end
+
       queries << match_query(:"all_searchable_text.id_codes", search_term, minimum_should_match: "1")
       dis_max_query(queries, tie_breaker: 0.1)
     end
@@ -52,7 +56,7 @@ module QueryComponents
       groups << field_boosts_words
       groups << field_boosts_phrase
       groups << field_boosts_all_terms
-      groups << field_boosts_synonyms unless debug[:disable_synonyms]
+      groups << field_boosts_synonyms unless search_params.disable_synonyms?
       groups << field_boosts_shingles
       groups << field_boosts_id_codes
 

--- a/lib/search_parameters.rb
+++ b/lib/search_parameters.rb
@@ -11,4 +11,20 @@ class SearchParameters
       public_send("#{k}=", v)
     end
   end
+
+  def disable_popularity?
+    debug[:disable_popularity]
+  end
+
+  def disable_synonyms?
+    debug[:disable_synonyms]
+  end
+
+  def enable_new_weighting?
+    debug[:new_weighting]
+  end
+
+  def disable_best_bets?
+    debug[:disable_best_bets]
+  end
 end

--- a/lib/search_parameters.rb
+++ b/lib/search_parameters.rb
@@ -1,0 +1,14 @@
+# SearchParameters
+#
+# Value object that holds the parsed parameters for a search.
+class SearchParameters
+  attr_accessor :query, :order, :start, :count, :return_fields, :facets,
+                :filters, :debug
+
+  def initialize(params = {})
+    params = { facets: [], filters: {}, debug: {} }.merge(params)
+    params.each do |k, v|
+      public_send("#{k}=", v)
+    end
+  end
+end

--- a/lib/unified_search/spell_check_fetcher.rb
+++ b/lib/unified_search/spell_check_fetcher.rb
@@ -16,7 +16,7 @@ require 'unified_search/suggestion_blacklist'
 # Our solution is to run a separate query to fetch the suggestions, only using
 # the indices we want.
 module UnifiedSearch
-  class SpellCheckFetcher < Struct.new(:search_term, :registries)
+  class SpellCheckFetcher < Struct.new(:search_params, :registries)
     def es_response
       return unless should_correct_query?
       search_client.raw_search(elasticsearch_query)['suggest']
@@ -25,7 +25,7 @@ module UnifiedSearch
   private
 
     def should_correct_query?
-      SuggestionBlacklist.new(registries).should_correct?(search_term)
+      SuggestionBlacklist.new(registries).should_correct?(search_params.query)
     end
 
     def search_client
@@ -35,7 +35,7 @@ module UnifiedSearch
     def elasticsearch_query
       {
         size: 0,
-        suggest: QueryComponents::Suggest.new(query: search_term).payload
+        suggest: QueryComponents::Suggest.new(search_params).payload
       }
     end
 

--- a/lib/unified_search_builder.rb
+++ b/lib/unified_search_builder.rb
@@ -12,45 +12,41 @@ require "query_components/facets"
 
 # Builds a query for a search across all GOV.UK indices
 class UnifiedSearchBuilder
-  attr_reader :params
+  attr_reader :search_params
 
-  def initialize(params)
-    @params = params
+  def initialize(search_params)
+    @search_params = search_params
   end
 
   def payload
     hash_without_blank_values(
-      from: params[:start],
-      size: params[:count],
-      fields: params[:return_fields],
+      from: search_params.start,
+      size: search_params.count,
+      fields: search_params.return_fields,
       query: query,
       filter: filter,
       sort: sort,
       facets: facets,
-      explain: explain_query?,
+      explain: search_params.debug[:explain],
     )
   end
 
   def query
-    QueryComponents::Query.new(params).payload
+    QueryComponents::Query.new(search_params).payload
   end
 
   def filter
-    QueryComponents::Filter.new(params).payload
+    QueryComponents::Filter.new(search_params).payload
   end
 
   private
 
   def sort
-    QueryComponents::Sort.new(params).payload
+    QueryComponents::Sort.new(search_params).payload
   end
 
   def facets
-    QueryComponents::Facets.new(params).payload
-  end
-
-  def explain_query?
-    params[:debug] && params[:debug][:explain]
+    QueryComponents::Facets.new(search_params).payload
   end
 
   def hash_without_blank_values(hash)

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -33,7 +33,7 @@ class UnifiedSearchPresenter
     {
       results: presented_results,
       total: es_response["hits"]["total"],
-      start: search_params[:start],
+      start: search_params.start,
       facets: presented_facets,
       suggested_queries: suggested_queries
     }

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -14,21 +14,20 @@ class UnifiedSearcher
   end
 
   # Search and combine the indices and return a hash of ResultSet objects
-  def search(params)
-    builder = UnifiedSearchBuilder.new(params)
+  def search(search_params)
+    builder = UnifiedSearchBuilder.new(search_params)
     es_response = index.raw_search(builder.payload)
 
-    example_fetcher = FacetExampleFetcher.new(index, es_response, params,
-                                              builder)
+    example_fetcher = FacetExampleFetcher.new(index, es_response, search_params, builder)
     facet_examples = example_fetcher.fetch
 
     # Augment the response with the suggest result from a separate query.
-    if params[:query]
-      es_response['suggest'] = fetch_spell_checks(params)
+    if search_params.query
+      es_response['suggest'] = fetch_spell_checks(search_params)
     end
 
     UnifiedSearchPresenter.new(
-      params,
+      search_params,
       es_response,
       registries,
       facet_examples,
@@ -38,7 +37,7 @@ class UnifiedSearcher
 
 private
 
-  def fetch_spell_checks(params)
-    UnifiedSearch::SpellCheckFetcher.new(params[:query], registries).es_response
+  def fetch_spell_checks(search_params)
+    UnifiedSearch::SpellCheckFetcher.new(search_params, registries).es_response
   end
 end

--- a/test/support/test_helpers.rb
+++ b/test/support/test_helpers.rb
@@ -37,15 +37,15 @@ module TestHelpers
   end
 
   def search_query_params(options={})
-    {
+    SearchParameters.new({
       start: 0,
       count: 20,
       query: "cheese",
       order: nil,
       filters: {},
-      fields: nil,
+      return_fields: nil,
       facets: nil,
       debug: {},
-    }.merge(options)
+    }.merge(options))
   end
 end

--- a/test/unit/facet_example_fetcher_test.rb
+++ b/test/unit/facet_example_fetcher_test.rb
@@ -45,7 +45,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
 
   context "#prepare_response" do
     should "map an empty response" do
-      fetcher = FacetExampleFetcher.new(@index, {}, {}, @builder)
+      fetcher = FacetExampleFetcher.new(@index, {}, SearchParameters.new, @builder)
 
       response = fetcher.send(:prepare_response, [], [])
 
@@ -53,7 +53,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
     end
 
     should "map a response to facets without fields" do
-      fetcher = FacetExampleFetcher.new(@index, {}, {}, @builder)
+      fetcher = FacetExampleFetcher.new(@index, {}, SearchParameters.new, @builder)
       slugs = ['a-slug-name']
       response_list = [{ 'hits' => { 'total' => 1, 'hits' => [ { '_id' => 'a-slug-name' }]}}]
 
@@ -67,7 +67,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
     setup do
       @index = stub_index("content index")
       @builder = stub("builder")
-      @fetcher = FacetExampleFetcher.new(@index, {}, {}, @builder)
+      @fetcher = FacetExampleFetcher.new(@index, {}, SearchParameters.new, @builder)
     end
 
     should "get an empty hash of examples" do
@@ -87,7 +87,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
           ]
         }
       }}
-      params = {
+      params = SearchParameters.new(
         facets: {
           "sector" => {
             requested: 10,
@@ -96,7 +96,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
             example_scope: :global
           }
         }
-      }
+      )
       @builder = stub("builder")
       @fetcher = FacetExampleFetcher.new(@index, main_query_response, params, @builder)
     end
@@ -139,7 +139,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
         }
       }}
 
-      params = {
+      params = SearchParameters.new(
         facets: {
           "sector" => {
             requested: 10,
@@ -148,7 +148,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
             example_scope: :query
           }
         }
-      }
+      )
 
       @builder = stub("builder")
       @fetcher = FacetExampleFetcher.new(@index, main_query_response, params, @builder)
@@ -193,7 +193,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
           ]
         }
       }}
-      params = {
+      params = SearchParameters.new(
         facets: {
           "sector" => {
             requested: 10,
@@ -202,7 +202,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
             example_scope: :global
           }
         }
-      }
+      )
       @builder = stub("builder")
       @fetcher = FacetExampleFetcher.new(@index, main_query_response, params, @builder)
     end
@@ -225,7 +225,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
         }
       }}
 
-      params = {
+      params = SearchParameters.new(
         facets: {
           "sector" => {
             requested: 10,
@@ -234,7 +234,7 @@ class FacetExampleFetcherTest < ShouldaUnitTestCase
             example_scope: :query
           }
         }
-      }
+      )
 
       @builder = stub("builder")
       @fetcher = FacetExampleFetcher.new(@index, main_query_response, params, @builder)

--- a/test/unit/query_components/best_bets_test.rb
+++ b/test/unit/query_components/best_bets_test.rb
@@ -4,7 +4,7 @@ require "unified_search_builder"
 class BestBetsTest < ShouldaUnitTestCase
   context "when best bets is disabled in debug" do
     should "return the query without modification" do
-      builder = QueryComponents::BestBets.new(debug: { disable_best_bets: true })
+      builder = QueryComponents::BestBets.new(SearchParameters.new(debug: { disable_best_bets: true }))
 
       result = builder.wrap('QUERY')
 

--- a/test/unit/query_components/facets_test.rb
+++ b/test/unit/query_components/facets_test.rb
@@ -28,8 +28,10 @@ class FacetsTest < ShouldaUnitTestCase
   context "search with facet and filter on same field" do
     setup do
       @builder = QueryComponents::Facets.new(
-        filters: [ text_filter("organisations", ["hm-magic"]) ],
-        facets: {"organisations" => {requested: 10, scope: :exclude_field_filter}},
+        SearchParameters.new(
+          filters: [ text_filter("organisations", ["hm-magic"]) ],
+          facets: {"organisations" => {requested: 10, scope: :exclude_field_filter}},
+        )
       )
     end
 
@@ -51,8 +53,10 @@ class FacetsTest < ShouldaUnitTestCase
   context "search with facet and filter on same field, and scope set to all_filters" do
     setup do
       @builder = QueryComponents::Facets.new(
-        filters: [ text_filter("organisations", ["hm-magic"]) ],
-        facets: {"organisations" => {requested: 10, scope: :all_filters}},
+        SearchParameters.new(
+          filters: [ text_filter("organisations", ["hm-magic"]) ],
+          facets: {"organisations" => {requested: 10, scope: :all_filters}},
+        )
       )
     end
 
@@ -77,8 +81,10 @@ class FacetsTest < ShouldaUnitTestCase
   context "search with facet and filter on different field" do
     setup do
       @builder = QueryComponents::Facets.new(
-        filters: [ text_filter("section", "levitation") ],
-        facets: {"organisations" => {requested: 10, scope: :exclude_field_filter}},
+        SearchParameters.new(
+          filters: [ text_filter("section", "levitation") ],
+          facets: {"organisations" => {requested: 10, scope: :exclude_field_filter}},
+        )
       )
     end
 

--- a/test/unit/query_components/filter_test.rb
+++ b/test/unit/query_components/filter_test.rb
@@ -5,7 +5,7 @@ class FilterTest < ShouldaUnitTestCase
   context "search with one filter" do
     should "append the correct text filters" do
       builder = QueryComponents::Filter.new(
-        filters: [ text_filter("organisations", ["hm-magic"]) ]
+        SearchParameters.new(filters: [ text_filter("organisations", ["hm-magic"]) ])
       )
 
       result = builder.payload
@@ -18,7 +18,7 @@ class FilterTest < ShouldaUnitTestCase
 
     should "append the correct date filters" do
       builder = QueryComponents::Filter.new(
-        filters: [ make_date_filter_param("field_with_date", ["from:2014-04-01 00:00,to:2014-04-02 00:00"]) ]
+        SearchParameters.new(filters: [ make_date_filter_param("field_with_date", ["from:2014-04-01 00:00,to:2014-04-02 00:00"]) ])
       )
 
       result = builder.payload
@@ -37,7 +37,7 @@ class FilterTest < ShouldaUnitTestCase
   context "search with a filter with multiple options" do
     should "have correct filter" do
       builder = QueryComponents::Filter.new(
-        filters: [ text_filter("organisations", ["hm-magic", "hmrc"]) ],
+        SearchParameters.new(filters: [ text_filter("organisations", ["hm-magic", "hmrc"]) ],)
       )
 
       result = builder.payload
@@ -52,10 +52,12 @@ class FilterTest < ShouldaUnitTestCase
   context "search with a filter and rejects" do
     should "have correct filter" do
       builder = QueryComponents::Filter.new(
-        filters: [
-          text_filter("organisations", ["hm-magic", "hmrc"]),
-          reject_filter("mainstream_browse_pages", ["benefits"]),
-        ],
+        SearchParameters.new(
+          filters: [
+            text_filter("organisations", ["hm-magic", "hmrc"]),
+            reject_filter("mainstream_browse_pages", ["benefits"]),
+          ]
+        )
       )
 
       result = builder.payload
@@ -73,10 +75,12 @@ class FilterTest < ShouldaUnitTestCase
   context "search with multiple filters" do
     should "have correct filter" do
       builder = QueryComponents::Filter.new(
-        filters: [
-          text_filter("organisations", ["hm-magic", "hmrc"]),
-          text_filter("section", ["levitation"]),
-        ],
+        SearchParameters.new(
+          filters: [
+            text_filter("organisations", ["hm-magic", "hmrc"]),
+            text_filter("section", ["levitation"]),
+          ],
+        )
       )
 
       result = builder.payload

--- a/test/unit/query_components/sort_test_test.rb
+++ b/test/unit/query_components/sort_test_test.rb
@@ -4,7 +4,7 @@ require "unified_search_builder"
 class SortTest < ShouldaUnitTestCase
   context "without explicit ordering" do
     should "order by popularity" do
-      builder = QueryComponents::Sort.new({})
+      builder = QueryComponents::Sort.new(SearchParameters.new)
 
       result = builder.payload
 
@@ -14,7 +14,7 @@ class SortTest < ShouldaUnitTestCase
 
   context "with debug popularity off" do
     should "not explicitly order" do
-      builder = QueryComponents::Sort.new(debug: { disable_popularity: true })
+      builder = QueryComponents::Sort.new(SearchParameters.new(debug: { disable_popularity: true }))
 
       result = builder.payload
 
@@ -24,7 +24,7 @@ class SortTest < ShouldaUnitTestCase
 
   context "search with ascending sort" do
     should "put documents without a timestamp at the bottom" do
-      builder = QueryComponents::Sort.new(order: ["public_timestamp", "asc"])
+      builder = QueryComponents::Sort.new(SearchParameters.new(order: ["public_timestamp", "asc"]))
 
       result = builder.payload
 
@@ -37,7 +37,7 @@ class SortTest < ShouldaUnitTestCase
 
   context "search with descending sort" do
     should "put documents without a timestamp at the bottom" do
-      builder = QueryComponents::Sort.new(order: ["public_timestamp", "desc"])
+      builder = QueryComponents::Sort.new(SearchParameters.new(order: ["public_timestamp", "desc"]))
 
       result = builder.payload
 

--- a/test/unit/unified_search/spell_check_fetcher_test.rb
+++ b/test/unit/unified_search/spell_check_fetcher_test.rb
@@ -11,7 +11,7 @@ class UnifiedSearch::SpellCheckFetcherTest < ShouldaUnitTestCase
         '/mainstream,government/_search' => { suggest: { spelling_suggestions: 'a-hash' } }
       )
 
-      es_response = UnifiedSearch::SpellCheckFetcher.new('bolo', stub('registries')).es_response
+      es_response = UnifiedSearch::SpellCheckFetcher.new(SearchParameters.new(query: 'bolo'), stub('registries')).es_response
 
       assert_equal es_response, { 'spelling_suggestions' => 'a-hash' }
     end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -21,7 +21,7 @@ class UnifiedSearchBuilderTest < ShouldaUnitTestCase
 
   def builder_with_params(params)
     UnifiedSearchBuilder.new(
-      { filters: [] }.merge(params)
+      SearchParameters.new({ filters: [] }.merge(params))
     )
   end
 end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -134,11 +134,11 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   def search_presenter(options)
     org_registry = options[:org_registry]
     UnifiedSearchPresenter.new(
-      {
+      SearchParameters.new(
         start: options.fetch(:start, 0),
         filters: options.fetch(:filters, []),
         facets: options.fetch(:facets, {}),
-      },
+      ),
       sample_es_response(options.fetch(:es_response, {})),
       org_registry.nil? ? {} : { organisations: org_registry },
       options.fetch(:facet_examples, {}),
@@ -154,7 +154,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
           "total" => 0
         }
       }
-      @output = UnifiedSearchPresenter.new({ start: 0 }, results).present
+      @output = UnifiedSearchPresenter.new(SearchParameters.new(start: 0), results).present
     end
 
     should "present empty list of results" do
@@ -172,7 +172,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
   context "results with no registries" do
     setup do
-      @output = UnifiedSearchPresenter.new({ start: 0 }, sample_es_response).present
+      @output = UnifiedSearchPresenter.new(SearchParameters.new(start: 0), sample_es_response).present
     end
 
     should "have correct total" do
@@ -215,7 +215,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         es_response['hits']['hits'] = [ @empty_result ]
       }
 
-      @output = UnifiedSearchPresenter.new({ start: 0 }, response).present
+      @output = UnifiedSearchPresenter.new(SearchParameters.new(start: 0), response).present
     end
 
     should 'return only basic metadata of fields' do
@@ -238,7 +238,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         .returns(farming_topic_document)
 
       @output = UnifiedSearchPresenter.new(
-        { start: 0 },
+        SearchParameters.new(start: 0),
         sample_es_response,
         { topics: topic_registry },
       ).present
@@ -287,7 +287,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   context "results with facets" do
     setup do
       @output = UnifiedSearchPresenter.new(
-        { start: 0, facets: { "organisations" => facet_params(1) } },
+        SearchParameters.new(start: 0, facets: { "organisations" => facet_params(1) }),
         sample_es_response("facets" => sample_facet_data),
       ).present
     end
@@ -332,11 +332,11 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   context "results with facets and a filter applied" do
     setup do
       @output = UnifiedSearchPresenter.new(
-        {
+        SearchParameters.new(
           start: 0,
           filters: [text_filter("organisations", ["hmrc"])],
           facets: {"organisations" => facet_params(2)},
-        },
+        ),
         sample_es_response("facets" => sample_facet_data),
       ).present
     end
@@ -383,11 +383,11 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   context "results with facets and a filter which matches nothing applied" do
     setup do
       @output = UnifiedSearchPresenter.new(
-        {
+        SearchParameters.new(
           start: 0,
           filters: [text_filter("organisations", ["hm-cheesemakers"])],
           facets: {"organisations" => facet_params(1)},
-        },
+        ),
         sample_es_response("facets" => sample_facet_data),
       ).present
     end
@@ -434,10 +434,10 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   context "results with facet counting only" do
     setup do
       @output = UnifiedSearchPresenter.new(
-        {
+        SearchParameters.new(
           start: 0,
           facets: { "organisations" => facet_params(0) },
-        },
+        ),
         sample_es_response("facets" => sample_facet_data),
       ).present
     end
@@ -558,10 +558,10 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       org_registry = sample_org_registry
 
       @output = UnifiedSearchPresenter.new(
-        {
+        SearchParameters.new(
           start: 0,
           facets: {"organisations" => facet_params(1), "topics" => facet_params(1)},
-        },
+        ),
         sample_es_response("facets" => sample_facet_data_with_topics),
         { organisations: org_registry },
       ).present
@@ -619,10 +619,10 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
       org_registry = sample_org_registry
 
       @output = UnifiedSearchPresenter.new(
-        {
+        SearchParameters.new(
           start: 0,
           facets: { "organisations" => facet_params(1) }
-        },
+        ),
         sample_es_response("facets" => sample_facet_data),
         { organisations: org_registry },
         {"organisations" => {

--- a/test/unit/unified_searcher_test.rb
+++ b/test/unit/unified_searcher_test.rb
@@ -5,7 +5,6 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
   context "#search" do
     should 'search with the results from the builder and return a presenter' do
       index = stub('index', :schema)
-      searcher = UnifiedSearcher.new(index, stub)
 
       search_payload = stub('payload')
       UnifiedSearchBuilder.any_instance.expects(:payload).returns(search_payload)
@@ -14,7 +13,7 @@ class UnifiedSearcherTest < ShouldaUnitTestCase
       FacetExampleFetcher.any_instance.expects(:fetch).returns(stub('fetch'))
       UnifiedSearchPresenter.any_instance.expects(:present).returns(stub('presenter'))
 
-      searcher.search({})
+      UnifiedSearcher.new(index, stub).search(SearchParameters.new({}))
     end
   end
 end


### PR DESCRIPTION
`SearchParameters` is a value object tasked with holding the search parameters produced by the `SearchParameterParser`.

Currently the parsed parameters are passed down through the system as a hash. This causes defensive coding lower down in the system, where we have to check if some value such as `params[:debug]` is nil or an empty hash. It also causes the same variables to have many different names, `applied_filters` is an alias for `params[:filters]` sometimes.

This can be done cleaner by having methods on the object that will never return nil when a array or hash is expected.

The upside to using this value object over a hash is that we can be sure about correctly calling its interface. Previously, a call to `params[:qeury]` returns nil. `search_query.qeury` obviously does not.

A downside to this approach is that we need to type a little more, especially in tests. An upside of the downside is that its super clear that we're handling search parameters there, and not some other hash. The readability of the tests has slightly improved, I believe. 

To signal to the reader that something is a `SearchParameters` object, the variable name `search_params` is consistently used, instead of just `params`.

This will be especially useful to cleanly implement the search highlighter (https://trello.com/c/z0yi0Qit).
