### PR TITLE
Add employment appeal tribunal decisions schema

### DIFF
--- a/config/schema/document_types/employment_appeal_tribunal_decision.json
+++ b/config/schema/document_types/employment_appeal_tribunal_decision.json
@@ -1,0 +1,11 @@
+{
+  "fields": [
+    "tribunal_decision_categories",
+    "tribunal_decision_categories_name",
+    "tribunal_decision_decision_date",
+    "tribunal_decision_landmark",
+    "tribunal_decision_landmark_name",
+    "tribunal_decision_sub_categories",
+    "tribunal_decision_sub_categories_name"
+  ]
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -401,6 +401,12 @@
   "tribunal_decision_judges_name": {
     "type": "searchable_identifiers"
   },
+  "tribunal_decision_categories": {
+    "type": "identifiers"
+  },
+  "tribunal_decision_categories_name": {
+    "type": "searchable_identifiers"
+  },
   "tribunal_decision_category": {
     "type": "identifier"
   },
@@ -412,6 +418,12 @@
   },
   "tribunal_decision_sub_category_name": {
     "type": "searchable_identifier"
+  },
+  "tribunal_decision_sub_categories": {
+    "type": "identifiers"
+  },
+  "tribunal_decision_sub_categories_name": {
+    "type": "searchable_identifiers"
   },
   "tribunal_decision_landmark": {
     "type": "identifier"

--- a/config/schema/indexes/mainstream.json
+++ b/config/schema/indexes/mainstream.json
@@ -7,6 +7,7 @@
     "countryside_stewardship_grant",
     "drug_safety_update",
     "edition",
+    "employment_appeal_tribunal_decision",
     "employment_tribunal_decision",
     "european_structural_investment_fund",
     "hmrc_manual",


### PR DESCRIPTION
The Employment Appeal Tribunal publishes decisions that describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.
