### PR TITLE
Import scripts for alpha taxonomy data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,4 +37,4 @@ group :development do
   gem "mr-sparkle", "0.2.0"
 end
 
-gem "pry", group: [:development, :test]
+gem "pry-byebug", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       multi_json
     ansi (1.4.3)
     builder (3.1.3)
+    byebug (8.2.0)
     celluloid (0.14.1)
       timers (>= 1.0.0)
     chronic (0.9.1)
@@ -64,10 +65,13 @@ GEM
     nokogiri (1.5.5)
     null_logger (0.0.1)
     plek (1.11.0)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -149,7 +153,7 @@ DEPENDENCIES
   mr-sparkle (= 0.2.0)
   nokogiri (= 1.5.5)
   plek (= 1.11.0)
-  pry
+  pry-byebug
   rack (~> 1.6)
   rack-logstasher (= 0.0.3)
   rack-test

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "rake/testtask"
 require "logging"
+require "pry-byebug"
 
 PROJECT_ROOT = File.dirname(__FILE__)
 LIBRARY_PATH = File.join(PROJECT_ROOT, "lib")
@@ -10,7 +11,7 @@ end
 
 require "config"
 
-Dir[File.join(PROJECT_ROOT, 'lib/tasks/*.rake')].each { |file| load file }
+Dir[File.join(PROJECT_ROOT, 'lib/tasks/**/*.rake')].each { |file| load file }
 
 desc "Run all the tests"
 task "test" => ["test:units", "test:integration"]

--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -14,6 +14,7 @@
     "updated_at",
     "public_timestamp",
     "latest_change_note",
-    "spelling_text"
+    "spelling_text",
+    "alpha_taxonomy"
   ]
 }

--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -1,6 +1,7 @@
 {
   "fields": [
     "all_searchable_text",
+    "alpha_taxonomy",
     "format",
     "title",
     "description",
@@ -14,7 +15,6 @@
     "updated_at",
     "public_timestamp",
     "latest_change_note",
-    "spelling_text",
-    "alpha_taxonomy"
+    "spelling_text"
   ]
 }

--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -2,19 +2,19 @@
   "fields": [
     "all_searchable_text",
     "alpha_taxonomy",
-    "format",
-    "title",
     "description",
-    "link",
+    "format",
     "indexable_content",
-    "popularity",
-    "organisations",
-    "specialist_sectors",
-    "policies",
-    "mainstream_browse_pages",
-    "updated_at",
-    "public_timestamp",
     "latest_change_note",
-    "spelling_text"
+    "link",
+    "mainstream_browse_pages",
+    "organisations",
+    "policies",
+    "popularity",
+    "public_timestamp",
+    "specialist_sectors",
+    "spelling_text",
+    "title",
+    "updated_at"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -8,6 +8,10 @@
     "type": "identifier"
   },
 
+  "alpha_taxonomy": {
+    "type": "identifiers"
+  },
+
   "title": {
     "type": "searchable_sortable_text"
   },

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -38,7 +38,7 @@ module Indexer
     end
 
     def prepare_tags_field(doc_hash)
-      Indexer::TagLookup.new.prepare_tags(doc_hash)
+      Indexer::TagLookup.prepare_tags(doc_hash)
     end
 
     def prepare_format_field(doc_hash)

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -1,3 +1,5 @@
+require "taxonomy_prototype/taxon_finder"
+
 module Indexer
   class DocumentPreparer
     def initialize(client)
@@ -9,6 +11,7 @@ module Indexer
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_format_field(doc_hash)
         doc_hash = prepare_tags_field(doc_hash)
+        doc_hash = add_prototype_taxonomy(doc_hash)
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
@@ -16,6 +19,14 @@ module Indexer
     end
 
   private
