### PR TITLE
Improve TaxonFinder unit test

### DIFF
--- a/test/unit/taxonomy_prototype/taxon_finder_test.rb
+++ b/test/unit/taxonomy_prototype/taxon_finder_test.rb
@@ -1,13 +1,18 @@
 require "test_helper"
 require "taxonomy_prototype/taxon_finder"
+require "tempfile"
 
 describe TaxonomyPrototype::TaxonFinder do
   describe "find_by(slug:)" do
     before do
-      CSV.stubs(:read).returns([
-        ["test-taxon-1", "/test/slug/1"],
-        ["test-taxon-2 > test-taxon-3", "/test/slug/2"]
-      ])
+      @temp_taxon_file = Tempfile.new("taxon_finder_test.csv")
+      @temp_taxon_file.write("test-taxon-1\t/test/slug/1\ntest-taxon-2 > test-taxon-3\t/test/slug/2\n")
+      @temp_taxon_file.close
+      ::TaxonomyPrototype::DataDownloader.stubs(:cache_location).returns(@temp_taxon_file.path)
+    end
+
+    after do
+      @temp_taxon_file.unlink
     end
 
     it "returns a taxon when given a matching slug" do


### PR DESCRIPTION
This now exercises the logic in TaxonFinder using a tempfile that contains
fixture data that matches the form expected of a typical input CSV file.
This approach more completely tests the unit as a whole, including the
config for how a CSV should be read.
