### PR TITLE
Look up tags in content-api before indexing

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -129,6 +129,9 @@ module Elasticsearch
       queue.queue_many(document_hashes)
     end
 
+    # `bulk_index` is the only method that inserts/updates documents. The other
+    # indexing-methods like `add`, `add_queued` and `amend` eventually end up
+    # calling this method.
     def bulk_index(document_hashes_or_payload, options = {} )
       client = build_client(options)
       payload_generator = Indexer::BulkPayloadGenerator.new(@index_name, @search_config, @client, @is_content_index)

--- a/lib/indexer.rb
+++ b/lib/indexer.rb
@@ -1,6 +1,7 @@
 require 'indexer/popularity_lookup'
 require 'indexer/bulk_payload_generator'
 require 'indexer/document_preparer'
+require 'indexer/tag_lookup'
 
 module Indexer
 end

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -8,6 +8,7 @@ module Indexer
       if is_content_index
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_format_field(doc_hash)
+        doc_hash = prepare_tags_field(doc_hash)
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
@@ -23,6 +24,10 @@ module Indexer
         pop = popularities[link]
       end
       doc_hash.merge("popularity" => pop)
+    end
+
+    def prepare_tags_field(doc_hash)
+      Indexer::TagLookup.new.prepare_tags(doc_hash)
     end
 
     def prepare_format_field(doc_hash)