+    def add_prototype_taxonomy(doc_hash)
+      taxon = ::TaxonomyPrototype::TaxonFinder.find_by(slug: doc_hash["link"])
+      if taxon
+        doc_hash.merge("alpha_taxonomy" => taxon)
+      else
+        doc_hash
+      end
+    end
 
     def prepare_popularity_field(doc_hash, popularities)
       pop = 0.0

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -24,6 +24,7 @@ module Indexer
       if taxon
         doc_hash.merge("alpha_taxonomy" => taxon)
       else
+        doc_hash.delete("alpha_taxonomy")
         doc_hash
       end
     end

--- a/lib/indexer/tag_lookup.rb
+++ b/lib/indexer/tag_lookup.rb
@@ -2,6 +2,10 @@ require 'gds_api/content_api'
 
 module Indexer
   class TagLookup
+    def self.prepare_tags(doc_hash)
+      new.prepare_tags(doc_hash)
+    end
+
     def prepare_tags(doc_hash)
       artefact = find_document_from_content_api(doc_hash["link"])
       return doc_hash unless artefact

--- a/lib/tasks/taxonomy_data.rake
+++ b/lib/tasks/taxonomy_data.rake
@@ -1,0 +1,7 @@
+require PROJECT_ROOT + "/lib/taxonomy_prototype/data_downloader"
+
+namespace :taxonomy_prototype do
+  task :download_data do
+    TaxonomyPrototype::DataDownloader.new.download
+  end
+end

--- a/lib/taxonomy_prototype/data_downloader.rb
+++ b/lib/taxonomy_prototype/data_downloader.rb
@@ -1,0 +1,82 @@
+require 'open-uri'
+require 'csv'
+
+module TaxonomyPrototype
+  class DataDownloader
+    # This class downloads taxonomy data from a specified set of spreadsheets.
+    # It assumes the following about each sheet it imports:
+    # a) it is stored on Google drive.
+    # b) it is 'published' as a single sheet (not the entire document/workbook),
+    #    with tab-seperated values.
+    # c) it's key and gid are populated in the SHEETS constant.
+
+    class_attribute :cache_location
+    self.cache_location = File.dirname(__FILE__) + "../../data/prototype_taxonomy/import_dataset.csv"
+
+    SHEETS = [
+      { :name => "early_years", key: "1zjRy7XKrcroscX4cEqc4gM9Eq0DuVWEm_5wATsolRJY", gid: "1025053831" },
+      { :name => "curriculum_content_mapping", key: "1rViQioxz5iu3hGYFldNOJift0PqjX0fYd8LZz07ljd4", gid: "678558707" },
+    ]
+
+    def initialize(log_output: Logging.logger(STDOUT))
+      @log_output = log_output
+      @log_output.level = :info
+    end
+
+    def download
+      begin
+        File.open(self.class.cache_location, "wb") do |file|
+          SHEETS.each do |sheet|
+            sheet_url = spreadsheet_url(key: sheet[:key], gid: sheet[:gid])
+            logger.info "Attempting download of #{sheet[:name]} (#{sheet_url})"
+            remote_taxonomy_data = open(sheet_url).read
+            logger.info "Downloaded #{sheet[:name]}"
+
+            relevant_columns_in(remote_taxonomy_data).each do |row|
+              mapped_to = row[0]
+              link = row[1]
+              if mapped_to[0..2] == "n/a"
+                next
+              else
+                taxonomy_slug = sluggify(mapped_to)
+                file.write("#{taxonomy_slug}\t#{link}\n")
+              end
+            end
+            logger.info "Finished copying #{sheet[:name]}"
+          end
+        end
+      rescue => e
+        @log_output.error "Failed to download and merge all taxonomy sheets"
+        @log_output.error "Exception: #{e}"
+        @log_output.error "#{e.backtrace.join("\n")}"
+        File.delete self.class.cache_location if File.exist? self.class.cache_location
+      end
+    end
+
+private
+
+    def relevant_columns_in(remote_taxonomy_data)
+      tsv_data = CSV.parse(remote_taxonomy_data, col_sep: "\t", headers: true)
+      desired_columns = ["mapped to", "link"]
+      columns_in_data = tsv_data.headers.map { |header| header.downcase }
+
+      if desired_columns.all? { |column_name| columns_in_data.include? column_name }
+        tsv_data.values_at(*desired_columns)
+      else
+        raise ArgumentError, "Column names did not match expected values #{desired_columns}"
+      end
+    end
+
+    def spreadsheet_url(key: ,gid:)
+      "https://docs.google.com/spreadsheets/d/#{key}/pub?gid=#{gid}&single=true&output=tsv"
+    end
+
+    def sluggify(taxonomy_label)
+      # Standardise the appearance of taxonomy labels extracted from the
+      # spreadsheets.
+      taxonomy_label.split(', ').map do |taxon|
+        taxon.gsub(/\W/, '')
+      end.join(' > ')
+    end
+  end
+end

