### PR TITLE
TagLookup: add tests & refactor

### DIFF
--- a/test/unit/indexer/tag_lookup_test.rb
+++ b/test/unit/indexer/tag_lookup_test.rb
@@ -17,9 +17,9 @@ describe Indexer::TagLookup do
     it 'returns an unchanged document if the document is HTTP Gone' do
       stub_request(:get, "#{Plek.find('contentapi')}/no-link.json").to_return(status: 410)
 
-      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/no-link"})
+      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/no-link", "specialist_sectors" => ["foo", "foo", "bar"] })
 
-      assert_equal({ "link" => "/no-link" }, result)
+      assert_equal({"link" => "/no-link", "specialist_sectors" => ["foo", "foo", "bar"]}, result)
     end
 
     it 'returns an unchanged document for external URLs' do
@@ -48,12 +48,13 @@ describe Indexer::TagLookup do
       content_api_has_an_artefact("foo/bar", {
         "tags" => [
           tag_for_slug("bar", "specialist_sector"),
+          tag_for_slug("foo", "specialist_sector"),
         ]
       })
 
-      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/foo/bar", "specialist_sectors" => ["foo"] })
+      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/foo/bar", "specialist_sectors" => ["foo", "foo", "baz"] })
 
-      assert_equal ["foo", "bar"], result["specialist_sectors"]
+      assert_equal ["foo", "baz", "bar"], result["specialist_sectors"]
     end
   end
 end


### PR DESCRIPTION
This PR refactors the `TagLookup` class and adds tests for behaviours where there are duplicated tags for a document.

The immediate motivation for this is that we tried understanding the transformation process during an incident-related investigation. The complexity of the code made this more difficult than necessary.

Commit messages contain more detail.
