### PR TITLE
Add highlighted title and description

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -145,7 +145,8 @@ class Rummager < Sinatra::Application
     results = result_set.results.map do |document|
       # Wrap in hash to be compatible with the way UnifiedSearch works.
       raw_result = { "fields" => document.to_hash }
-      ResultPresenter.new(raw_result, {}, nil).present
+      search_params = SearchParameters.new(return_fields: raw_result['fields'].keys)
+      ResultPresenter.new(raw_result, {}, nil, search_params).present
     end
 
     { total: result_set.total, results: results }.to_json

--- a/lib/highlighted_description.rb
+++ b/lib/highlighted_description.rb
@@ -1,0 +1,63 @@
+require "active_support/core_ext/string"
+
+class HighlightedDescription
+  ELLIPSIS = "…"
+
+  attr_reader :raw_result
+
+  def initialize(raw_result)
+    @raw_result = raw_result
+  end
+
+  def text
+    if highlighted_description
+      highlighted_description_with_ellipses
+    else
+      truncated_original_description
+    end
+  end
+
+private
+
+  def highlighted_description
+    # `highlight` will be missing if none of the search terms match what's in
+    # the title, eg. when displaying best bets.
+    raw_result['highlight'] &&
+      raw_result['highlight']['description'].to_a.first
+  end
+
+  # The highlighting will return a truncated version of the description. It
+  # "centers" the truncation on the highlighted word, so that if the word
+  # appears at the end of the description, it will strip off the first n chars.
+  # When that has happened we'd like to add ellipsis to the truncated side(s).
+  def highlighted_description_with_ellipses
+    # The basic trick here is find out if the original and highlighted
+    # versions are the same.
+    escaped_original = Rack::Utils.escape_html(original_description)
+    highlighted_without_tags = highlighted_description
+      .gsub('<em>', '').gsub('</em>', '')
+
+    output = highlighted_description
+
+    unless escaped_original.starts_with?(highlighted_without_tags)
+      output = ELLIPSIS + output
+    end
+
+    unless escaped_original.ends_with?(highlighted_without_tags)
+      output = output + ELLIPSIS
+    end
+
+    output
+  end
+
+  def truncated_original_description
+    Rack::Utils.escape_html(
+      original_description.truncate(225, omission: ELLIPSIS)
+    )
+  end
+
+  def original_description
+    # `fields.description` is nil if the document doesn't have a description set.
+    raw_result['fields']['description'] || ""
+  end
+end

--- a/lib/highlighted_title.rb
+++ b/lib/highlighted_title.rb
@@ -1,0 +1,24 @@
+class HighlightedTitle
+  attr_reader :raw_result
+
+  def initialize(raw_result)
+    @raw_result = raw_result
+  end
+
+  def text
+    highlighted_title || original_title
+  end
+
+private
+
+  def highlighted_title
+    # `highlight` will be missing if none of the search terms match what's in
+    # the title, eg. when displaying best bets.
+    raw_result['highlight'] &&
+      raw_result['highlight']['title'].to_a.first
+  end
+
+  def original_title
+    Rack::Utils.escape_html(raw_result['fields']['title'])
+  end
+end

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -1,6 +1,8 @@
 require_relative "base_parameter_parser"
 
 class SearchParameterParser < BaseParameterParser
+  VIRTUAL_FIELDS = %w[title_with_highlighting description_with_highlighting]
+
   def initialize(params, schema)
     @schema = schema
     process(params)
@@ -148,7 +150,7 @@ private
   end
 
   def allowed_return_fields
-    @schema.field_definitions.keys
+    @schema.field_definitions.keys + VIRTUAL_FIELDS
   end
 
   def schema_get_field_type(field_name)

--- a/lib/query_components/highlight.rb
+++ b/lib/query_components/highlight.rb
@@ -1,0 +1,20 @@
+module QueryComponents
+  class Highlight < BaseComponent
+    def payload
+      {
+        pre_tags: ['<em>'],
+        post_tags: ['</em>'],
+        encoder: 'html',
+        fields: {
+          title: {
+            number_of_fragments: 0,
+          },
+          description: {
+            number_of_fragments: 1,
+            fragment_size: 285,
+          },
+        }
+      }
+    end
+  end
+end

--- a/lib/search_parameters.rb
+++ b/lib/search_parameters.rb
@@ -6,10 +6,14 @@ class SearchParameters
                 :filters, :debug
 
   def initialize(params = {})
-    params = { facets: [], filters: {}, debug: {} }.merge(params)
+    params = { facets: [], filters: {}, debug: {}, return_fields: [] }.merge(params)
     params.each do |k, v|
       public_send("#{k}=", v)
     end
+  end
+
+  def field_requested?(name)
+    return_fields.include?(name)
   end
 
   def disable_popularity?

--- a/lib/unified_search_presenter.rb
+++ b/lib/unified_search_presenter.rb
@@ -47,7 +47,7 @@ private
 
   def presented_results
     es_response["hits"]["hits"].map do |raw_result|
-      ResultPresenter.new(raw_result.to_hash, @registries, @schema).present
+      ResultPresenter.new(raw_result.to_hash, @registries, @schema, search_params).present
     end
   end
 

