### PR TITLE
Allow faceting on all filterable fields

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -23,21 +23,6 @@ class BaseParameterParser
     "document_type" => "_type",
   }
 
-  # The fields listed here are the only ones which can be used to calculated
-  # facets for.  This should be a subset of allowed_filter_fields
-  ALLOWED_FACET_FIELDS = %w(
-    detailed_format
-    document_collections
-    format
-    mainstream_browse_pages
-    manual
-    organisations
-    people
-    policies
-    search_format_types
-    specialist_sectors
-  )
-
   # The fields for which facet examples are allowed to be requested.
   # This is locked down because these can only be requested with the current
   # version of elasticsearch by performing a separate query for each facet

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -263,7 +263,7 @@ private
       if (m = key.match(/\Afacet_(.*)/))
         field = m[1]
         value = single_param(key)
-        if ALLOWED_FACET_FIELDS.include? field
+        if allowed_filter_fields.include?(field)
           facet_parser = FacetParameterParser.new(field, value, allowed_return_fields)
           if facet_parser.valid?
             facets[field] = facet_parser.parsed_params


### PR DESCRIPTION
Rummager restricts the fields we use to facet. Removing that restriction will improve Rummager by having less schema/data knowledge leak into application code, making it easier to work with.

The allowed facets fields is already a subset of allowed_filter_fields, so making them equivalent is safe[1]

[1] _I assume_. To be confirmed by @rboulton.
