### PR TITLE
Allow users to explicitly request spelling suggestions

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -31,6 +31,7 @@ private
       filters: filters,
       facets: facets,
       debug: debug_options,
+      suggest: character_separated_param("suggest"),
     }
 
     unused_params = @params.keys - @used_params

--- a/lib/search_parameters.rb
+++ b/lib/search_parameters.rb
@@ -3,7 +3,7 @@
 # Value object that holds the parsed parameters for a search.
 class SearchParameters
   attr_accessor :query, :order, :start, :count, :return_fields, :facets,
-                :filters, :debug
+                :filters, :debug, :suggest
 
   def initialize(params = {})
     params = { facets: [], filters: {}, debug: {}, return_fields: [] }.merge(params)

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -28,7 +28,7 @@ class UnifiedSearchTest < MultiIndexTest
       link: "/some-nice-link"
     )
 
-    get "/unified_search?q=serch"
+    get "/unified_search?q=serch&suggest=spelling"
 
     assert_equal ['search'], parsed_response['suggested_queries']
   end

--- a/test/unit/parameter_parser/search_parameter_parser_test.rb
+++ b/test/unit/parameter_parser/search_parameter_parser_test.rb
@@ -14,6 +14,7 @@ class SearchParameterParserTest < ShouldaUnitTestCase
       filters: [],
       facets: {},
       debug: {},
+      suggest: [],
     }.merge(params)
   end
 


### PR DESCRIPTION
Currently, rummager is providing spelling suggesting for all requests, even when the client won't use the result (like finder-frontend and whitehall). We want clients to be able to explicitly request spelling corrections to be enabled. A request to this URL should return the spelling suggestions:

https://www.gov.uk/api/search.json?q=taxes&suggest=spelling

This will speed up all requests that do not have spelling suggestions.

Note that this PR does not change the current behaviour of rummager - this commit only adds support for _sending_ the parameter. We can't update `frontend` first, because rummager rejects requests with unknown params (as evidenced by above URL).
#### API

I've considered the parameter to be `add_spelling=true`, but the parameter parser doesn't currently support booleans. By using a `character_separated_param` we can expand the parameter to include other suggest-y things in the future, like perhaps `suggest=spelling,related_search_terms`.

Trello: https://trello.com/c/P0tJYcUH

Next up: updating frontend.
