### PR TITLE
Extract some classes from Elasticsearch::Index

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -10,6 +10,7 @@ require "elasticsearch/escaping"
 require "elasticsearch/result_set"
 require "elasticsearch/scroll_enumerator"
 require "multivalue_converter"
+require "indexer/document_preparer"
 
 module Elasticsearch
   class InvalidQuery < ArgumentError; end
@@ -156,6 +157,7 @@ module Elasticsearch
         data = item["index"] || item["create"]
         data.has_key?("error")
       end
+
       if failed_items.any?
         # Because bulk writes return a 200 status code regardless, we need to
         # parse through the errors to detect responses that indicate a locked
@@ -301,6 +303,8 @@ module Elasticsearch
 
     # Convert a best bet query to a string formed by joining the normalised
     # words in the query with spaces.
+    #
+    # duplicated in document_preparer.rb
     def analyzed_best_bet_query(query)
       analyzed_query = JSON.parse(@client.get_with_payload(
         "_analyze?analyzer=best_bet_stemmed_match", query))
@@ -426,96 +430,12 @@ module Elasticsearch
     end
 
     def index_doc(doc_hash, popularities, options)
-      if @is_content_index
-        doc_hash = prepare_popularity_field(doc_hash, popularities)
-        doc_hash = prepare_mainstream_browse_page_field(doc_hash)
-        doc_hash = prepare_tag_field(doc_hash)
-        doc_hash = prepare_format_field(doc_hash)
-        doc_hash = prepare_public_timestamp_field(doc_hash)
-      end
-
-      doc_hash = prepare_if_best_bet(doc_hash)
-      doc_hash
-    end
-
-    def prepare_popularity_field(doc_hash, popularities)
-      pop = 0.0
-      unless popularities.nil?
-        link = doc_hash["link"]
-        pop = popularities[link]
-      end
-      doc_hash.merge("popularity" => pop)
-    end
-
-    def prepare_mainstream_browse_page_field(doc_hash)
-      # Mainstream browse pages were modelled as three separate fields:
-      # section, subsection and subsubsection.  This is unhelpful in many ways,
-      # so model them instead as a single field containing the full path.
-      #
-      # In future, we'll get them in this form directly, at which point we'll
-      # also be able to there may be multiple browse pages tagged to a piece of
-      # content.
-      return doc_hash if doc_hash["mainstream_browse_pages"]
-
-      path = [
-        doc_hash["section"],
-        doc_hash["subsection"],
-        doc_hash["subsubsection"]
-      ].compact.join("/")
-
-      if path == ""
-        doc_hash
-      else
-        doc_hash.merge("mainstream_browse_pages" => [path])
-      end
-    end
-
-    def prepare_tag_field(doc_hash)
-      tags = []
-
-      tags.concat(Array(doc_hash["organisations"]).map { |org| "organisation:#{org}" })
-      tags.concat(Array(doc_hash["specialist_sectors"]).map { |sector| "sector:#{sector}" })
-
-      doc_hash.merge("tags" => tags)
-    end
-
-    def prepare_format_field(doc_hash)
-      if doc_hash["format"].nil?
-        doc_hash.merge("format" => doc_hash["_type"])
-      else
-        doc_hash
-      end
-    end
-
-    def prepare_public_timestamp_field(doc_hash)
-      if doc_hash["public_timestamp"].nil? && !doc_hash["last_update"].nil?
-        doc_hash.merge("public_timestamp" => doc_hash["last_update"])
-      else
-        doc_hash
-      end
-    end
-
-    # If a document is a best bet, and is using the stemmed_query field, we
-    # need to populate the stemmed_query_as_term field with a processed version
-    # of the field.  This produces a representation of the best-bet query with
-    # all words stemmed and lowercased, and joined with a single space.
-    #
-    # At search time, all best bets with at least one word in common with the
-    # user's query are fetched, and the stemmed_query_as_term field of each is
-    # checked to see if it is a substring match for the (similarly normalised)
-    # user's query.  If so, the best bet is used.
-    def prepare_if_best_bet(doc_hash)
-      if doc_hash["_type"] != "best_bet"
-        return doc_hash
-      end
-
-      stemmed_query = doc_hash["stemmed_query"]
-      if stemmed_query.nil?
-        return doc_hash
-      end
-
-      doc_hash["stemmed_query_as_term"] = " #{analyzed_best_bet_query(stemmed_query)} "
-      doc_hash
+      DocumentPreparer.new(@client).prepared(
+        doc_hash,
+        popularities,
+        options,
+        @is_content_index
+      )
     end
 
     def lookup_popularities(links)

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -11,6 +11,7 @@ require "elasticsearch/result_set"
 require "elasticsearch/scroll_enumerator"
 require "multivalue_converter"
 require "indexer/document_preparer"