--- a/test/integration/unified_search/results_with_highlighting_test.rb
+++ b/test/integration/unified_search/results_with_highlighting_test.rb
@@ -1,0 +1,110 @@
+require "integration_test_helper"
+require_relative "../multi_index_test"
+
+class ResultsWithHighlightingTest < MultiIndexTest
+  def setup
+    stub_elasticsearch_settings
+    create_meta_indexes
+    reset_content_indexes
+  end
+
+  def test_returns_highlighted_title
+    commit_document("mainstream_test",
+      title: "I am the result",
+      link: "/some-nice-link",
+    )
+
+    get "/unified_search?q=result&fields[]=title_with_highlighting"
+
+    refute first_search_result.key?('title')
+    assert_equal "I am the <em>result</em>",
+      first_search_result['title_with_highlighting']
+  end
+
+  def test_returns_highlighted_title_fallback
+    commit_document("mainstream_test",
+      title: "Thing without",
+      description: "I am the result",
+      link: "/some-nice-link",
+    )
+
+    get "/unified_search?q=result&fields[]=title_with_highlighting"
+
+    refute first_search_result.key?('title')
+    assert_equal "Thing without",
+      first_search_result['title_with_highlighting']
+  end
+
+  def test_returns_highlighted_description
+    commit_document("mainstream_test",
+      link: "/some-nice-link",
+      description:"This is a test search result of many results."
+    )
+
+    get "/unified_search?q=result&fields[]=description_with_highlighting"
+
+    refute first_search_result.key?('description')
+    assert_equal "This is a test search <em>result</em> of many <em>results</em>.",
+      first_search_result['description_with_highlighting']
+  end
+
+  def test_returns_documents_html_escaped
+    commit_document("mainstream_test",
+      title: "Escape & highlight my title",
+      link: "/some-nice-link",
+      description:"Escape & highlight the description as well."
+    )
+
+    get "/unified_search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
+
+    assert_equal "Escape &amp; <em>highlight</em> the description as well.",
+      first_search_result['description_with_highlighting']
+    assert_equal "Escape &amp; <em>highlight</em> my title",
+      first_search_result['title_with_highlighting']
+  end
+
+  def test_returns_truncated_correctly_where_result_at_start_of_description
+    commit_document("mainstream_test",
+      link: "/some-nice-link",
+      description: "word " + ("something " * 200)
+    )
+
+    get "/unified_search?q=word&fields[]=description_with_highlighting"
+    description = first_search_result['description_with_highlighting']
+
+    assert description.starts_with?("<em>word</em>")
+    assert description.ends_with?("…")
+  end
+
+  def test_returns_truncated_correctly_where_result_at_end_of_description
+    commit_document("mainstream_test",
+      link: "/some-nice-link",
+      description: ("something " * 200) + " word"
+    )
+
+    get "/unified_search?q=word&fields[]=description_with_highlighting"
+    description = first_search_result['description_with_highlighting']
+
+    assert description.starts_with?("…")
+    assert description.size < 350
+  end
+
+  def test_returns_truncated_correctly_where_result_in_middle_of_description
+    commit_document("mainstream_test",
+      link: "/some-nice-link",
+      description: ("something " * 200) + " word " + ("something " * 200)
+    )
+
+    get "/unified_search?q=word&fields[]=description_with_highlighting"
+    description = first_search_result['description_with_highlighting']
+
+    assert description.ends_with?("…")
+    assert description.starts_with?("…")
+  end
+
+private
+
+  def first_search_result
+    @first_search_result ||= parsed_response['results'].first
+  end
+end

--- a/test/unit/highlighted_description_test.rb
+++ b/test/unit/highlighted_description_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+require "highlighted_description"
+
+class HighlightedDescriptionTest < MiniTest::Unit::TestCase
+  def test_adds_highlighting_if_present
+    raw_result = {
+      "fields" => { "description" => "I will be hightlighted." },
+      "highlight" => { "description" => ["I will be <em>hightlighted</em>."] }
+    }
+
+    highlighted_description = HighlightedDescription.new(raw_result).text
+
+    assert_equal "I will be <em>hightlighted</em>.", highlighted_description
+  end
+
+  def test_uses_default_description_if_hightlight_not_found
+    raw_result = {
+      "fields" => { "description" => "I will not be hightlighted & escaped." }
+    }
+
+    highlighted_description = HighlightedDescription.new(raw_result).text
+
+    assert_equal "I will not be hightlighted &amp; escaped.", highlighted_description
+  end
+
+  def test_truncates_default_description_if_hightlight_not_found
+    raw_result = {
+      "fields" => { "description" => ("This is a sentence that is too long." * 10) }
+    }
+
+    highlighted_description = HighlightedDescription.new(raw_result).text
+
+    assert_equal 225, highlighted_description.size
+    assert highlighted_description.ends_with?('…')
+  end
+
+  def test_returns_empty_string_if_theres_no_description
+    raw_result = {
+      "fields" => { "description" => nil }
+    }
+
+    highlighted_description = HighlightedDescription.new(raw_result).text
+
+    assert_equal "", highlighted_description
+  end
+end

