### PR TITLE
Remove pry-byebug from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require "rake/testtask"
 require "logging"
-require "pry-byebug"
 
 PROJECT_ROOT = File.dirname(__FILE__)
 LIBRARY_PATH = File.join(PROJECT_ROOT, "lib")


### PR DESCRIPTION
This file is not in the production Gemfile, so this will crash when deployed.

@mobaig 
