### PR TITLE
Add two new alert types for MHRA

### DIFF
--- a/config/schema/document_types/medical_safety_alert.json
+++ b/config/schema/document_types/medical_safety_alert.json
@@ -14,6 +14,14 @@
       {
         "label": "Medical device alert",
         "value": "devices"
+      },
+      {
+        "label": "Field safety notices",
+        "value": "field-safety"
+      },
+      {
+        "label": "Drug alerts: company-led",
+        "value": "company-led-drug"
       }
     ],
 


### PR DESCRIPTION
https://trello.com/c/tiCatwpE/117-add-two-new-alert-types-to-mhra-drug-device-alerts-finder-small

These new alert types will be added in specialist-publisher and need to be surfaced in Rummager.

Related:
https://github.com/alphagov/govuk-content-schemas/pull/133
https://github.com/alphagov/specialist-publisher/pull/581