+require "indexer/popularity_lookup"
 
 module Elasticsearch
   class InvalidQuery < ArgumentError; end
@@ -439,76 +440,7 @@ module Elasticsearch
     end
 
     def lookup_popularities(links)
-      if traffic_index.nil?
-        return nil
-      end
-      results = traffic_index.raw_search({
-        query: {
-          terms: {
-            path_components: links
-          }
-        },
-        fields: ["rank_14"],
-        sort: [
-          { rank_14: { order: "asc" }}
-        ],
-        size: 10 * links.size,
-      })
-      ranks = Hash.new(traffic_index_size)
-      results["hits"]["hits"].each do |hit|
-        link = hit["_id"]
-        rank = Array(hit["fields"]["rank_14"]).first
-        if rank.nil?
-          next
-        end
-        ranks[link] = [rank, ranks[link]].min
-      end
-
-      Hash[links.map { |link|
-        popularity_score = if ranks[link] == 0
-          0
-        else
-          1.0 / (ranks[link] + @search_config.popularity_rank_offset)
-        end
-        [link, popularity_score]
-      }]
-    end
-
-    def traffic_index
-      if @opened_traffic_index
-        return @traffic_index
-      end
-      @traffic_index = open_traffic_index
-      @opened_traffic_index = true
-      return @traffic_index
-    end
-
-    def traffic_index_size
-      results = traffic_index.raw_search({
-        query: { match_all: {}},
-        size: 0
-      })
-      results["hits"]["total"]
-    end
-
-    def open_traffic_index
-      if @index_name.start_with?("page-traffic")
-        return nil
-      end
-
-      traffic_index_name = @search_config.auxiliary_index_names.find {|index|
-        index.start_with?("page-traffic")
-      }
-
-      if traffic_index_name
-        result = @search_config.search_server.index(traffic_index_name)
-
-        if result.exists?
-          return result
-        end
-      end
-
-      return nil
+      PopularityLookup.new(@index_name, @search_config).lookup_popularities(links)
     end
 
     def queue

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -1,0 +1,110 @@
+class DocumentPreparer
+  def initialize(client)
+    @client = client
+  end
+
+  def prepared(doc_hash, popularities, options, is_content_index)
+    if is_content_index
+      doc_hash = prepare_popularity_field(doc_hash, popularities)
+      doc_hash = prepare_mainstream_browse_page_field(doc_hash)
+      doc_hash = prepare_tag_field(doc_hash)
+      doc_hash = prepare_format_field(doc_hash)
+      doc_hash = prepare_public_timestamp_field(doc_hash)
+    end
+
+    doc_hash = prepare_if_best_bet(doc_hash)
+    doc_hash
+  end
+
+private
+
+  def prepare_popularity_field(doc_hash, popularities)
+    pop = 0.0
+    unless popularities.nil?
+      link = doc_hash["link"]
+      pop = popularities[link]
+    end
+    doc_hash.merge("popularity" => pop)
+  end
+
+  def prepare_mainstream_browse_page_field(doc_hash)
+    # Mainstream browse pages were modelled as three separate fields:
+    # section, subsection and subsubsection.  This is unhelpful in many ways,
+    # so model them instead as a single field containing the full path.
+    #
+    # In future, we'll get them in this form directly, at which point we'll
+    # also be able to there may be multiple browse pages tagged to a piece of
+    # content.
+    return doc_hash if doc_hash["mainstream_browse_pages"]
+
+    path = [
+      doc_hash["section"],
+      doc_hash["subsection"],
+      doc_hash["subsubsection"]
+    ].compact.join("/")
+
+    if path == ""
+      doc_hash
+    else
+      doc_hash.merge("mainstream_browse_pages" => [path])
+    end
+  end
+
+  def prepare_tag_field(doc_hash)
+    tags = []
+
+    tags.concat(Array(doc_hash["organisations"]).map { |org| "organisation:#{org}" })
+    tags.concat(Array(doc_hash["specialist_sectors"]).map { |sector| "sector:#{sector}" })
+
+    doc_hash.merge("tags" => tags)
+  end
+
+  def prepare_format_field(doc_hash)
+    if doc_hash["format"].nil?
+      doc_hash.merge("format" => doc_hash["_type"])
+    else
+      doc_hash
+    end
+  end
+
+  def prepare_public_timestamp_field(doc_hash)
+    if doc_hash["public_timestamp"].nil? && !doc_hash["last_update"].nil?
+      doc_hash.merge("public_timestamp" => doc_hash["last_update"])
+    else
+      doc_hash
+    end
+  end
+
+  # If a document is a best bet, and is using the stemmed_query field, we
+  # need to populate the stemmed_query_as_term field with a processed version
+  # of the field.  This produces a representation of the best-bet query with
+  # all words stemmed and lowercased, and joined with a single space.
+  #
+  # At search time, all best bets with at least one word in common with the
+  # user's query are fetched, and the stemmed_query_as_term field of each is
+  # checked to see if it is a substring match for the (similarly normalised)
+  # user's query.  If so, the best bet is used.
+  def prepare_if_best_bet(doc_hash)
+    if doc_hash["_type"] != "best_bet"
+      return doc_hash
+    end
+
+    stemmed_query = doc_hash["stemmed_query"]
+    if stemmed_query.nil?
+      return doc_hash
+    end
+
+    doc_hash["stemmed_query_as_term"] = " #{analyzed_best_bet_query(stemmed_query)} "
+    doc_hash
+  end
+
+  # duplicated in index.rb
+  def analyzed_best_bet_query(query)
+    analyzed_query = JSON.parse(@client.get_with_payload(
+      "_analyze?analyzer=best_bet_stemmed_match", query))
+
+    analyzed_query["tokens"].map { |token_info|
+      token_info["token"]
+    }.join(" ")
+  end
+end