--- a/lib/indexer/tag_lookup.rb
+++ b/lib/indexer/tag_lookup.rb
@@ -1,0 +1,59 @@
+require 'gds_api/content_api'
+
+module Indexer
+  class TagLookup
+    def prepare_tags(doc_hash)
+      artefact = artefact_for_link(doc_hash["link"])
+      if artefact.nil?
+        return doc_hash
+      end
+
+      from_content_api = tags_from_artefact(artefact)
+      doc_hash.merge(merge_tags(doc_hash, from_content_api))
+    end
+
+  private
+
+    def artefact_for_link(link)
+      if link.match(/\Ahttps?:\/\//)
+        # We don't support tags for things which are external links.
+        return nil
+      end
+      link = link.sub(/\A\//, '')
+      begin
+        content_api.artefact!(link)
+      rescue GdsApi::HTTPNotFound
+        nil
+      end
+    end
+
+    def tags_from_artefact(artefact)
+      tags = Hash.new { [] }
+      artefact.tags.each do |tag|
+        slug = tag.slug
+        type = tag.details.type
+        case type
+        when "organisation"
+          tags["organisations"] <<= slug
+        when "section"
+          tags["mainstream_browse_pages"] <<= slug
+        when "specialist_sector"
+          tags["specialist_sectors"] <<= slug
+        end
+      end
+      tags
+    end
+
+    def merge_tags(doc_hash, extra_tags)
+      merged_tags = {}
+      %w{specialist_sectors mainstream_browse_pages organisations}.each do |tag_type|
+        merged_tags[tag_type] = doc_hash.fetch(tag_type, []).concat(extra_tags[tag_type]).uniq
+      end
+      merged_tags
+    end
+
+    def content_api
+      @content_api ||= GdsApi::ContentApi.new(Plek.find("contentapi"))
+    end
+  end
+end

--- a/test/integration/bulk_loader_test.rb
+++ b/test/integration/bulk_loader_test.rb
@@ -5,6 +5,7 @@ require "cgi"
 class BulkLoaderTest < IntegrationTest
 
   def setup
+    stub_tagging_lookup
     stub_elasticsearch_settings
     clean_test_indexes
 

--- a/test/integration/elasticsearch_indexing_test.rb
+++ b/test/integration/elasticsearch_indexing_test.rb
@@ -1,6 +1,8 @@
 require "integration_test_helper"
+require "gds_api/test_helpers/content_api"
 
 class ElasticsearchIndexingTest < IntegrationTest
+  include GdsApi::TestHelpers::ContentApi
 
   SAMPLE_DOCUMENT = {
     "title" => "TITLE",
@@ -20,13 +22,32 @@ class ElasticsearchIndexingTest < IntegrationTest
   end
 
   def test_adding_a_document_to_the_search_index
-    post "/documents", SAMPLE_DOCUMENT.to_json
+    content_api_has_an_artefact("an-example-answer", {
+      "tags" => [
+        tag_for_slug("bar", "specialist_sector"),
+      ]
+    })
+
+    post "/documents", {
+      "title" => "TITLE",
+      "format" => "answer",
+      "link" => "/an-example-answer",
+      "indexable_content" => "HERE IS SOME CONTENT",
+    }.to_json
 
     assert last_response.ok?
-    assert_document_is_in_rummager(SAMPLE_DOCUMENT)
+    assert_document_is_in_rummager({
+      "title" => "TITLE",
+      "format" => "answer",
+      "link" => "/an-example-answer",
+      "indexable_content" => "HERE IS SOME CONTENT",
+      "specialist_sectors" => ["bar"]
+    })
   end
 
   def test_adding_a_document_to_the_search_index_with_queue
+    stub_tagging_lookup
+
     # the queue is disabled in testing by default, but testing/sidekiq/inline
     # executes jobs immediatly.
     app.settings.enable_queue = true

--- a/test/support/test_helpers.rb
+++ b/test/support/test_helpers.rb
@@ -15,4 +15,9 @@ module TestHelpers
       debug: {},
     }.merge(options))
   end
+
+  def stub_tagging_lookup
+    stub_request(:get, %r[#{Plek.find('contentapi')}/*]).
+      to_return(status: 404, body: {}.to_json)
+  end
 end

--- a/test/unit/elasticsearch/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch/elasticsearch_index_test.rb
@@ -51,6 +51,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_add_sends_updates_to_the_bulk_index_endpoint
+    stub_tagging_lookup
     stub_traffic_index
     stub_popularity_index_requests(["/foo/bar"], 1.0)
 
@@ -81,6 +82,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_should_raise_error_for_failures_in_bulk_update
+    stub_tagging_lookup
     stub_traffic_index
     stub_popularity_index_requests(["/foo/bar", "/foo/baz"], 1.0, 20)
 
@@ -111,6 +113,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_should_bulk_update_documents_with_raw_command_stream
+    stub_tagging_lookup
     stub_traffic_index
     stub_popularity_index_requests(["/foo/bar"], 1.0)
 

--- a/test/unit/indexer/tag_lookup_test.rb
+++ b/test/unit/indexer/tag_lookup_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+require "gds_api/test_helpers/content_api"
+require "indexer"
+
+describe Indexer::TagLookup do
+  include GdsApi::TestHelpers::ContentApi
+
+  describe '#prepare_tags' do
+    it 'returns an unchanged document if there are no tags for the document' do
+      stub_request(:get, "#{Plek.find('contentapi')}/no-link.json").to_return(status: 404)
+
+      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/no-link"})
+
+      assert_equal({ "link" => "/no-link" }, result)
+    end
+
+    it 'returns an unchanged document for external URLs' do
+      result = Indexer::TagLookup.new.prepare_tags({ "link" => "http://example.com/some-link"})
+
+      assert_equal({ "link" => "http://example.com/some-link" }, result)
+    end
+
+    it 'adds the tags from the tagging-api to the document' do
+      content_api_has_an_artefact("foo/bar", {
+        "tags" => [
+          tag_for_slug("benefits/advice", "section"),
+          tag_for_slug("benefits/more-advice", "specialist_sector"),
+          tag_for_slug("hmrc", "organisation"),
+        ]
+      })
+
+      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/foo/bar"})
+
+      assert_equal ["benefits/more-advice"], result["specialist_sectors"]
+      assert_equal ["benefits/advice"], result["mainstream_browse_pages"]
+      assert_equal ["hmrc"], result["organisations"]
+    end
+
+    it 'merges tags from the tagging-api with those already in the document' do
+      content_api_has_an_artefact("foo/bar", {
+        "tags" => [
+          tag_for_slug("bar", "specialist_sector"),
+        ]
+      })
+
+      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/foo/bar", "specialist_sectors" => ["foo"] })
+
+      assert_equal ["foo", "bar"], result["specialist_sectors"]
+    end
+  end
+end


### PR DESCRIPTION
This commit adjusts rummager's indexing process such that it makes a call to the content-api (https://github.com/alphagov/govuk_content_api) when the document is being prepared for sending to elasticsearch, and uses information from that to populate the tagging fields (ie,
`organisations`, `mainstream_browse_pages`, and `specialist_sectors`).

This is, perhaps surprisingly, part of the migration away from using content-api / panopticon for getting tag information.

The idea is that instead of applications having to send content to rummager via panopticon, and using panopticon to add the tag information, applications can instead send content directly to rummager, and rummager will sort out getting the right tag information.  This allows us to change publishing apps such that they no longer talk to panopticon, while maintaining the correct data in rummager.

Once all the tag data has been populated in the content-store, and we've got the content-store keeping sync with panopticon, we'll change this to fetch tags from the content store instead of content-api.

---

The above description was taken from the original commit by @rboulton (branch [fetch_tags_from_content_api](https://github.com/alphagov/rummager/tree/fetch_tags_from_content_api)). The code in the `TagLookup` class was taken from that PR.

Trello: https://trello.com/c/xQtX24kW
