### PR TITLE
Handle documents that are "410 Gone" in tag lookup

### DIFF
--- a/lib/indexer/tag_lookup.rb
+++ b/lib/indexer/tag_lookup.rb
@@ -22,7 +22,7 @@ module Indexer
       link = link.sub(/\A\//, '')
       begin
         content_api.artefact!(link)
-      rescue GdsApi::HTTPNotFound
+      rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
         nil
       end
     end

--- a/test/unit/indexer/tag_lookup_test.rb
+++ b/test/unit/indexer/tag_lookup_test.rb
@@ -14,6 +14,14 @@ describe Indexer::TagLookup do
       assert_equal({ "link" => "/no-link" }, result)
     end
 
+    it 'returns an unchanged document if the document is HTTP Gone' do
+      stub_request(:get, "#{Plek.find('contentapi')}/no-link.json").to_return(status: 410)
+
+      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/no-link"})
+
+      assert_equal({ "link" => "/no-link" }, result)
+    end
+
     it 'returns an unchanged document for external URLs' do
       result = Indexer::TagLookup.new.prepare_tags({ "link" => "http://example.com/some-link"})
 


### PR DESCRIPTION
TagLookup checks if there are tags connected to an artefact in panopticon.

Some artefacts are unpublished and return a 410 ("Gone"). For the purposes of this lookup, we will assume there's nothing tagged to these items.

Trello: https://trello.com/c/xQtX24kW
