### PR TITLE
Extract code from Elasticsearch::Index

### DIFF
--- a/lib/elasticsearch/advanced_search.rb
+++ b/lib/elasticsearch/advanced_search.rb
@@ -1,0 +1,47 @@
+require "elasticsearch/advanced_search_query_builder"
+
+module Elasticsearch
+  class AdvancedSearch
+    def initialize(mappings, document_types, client)
+      @mappings = mappings
+      @document_types = document_types
+      @client = client
+    end
+
+    def result_set(params)
+      logger.info "params:#{params.inspect}"
+      if params["per_page"].nil? || params["page"].nil?
+        raise InvalidQuery.new("Pagination params are required.")
+      end
+
+      # Delete params that we don't want to be passed as filter_params
+      order     = params.delete("order")
+      keywords  = params.delete("keywords")
+      per_page  = params.delete("per_page").to_i
+      page      = params.delete("page").to_i
+
+      query_builder = AdvancedSearchQueryBuilder.new(keywords, params, order, @mappings)
+      raise InvalidQuery.new(query_builder.error) unless query_builder.valid?
+
+      starting_index = page <= 1 ? 0 : (per_page * (page - 1))
+      payload = {
+        "from" => starting_index,
+        "size" => per_page
+      }
+
+      payload.merge!(query_builder.query_hash)
+
+      ResultSet.from_elasticsearch(@document_types, raw_search(payload))
+    end
+
+  private
+
+    def raw_search(payload)
+      JSON.parse(@client.get_with_payload("_search", payload.to_json))
+    end
+
+    def logger
+      Logging.logger[self]
+    end
+  end
+end

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -32,18 +32,6 @@ module Elasticsearch
   class Index
     include Elasticsearch::Escaping
 
-    # An enumerator with a manually-specified size.
-    # This means we can count the number of documents in an index without
-    # having to load them all.
-    class SizedEnumerator < Enumerator
-      attr_reader :size
-
-      def initialize(size, &block)
-        super(&block)
-        @size = size
-      end
-    end
-
     # The number of documents to retrieve at once when retrieving all documents
     # Gotcha: this is actually the number of documents per shard, so there will
     # be up to some multiple of this number per page.
@@ -70,10 +58,6 @@ module Elasticsearch
       @search_config = search_config
       @document_types = @search_config.schema_config.document_types(base_index_name)
       @is_content_index = !(@search_config.auxiliary_index_names.include? base_index_name)
-    end
-
-    def field_names
-      @mappings["edition"]["properties"].keys
     end
 
     # Translate index names like `mainstream-2015-05-06t09..` into its

--- a/lib/indexer/bulk_payload_generator.rb
+++ b/lib/indexer/bulk_payload_generator.rb
@@ -1,0 +1,92 @@
+module Elasticsearch
+  class BulkPayloadGenerator
+    def initialize(index_name, search_config, client, is_content_index)
+      @index_name = index_name
+      @search_config = search_config
+      @client = client
+      @is_content_index = is_content_index
+    end
+
+    # Payload to index documents using the `_bulk` endpoint
+    #
+    # The format is as follows:
+    #
+    #   {"index": {"_type": "edition", "_id": "/bank-holidays"}}
+    #   { <document source> }
+    #   {"index": {"_type": "edition", "_id": "/something-else"}}
+    #   { <document source> }
+    #
+    # See <http://www.elasticsearch.org/guide/reference/api/bulk/>
+    def bulk_payload(document_hashes_or_payload, options)
+      if document_hashes_or_payload.is_a?(Array)
+        index_items = index_items_from_document_hashes(document_hashes_or_payload, options)
+      else
+        index_items = index_items_from_raw_string(document_hashes_or_payload, options)
+      end
+
+      # Make sure the payload ends with a newline character: elasticsearch
+      # requires this.
+      index_items.flatten.join("\n") + "\n"
+    end
+
+  private
+
+    def index_items_from_document_hashes(document_hashes, options)
+      links = document_hashes.map {
+        |doc_hash| doc_hash["link"]
+      }.compact
+      popularities = lookup_popularities(links)
+      document_hashes.map { |doc_hash|
+        [index_action(doc_hash).to_json, index_doc(doc_hash, popularities, options).to_json]
+      }
+    end
+
+    def lookup_popularities(links)
+      PopularityLookup.new(@index_name, @search_config).lookup_popularities(links)
+    end
+
+    def index_action(doc_hash)
+      {
+        "index" => {
+          "_type" => doc_hash["_type"],
+          "_id" => (doc_hash["_id"] || doc_hash["link"])
+        }
+      }
+    end
+
+    def index_doc(doc_hash, popularities, options)
+      DocumentPreparer.new(@client).prepared(
+        doc_hash,
+        popularities,
+        options,
+        @is_content_index
+      )
+    end
+
+    def index_items_from_raw_string(payload, options)
+      actions = []
+      links = []
+      payload.each_line.each_slice(2).map do |command, doc|
+        command_hash = JSON.parse(command)
+        doc_hash = JSON.parse(doc)
+        actions << [command_hash, doc_hash]
+        links << doc_hash["link"]
+      end
+      popularities = lookup_popularities(links.compact)
+      actions.map { |command_hash, doc_hash|
+        if command_hash.keys == ["index"]
+          doc_hash["_type"] = command_hash["index"]["_type"]
+          [
+            command_hash.to_json,
+            index_doc(doc_hash, popularities, options).to_json
+          ]
+        else
+          [
+            command_hash.to_json,
+            doc_hash.to_json
+          ]
+        end
+      }
+    end
+  end
+end

--- a/test/functional/index_group_test.rb
+++ b/test/functional/index_group_test.rb
@@ -38,7 +38,6 @@ class IndexGroupTest < MiniTest::Unit::TestCase
     assert_requested(stub)
     assert index.is_a? Elasticsearch::Index
     assert_match(/^mainstream-/, index.index_name)
-    assert index.field_names.include? "title"
   end
 
   def test_switch_index_with_no_existing_alias

--- a/test/unit/elasticsearch/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch/elasticsearch_index_test.rb
@@ -261,21 +261,6 @@ eos
     assert_requested(request)
   end
 
-  def test_should_allow_custom_timeouts_on_add
-    stub_response = stub("response", body: '{"items": []}')
-    RestClient::Request.expects(:execute)
-      .with(has_entries(
-        timeout: 20,
-        open_timeout: 25
-      )).returns(stub_response)
-
-    # stub out popularity logic as we don't care about these for the purpose of
-    # this unit test
-    @wrapper.stubs(:lookup_popularities)
-
-    @wrapper.add([], timeout: 20, open_timeout: 25)
-  end
-
   def test_add_queued_documents
     json_document = {
         "_type" => "edition",


### PR DESCRIPTION
`Elasticsearch::Index` is a very large class with too many responsibilities. By delegating things to extracted classes we can start to pull apart the unit tests, which are testing (or stubbing) too much at the moment, making it difficult to add functionality.

There's no change in functionality from this PR.

Ground work for https://trello.com/c/xQtX24kW