--- a/lib/taxonomy_prototype/data_downloader.rb
+++ b/lib/taxonomy_prototype/data_downloader.rb
@@ -1,5 +1,4 @@
 require 'open-uri'
-require 'csv'
 
 module TaxonomyPrototype
   class DataDownloader
@@ -32,16 +31,8 @@ module TaxonomyPrototype
             remote_taxonomy_data = open(sheet_url).read
             logger.info "Downloaded #{sheet[:name]}"
 
-            relevant_columns_in(remote_taxonomy_data).each do |row|
-              mapped_to = row[0]
-              link = row[1]
-              if mapped_to[0..2] == "n/a"
-                next
-              else
-                taxonomy_slug = sluggify(mapped_to)
-                file.write("#{taxonomy_slug}\t#{link}\n")
-              end
-            end
+            DataParser.new(remote_taxonomy_data).write_to(file)
+
             logger.info "Finished copying #{sheet[:name]}"
           end
         end
@@ -54,35 +45,8 @@ module TaxonomyPrototype
     end
 
 private
-
-    def relevant_columns_in(remote_taxonomy_data)
-      tsv_data = CSV.parse(remote_taxonomy_data, col_sep: "\t", headers: true)
-      desired_columns = ["mapped to", "link"]
-      columns_in_data = tsv_data.headers.map { |header| header.downcase }
-
-      if desired_columns.all? { |column_name| columns_in_data.include? column_name }
-        tsv_data.values_at(*desired_columns)
-      else
-        raise ArgumentError, "Column names did not match expected values #{desired_columns}"
-      end
-    end
-
     def spreadsheet_url(key: ,gid:)
       "https://docs.google.com/spreadsheets/d/#{key}/pub?gid=#{gid}&single=true&output=tsv"
-    end
-
-    # Standardise the appearance of taxonomy labels extracted from the spreadsheets.
-    def sluggify(taxonomy_label)
-      taxonomy_label.split(', ').map do |taxon|
-        taxon.downcase!
-        # Turn unwanted chars into hyphen
-        taxon.gsub!(/[^a-z0-9\-_]+/, '-')
-        # No more than one hyphen in a row.
-        taxon.gsub!(/-{2,}/, '-')
-        # Remove leading/trailing separator.
-        taxon.gsub!(/^-|-$/, '')
-        taxon
-      end.join(' > ')
     end
   end
 end

--- a/lib/taxonomy_prototype/data_downloader.rb
+++ b/lib/taxonomy_prototype/data_downloader.rb
@@ -11,7 +11,7 @@ module TaxonomyPrototype
     # c) it's key and gid are populated in the SHEETS constant.
 
     class_attribute :cache_location
