### PR TITLE
Remove tags field

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -11,7 +11,6 @@
     "specialist_sectors",
     "policies",
     "mainstream_browse_pages",
-    "tags",
     "updated_at",
     "public_timestamp",
     "latest_change_note",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -46,10 +46,6 @@
     "type": "identifiers"
   },
 
-  "tags": {
-    "type": "identifiers"
-  },
-
   "updated_at": {
     "type": "date"
   },

--- a/docs/content-api.md
+++ b/docs/content-api.md
@@ -29,10 +29,6 @@ Currently returns a hash with one element: `raw_source`, which contains the raw 
       "mainstream_browse_pages":[  
          "driving/car-tax-discs"
       ],
-      "tags":[  
-         "organisation:department-for-transport",
-         "organisation:driver-and-vehicle-licensing-agency"
-      ],
       "_type":"edition",
       "_id":"/vehicle-tax"
    }

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -6,7 +6,6 @@ class DocumentPreparer
   def prepared(doc_hash, popularities, options, is_content_index)
     if is_content_index
       doc_hash = prepare_popularity_field(doc_hash, popularities)
-      doc_hash = prepare_tag_field(doc_hash)
       doc_hash = prepare_format_field(doc_hash)
     end
 
@@ -23,15 +22,6 @@ private
       pop = popularities[link]
     end
     doc_hash.merge("popularity" => pop)
-  end
-
-  def prepare_tag_field(doc_hash)
-    tags = []
-
-    tags.concat(Array(doc_hash["organisations"]).map { |org| "organisation:#{org}" })
-    tags.concat(Array(doc_hash["specialist_sectors"]).map { |sector| "sector:#{sector}" })
-
-    doc_hash.merge("tags" => tags)
   end
 
   def prepare_format_field(doc_hash)

--- a/test/integration/elasticsearch_amendment_test.rb
+++ b/test/integration/elasticsearch_amendment_test.rb
@@ -35,17 +35,6 @@ class ElasticsearchAmendmentTest < IntegrationTest
     assert_document_is_in_rummager(sample_document_attributes.merge("title" => "A new title"))
   end
 
-  def test_should_amend_tags_correctly
-    post "/documents/%2Fan-example-answer", [
-      "specialist_sectors[]=oil-and-gas/licensing",
-    ].join("&")
-
-    assert_document_is_in_rummager(sample_document_attributes.merge(
-      "tags" => ["organisation:hm-magic", "sector:oil-and-gas/licensing"],
-      "specialist_sectors" => ["oil-and-gas/licensing"],
-    ))
-  end
-
   def test_should_fail_to_amend_link
     post "/documents/%2Fan-example-answer", "link=/wibble"
 

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -468,7 +468,6 @@ class UnifiedSearchTest < MultiIndexTest
       "link" => "/cma-cases/somewhat-unique-cma-case",
       "indexable_content" => "Mergers of cheeses and faces",
       "_type" => "cma_case",
-      "tags" => [],
       "specialist_sectors" => ["farming"],
       "opened_date" => "2014-04-01",
     }

--- a/test/unit/elasticsearch/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch/elasticsearch_index_test.rb
@@ -144,7 +144,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0.09090909090909091,"tags":[],"format":"edition"}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0.09090909090909091,"format":"edition"}
     eos
     response = <<-eos
 {"took":5,"items":[
@@ -172,7 +172,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"not_an_edition","_id":"some_id"}}
-{"_type":"not_an_edition","_id":"some_id","title":"TITLE ONE","link":"/a/link","popularity":0.09090909090909091,"tags":[],"format":"not_an_edition"}
+{"_type":"not_an_edition","_id":"some_id","title":"TITLE ONE","link":"/a/link","popularity":0.09090909090909091,"format":"not_an_edition"}
   eos
     response = <<-eos
 {"took":5,"items":[
@@ -193,7 +193,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0.09090909090909091,"tags":[],"format":"edition"}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0.09090909090909091,"format":"edition"}
     eos
     stub_request(:post, "http://example.com:9200/mainstream_test/_bulk").with(
         body: payload,
@@ -245,7 +245,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     # Note that this comes with a trailing newline, which elasticsearch needs
     payload = <<-eos
 {"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0,"tags":[],"format":"edition"}
+{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0,"format":"edition"}
 eos
     response = <<-eos
 {"took":5,"items":[
@@ -259,35 +259,6 @@ eos
     @wrapper.add [document]
 
     assert_requested(request)
-  end
-
-  def test_should_populate_tags_field
-    stub_popularity_index_requests(["/foo/bar"], 1.0)
-
-    json_document = {
-      "_type" => "edition",
-      "link" => "/foo/bar",
-      "specialist_sectors" => ["oil-and-gas/licensing", "oil-and-gas/onshore-oil-and-gas"],
-      "organisations" => ["hm-magic"],
-    }
-    document = stub("document", elasticsearch_export: json_document)
-
-    # Note that this comes with a trailing newline, which elasticsearch needs
-    payload = <<-eos
-{"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","specialist_sectors":["oil-and-gas/licensing","oil-and-gas/onshore-oil-and-gas"],"organisations":["hm-magic"],"popularity":0.09090909090909091,"tags":["organisation:hm-magic","sector:oil-and-gas/licensing","sector:oil-and-gas/onshore-oil-and-gas"],"format":"edition"}
-    eos
-    response = <<-eos
-{"took":5,"items":[
-  { "index": { "_index":"mainstream_test", "_type":"edition", "_id":"/foo/bar", "ok":true } }
-]}
-    eos
-    stub_request(:post, "http://example.com:9200/mainstream_test/_bulk").with(
-        body: payload,
-        headers: {"Content-Type" => "application/json"}
-    ).to_return(body: response)
-    @wrapper.add [document]
-    assert_requested(:post, "http://example.com:9200/mainstream_test/_bulk")
   end
 
   def test_should_allow_custom_timeouts_on_add


### PR DESCRIPTION
The tags field isn't used anywhere: it was an aborted attempt to unify
all the tagging information into a single elasticsearch field, so that a
combined facet across all of the tags could be calculated.  We're not
actually doing this, so currently the field isn't used at all and might
as well be removed.