--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -1,0 +1,85 @@
+class PopularityLookup
+  def initialize(index_name, search_config)
+    @index_name = index_name
+    @search_config = search_config
+  end
+
+  def lookup_popularities(links)
+    if traffic_index.nil?
+      return nil
+    end
+
+    results = traffic_index.raw_search({
+      query: {
+        terms: {
+          path_components: links
+        }
+      },
+      fields: ["rank_14"],
+      sort: [
+        { rank_14: { order: "asc" }}
+      ],
+      size: 10 * links.size,
+    })
+
+    ranks = Hash.new(traffic_index_size)
+
+    results["hits"]["hits"].each do |hit|
+      link = hit["_id"]
+      rank = Array(hit["fields"]["rank_14"]).first
+      if rank.nil?
+        next
+      end
+      ranks[link] = [rank, ranks[link]].min
+    end
+
+    Hash[links.map { |link|
+      popularity_score = if ranks[link] == 0
+        0
+      else
+        1.0 / (ranks[link] + @search_config.popularity_rank_offset)
+      end
+      [link, popularity_score]
+    }]
+  end
+
+private
+
+  def traffic_index
+    if @opened_traffic_index
+      return @traffic_index
+    end
+    @traffic_index = open_traffic_index
+    @opened_traffic_index = true
+    return @traffic_index
+  end
+
+  def traffic_index_size
+    results = traffic_index.raw_search({
+      query: { match_all: {}},
+      size: 0
+    })
+    results["hits"]["total"]
+  end
+
+  def open_traffic_index
+
+    if @index_name.start_with?("page-traffic")
+      return nil
+    end
+
+    traffic_index_name = @search_config.auxiliary_index_names.find {|index|
+      index.start_with?("page-traffic")
+    }
+
+    if traffic_index_name
+      result = @search_config.search_server.index(traffic_index_name)
+
+      if result.exists?
+        return result
+      end
+    end
+
+    return nil
+  end
+end

--- a/test/unit/elasticsearch/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch/elasticsearch_index_test.rb
@@ -12,7 +12,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     @wrapper = Elasticsearch::Index.new(@base_uri, "mainstream_test", "mainstream_test", default_mappings, search_config)
 
     @traffic_index = Elasticsearch::Index.new(@base_uri, "page-traffic_test", "page-traffic_test", page_traffic_mappings, search_config)
-    @wrapper.stubs(:traffic_index).returns(@traffic_index)
+    PopularityLookup.any_instance.stubs(:traffic_index).returns(@traffic_index)
     @traffic_index.stubs(:real_name).returns("page-traffic_test")
   end
 


### PR DESCRIPTION
`Elasticsearch::Index` is fairly large (600 loc) and does a lot of different things. 

This PR extracts a `PopularityLookup` class responsible for adding the `popularity` field to the search results. The `popularity` field is used to surface popular pages higher.

The `DocumentPreparer` class is responsible for taking a adding and modifying a search result document _before_ it is sent to elasticsearch.

The tests for the `Index` class have not been split up, as these are difficult to untangle. The motivation for the refactor is that we'll be updating the way documents are indexed (Trello: https://trello.com/c/yY2jFlXl). This will help with that change and will also make splitting up the tests easier.
