### PR TITLE
Stop populating mainstream_browse_pages

### DIFF
--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -6,7 +6,6 @@ class DocumentPreparer
   def prepared(doc_hash, popularities, options, is_content_index)
     if is_content_index
       doc_hash = prepare_popularity_field(doc_hash, popularities)
-      doc_hash = prepare_mainstream_browse_page_field(doc_hash)
       doc_hash = prepare_tag_field(doc_hash)
       doc_hash = prepare_format_field(doc_hash)
       doc_hash = prepare_public_timestamp_field(doc_hash)
@@ -25,29 +24,6 @@ private
       pop = popularities[link]
     end
     doc_hash.merge("popularity" => pop)
-  end
-
-  def prepare_mainstream_browse_page_field(doc_hash)
-    # Mainstream browse pages were modelled as three separate fields:
-    # section, subsection and subsubsection.  This is unhelpful in many ways,
-    # so model them instead as a single field containing the full path.
-    #
-    # In future, we'll get them in this form directly, at which point we'll
-    # also be able to there may be multiple browse pages tagged to a piece of
-    # content.
-    return doc_hash if doc_hash["mainstream_browse_pages"]
-
-    path = [
-      doc_hash["section"],
-      doc_hash["subsection"],
-      doc_hash["subsubsection"]
-    ].compact.join("/")
-
-    if path == ""
-      doc_hash
-    else
-      doc_hash.merge("mainstream_browse_pages" => [path])
-    end
   end
 
   def prepare_tag_field(doc_hash)

--- a/test/unit/elasticsearch/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch/elasticsearch_index_test.rb
@@ -290,38 +290,6 @@ eos
     assert_requested(:post, "http://example.com:9200/mainstream_test/_bulk")
   end
 
-  def test_should_populate_mainstream_browse_pages_field
-    stub_popularity_index_requests(["/foo/bar"], 1.0)
-
-    json_document = {
-      "_type" => "edition",
-      "link" => "/foo/bar",
-      "section" => "benefits",
-      "subsection" => "entitlement",
-    }
-    document = stub("document", elasticsearch_export: json_document)
-
-    # Note that this comes with a trailing newline, which elasticsearch needs
-    payload = <<-eos
-{"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","section":"benefits","subsection":"entitlement","popularity":0.09090909090909091,"mainstream_browse_pages":["benefits/entitlement"],"tags":[],"format":"edition"}
-    eos
-    response = <<-eos
-{"took":5,"items":[
-  { "index": { "_index":"mainstream_test", "_type":"edition", "_id":"/foo/bar", "ok":true } }
-]}
-    eos
-
-    bulk_request = stub_request(:post, "http://example.com:9200/mainstream_test/_bulk").with(
-        body: payload,
-        headers: {"Content-Type" => "application/json"}
-    ).to_return(body: response)
-
-    @wrapper.add [document]
-
-    assert_requested(bulk_request)
-  end
-
   def test_should_populate_public_timestamp_based_on_last_update_field
     stub_popularity_index_requests(["/document/thing"], 1.0)
 


### PR DESCRIPTION
`mainstream_browse_pages` are already directly populated by publishing apps. 

We don't need to populate them with the section/subsection data.

Part of: https://trello.com/c/N0dU4k3G