--- a/test/unit/highlighted_title_test.rb
+++ b/test/unit/highlighted_title_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+require "highlighted_title"
+
+class HighlightedTitleTest < MiniTest::Unit::TestCase
+  def test_title_highlighted
+    title = HighlightedTitle.new({
+      "fields" => { "title" => "A Title" },
+      "highlight" => { "title" => ["A Highlighted Title"] }
+    })
+
+    assert_equal "A Highlighted Title", title.text
+  end
+
+  def test_fallback_title_is_escaped
+    title = HighlightedTitle.new({
+      "fields" => { "title" => "A & Title" },
+    })
+
+    assert_equal "A &amp; Title", title.text
+  end
+end

--- a/test/unit/result_presenter_test.rb
+++ b/test/unit/result_presenter_test.rb
@@ -9,7 +9,7 @@ class ResultPresenterTest < MiniTest::Unit::TestCase
       'fields' => { 'format' => ['a-string'] }
     }
 
-    result = ResultPresenter.new(document, nil, sample_schema).present
+    result = ResultPresenter.new(document, nil, sample_schema, SearchParameters.new(return_fields: %w[format])).present
 
     assert_equal "a-string", result["format"]
   end
@@ -21,7 +21,7 @@ class ResultPresenterTest < MiniTest::Unit::TestCase
       'fields' => { 'railway_type' => ['heavy-rail', 'light-rail'] }
     }
 
-    result = ResultPresenter.new(document, nil, sample_schema).present
+    result = ResultPresenter.new(document, nil, sample_schema, SearchParameters.new(return_fields: %w[railway_type])).present
 
     assert_equal [{"label"=>"Heavy rail", "value"=>"heavy-rail"},
         {"label"=>"Light rail", "value"=>"light-rail"}], result["railway_type"]

--- a/test/unit/temporary_link_fix_test.rb
+++ b/test/unit/temporary_link_fix_test.rb
@@ -9,7 +9,7 @@ class TemporaryLinkFixTest < MiniTest::Unit::TestCase
       'fields' => { 'link' => ['some/link'] }
     }
 
-    result = ResultPresenter.new(document, nil, sample_schema).present
+    result = ResultPresenter.new(document, nil, sample_schema, SearchParameters.new(return_fields: %w[link])).present
 
     assert_equal "/some/link", result["link"]
   end
@@ -21,7 +21,7 @@ class TemporaryLinkFixTest < MiniTest::Unit::TestCase
       'fields' => { 'link' => ['http://example.org/some-link'] }
     }
 
-    result = ResultPresenter.new(document, nil, sample_schema).present
+    result = ResultPresenter.new(document, nil, sample_schema, SearchParameters.new(return_fields: %w[link])).present
 
     assert_equal "http://example.org/some-link", result["link"]
   end
@@ -33,7 +33,7 @@ class TemporaryLinkFixTest < MiniTest::Unit::TestCase
       'fields' => { 'link' => ['/some-link'] }
     }
 
-    result = ResultPresenter.new(document, nil, sample_schema).present
+    result = ResultPresenter.new(document, nil, sample_schema, SearchParameters.new(return_fields: %w[link])).present
 
     assert_equal "/some-link", result["link"]
   end

--- a/test/unit/unified_search_builder_test.rb
+++ b/test/unit/unified_search_builder_test.rb
@@ -14,7 +14,7 @@ class UnifiedSearchBuilderTest < ShouldaUnitTestCase
 
       assert_equal 11, result[:from]
       assert_equal 34, result[:size]
-      assert_equal ['a_field'], result[:fields]
+      assert result[:fields].include?('a_field')
       assert result.key?(:query)
     end
   end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -238,7 +238,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         .returns(farming_topic_document)
 
       @output = UnifiedSearchPresenter.new(
-        SearchParameters.new(start: 0),
+        SearchParameters.new(start: 0, return_fields: %w[topics]),
         sample_es_response,
         { topics: topic_registry },
       ).present


### PR DESCRIPTION
This commit allows users to request two virtual fields in the search results: `title_with_highlighting` and `description_with_highlighting`.

These contain the title and description with `<em>` tags around the words the user was looking for. Elasticsearch automatically highlights stemmed words and synonyms, so when the user searches for "oversea", the words "overseas" and "abroad" will also be highlighted.

About the configuration of the highlight query: `number_of_fragments` specifies how many "fragments" elasticsearch will return. We set `number_of_fragments: 0` for titles to make ES return the entire string. For descriptions we use `number_of_fragments: 1` to enable truncation. This is preferable to doing the truncation ourselves, because ES can do truncation on both sides of the description by "centering" on the highlighted word. This does mean we need some voodoo to append/prepend ellipses the text.

Screenshot of [frontend once that uses this feature](https://github.com/alphagov/frontend/pull/858):

![screen shot 2015-08-14 at 14 42 23](https://cloud.githubusercontent.com/assets/233676/9275094/aa50c628-4292-11e5-8a92-3be93911187a.png)
