### PR TITLE
Using sidekiq-statsd gem to plot sidekiq activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'nokogiri', "1.5.5"
 gem 'whenever', require: false
 gem "slop", "3.4.5"
 gem "sidekiq", "2.13.0"
+gem "sidekiq-statsd", "0.1.5"
 # pin to version that includes security vulnerability fix
 gem "redis-namespace", "1.3.1"
 gem "plek", "1.11.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
       json
       redis (>= 3.0)
       redis-namespace
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -112,6 +116,7 @@ GEM
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     slop (3.4.5)
+    statsd-ruby (1.2.1)
     tilt (1.3.3)
     timecop (0.7.3)
     timers (1.1.0)
@@ -153,6 +158,7 @@ DEPENDENCIES
   rest-client (= 1.8.0)
   shoulda-context
   sidekiq (= 2.13.0)
+  sidekiq-statsd (= 0.1.5)
   simplecov (~> 0.10.0)
   simplecov-rcov
   sinatra (= 1.3.4)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -15,6 +15,10 @@ redis_config = {
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.rummager', prefix: 'workers'
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In order to improve tracking of what's going on with Sidekiq workers, add `sidekiq-statsd` gem and configuration.

Part of https://trello.com/c/z2aHqwS8/48-add-sidekiq-statsd-to-apps-that-use-sidekiq
