### PR TITLE
Remove synonyms for PA3 and PA4

### DIFF
--- a/config/schema/old_synonyms.yml
+++ b/config/schema/old_synonyms.yml
@@ -297,7 +297,6 @@ synonyms: [
   "mi12 => mi12, mortgage interest",
   "ni17a => maternity benefits",
   "p38s => student holiday job",
-  "pa3, pa4 => probate",
   "pd2 => passports change your name",
   "pff => pff2",
   "pr2 => pr2, student finance forms",


### PR DESCRIPTION
Remove PA3 probate synonym to fix Countryside Stewardship grant PA3 not appearing in search and finder (https://govuk.zendesk.com/agent/tickets/1167282). We'll use best bets to return the probate content instead.
