### PR TITLE
Stop using `Document` for Registries

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -9,6 +9,7 @@ require "elasticsearch/index_queue"
 require "elasticsearch/escaping"
 require "elasticsearch/result_set"
 require "elasticsearch/scroll_enumerator"
+require "multivalue_converter"
 
 module Elasticsearch
   class InvalidQuery < ArgumentError; end
@@ -257,7 +258,7 @@ module Elasticsearch
       }
 
       ScrollEnumerator.new(@client, search_body, batch_size) do |hit|
-        Document.new(field_definitions, hit["fields"])
+        MultivalueConverter.new(hit["fields"], field_definitions).converted_hash
       end
     end
 

--- a/lib/elasticsearch/index_for_search.rb
+++ b/lib/elasticsearch/index_for_search.rb
@@ -1,5 +1,6 @@
 require "json"
 require "elasticsearch/client"
+require "multivalue_converter"
 
 module Elasticsearch
 
@@ -49,7 +50,7 @@ module Elasticsearch
       }
 
       ScrollEnumerator.new(@client, search_body, batch_size) do |hit|
-        Document.new(field_definitions, hit["fields"])
+        MultivalueConverter.new(hit["fields"], field_definitions).converted_hash
       end
     end
 

--- a/lib/entity_expander.rb
+++ b/lib/entity_expander.rb
@@ -50,7 +50,7 @@ class EntityExpander
     expanded_item = registry[slug]
 
     if expanded_item
-      expanded_item.to_hash.merge("slug" => slug)
+      expanded_item.merge("slug" => slug)
     else
       { "slug" => slug }
     end

--- a/lib/field_presenter.rb
+++ b/lib/field_presenter.rb
@@ -29,7 +29,7 @@ private
     if registry
       value = registry[slug]
       if value
-        return value.to_hash.merge("slug" => slug)
+        return value.merge("slug" => slug)
       end
     end
     {"slug" => slug}

--- a/lib/field_presenter.rb
+++ b/lib/field_presenter.rb
@@ -1,8 +1,8 @@
 class FieldPresenter
-  attr_reader :registry_by_field
+  attr_reader :registries
 
-  def initialize(registry_by_field)
-    @registry_by_field = registry_by_field
+  def initialize(registries)
+    @registries = registries
   end
 
   # Expand a field given a slug, if the field should be expanded.
@@ -19,13 +19,13 @@ private
   # Return true if the field should be expanded (ie, there is a registry for
   # it).
   def should_expand(field)
-    !! registry_by_field[field.to_sym]
+    !! registries[field.to_sym]
   end
 
   # Return an expanded value for a field given a slug.  Always returns a hash
   # with at least the key "slug".
   def value_by_slug(field, slug)
-    registry = registry_by_field[field.to_sym]
+    registry = registries[field.to_sym]
     if registry
       value = registry[slug]
       if value

--- a/lib/multivalue_converter.rb
+++ b/lib/multivalue_converter.rb
@@ -1,0 +1,23 @@
+require "active_support/core_ext/array"
+
+# Elasticsearch returns all fields as arrays by default. We convert those
+# arrays into a single value here, unless we've explicitly set the field to
+# be "multivalued" in the database schema.
+class MultivalueConverter
+  def initialize(fields, field_definitions)
+    @fields = fields
+    @field_definitions = field_definitions
+  end
+
+  def converted_hash
+    result = @fields
+
+    @fields.each do |field_name, values|
+      values = Array.wrap(values)
+      next if @field_definitions.fetch(field_name).type.multivalued
+      @fields[field_name] = values.first
+    end
+
+    result
+  end
+end

--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -21,7 +21,7 @@ module Registry
     end
 
     def [](slug)
-      all.find { |o| o.slug == slug }
+      all.find { |o| o['slug'] == slug }
     end
 
   private

