### PR TITLE
Remove bundled_with from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,3 @@ DEPENDENCIES
   unicorn (= 4.6.2)
   webmock (~> 1.21.0)
   whenever
-
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
Removes `BUNDLED WITH`, added in https://github.com/alphagov/rummager/pull/480
