### PR TITLE
Fix rendering app for the sitemaps.

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -26,7 +26,7 @@ namespace :publishing_api do
       publisher.publish(route.merge(
         format: "special_route",
         publishing_app: "rummager",
-        rendering_app: "frontend",
+        rendering_app: "rummager",
         public_updated_at: Time.now.iso8601,
         update_type: "major",
       ))


### PR DESCRIPTION
They're served by rummager itself, not by frontend.

This was inadvertantly changed in #480
