### PR TITLE
Use two test indexes instead of three

### DIFF
--- a/test/functional/content_endpoints_test.rb
+++ b/test/functional/content_endpoints_test.rb
@@ -8,7 +8,7 @@ class ContentEndpointsTest < IntegrationTest
   def test_content_document_not_found
     result = { "hits" => { "hits" => [] } }
 
-    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+    stub_request(:get, "http://localhost:9200/mainstream_test,government_test/_search").
       to_return(status: 200, body: JSON.dump(result))
 
     get "/content?link=/a-document/that-does-not-exist"
@@ -27,7 +27,7 @@ class ContentEndpointsTest < IntegrationTest
             "_score"=>1.0,
             "_source"=> 'THE_RAW_SOURCE' }]}}
 
-    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+    stub_request(:get, "http://localhost:9200/mainstream_test,government_test/_search").
       to_return(status: 200, body: JSON.dump(result))
 
     get "/content?link=a-document/in-search"
@@ -47,7 +47,7 @@ class ContentEndpointsTest < IntegrationTest
             "_score"=>1.0,
             "_source"=> 'THE_RAW_SOURCE' }]}}
 
-    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+    stub_request(:get, "http://localhost:9200/mainstream_test,government_test/_search").
       to_return(status: 200, body: JSON.dump(result))
 
     stub_request(:delete, "http://localhost:9200/mainstream_test/edition/%2Fvehicle-tax").
@@ -61,7 +61,7 @@ class ContentEndpointsTest < IntegrationTest
   def test_deleting_a_document_that_doesnt_exist
     result = { "hits" => { "hits" => [] } }
 
-    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+    stub_request(:get, "http://localhost:9200/mainstream_test,government_test/_search").
       to_return(status: 200, body: JSON.dump(result))
 
     delete "/content?link=a-document/in-search"
@@ -80,7 +80,7 @@ class ContentEndpointsTest < IntegrationTest
             "_score"=>1.0,
             "_source"=> 'THE_RAW_SOURCE' }]}}
 
-    stub_request(:get, "http://localhost:9200/mainstream_test,detailed_test,government_test/_search").
+    stub_request(:get, "http://localhost:9200/mainstream_test,government_test/_search").
       to_return(status: 200, body: JSON.dump(result))
 
     Elasticsearch::Index.any_instance.expects(:delete).raises(Elasticsearch::IndexLocked)

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -46,7 +46,6 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?q=important"
 
-    assert result_links.include? "/detailed-1"
     assert result_links.include? "/government-1"
     assert result_links.include? "/mainstream-1"
   end
@@ -85,7 +84,7 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?filter_mainstream_browse_pages=1"
 
-    assert_equal ["/mainstream-1", "/detailed-1", "/government-1"],
+    assert_equal ["/mainstream-1", "/government-1"],
       result_links
   end
 
@@ -94,7 +93,7 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?reject_mainstream_browse_pages=1"
 
-    assert_equal ["/detailed-2", "/government-2", "/mainstream-2"],
+    assert_equal ["/government-2", "/mainstream-2"],
       result_links.sort
   end
 
@@ -103,7 +102,7 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?filter_specialist_sectors=_MISSING"
 
-    assert_equal ["/detailed-1", "/government-1", "/mainstream-1"],
+    assert_equal ["/government-1", "/mainstream-1"],
       result_links.sort
   end
 
@@ -112,7 +111,7 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
 
-    assert_equal ["/detailed-1", "/government-1", "/mainstream-1"],
+    assert_equal ["/government-1", "/mainstream-1"],
       result_links.sort
   end
 
@@ -122,7 +121,6 @@ class UnifiedSearchTest < MultiIndexTest
     get "/unified_search?reject_mainstream_browse_pages=1&filter_specialist_sectors[]=farming"
 
     assert_equal [
-      "/detailed-2",
       "/government-2",
       "/mainstream-2",
     ], result_links.sort
@@ -143,15 +141,15 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?q=important&facet_mainstream_browse_pages=2"
 
