### PR TITLE
Only enable highlighting when requested by the client

### DIFF
--- a/lib/query_components/highlight.rb
+++ b/lib/query_components/highlight.rb
@@ -1,6 +1,8 @@
 module QueryComponents
   class Highlight < BaseComponent
     def payload
+      return unless highlighted_field_requested?
+
       {
         pre_tags: ['<mark>'],
         post_tags: ['</mark>'],
@@ -15,6 +17,13 @@ module QueryComponents
           },
         }
       }
+    end
+
+  private
+
+    def highlighted_field_requested?
+      search_params.field_requested?('title_with_highlighting') ||
+        search_params.field_requested?('description_with_highlighting')
     end
   end
 end

--- a/test/unit/query_components/highlight_test.rb
+++ b/test/unit/query_components/highlight_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "unified_search_builder"
+
+describe QueryComponents::Highlight do
+  describe '#payload' do
+    it 'enables highlighting on title' do
+      parameters = SearchParameters.new(return_fields: %w[title_with_highlighting])
+
+      payload = QueryComponents::Highlight.new(parameters).payload
+
+      assert payload[:fields].keys.include?(:title)
+    end
+
+    it 'enables highlighting on description' do
+      parameters = SearchParameters.new(return_fields: %w[description_with_highlighting])
+
+      payload = QueryComponents::Highlight.new(parameters).payload
+
+      assert payload[:fields].keys.include?(:description)
+    end
+
+    it 'does not enable highlighting when not requested' do
+      parameters = SearchParameters.new(return_fields: %w[title])
+
+      payload = QueryComponents::Highlight.new(parameters).payload
+
+      assert payload.nil?
+    end
+  end
+end


### PR DESCRIPTION
Currently we request highlighting from elasticsearch for all queries, even when the client hasn't asked for either `title_with_highlighting` or `description_with_highlighting`. This means elasticsearch has to do work that's not needed, and we're throwing away the result.

This commit makes it so that we highlight if the client requests _either_ title or description. We could make it so that it doesn't highlight description when only asking for the title and not description, but that would require more code and is a use case not likely to happen.

For review by @rboulton 
