### PR TITLE
Allow sorting by tribunal decision date

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -11,6 +11,7 @@ class BaseParameterParser
     public_timestamp
     closing_date
     title
+    tribunal_decision_decision_date
   )
 
   SORT_MAPPINGS = {


### PR DESCRIPTION
HM Courts & Tribunals Service would like the search results for tribunal decisions to be sorted by the
decision date, with the most recent decisions listed first.

The same field `tribunal_decision_decision_date` is present in each of the tribunal decision finder configurations. So this addition to the `ALLOWED_SORT_FIELDS` hash only needs to happen once.
