### PR TITLE
Sinatra apps need to explicitly require `sidekiq-statsd`

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
 require "sidekiq"
+require "sidekiq-statsd"
 
 redis_config_hash = YAML.load_file("config/redis.yml").symbolize_keys
 


### PR DESCRIPTION
Sidekiq-statsd is automatically loaded in rails apps, but not in sinatra apps.