-    self.cache_location = File.dirname(__FILE__) + "../../data/prototype_taxonomy/import_dataset.csv"
+    self.cache_location = File.dirname(__FILE__) + "/../../data/prototype_taxonomy/import_dataset.csv"
 
     SHEETS = [
       { :name => "early_years", key: "1zjRy7XKrcroscX4cEqc4gM9Eq0DuVWEm_5wATsolRJY", gid: "1025053831" },
@@ -71,11 +71,17 @@ private
       "https://docs.google.com/spreadsheets/d/#{key}/pub?gid=#{gid}&single=true&output=tsv"
     end
 
+    # Standardise the appearance of taxonomy labels extracted from the spreadsheets.
     def sluggify(taxonomy_label)
-      # Standardise the appearance of taxonomy labels extracted from the
-      # spreadsheets.
       taxonomy_label.split(', ').map do |taxon|
-        taxon.gsub(/\W/, '')
+        taxon.downcase!
+        # Turn unwanted chars into hyphen
+        taxon.gsub!(/[^a-z0-9\-_]+/, '-')
+        # No more than one hyphen in a row.
+        taxon.gsub!(/-{2,}/, '-')
+        # Remove leading/trailing separator.
+        taxon.gsub!(/^-|-$/, '')
+        taxon
       end.join(' > ')
     end
   end

--- a/lib/taxonomy_prototype/data_downloader.rb
+++ b/lib/taxonomy_prototype/data_downloader.rb
@@ -1,4 +1,5 @@
 require 'open-uri'
+require 'taxonomy_prototype/data_parser'
 
 module TaxonomyPrototype
   class DataDownloader
@@ -11,7 +12,7 @@ module TaxonomyPrototype
 
     class_attribute :cache_location
     self.cache_location = begin
-      default = File.dirname(__FILE__) + "/../../data/alpha_taxonomy/import_dataset.csv"
+      default = File.dirname(__FILE__) + "/../../data/alpha_taxonomy_import.csv"
       ENV["TAXON_IMPORT_FILE"] || default
     end
 
@@ -34,7 +35,7 @@ module TaxonomyPrototype
             remote_taxonomy_data = open(sheet_url).read
             logger.info "Downloaded #{sheet[:name]}"
 
-            DataParser.new(remote_taxonomy_data).write_to(file)
+            TaxonomyPrototype::DataParser.new(remote_taxonomy_data).write_to(file)
 
             logger.info "Finished copying #{sheet[:name]}"
           end

--- a/lib/taxonomy_prototype/data_downloader.rb
+++ b/lib/taxonomy_prototype/data_downloader.rb
@@ -10,7 +10,10 @@ module TaxonomyPrototype
     # c) it's key and gid are populated in the SHEETS constant.
 
     class_attribute :cache_location
-    self.cache_location = File.dirname(__FILE__) + "/../../data/prototype_taxonomy/import_dataset.csv"
+    self.cache_location = begin
+      default = File.dirname(__FILE__) + "/../../data/alpha_taxonomy/import_dataset.csv"
+      ENV["TAXON_IMPORT_FILE"] || default
+    end
 
     SHEETS = [
       { :name => "early_years", key: "1zjRy7XKrcroscX4cEqc4gM9Eq0DuVWEm_5wATsolRJY", gid: "1025053831" },

--- a/lib/taxonomy_prototype/data_parser.rb
+++ b/lib/taxonomy_prototype/data_parser.rb
@@ -1,0 +1,49 @@
+require 'csv'
+
+module TaxonomyPrototype
+  class DataParser
+    def initialize(taxonomy_data)
+      @taxonomy_data = taxonomy_data
+    end
+
+    def write_to(file)
+      relevant_columns_in(@taxonomy_data).each do |row|
+        mapped_to = row[0]
+        link = row[1]
+        if mapped_to[0..2] == "n/a"
+          next
+        else
+          taxonomy_slug = sluggify(mapped_to)
+          file.write("#{taxonomy_slug}\t#{link}\n")
+        end
+      end
+    end
+
+private
+    def relevant_columns_in(remote_taxonomy_data)
+      tsv_data = CSV.parse(remote_taxonomy_data, col_sep: "\t", headers: true)
+      desired_columns = ["mapped to", "link"]
+      columns_in_data = tsv_data.headers.map { |header| header.downcase }
+
+      if desired_columns.all? { |column_name| columns_in_data.include? column_name }
+        tsv_data.values_at(*desired_columns)
+      else
+        raise ArgumentError, "Column names did not match expected values #{desired_columns}"
+      end
+    end
+
+    # Standardise the appearance of taxonomy labels extracted from the spreadsheets.
+    def sluggify(taxonomy_label)
+      taxonomy_label.split(', ').map do |taxon|
+        taxon.downcase!
+        # Turn unwanted chars into hyphen
+        taxon.gsub!(/[^a-z0-9\-_]+/, '-')
+        # No more than one hyphen in a row.
+        taxon.gsub!(/-{2,}/, '-')
+        # Remove leading/trailing separator.
+        taxon.gsub!(/^-|-$/, '')
+        taxon
+      end.join(' > ')
+    end
+  end
+end

--- a/lib/taxonomy_prototype/taxon_finder.rb
+++ b/lib/taxonomy_prototype/taxon_finder.rb
@@ -1,0 +1,18 @@
+require "taxonomy_prototype/data_downloader"
+
+module TaxonomyPrototype
+  class TaxonFinder
+    def self.find_by(slug:)
+      new.find_by(slug)
+    end
+
+    def find_by(slug)
+      cache_location = ::TaxonomyPrototype::DataDownloader.cache_location
+      if File.exist?(cache_location)
+        taxonomy_mappings = CSV.read(cache_location)
+        matched_mapping = taxonomy_mappings.find { |mapping| mapping.last == slug }
+        matched_mapping.first.split(" > ") if matched_mapping
+      end
+    end
+  end
+end

--- a/test/integration/alpha_taxonomy_filter_test.rb
+++ b/test/integration/alpha_taxonomy_filter_test.rb
@@ -1,0 +1,30 @@
+require "integration_test_helper"
+require "gds_api/test_helpers/content_api"
+
+class AlphaTaxonomyFilterTest < IntegrationTest
+  include GdsApi::TestHelpers::ContentApi
+
+  def setup
+    stub_elasticsearch_settings
+    create_test_indexes
+  end
+
+  def teardown
+    clean_test_indexes
+  end
+
+  def test_filtering_on_a_taxon
+    content_api_has_an_artefact("an-example-artefact")
+    post "/documents", {
+      "link" => "/an-example-artefact",
+      "alpha_taxonomy" => ["foo", "bar"]
+    }.to_json
+    assert last_response.ok?
+    post "/mainstream_test/commit"
+
+    get "/unified_search.json?filter_alpha_taxonomy[]=bar"
+
+    assert_equal parsed_response["total"], 1
+    assert_equal parsed_response["results"].first["link"], "/an-example-artefact"
+  end
+end

--- a/test/integration/alpha_taxonomy_filter_test.rb
+++ b/test/integration/alpha_taxonomy_filter_test.rb
@@ -7,6 +7,7 @@ class AlphaTaxonomyFilterTest < IntegrationTest
   def setup
     stub_elasticsearch_settings
     create_test_indexes
+    TaxonomyPrototype::TaxonFinder.stubs(:find_by).returns(["foo", "bar"])
   end
 
   def teardown
@@ -16,15 +17,14 @@ class AlphaTaxonomyFilterTest < IntegrationTest
   def test_filtering_on_a_taxon
     content_api_has_an_artefact("an-example-artefact")
     post "/documents", {
-      "link" => "/an-example-artefact",
-      "alpha_taxonomy" => ["foo", "bar"]
+      "link" => "/an-example-artefact"
     }.to_json
     assert last_response.ok?
     post "/mainstream_test/commit"
 
     get "/unified_search.json?filter_alpha_taxonomy[]=bar"
 
-    assert_equal parsed_response["total"], 1
-    assert_equal parsed_response["results"].first["link"], "/an-example-artefact"
+    assert_equal 1, parsed_response["total"]
+    assert_equal "/an-example-artefact", parsed_response["results"].first["link"]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ require "pp"
 require "shoulda-context"
 require "logging"
 require "timecop"
+require "pry"
 
 require "webmock/minitest"
 

--- a/test/unit/indexer/document_preparer_test.rb
+++ b/test/unit/indexer/document_preparer_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "indexer"
+
+describe Indexer::DocumentPreparer do
+  describe "#prepared" do
+    let(:doc_hash) { {"link" => "some-slug" } }
+
+    before do
+      Indexer::TagLookup.stubs(:new).returns(
+        OpenStruct.new(prepare_tags: doc_hash)
+      )
+    end
+
+    describe "alpha taxonomies" do
+      it "adds an alpha taxonomy to the doc if a match is found" do
+        ::TaxonomyPrototype::TaxonFinder.stubs(:find_by).returns(["taxon-1", "taxon-2"])
+
+        updated_doc_hash = Indexer::DocumentPreparer.new("fake_client").prepared(doc_hash, nil, true)
+        assert_equal doc_hash.merge("alpha_taxonomy" => ["taxon-1", "taxon-2"]), updated_doc_hash
+      end
+
+      it "does nothing to the doc if no match is found" do
+        ::TaxonomyPrototype::TaxonFinder.stubs(:find_by).returns(nil)
+
+        updated_doc_hash = Indexer::DocumentPreparer.new("fake_client").prepared(doc_hash, nil, true)
+        assert_equal doc_hash, updated_doc_hash
+      end
+    end
+  end
+end

--- a/test/unit/indexer/document_preparer_test.rb
+++ b/test/unit/indexer/document_preparer_test.rb
@@ -6,9 +6,7 @@ describe Indexer::DocumentPreparer do
     let(:doc_hash) { {"link" => "some-slug" } }
 
     before do
-      Indexer::TagLookup.stubs(:new).returns(
-        OpenStruct.new(prepare_tags: doc_hash)
-      )
+      Indexer::TagLookup.stubs(:prepare_tags).returns(doc_hash)
     end
 
     describe "alpha taxonomies" do

--- a/test/unit/indexer/tag_lookup_test.rb
+++ b/test/unit/indexer/tag_lookup_test.rb
@@ -9,7 +9,7 @@ describe Indexer::TagLookup do
     it 'returns an unchanged document if there are no tags for the document' do
       stub_request(:get, "#{Plek.find('contentapi')}/no-link.json").to_return(status: 404)
 
-      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/no-link"})
+      result = Indexer::TagLookup.prepare_tags({ "link" => "/no-link"})
 
       assert_equal({ "link" => "/no-link" }, result)
     end
@@ -17,13 +17,13 @@ describe Indexer::TagLookup do
     it 'returns an unchanged document if the document is HTTP Gone' do
       stub_request(:get, "#{Plek.find('contentapi')}/no-link.json").to_return(status: 410)
 
-      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/no-link", "specialist_sectors" => ["foo", "foo", "bar"] })
+      result = Indexer::TagLookup.prepare_tags({ "link" => "/no-link", "specialist_sectors" => ["foo", "foo", "bar"] })
 
       assert_equal({"link" => "/no-link", "specialist_sectors" => ["foo", "foo", "bar"]}, result)
     end
 
     it 'returns an unchanged document for external URLs' do
-      result = Indexer::TagLookup.new.prepare_tags({ "link" => "http://example.com/some-link"})
+      result = Indexer::TagLookup.prepare_tags({ "link" => "http://example.com/some-link"})
 
       assert_equal({ "link" => "http://example.com/some-link" }, result)
     end
@@ -37,7 +37,7 @@ describe Indexer::TagLookup do
         ]
       })
 
