### PR TITLE
Turn off the cache in GdsApi::ContentApi call

### DIFF
--- a/lib/indexer/tag_lookup.rb
+++ b/lib/indexer/tag_lookup.rb
@@ -46,7 +46,10 @@ module Indexer
     end
 
     def content_api
-      @content_api ||= GdsApi::ContentApi.new(Plek.find("contentapi"))
+      # We'll rarely look up the same content item twice in quick succession,
+      # so the cache isn't much use.  Additionally, it's not threadsafe, so
+      # using it can cause bulk imports to break.
+      @content_api ||= GdsApi::ContentApi.new(Plek.find("contentapi"), disable_cache: true)
     end
   end
 end


### PR DESCRIPTION
We have recently experienced some problems with running the
`rummager:migrate_index` rake task, where the process hangs for hours
using 100% CPU.  Debugging with GDB indicated that the process gets
stuck in a loop inside the implementation of "priority_queue", while
removing an item from a data-structure.  This implementation comes from
the `PriorityQueue` gem, which in turn is used solely by the `lrucache`
gem, which is used by gds-api-adapters to maintain an in-memory cache of
recent requests.

When running `rummage:migrate_index`, we spread the work across multiple
threads for performance reasons.  When this was originally implemented,
no external requests were made by these threads, but we recently added a
check against gds-content-api when indexing to add tags (commit
39ceb6e2996e251945aeef1acffaae079b8d8834).  This is fine in normal
processing of index updates, which are done in a single-threaded
process, but for the multi-threaded bulk update it makes concurrent
accesses to the priority queue in the lrucache.  This is not a
concurrency-safe datastructure, nor is it protected by any mutex locks,
so the type of failure we observed will occasionally happen.

There are two ways to fix this - one would be to use a threadsafe cache
(either using a different underlying datastructure, or wrapping
appropriate accesses in mutexes).  This would be invasive, and add an
overhead for the vast majority of our code which doesn't use multiple
threads.

The alternative is to avoid using the cache. gds-api-adapters provides
an option (`disable_cache`) for doing this. The indexing code is
unlikely to make repeated requests for a given url anyway, so avoiding
this cache saves us some memory at little cost, as well as resolving
this issue.

There's no clear way I can think of to test this fix.  We're adding
monitoring to ensure that we notice quickly if the nightly
`migrate_index` job hangs in future, so I think that the lack of
explicit tests for this isn't a big problem.
