### PR TITLE
Prevent use of section fields in searches

### DIFF
--- a/config/schema/document_types/edition.json
+++ b/config/schema/document_types/edition.json
@@ -1,8 +1,5 @@
 {
   "fields": [
-    "section",
-    "subsection",
-    "subsubsection",
     "id",
     "acronym",
     "attachments",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -66,18 +66,6 @@
     "type": "unsearchable_text"
   },
 
-  "section": {
-    "type": "identifier"
-  },
-
-  "subsection": {
-    "type": "identifier"
-  },
-
-  "subsubsection": {
-    "type": "identifier"
-  },
-
   "id": {
     "type": "identifier"
   },

--- a/docs/content-api.md
+++ b/docs/content-api.md
@@ -15,8 +15,6 @@ Currently returns a hash with one element: `raw_source`, which contains the raw 
 ```json
 {  
    "raw_source":{  
-      "section":"driving",
-      "subsection":"car-tax-discs",
       "organisations":[  
          "department-for-transport",
          "driver-and-vehicle-licensing-agency"

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -36,7 +36,6 @@ class BaseParameterParser
     people
     policies
     search_format_types
-    section
     specialist_sectors
   )
 
@@ -52,7 +51,6 @@ class BaseParameterParser
     mainstream_browse_pages
     manual
     organisations
-    section
     specialist_sectors
   )
 
@@ -91,11 +89,8 @@ class BaseParameterParser
     link
     organisations
     public_timestamp
-    section
     slug
     specialist_sectors
-    subsection
-    subsubsection
     title
     topics
     world_locations

--- a/test/fixtures/default_mappings.rb
+++ b/test/fixtures/default_mappings.rb
@@ -9,7 +9,8 @@ module Fixtures
             "description" => { "type" => "string", "index" => "analyzed" },
             "format" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
             "link" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
-            "indexable_content" => { "type" => "string", "index" => "analyzed"}
+            "indexable_content" => { "type" => "string", "index" => "analyzed"},
+            "mainstream_browse_pages" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
           }
         },
         "best_bet" => {

--- a/test/fixtures/default_mappings.rb
+++ b/test/fixtures/default_mappings.rb
@@ -8,9 +8,6 @@ module Fixtures
             "title" => { "type" => "string", "index" => "analyzed" },
             "description" => { "type" => "string", "index" => "analyzed" },
             "format" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
-            "section" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
-            "subsection" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
-            "subsubsection" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
             "link" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
             "indexable_content" => { "type" => "string", "index" => "analyzed"}
           }

--- a/test/integration/elasticsearch_advanced_search_test.rb
+++ b/test/integration/elasticsearch_advanced_search_test.rb
@@ -34,7 +34,7 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
         "description" => "Government, government, government. Developers.",
         "format" => "answer",
         "link" => "/another-example-answer",
-        "section" => "Crime",
+        "mainstream_browse_pages" => "crime/example",
         "indexable_content" => "Tax, benefits, roads and stuff",
         "relevant_to_local_government" => false,
         "updated_at" => "2012-01-03"
@@ -44,7 +44,7 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
         "description" => "Government, government, government. Developers.",
         "format" => "answer",
         "link" => "/yet-another-example-answer",
-        "section" => "Crime",
+        "mainstream_browse_pages" => "crime/example",
         "indexable_content" => "Tax, benefits, roads and stuff, mostly about cheese",
         "relevant_to_local_government" => true,
         "updated_at" => "2012-01-04",
@@ -128,7 +128,7 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
   end
 
   def test_should_filter_results_by_a_property
-    get "/#{@index_name}/advanced_search.json?per_page=2&page=1&section=Crime"
+    get "/#{@index_name}/advanced_search.json?per_page=2&page=1&mainstream_browse_pages=crime/example"
     assert last_response.ok?
     assert_result_total 2
     assert_result_links "/another-example-answer", "/yet-another-example-answer", order: false
@@ -164,7 +164,7 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
         "description" => "Government, government, government. cheese.",
         "format" => "answer",
         "link" => "/cheese-example-answer",
-        "section" => "Crime",
+        "mainstream_browse_pages" => "crime/example",
         "indexable_content" => "Cheese tax.  Cheese recipies.  Cheese music.",
         "relevant_to_local_government" => true,
         "updated_at" => "2012-01-01"
@@ -176,7 +176,7 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
     end
     commit_index
 
-    get "/#{@index_name}/advanced_search.json?per_page=3&page=1&relevant_to_local_government=true&updated_at[after]=2012-01-02&keywords=tax&section=Crime"
+    get "/#{@index_name}/advanced_search.json?per_page=3&page=1&relevant_to_local_government=true&updated_at[after]=2012-01-02&keywords=tax&mainstream_browse_pages=crime/example"
 
     assert last_response.ok?
     assert_result_total 1
@@ -187,7 +187,7 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
     # The new organisation registry expands organisations from slugs into
     # hashes; for backwards compatibility, we shouldn't do this until it's
     # configured (and until clients can handle either format).
-    get "/#{@index_name}/advanced_search.json?per_page=3&page=1&relevant_to_local_government=true&updated_at[after]=2012-01-02&keywords=tax&section=Crime"
+    get "/#{@index_name}/advanced_search.json?per_page=3&page=1&relevant_to_local_government=true&updated_at[after]=2012-01-02&keywords=tax&mainstream_browse_pages=crime/example"
 
     assert last_response.ok?
     assert_result_total 1

--- a/test/integration/elasticsearch_deletion_test.rb
+++ b/test/integration/elasticsearch_deletion_test.rb
@@ -32,7 +32,7 @@ class ElasticsearchDeletionTest < IntegrationTest
             "description" => "Government, government, government. Developers.",
             "format" => "answer",
             "link" => "/another-example-answer",
-            "section" => "Crime",
+            "mainstream_browse_pages" => "crime/example",
             "indexable_content" => "Tax, benefits, roads and stuff"
           },
           {

--- a/test/integration/multi_index_test.rb
+++ b/test/integration/multi_index_test.rb
@@ -44,7 +44,7 @@ class MultiIndexTest < IntegrationTest
         "link" => "/#{short_index_name}-#{i}",
         "indexable_content" => "Something something important content id #{i}",
       }
-      fields["section"] = ["#{i}"]
+      fields["mainstream_browse_pages"] = ["#{i}"]
       if i % 2 == 0
         fields["specialist_sectors"] = ["farming"]
       end

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -61,7 +61,6 @@ class SitemapTest < IntegrationTest
         "description" => "Government, government, government. Developers.",
         "format" => "answer",
         "link" => "/another-example-answer",
-        "section" => "Crime",
         "indexable_content" => "Tax, benefits, roads and stuff"
       },
       {
@@ -69,7 +68,6 @@ class SitemapTest < IntegrationTest
         "description" => "Government, government, government. Developers.",
         "format" => "recommended-link",
         "link" => "http://www.example.com/external-example-answer",
-        "section" => "Crime",
         "indexable_content" => "Tax, benefits, roads and stuff"
       },
       {
@@ -80,7 +78,6 @@ class SitemapTest < IntegrationTest
         "description" => "We list some inside gov results in the mainstream index.",
         "format" => "inside-government-link",
         "link" => "https://www.gov.uk/government/some-content",
-        "section" => "Inside Government"
       }
     ]
   end

--- a/test/integration/specialist_document_search_test.rb
+++ b/test/integration/specialist_document_search_test.rb
@@ -19,7 +19,6 @@ class SpecialistDocumentSearchTest < MultiIndexTest
       "opened_date" => "2014-08-22",
       "case_type" => "mergers",
       "_type" => "cma_case",
-      "section" => ["1"],
     }
 
     commit_document("mainstream_test", cma_case_attributes)

--- a/test/support/integration_fixtures.rb
+++ b/test/support/integration_fixtures.rb
@@ -5,7 +5,6 @@ module IntegrationFixtures
     "title" => "TITLE1",
     "description" => "DESCRIPTION",
     "format" => "local_transaction",
-    "section" => "life-in-the-uk",
     "link" => "/URL"
   }
 

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -7,9 +7,6 @@ class DocumentTest < MiniTest::Unit::TestCase
       "title" => "TITLE",
       "description" => "DESCRIPTION",
       "format" => "answer",
-      "section" => "Life in the UK",
-      "subsection" => 'Queuing',
-      "subsubsection" => 'Barging to the front',
       "link" => "/an-example-answer",
       "indexable_content" => "HERE IS SOME CONTENT",
     }
@@ -19,9 +16,6 @@ class DocumentTest < MiniTest::Unit::TestCase
     assert_equal "TITLE", document.title
     assert_equal "DESCRIPTION", document.description
     assert_equal "answer", document.format
-    assert_equal "Life in the UK", document.section
-    assert_equal "Queuing", document.subsection
-    assert_equal "Barging to the front", document.subsubsection
     assert_equal "/an-example-answer", document.link
     assert_equal "HERE IS SOME CONTENT", document.indexable_content
   end

--- a/test/unit/elasticsearch/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/elasticsearch/elasticsearch_index_advanced_search_test.rb
@@ -38,21 +38,21 @@ class ElasticsearchIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def test_single_value_filter_param_is_turned_into_a_term_filter
-    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"section\":\"jones\"}}")}/)
-    @wrapper.advanced_search(default_params.merge('section' => 'jones'))
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"mainstream_browse_pages\":\"jones\"}}")}/)
+    @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => 'jones'))
 
-    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"section\":\"jones\"}}")}/)
-    @wrapper.advanced_search(default_params.merge('section' => ['jones']))
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"term\":{\"mainstream_browse_pages\":\"jones\"}}")}/)
+    @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => ['jones']))
   end
 
   def test_multiple_value_filter_param_is_turned_into_a_terms_filter
-    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"terms\":{\"section\":[\"jones\",\"richards\"]}}")}/)
-    @wrapper.advanced_search(default_params.merge('section' => ['jones', 'richards']))
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"terms\":{\"mainstream_browse_pages\":[\"jones\",\"richards\"]}}")}/)
+    @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => ['jones', 'richards']))
   end
 
   def test_filter_params_are_turned_into_anded_term_filters_on_that_property
-    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"and\":[{\"term\":{\"section\":\"jones\"}},{\"term\":{\"link\":\"richards\"}}]}")}/)
-    @wrapper.advanced_search(default_params.merge('section' => ['jones'], 'link' => ['richards']))
+    stub_empty_search(:body => /#{Regexp.escape("\"filter\":{\"and\":[{\"term\":{\"mainstream_browse_pages\":\"jones\"}},{\"term\":{\"link\":\"richards\"}}]}")}/)
+    @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => ['jones'], 'link' => ['richards']))
   end
 
   def test_filter_params_on_a_boolean_mapping_property_are_convered_to_true_based_on_something_that_looks_truthy

--- a/test/unit/parameter_parser/search_parameter_parser_test.rb
+++ b/test/unit/parameter_parser/search_parameter_parser_test.rb
@@ -463,14 +463,14 @@ class SearchParameterParserTest < ShouldaUnitTestCase
   should "understand multiple facet fields" do
     p = SearchParameterParser.new({
       "facet_organisations" => ["10"],
-      "facet_section" => ["5"],
+      "facet_mainstream_browse_pages" => ["5"],
     }, @schema)
 
     assert_equal("", p.error)
     assert p.valid?
     assert_equal(expected_params({facets: {
       "organisations" => expected_facet_params({requested: 10}),
-      "section" => expected_facet_params({requested: 5})
+      "mainstream_browse_pages" => expected_facet_params({requested: 5})
     }}), p.parsed_params)
   end
 

--- a/test/unit/query_components/facets_test.rb
+++ b/test/unit/query_components/facets_test.rb
@@ -82,7 +82,7 @@ class FacetsTest < ShouldaUnitTestCase
     setup do
       @builder = QueryComponents::Facets.new(
         SearchParameters.new(
-          filters: [ text_filter("section", "levitation") ],
+          filters: [ text_filter("mainstream_browse_pages", "levitation") ],
           facets: {"organisations" => {requested: 10, scope: :exclude_field_filter}},
         )
       )
@@ -98,7 +98,7 @@ class FacetsTest < ShouldaUnitTestCase
               size: 100000,
             },
             facet_filter: {
-              "terms" => {"section" => ["levitation"]}
+              "terms" => {"mainstream_browse_pages" => ["levitation"]}
             },
           },
         },

--- a/test/unit/query_components/filter_test.rb
+++ b/test/unit/query_components/filter_test.rb
@@ -78,7 +78,7 @@ class FilterTest < ShouldaUnitTestCase
         SearchParameters.new(
           filters: [
             text_filter("organisations", ["hm-magic", "hmrc"]),
-            text_filter("section", ["levitation"]),
+            text_filter("mainstream_browse_pages", ["levitation"]),
           ],
         )
       )
@@ -89,7 +89,7 @@ class FilterTest < ShouldaUnitTestCase
         result,
         {:and => [
           {"terms" => {"organisations" => ["hm-magic", "hmrc"]}},
-          {"terms" => {"section" => ["levitation"]}},
+          {"terms" => {"mainstream_browse_pages" => ["levitation"]}},
         ].compact}
       )
     end


### PR DESCRIPTION
Ban the `section`, `subsection` and `subsubsection` field from use in
searches (in facets or as return fields).  We believe we have removed
all use of these fields by apps (see
https://trello.com/c/N0dU4k3G/296-remove-section-subsection-and-subsubsection-from-rummager),
but will test this carefully on preview to be sure.

Note that the data will be removed from the database automatically after this is deployed by the nightly migration run.
