### PR TITLE
Reformat health check

### DIFF
--- a/lib/health_check/logging_config.rb
+++ b/lib/health_check/logging_config.rb
@@ -1,4 +1,5 @@
 Logging.init :debug, :info, :warn, :pass, :fail, :error, :fatal
+
 Logging.color_scheme('bright',
   :levels => {
     :pass  => :green,
@@ -8,14 +9,16 @@ Logging.color_scheme('bright',
   },
   :date => :blue,
   :logger => :cyan,
-  :message => :magenta
+  :message => :blue
 )
+
 Logging.appenders.stdout(
   'stdout',
   :layout => Logging.layouts.pattern(
-    :pattern => '%-5l %m\n',
+    :pattern => '%l,%m\n',
     :color_scheme => 'bright'
   )
 )
+
 Logging.logger.root.appenders = Logging.appenders.stdout
 Logging.logger.root.level = :info

--- a/lib/health_check/result.rb
+++ b/lib/health_check/result.rb
@@ -1,3 +1,7 @@
 module HealthCheck
-  Result = Struct.new(:success, :score, :possible_score)
+  Result = Struct.new(
+    :success, :score, :possible_score,
+    :success_label, :found_label, :path,
+    :search_term, :position_found, :expectation
+  )
 end

--- a/lib/health_check/search_check_report.rb
+++ b/lib/health_check/search_check_report.rb
@@ -1,0 +1,24 @@
+class SearchCheckReport
+  def initialize(output_file: CSV.open('search_check_results.csv', 'wb'))
+    @report = output_file
+    @report << [
+      "Pass or Fail",
+      "Found or not",
+      "Page",
+      "Search Term",
+      "Position found",
+      "Position wanted"
+    ]
+  end
+
+  def <<(result)
+    @report << [
+      result.success_label,
+      result.found_label,
+      result.path,
+      result.search_term,
+      result.position_found,
+      result.expectation
+    ]
+  end
+end

--- a/lib/health_check/search_checker.rb
+++ b/lib/health_check/search_checker.rb
@@ -16,8 +16,8 @@ module HealthCheck
 
       checks.each do |check|
         search_results = search_client.search(check.search_term)[:results]
-        result = check.result(search_results)
-        calculator.add(result)
+        check_result   = check.result(search_results)
+        calculator.add(check_result)
       end
 
       calculator

--- a/lib/health_check/search_checker.rb
+++ b/lib/health_check/search_checker.rb
@@ -1,14 +1,16 @@
 require "uri"
 require "health_check/check_file_parser"
 require "health_check/calculator"
+require "health_check/search_check_report"
 
 module HealthCheck
   class SearchChecker
     attr_reader :search_client
 
-    def initialize(options = {})
-      @test_data_file = options[:test_data]
-      @search_client = options[:search_client]
+    def initialize(search_client:, test_data:, produce_report: true)
+      @test_data_file = test_data
+      @search_client = search_client
+      @file_output = produce_report ? SearchCheckReport.new : File.open(File::NULL, 'w')
     end
 
     def run!
@@ -16,7 +18,8 @@ module HealthCheck
 
       checks.each do |check|
         search_results = search_client.search(check.search_term)[:results]
-        check_result   = check.result(search_results)
+        check_result = check.result(search_results)
+        @file_output << check_result
         calculator.add(check_result)
       end
 


### PR DESCRIPTION
Potentially lots more here that could be improved/cleaned up/extracted, but wanted to get feedback on this sooner rather than later.

Ticket: https://trello.com/c/sia4T2Ip/210-reformat-rummager-s-search-health-check-output-so-it-s-easier-to-analyse

Essentially:
- clean up the logging output of the health check, removing the sentences makes it easier to scan
- write the results of the health check to a CSV file in the root of the project

Sample output:

![screen shot 2015-09-09 at 13 14 48](https://cloud.githubusercontent.com/assets/519250/9761469/d3201c2c-56f4-11e5-8fb2-1e233a3dbe46.png)