--- a/lib/unified_search/suggestion_blacklist.rb
+++ b/lib/unified_search/suggestion_blacklist.rb
@@ -31,7 +31,7 @@ module UnifiedSearch
     # spelling errors. We use the organisation index to ignore all acronyms.
     def organisation_acronyms
       organisation_registry = registries[:organisations]
-      organisation_registry.all.map(&:acronym).compact.map(&:downcase)
+      organisation_registry.all.map { |r| r['acronym'] }.compact.map(&:downcase)
     end
   end
 end

--- a/test/unit/base_registry_test.rb
+++ b/test/unit/base_registry_test.rb
@@ -10,14 +10,11 @@ class BaseRegistryTest < MiniTest::Unit::TestCase
   end
 
   def example_document
-    Document.new(
-      sample_field_definitions(%w(slug link title)),
-      {
-        slug: "example-document",
-        link: "/government/example-document",
-        title: "Example document"
-      }
-    )
+    {
+      "slug" => "example-document",
+      "link" => "/government/example-document",
+      "title" => "Example document"
+    }
   end
 
   def test_uses_time_as_default_clock
@@ -33,9 +30,7 @@ class BaseRegistryTest < MiniTest::Unit::TestCase
       .returns([example_document])
 
     fetched_document = @base_registry["example-document"]
-    assert_equal example_document.slug, fetched_document.slug
-    assert_equal example_document.link, fetched_document.link
-    assert_equal example_document.title, fetched_document.title
+    assert_equal example_document, fetched_document
   end
 
   def test_only_required_fields_are_requested_from_index

--- a/test/unit/elasticsearch/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch/elasticsearch_index_test.rb
@@ -530,7 +530,7 @@ EOS
     ).then.to_raise("should never happen")
 
     result = @wrapper.documents_by_format("organisation", sample_field_definitions(%w(link title)))
-    assert_equal (1..10).map {|i| "Organisation #{i}" }, result.map(&:title)
+    assert_equal (1..10).map {|i| "Organisation #{i}" }, result.map { |r| r['title'] }
   end
 
   def test_can_fetch_documents_by_format_with_certain_fields
@@ -555,8 +555,8 @@ EOS
     ).then.to_raise("should never happen")
 
     result = @wrapper.documents_by_format("organisation", sample_field_definitions(%w(link title))).to_a
-    assert_equal (1..10).map {|i| "Organisation #{i}" }, result.map(&:title)
-    assert_equal (1..10).map {|i| "/organisation-#{i}" }, result.map(&:link)
+    assert_equal (1..10).map {|i| "Organisation #{i}" }, result.map { |r| r['title'] }
+    assert_equal (1..10).map {|i| "/organisation-#{i}" }, result.map { |r| r['link'] }
   end
 
   def test_all_documents_size

--- a/test/unit/multivalue_converter_test.rb
+++ b/test/unit/multivalue_converter_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+require "multivalue_converter"
+
+class MultivalueConverterTest < MiniTest::Unit::TestCase
+  def test_keeps_multivalue_fields_as_array
+    fields = {
+      "title" => ["the title"],
+      "organisations" => ["hmrc", "dvla"],
+    }
+
+    converted_hash = MultivalueConverter.new(fields, sample_field_definitions).converted_hash
+
+    assert_equal ["hmrc", "dvla"], converted_hash["organisations"]
+  end
+
+  def test_converts_single_value_fields_as_single_value
+    fields = {
+      "title" => ["the title"],
+      "organisations" => ["hmrc", "dvla"],
+    }
+
+    converted_hash = MultivalueConverter.new(fields, sample_field_definitions).converted_hash
+
+    assert_equal "the title", converted_hash["title"]
+  end
+
+  # This might not be necessary since the new ES.
+  def test_converts_also_from_single_value_fields
+    fields = {
+      "title" => "the title",
+      "organisations" => ["hmrc", "dvla"],
+    }
+
+    converted_hash = MultivalueConverter.new(fields, sample_field_definitions).converted_hash
+
+    assert_equal "the title", converted_hash["title"]
+  end
+end

