### PR TITLE
Add UTAAC tribunal decisions schema

### DIFF
--- a/config/schema/document_types/utaac_decision.json
+++ b/config/schema/document_types/utaac_decision.json
@@ -1,0 +1,11 @@
+{
+  "fields": [
+    "tribunal_decision_category",
+    "tribunal_decision_category_name",
+    "tribunal_decision_decision_date",
+    "tribunal_decision_judges",
+    "tribunal_decision_judges_name",
+    "tribunal_decision_sub_category",
+    "tribunal_decision_sub_category_name"
+  ]
+}

--- a/config/schema/indexes/mainstream.json
+++ b/config/schema/indexes/mainstream.json
@@ -17,6 +17,7 @@
     "medical_safety_alert",
     "policy",
     "raib_report",
+    "utaac_decision",
     "vehicle_recalls_and_faults_alert"
   ]
 }


### PR DESCRIPTION
Upper Tribunal Administrative Appeals Chamber (UTAAC) publishes decisions that describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.
