### PR TITLE
Fix curly apostrophe in JSA synonym

### DIFF
--- a/config/schema/old_synonyms.yml
+++ b/config/schema/old_synonyms.yml
@@ -178,7 +178,7 @@ synonyms: [
   "idi, immigration directorate instructions",
   "iib => industrial injuries disablement benefit",
   "ilr => indefinite leave, settle, individualised learner record",
-  "jsa, jobseeker’s allowance",
+  "jsa, jobseeker's allowance",
   "lha, local housing allowance",
   "lpa, lasting power of attorney",
   "nasm => noise amelioration scheme military",


### PR DESCRIPTION
This is stopping the word "Jobseeker's" from being correctly highlighted in the new search highlighting feature: https://www.gov.uk/search?q=jsa&enable_highlighting=1
