### PR TITLE
Add additional logging for alpha taxonomy import

### DIFF
--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -4,6 +4,7 @@ module Indexer
   class DocumentPreparer
     def initialize(client)
       @client = client
+      @logger = Logging.logger[self]
     end
 
     def prepared(doc_hash, popularities, is_content_index)
@@ -22,6 +23,7 @@ module Indexer
     def add_prototype_taxonomy(doc_hash)
       taxon = ::TaxonomyPrototype::TaxonFinder.find_by(slug: doc_hash["link"])
       if taxon
+        @logger.info "ALPHA_TAX: Merging taxon #{taxon} for #{doc_hash["link"]}"
         doc_hash.merge("alpha_taxonomy" => taxon)
       else
         doc_hash.delete("alpha_taxonomy")

--- a/lib/taxonomy_prototype/taxon_finder.rb
+++ b/lib/taxonomy_prototype/taxon_finder.rb
@@ -7,9 +7,11 @@ module TaxonomyPrototype
     end
 
     def find_by(slug)
+      logger = Logging.logger[self]
       cache_location = ::TaxonomyPrototype::DataDownloader.cache_location
       if File.exist?(cache_location)
         taxonomy_mappings = CSV.read(cache_location)
+        logger.info "ALPHA TAX: Attempting to match #{slug}"
         matched_mapping = taxonomy_mappings.find { |mapping| mapping.last == slug }
         matched_mapping.first.split(" > ") if matched_mapping
       end

--- a/lib/taxonomy_prototype/taxon_finder.rb
+++ b/lib/taxonomy_prototype/taxon_finder.rb
@@ -10,7 +10,7 @@ module TaxonomyPrototype
       logger = Logging.logger[self]
       cache_location = ::TaxonomyPrototype::DataDownloader.cache_location
       if File.exist?(cache_location)
-        taxonomy_mappings = CSV.read(cache_location)
+        taxonomy_mappings = CSV.read(cache_location, col_sep: "\t")
         logger.info "ALPHA TAX: Attempting to match #{slug}"
         matched_mapping = taxonomy_mappings.find { |mapping| mapping.last == slug }
         matched_mapping.first.split(" > ") if matched_mapping


### PR DESCRIPTION
As this is carried out as part of the index migration, it's long-running
and difficult to debug. Additional logging will help diagnose issues
with the import.