-      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/foo/bar"})
+      result = Indexer::TagLookup.prepare_tags({ "link" => "/foo/bar"})
 
       assert_equal ["benefits/more-advice"], result["specialist_sectors"]
       assert_equal ["benefits/advice"], result["mainstream_browse_pages"]
@@ -52,7 +52,7 @@ describe Indexer::TagLookup do
         ]
       })
 
-      result = Indexer::TagLookup.new.prepare_tags({ "link" => "/foo/bar", "specialist_sectors" => ["foo", "foo", "baz"] })
+      result = Indexer::TagLookup.prepare_tags({ "link" => "/foo/bar", "specialist_sectors" => ["foo", "foo", "baz"] })
 
       assert_equal ["foo", "baz", "bar"], result["specialist_sectors"]
     end

--- a/test/unit/taxonomy_prototype/data_parser_test.rb
+++ b/test/unit/taxonomy_prototype/data_parser_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "taxonomy_prototype/data_parser"
+
+describe TaxonomyPrototype::DataParser do
+  describe "write_to(file)" do
+    let(:test_output) { StringIO.new }
+
+    it "parses and writes the required data to the file" do
+      taxonomy_tsv_data = [
+        "mapped to\t"             +  "link",
+        "Foo Taxon (Label)\t"     +  "the-foo-slug",
+        "Bar Taxon (Label)\t"     +  "the-bar-slug",
+        "n/a - not applicable\t"  +  "the-n/a-slug",
+      ].join("\n")
+
+      TaxonomyPrototype::DataParser.new(taxonomy_tsv_data).write_to(test_output)
+
+      test_output.rewind
+      assert test_output.read, "foo-taxon-label\tthe-foo-slug\nbar-taxon-label\tthe-bar-slug\n"
+    end
+
+    it "falls over and dies if the expected columns aren't present" do
+      taxonomy_tsv_data = [
+        "some random column name\t"  +  "link",
+        "Foo Taxon (Label)\t"        +  "the-foo-slug",
+      ].join("\n")
+
+      assert_raises ArgumentError do
+        TaxonomyPrototype::DataParser.new(taxonomy_tsv_data).write_to(test_output)
+      end
+    end
+  end
+end

