### PR TITLE
Clean up remnants of "failed" queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,4 +4,3 @@
 :logfile: ./log/sidekiq.log
 :queues:
   - default
-  - failed

--- a/lib/elasticsearch/amend_worker.rb
+++ b/lib/elasticsearch/amend_worker.rb
@@ -2,7 +2,7 @@ require "elasticsearch/base_worker"
 
 module Elasticsearch
   class AmendWorker < BaseWorker
-    forward_to_failure_queue
+    notify_of_failures
 
     def perform(index_name, document_link, updates)
       logger.info "Amending document '#{document_link}' in '#{index_name}'"

--- a/lib/elasticsearch/base_worker.rb
+++ b/lib/elasticsearch/base_worker.rb
@@ -28,9 +28,9 @@ module Elasticsearch
       Logging.logger[self]
     end
 
-    def self.forward_to_failure_queue
+    def self.notify_of_failures
       sidekiq_retries_exhausted do |msg|
-        logger.warn "Job '#{msg["jid"]}' failed; forwarding to failure queue"
+        logger.warn "Job '#{msg["jid"]}' failed"
         Airbrake.notify_or_ignore(FailedJobException.new(msg))
       end
     end

--- a/lib/elasticsearch/bulk_index_worker.rb
+++ b/lib/elasticsearch/bulk_index_worker.rb
@@ -2,7 +2,7 @@ require "elasticsearch/base_worker"
 
 module Elasticsearch
   class BulkIndexWorker < BaseWorker
-    forward_to_failure_queue
+    notify_of_failures
 
     def perform(index_name, document_hashes)
       noun = document_hashes.size > 1 ? "documents" : "document"

--- a/lib/elasticsearch/delete_worker.rb
+++ b/lib/elasticsearch/delete_worker.rb
@@ -2,7 +2,7 @@ require "elasticsearch/base_worker"
 
 module Elasticsearch
   class DeleteWorker < BaseWorker
-    forward_to_failure_queue
+    notify_of_failures
 
     def perform(index_name, document_type, document_id = nil)
       # Handle previous method signature to cope with leftover queued jobs when


### PR DESCRIPTION
The failed queue was used before f3a6680 to report failed jobs. This has been replaced by reporting to errbit (https://github.com/alphagov/rummager/pull/243).

This commit cleans up some of the remnants.

cc @joshmyers @rboulton 
