### PR TITLE
Remove `last_update` field

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -13,7 +13,6 @@
     "mainstream_browse_pages",
     "tags",
     "updated_at",
-    "last_update",
     "public_timestamp",
     "latest_change_note",
     "spelling_text"

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -54,10 +54,6 @@
     "type": "date"
   },
 
-  "last_update": {
-    "type": "date"
-  },
-
   "public_timestamp": {
     "type": "date"
   },

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -8,7 +8,6 @@ class DocumentPreparer
       doc_hash = prepare_popularity_field(doc_hash, popularities)
       doc_hash = prepare_tag_field(doc_hash)
       doc_hash = prepare_format_field(doc_hash)
-      doc_hash = prepare_public_timestamp_field(doc_hash)
     end
 
     doc_hash = prepare_if_best_bet(doc_hash)
@@ -38,14 +37,6 @@ private
   def prepare_format_field(doc_hash)
     if doc_hash["format"].nil?
       doc_hash.merge("format" => doc_hash["_type"])
-    else
-      doc_hash
-    end
-  end
-
-  def prepare_public_timestamp_field(doc_hash)
-    if doc_hash["public_timestamp"].nil? && !doc_hash["last_update"].nil?
-      doc_hash.merge("public_timestamp" => doc_hash["last_update"])
     else
       doc_hash
     end

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -8,7 +8,6 @@ class BaseParameterParser
   # elasticsearch, and because elasticsearch gives fairly obscure error
   # messages if undefined sort fields are used.
   ALLOWED_SORT_FIELDS = %w(
-    last_update
     public_timestamp
     closing_date
     title

--- a/test/unit/elasticsearch/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch/elasticsearch_index_test.rb
@@ -290,39 +290,6 @@ eos
     assert_requested(:post, "http://example.com:9200/mainstream_test/_bulk")
   end
 
-  def test_should_populate_public_timestamp_based_on_last_update_field
-    stub_popularity_index_requests(["/document/thing"], 1.0)
-
-    json_document = {
-      "_type" => "edition",
-      "link" => "/document/thing",
-      "last_update" => "2015-03-26T10:300:00.006+00:00"
-    }
-
-    document = stub("document", elasticsearch_export: json_document)
-
-    payload = <<-EOS
-{"index":{"_type":"edition","_id":"/document/thing"}}
-{"_type":"edition","link":"/document/thing","last_update":"2015-03-26T10:300:00.006+00:00","popularity":0.09090909090909091,"tags":[],"format":"edition","public_timestamp":"2015-03-26T10:300:00.006+00:00"}
-    EOS
-
-  response = <<-EOS
-{"took":5,"items":[
-  { "index": { "_index":"mainstream_test", "_type":"edition", "_id":"/document/thing", "ok":true } }
-]}
-EOS
-
-    bulk_request = stub_request(:post, "http://example.com:9200/mainstream_test/_bulk").with(
-        body: payload,
-        headers: {"Content-Type" => "application/json"}
-    ).to_return(body: response)
-
-    @wrapper.add [document]
-
-    assert_requested(bulk_request)
-  end
-
-
   def test_should_allow_custom_timeouts_on_add
     stub_response = stub("response", body: '{"items": []}')
     RestClient::Request.expects(:execute)


### PR DESCRIPTION
This field has been deprecated and is not used anywhere anymore.

Trello: https://trello.com/c/yY2jFlXl
