### PR TITLE
Add employment tribunal decisions schema

### DIFF
--- a/config/schema/document_types/employment_tribunal_decision.json
+++ b/config/schema/document_types/employment_tribunal_decision.json
@@ -1,0 +1,9 @@
+{
+  "fields": [
+    "tribunal_decision_categories",
+    "tribunal_decision_categories_name",
+    "tribunal_decision_country",
+    "tribunal_decision_country_name",
+    "tribunal_decision_decision_date"
+  ]
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -380,6 +380,18 @@
     "description": "A flag set by editors to mark a document as being important to policy",
     "type": "boolean"
   },
+  "tribunal_decision_categories": {
+    "type": "identifiers"
+  },
+  "tribunal_decision_categories_name": {
+    "type": "searchable_identifiers"
+  },
+  "tribunal_decision_country": {
+    "type": "identifier"
+  },
+  "tribunal_decision_country_name": {
+    "type": "searchable_identifier"
+  },
   "tribunal_decision_decision_date": {
     "type": "date"
   },

--- a/config/schema/indexes/mainstream.json
+++ b/config/schema/indexes/mainstream.json
@@ -7,6 +7,7 @@
     "countryside_stewardship_grant",
     "drug_safety_update",
     "edition",
+    "employment_tribunal_decision",
     "european_structural_investment_fund",
     "hmrc_manual",
     "hmrc_manual_section",


### PR DESCRIPTION
Employment tribunals publish decisions that describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.