-    assert_equal 6, parsed_response["total"]
+    assert_equal 4, parsed_response["total"]
 
     facets = parsed_response["facets"]
 
     assert_equal({
       "mainstream_browse_pages" => {
         "options" => [
-          {"value"=>{"slug"=>"1"}, "documents"=>3},
-          {"value"=>{"slug"=>"2"}, "documents"=>3},
+          {"value"=>{"slug"=>"1"}, "documents"=>2},
+          {"value"=>{"slug"=>"2"}, "documents"=>2},
         ],
         "documents_with_no_value" => 0,
         "total_options" => 2,
@@ -168,11 +166,12 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?q=important&facet_mainstream_browse_pages=2"
 
-    assert_equal 6, parsed_response["total"]
+    assert_equal 4, parsed_response["total"]
     facets_without_filter = parsed_response["facets"]
 
     get "/unified_search?q=important&facet_mainstream_browse_pages=2&filter_mainstream_browse_pages=1"
-    assert_equal 3, parsed_response["total"]
+    assert_equal 2, parsed_response["total"]
+
     facets_with_filter = parsed_response["facets"]
 
     assert_equal(facets_with_filter, facets_without_filter)
@@ -184,12 +183,12 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?q=important&facet_mainstream_browse_pages=1"
 
-    assert_equal 6, parsed_response["total"]
+    assert_equal 4, parsed_response["total"]
     facets = parsed_response["facets"]
     assert_equal({
       "mainstream_browse_pages" => {
         "options" => [
-          {"value"=>{"slug"=>"1"}, "documents"=>3},
+          {"value"=>{"slug"=>"1"}, "documents"=>2},
         ],
         "documents_with_no_value" => 0,
         "total_options" => 2,
@@ -204,13 +203,13 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?q=important&facet_mainstream_browse_pages=2,scope:all_filters&filter_mainstream_browse_pages=1"
 
-    assert_equal 3, parsed_response["total"]
+    assert_equal 2, parsed_response["total"]
     facets = parsed_response["facets"]
 
     assert_equal({
       "mainstream_browse_pages" => {
         "options" => [
-          {"value"=>{"slug"=>"1"}, "documents"=>3},
+          {"value"=>{"slug"=>"1"}, "documents"=>2},
         ],
         "documents_with_no_value" => 0,
         "total_options" => 1,
@@ -225,21 +224,20 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?q=important&facet_mainstream_browse_pages=1,examples:5,example_scope:global,example_fields:link:title:mainstream_browse_pages"
 
-    assert_equal 6, parsed_response["total"]
+    assert_equal 4, parsed_response["total"]
     facets = parsed_response["facets"]
     assert_equal({
       "value" => {
         "slug" => "1",
         "example_info" => {
-          "total" => 3,
+          "total" => 2,
           "examples" => [
             {"mainstream_browse_pages" => ["1"], "title" => "sample mainstream document 1", "link" => "/mainstream-1"},
-            {"mainstream_browse_pages" => ["1"], "title" => "sample detailed document 1", "link" => "/detailed-1"},
             {"mainstream_browse_pages" => ["1"], "title" => "sample government document 1", "link" => "/government-1"},
           ]
         }
       },
-      "documents" => 3,
+      "documents" => 2,
     }, facets.fetch("mainstream_browse_pages").fetch("options").fetch(0))
   end
 
@@ -248,22 +246,21 @@ class UnifiedSearchTest < MultiIndexTest
 
     get "/unified_search?q=important&facet_mainstream_browse_pages=1,examples:5,example_scope:query,example_fields:link:title:mainstream_browse_pages"
 
-    assert_equal 6, parsed_response["total"]
+    assert_equal 4, parsed_response["total"]
 
     facets = parsed_response["facets"]
     assert_equal({
       "value" => {
         "slug" => "1",
         "example_info" => {
-          "total" => 3,
+          "total" => 2,
           "examples" => [
             {"mainstream_browse_pages" => ["1"], "title" => "sample mainstream document 1", "link" => "/mainstream-1"},
-            {"mainstream_browse_pages" => ["1"], "title" => "sample detailed document 1", "link" => "/detailed-1"},
             {"mainstream_browse_pages" => ["1"], "title" => "sample government document 1", "link" => "/government-1"},
           ]
         }
       },
-      "documents" => 3,
+      "documents" => 2,
     }, facets.fetch("mainstream_browse_pages").fetch("options").fetch(0))
   end
 

--- a/test/support/elasticsearch_integration_helpers.rb
+++ b/test/support/elasticsearch_integration_helpers.rb
@@ -1,6 +1,6 @@
 module ElasticsearchIntegrationHelpers
   AUXILIARY_INDEX_NAMES = ["page-traffic_test", "metasearch_test"]
-  INDEX_NAMES = ["mainstream_test", "detailed_test", "government_test"]
+  INDEX_NAMES = ["mainstream_test", "government_test"]
   DEFAULT_INDEX_NAME = INDEX_NAMES.first
 
   def check_index_name!(index_name)

--- a/test/unit/unified_search_presenter_test.rb
+++ b/test/unit/unified_search_presenter_test.rb
@@ -28,7 +28,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
         "link" => "/duty-relief-for-imports-and-exports",
       },
     }, {
-      "_index" => "detailed-2014-03-19t14:35:27z-27e2831f-bd14-47d8-9c7a-3017e213efe3",
+      "_index" => "mainstream-2014-03-19t14:35:27z-27e2831f-bd14-47d8-9c7a-3017e213efe3",
       _type: "edition",
       _id: "/dairy-farming-and-schemes",
       "_score" => 0.34655035,
@@ -177,7 +177,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
     should "have short index names" do
       @output[:results].each do |result|
-        assert_contains %w[mainstream detailed government service-manual], result[:index]
+        assert_contains %w[mainstream government service-manual], result[:index]
       end
     end
 
@@ -243,7 +243,7 @@ class UnifiedSearchPresenterTest < ShouldaUnitTestCase
 
     should "have short index names" do
       @output[:results].each do |result|
-        assert_contains %w[mainstream detailed government service-manual], result[:index]
+        assert_contains %w[mainstream government service-manual], result[:index]
       end
     end
 


### PR DESCRIPTION
The tests currently use three test indexes to test because that's also the case in the real world. This is not necessary and doesn't buy us anything. By having two indexes we still test that "unified" searching still works.

Using only two test indexes cuts down the test runtime by about 30%, from 1m57 to 1m22 on my machine. This is so because most integration tests remove, create and populate the indexes before each example. 
