### PR TITLE
Use <mark> element for highlighted text

### DIFF
--- a/lib/highlighted_description.rb
+++ b/lib/highlighted_description.rb
@@ -35,7 +35,7 @@ private
     # versions are the same.
     escaped_original = Rack::Utils.escape_html(original_description)
     highlighted_without_tags = highlighted_description
-      .gsub('<em>', '').gsub('</em>', '')
+      .gsub('<mark>', '').gsub('</mark>', '')
 
     output = highlighted_description
 

--- a/lib/query_components/highlight.rb
+++ b/lib/query_components/highlight.rb
@@ -2,8 +2,8 @@ module QueryComponents
   class Highlight < BaseComponent
     def payload
       {
-        pre_tags: ['<em>'],
-        post_tags: ['</em>'],
+        pre_tags: ['<mark>'],
+        post_tags: ['</mark>'],
         encoder: 'html',
         fields: {
           title: {

--- a/test/integration/unified_search/results_with_highlighting_test.rb
+++ b/test/integration/unified_search/results_with_highlighting_test.rb
@@ -17,7 +17,7 @@ class ResultsWithHighlightingTest < MultiIndexTest
     get "/unified_search?q=result&fields[]=title_with_highlighting"
 
     refute first_search_result.key?('title')
-    assert_equal "I am the <em>result</em>",
+    assert_equal "I am the <mark>result</mark>",
       first_search_result['title_with_highlighting']
   end
 
@@ -44,7 +44,7 @@ class ResultsWithHighlightingTest < MultiIndexTest
     get "/unified_search?q=result&fields[]=description_with_highlighting"
 
     refute first_search_result.key?('description')
-    assert_equal "This is a test search <em>result</em> of many <em>results</em>.",
+    assert_equal "This is a test search <mark>result</mark> of many <mark>results</mark>.",
       first_search_result['description_with_highlighting']
   end
 
@@ -57,9 +57,9 @@ class ResultsWithHighlightingTest < MultiIndexTest
 
     get "/unified_search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
 
-    assert_equal "Escape &amp; <em>highlight</em> the description as well.",
+    assert_equal "Escape &amp; <mark>highlight</mark> the description as well.",
       first_search_result['description_with_highlighting']
-    assert_equal "Escape &amp; <em>highlight</em> my title",
+    assert_equal "Escape &amp; <mark>highlight</mark> my title",
       first_search_result['title_with_highlighting']
   end
 
@@ -72,7 +72,7 @@ class ResultsWithHighlightingTest < MultiIndexTest
     get "/unified_search?q=word&fields[]=description_with_highlighting"
     description = first_search_result['description_with_highlighting']
 
-    assert description.starts_with?("<em>word</em>")
+    assert description.starts_with?("<mark>word</mark>")
     assert description.ends_with?("…")
   end
 

--- a/test/unit/highlighted_description_test.rb
+++ b/test/unit/highlighted_description_test.rb
@@ -5,12 +5,12 @@ class HighlightedDescriptionTest < MiniTest::Unit::TestCase
   def test_adds_highlighting_if_present
     raw_result = {
       "fields" => { "description" => "I will be hightlighted." },
-      "highlight" => { "description" => ["I will be <em>hightlighted</em>."] }
+      "highlight" => { "description" => ["I will be <mark>hightlighted</mark>."] }
     }
 
     highlighted_description = HighlightedDescription.new(raw_result).text
 
-    assert_equal "I will be <em>hightlighted</em>.", highlighted_description
+    assert_equal "I will be <mark>hightlighted</mark>.", highlighted_description
   end
 
   def test_uses_default_description_if_hightlight_not_found


### PR DESCRIPTION
The `<mark>` element is much more applicable for highlighting words. From the HTML5 spec:

> The mark element represents a run of text in one document marked or
> highlighted for reference purposes, due to its relevance in another
> context. When used in a quotation or other block of text referred to
> from the prose, it indicates a highlight that was not originally
> present but which has been added to bring the reader's attention to a
> part of the text that might not have been considered important by the
> original author when the block was originally written, but which is now
> under previously unexpected scrutiny. When used in the main prose of a
> document, it indicates a part of the document that has been highlighted
> due to its likely relevance to the user's current activity.

http://www.w3.org/TR/html5/text-level-semantics.html#the-mark-element

https://github.com/alphagov/frontend/pull/858, the PR to display the results, will need updating.