--- a/test/unit/taxonomy_prototype/taxon_finder_test.rb
+++ b/test/unit/taxonomy_prototype/taxon_finder_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "taxonomy_prototype/taxon_finder"
+
+describe TaxonomyPrototype::TaxonFinder do
+  describe "find_by(slug:)" do
+    before do
+      CSV.stubs(:read).returns([
+        ["test-taxon-1", "/test/slug/1"],
+        ["test-taxon-2 > test-taxon-3", "/test/slug/2"]
+      ])
+    end
+
+    it "returns a taxon when given a matching slug" do
+      File.stubs(:exist?).returns(true)
+      taxon = TaxonomyPrototype::TaxonFinder.find_by(slug: "/test/slug/2")
+      assert_equal ["test-taxon-2", "test-taxon-3"], taxon
+    end
+
+    it "returns nothing given a non-matching slug" do
+      File.stubs(:exist?).returns(true)
+      taxon = TaxonomyPrototype::TaxonFinder.find_by(slug: "/test/slug/foobar")
+      assert_equal nil, taxon
+    end
+
+    it "returns nothing if the expected CSV is not present" do
+      File.stubs(:exist?).returns(false)
+      taxon = TaxonomyPrototype::TaxonFinder.find_by(slug: "/test/slug/2")
+      assert_equal nil, taxon
+    end
+  end
+end


### PR DESCRIPTION
To import alpha taxonomy definitions into Rummager, providing Design with easier access to taxonomy definitions when prototyping.

This PR includes a rake task for downloading taxonomy definitions in the project `data/prototype_taxonomy` directory. The intention is that this will be run via a Jenkins job to make the data available on all Rummager machines. The existing DocumentPreparer class has been updated to inspect this file for taxon mappings and add them to the document if there is a matching link.

Trello: https://trello.com/c/2f1Ct7tq
