### PR TITLE
Remove a bunch of `options` args

### DIFF
--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -135,7 +135,7 @@ module Elasticsearch
     def bulk_index(document_hashes_or_payload, options = {} )
       client = build_client(options)
       payload_generator = Indexer::BulkPayloadGenerator.new(@index_name, @search_config, @client, @is_content_index)
-      response = client.post("_bulk", payload_generator.bulk_payload(document_hashes_or_payload, options), content_type: :json)
+      response = client.post("_bulk", payload_generator.bulk_payload(document_hashes_or_payload), content_type: :json)
       items = JSON.parse(response.body)["items"]
       failed_items = items.select do |item|
         data = item["index"] || item["create"]

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -4,7 +4,7 @@ module Indexer
       @client = client
     end
 
-    def prepared(doc_hash, popularities, options, is_content_index)
+    def prepared(doc_hash, popularities, is_content_index)
       if is_content_index
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_format_field(doc_hash)


### PR DESCRIPTION
These `options` are not used anywhere, but passed down from `Index` to `BulkPayloadGenerator` to `DocumentPreparer`.