--- a/test/unit/specialist_sector_registry_test.rb
+++ b/test/unit/specialist_sector_registry_test.rb
@@ -10,12 +10,11 @@ class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
   end
 
   def oil_and_gas
-    Document.new(
-      sample_field_definitions(%w{link slug title}),
-      link: "/topic/oil-and-gas/licensing",
-      slug: "oil-and-gas/licensing",
-      title: "Licensing"
-    )
+    {
+      "link" => "/topic/oil-and-gas/licensing",
+      "slug" => "oil-and-gas/licensing",
+      "title" => "Licensing"
+    }
   end
 
   def test_can_fetch_sector_by_slug
@@ -23,8 +22,7 @@ class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
       .with("specialist_sector", anything)
       .returns([oil_and_gas])
     sector = @specialist_sector_registry["oil-and-gas/licensing"]
-    assert_equal oil_and_gas.link, sector.link
-    assert_equal oil_and_gas.title, sector.title
+    assert_equal oil_and_gas, sector
   end
 
   def test_only_required_fields_are_requested_from_index

--- a/test/unit/unified_search/suggestion_blacklist_test.rb
+++ b/test/unit/unified_search/suggestion_blacklist_test.rb
@@ -26,15 +26,12 @@ class UnifiedSearch::SuggestionBlacklistTest < ShouldaUnitTestCase
     end
 
     def stubbed_organisation_registry
-      mod_organisation = Document.new(
-        sample_field_definitions(%w(link title acronym organisation_type)),
-        {
-          link: "/government/organisations/ministry-of-defence",
-          title: "Ministry of Defence",
-          acronym: "MoD",
-          organisation_type: "Ministerial department"
-        }
-      )
+      mod_organisation = {
+        "link" => "/government/organisations/ministry-of-defence",
+        "title" => "Ministry of Defence",
+        "acronym" => "MoD",
+        "organisation_type" => "Ministerial department"
+      }
 
       stub('organisation_registry', all: [mod_organisation])
     end

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -81,24 +81,16 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
   end
 
   def sample_org_registry
-    magic_org_document = Document.new(
-      sample_field_definitions(%w{link title}),
-      link: "/government/departments/hm-magic",
-      title: "Ministry of Magic"
-    )
-    hmrc_org_document = Document.new(
-      sample_field_definitions(%w{link title}),
-      link: "/government/departments/hmrc",
-      title: "HMRC"
-    )
-    org_registry = stub("org registry")
-    org_registry.expects(:[])
-      .with("hm-magic")
-      .returns(magic_org_document)
-    org_registry.expects(:[])
-      .with("hmrc")
-      .returns(hmrc_org_document)
-    org_registry
+    {
+      "hm-magic" => {
+        "link" => "/government/departments/hm-magic",
+        "title" => "Ministry of Magic"
+      },
+      "hmrc" => {
+        "link" => "/government/departments/hmrc",
+        "title" => "HMRC"
+      }
+    }
   end
 
   def facet_response_magic
@@ -227,15 +219,12 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
   context "results with a registry" do
     setup do
-      farming_topic_document = Document.new(
-        sample_field_definitions(%w{link title}),
-        link: "/government/topics/farming",
-        title: "Farming"
-      )
-      topic_registry = stub("topic registry")
-      topic_registry.expects(:[])
-        .with("farming")
-        .returns(farming_topic_document)
+      topic_registry = {
+        "farming" => {
+          "link" => "/government/topics/farming",
+          "title" => "Farming"
+        }
+      }
 
       @output = UnifiedSearchPresenter.new(
         SearchParameters.new(start: 0),


### PR DESCRIPTION
`Index#documents_by_format` and `IndexForSearch#documents_by_format` use the `Document` class to wrap results. This is not necessary - the only task it performs is converting the elasticsearch response, which return all fields as arrays.

We add a MultivalueConverter class to perform this task.

This cleans up the tests and removes the use of the `Document` from the search-side.

Trello: https://trello.com/c/oCWEBqER
