### PR TITLE
Use Rummager as rendering app for sitemap files

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -26,7 +26,7 @@ namespace :publishing_api do
       publisher.publish(route.merge(
         format: "special_route",
         publishing_app: "rummager",
-        rendering_app: "frontend",
+        rendering_app: "rummager",
         public_updated_at: Time.now.iso8601,
         update_type: "major",
       ))


### PR DESCRIPTION
In production these routes were originally pointing at Rummager:

```
#<Route _id: 5277d004fa5ee55bbe000015, incoming_path: /sitemap.xml, route_type: exact, handler: backend, backend_id: rummager, redirect_to: nil, redirect_type: nil>
```

`frontend` fails to render this correctly.
