### PR TITLE
Only check spelling when explicitly requested

### DIFF
--- a/lib/search_parameters.rb
+++ b/lib/search_parameters.rb
@@ -31,4 +31,8 @@ class SearchParameters
   def disable_best_bets?
     debug[:disable_best_bets]
   end
+
+  def suggest_spelling?
+    query && suggest.include?('spelling')
+  end
 end

--- a/lib/unified_searcher.rb
+++ b/lib/unified_searcher.rb
@@ -22,7 +22,7 @@ class UnifiedSearcher
     facet_examples = example_fetcher.fetch
 
     # Augment the response with the suggest result from a separate query.
-    if search_params.query
+    if search_params.suggest_spelling?
       es_response['suggest'] = fetch_spell_checks(search_params)
     end
 


### PR DESCRIPTION
We currently do spelling corrections for all search requests, even when the client hasn't asked for it and won't use it. Since the suggester makes a separate HTTP query to elasticsearch this has significant
overhead.

We've previously introduced the `suggest=spelling` parameter (https://github.com/alphagov/rummager/pull/511) and updated the sole user of the feature, frontend, to send that parameter (https://github.com/alphagov/frontend/pull/880).

We can now restrict suggesting to clients that request it.

There are no new tests because the behaviour hasn't changed - the existing acceptance test already has the `suggest=spelling` parameter, so it will keep working. I've resisted the urge to test the negative
case, because that feels like overkill (testing the absence of things not asked for seems potentially endless) - but I'm open to people's thoughts on the matter.

Trello: https://trello.com/c/P0tJYcUH
