### PR TITLE
Index documents from published_documents message exchange

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,3 +38,4 @@ group :development do
 end
 
 gem "pry-byebug", group: [:development, :test]
+gem "govuk_message_queue_consumer", "~> 2.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,11 @@ GEM
     airbrake (4.0.0)
       builder
       multi_json
+    amq-protocol (2.0.1)
     ansi (1.4.3)
     builder (3.1.3)
+    bunny (2.2.2)
+      amq-protocol (>= 2.0.1)
     byebug (8.2.0)
     celluloid (0.14.1)
       timers (>= 1.0.0)
@@ -32,6 +35,8 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
+    govuk_message_queue_consumer (2.0.0)
+      bunny (~> 2.2.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.6.0)
@@ -147,6 +152,7 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   ci_reporter (= 1.7.1)
   gds-api-adapters (= 26.7.0)
+  govuk_message_queue_consumer (~> 2.0.0)
   logging (= 1.8.1)
   minitest (= 4.6.1)
   mocha

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 worker: bundle exec sidekiq -C ./config/sidekiq.yml
+publishing-api-document-indexer: bundle exec rake message_queue:index_documents_from_publishing_api

--- a/lib/index_documents.rb
+++ b/lib/index_documents.rb
@@ -1,0 +1,86 @@
+require_relative "../app"
+require 'gds_api/publishing_api_v2'
+
+class IndexDocuments
+  def process(message)
+    raw_links = links_from_payload(message)
+
+    if !raw_links.nil? && !raw_links.empty?
+      links = remap_keys(raw_links, content_tagger_to_rummager_map)
+      links.each do |(link_type, content_ids)|
+        links[link_type] = paths_from_content_ids(content_ids)
+      end
+
+      base_path = document_base_path(message)
+      update_index(base_path, links)
+    end
+
+    message.ack
+  end
+
+private
+  def links_from_payload(message)
+    message.payload["links"].try(:slice, *content_tagger_tags)
+  end
+
+  def paths_from_content_ids(content_ids)
+    content_ids.map { |content_id| base_path content_id }.compact.sort
+  end
+
+  def content_tagger_tags
+    %w{
+      mainstream_browse_page
+      parent
+      topics
+      organisations
+    }
+  end
+
+  def content_tagger_to_rummager_map
+    {
+      "topics" => "specialist_sectors",
+      "organisations" => "lead_organisations",
+      "mainstream_browse_page" => "mainstream_browse_pages",
+      "parent" => "parent",
+    }
+  end
+
+  def remap_keys(hash, keymap)
+    Hash[hash.map {|k, v| [keymap[k], v] }]
+  end
+
+  def document_base_path(message)
+    message.payload["base_path"]
+  end
+
+  def base_path(content_id)
+    GdsApi::PublishingApiV2.new(Plek.current.find('publishing-api')).get_content(content_id)["base_path"]
+  end
+
+  def update_index(base_path, links)
+    indices_with_base_path(base_path).map do |index|
+      index.amend(base_path, links)
+    end
+  end
+
+  def indices_with_base_path(document_base_path)
+    indices_to_search = search_server.index_for_search(search_config.content_index_names)
+    results = indices_to_search.raw_search(query: {term: {link: document_base_path}})
+
+    indices = results["hits"]["hits"].map do |hit|
+      Elasticsearch::Index.strip_alias_from_index_name(hit["_index"])
+    end
+
+    indices.map do |index|
+      search_server.index(index)
+    end
+  end
+
+  def search_server
+    @search_server ||= search_config.search_server
+  end
+
+  def search_config
+    @search_config ||= Rummager.settings.search_config
+  end
+end

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -1,0 +1,20 @@
+namespace :message_queue do
+  desc "Index documents that are published to the publishing-api"
+  task :index_documents_from_publishing_api do
+    # The following environment variables need to be set
+    # RABBITMQ_HOSTS
+    # RABBITMQ_VHOST
+    # RABBITMQ_USER
+    # RABBITMQ_PASSWORD
+
+    require 'govuk_message_queue_consumer'
+    require_relative '../index_documents'
+
+    # routing_key is defaulted to '#'
+    GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "rummager_to_be_indexed",
+      exchange_name: "published_documents",
+      processor: IndexDocuments.new,
+    ).run
+  end
+end

--- a/test/integration/index_documents_test.rb
+++ b/test/integration/index_documents_test.rb
@@ -1,0 +1,71 @@
+require "integration_test_helper"
+require 'govuk_message_queue_consumer'
+require 'govuk_message_queue_consumer/test_helpers'
+require './lib/index_documents'
+
+class IndexDocumentsTest < IntegrationTest
+  include IndexDocumentsTestHelpers
+
+  def setup
+    stub_elasticsearch_settings
+    create_test_indexes
+    stub_tagging_lookup
+    stub_calls_for_index_documents_test
+  end
+
+  def teardown
+    clean_test_indexes
+  end
+
+  def test_topics_get_indexed_from_publishing_api
+    Elasticsearch::Amender.any_instance.expects(:amend)
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_with_topics)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def test_empty_topics_get_indexed_from_publishing_api
+    Elasticsearch::Amender.any_instance.expects(:amend)
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_empty_topics)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def test_no_topics_no_update
+    Elasticsearch::Amender.any_instance.expects(:amend).never
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_no_topics)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def test_no_links_no_update
+    Elasticsearch::Amender.any_instance.expects(:amend).never
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_no_links)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def payload_with_topics
+    payload_empty_topics.merge({"links" => {"topics" => ["cc9eb8ab-7701-43a7-a66d-bdc5046224c0"]}})
+  end
+
+  def payload_empty_topics
+    payload_no_topics.merge({"links" => {"topics" => []}})
+  end
+
+  def payload_no_topics
+    payload_no_links.merge({"links" => {}})
+  end
+
+  def payload_no_links
+    { "base_path" => "/topic/animal-welfare/pets" }
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -3,3 +3,4 @@ require "app"
 require "elasticsearch/search_server"
 require "sidekiq/testing/inline"  # Make all queued jobs run immediately
 require "support/integration_test"
+require "support/index_document_test_helpers"

--- a/test/support/index_document_test_helpers.rb
+++ b/test/support/index_document_test_helpers.rb
@@ -1,0 +1,140 @@
+module IndexDocumentsTestHelpers
+  # There are quite a few api calls made when expanding/indexing
+  # data when topics are updated.
+
+  # Hide the stub requests in this helper
+  def stub_calls_for_index_documents_test
+    stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/cc9eb8ab-7701-43a7-a66d-bdc5046224c0").
+      to_return(status: 200, body: { id: 1234, base_path: "/ooo/aar" }.to_json)
+
+    stub_request(:get, "http://localhost:9200/mainstream_test,government_test/_search").
+      with(body: {query: {term: {link: "/topic/animal-welfare/pets"}}}.to_json).
+      to_return(status: 200, body: pet_topic_search_response_data)
+
+    stub_request(:get, "http://localhost:9200/mainstream_test/edition/%2Ftopic%2Fanimal-welfare%2Fpets").
+      to_return(status: 200, body: pets_search_result)
+
+    stub_request(:post, "http://localhost:9200/mainstream_test/_bulk").
+      with(body: post_no_specialist_sectors_to_elasticsearch).
+      to_return(status: 200, body: no_specialist_sectors_elasticsearch_post_response)
+
+    stub_request(:post, "http://localhost:9200/mainstream_test/_bulk").
+      with(body: post_specialist_sectors_to_elasticsearch).
+      to_return(status: 200, body: specialist_sectors_post_response)
+  end
+
+  def pet_topic_search_response_data
+    {
+      hits: {
+        hits: [
+          {
+            _index: "mainstream_test-2016-01-04t14:17:28z-00000000-0000-0000-0000-000000000000",
+            _type: "edition",
+            _id: "/topic/animal-welfare/pets",
+            _source: {
+              slug: "animal-welfare/pets",
+              description: "Info about pets.",
+              format: "specialist_sector",
+              link: "/topic/animal-welfare/pets",
+              title: "Pets",
+              _type: "edition",
+              _id: "/topic/animal-welfare/pets"
+            }
+          }
+        ]
+      }
+    }.to_json
+  end
+
+  def post_specialist_sectors_to_elasticsearch
+    # bulk operation receives multiple JSON objects joined by newlines
+    [
+      {
+        index: {
+          _type: "edition",
+          _id: "/topic/animal-welfare/pets"
+        }
+      }.to_json,
+      {
+        slug: "animal-welfare/pets",
+        specialist_sectors: ["/ooo/aar"],
+        description: "Info about pets.",
+        format: "specialist_sector",
+        link: "/topic/animal-welfare/pets",
+        title: "Pets",
+        _type: "edition",
+        _id: "/topic/animal-welfare/pets"
+      }.to_json
+    ].join("\n")
+  end
+
+  def post_no_specialist_sectors_to_elasticsearch
+    # bulk operation receives multiple JSON objects joined by newlines
+    [
+      {
+        index: {
+          _type: "edition",
+          _id: "/topic/animal-welfare/pets"
+        }
+      }.to_json,
+      {
+        popularity: "5.6085249579360626e-05",
+        slug: "animal-welfare/pets",
+        description: "Info about pets.",
+        format: "specialist_sector",
+        link: "/topic/animal-welfare/pets",
+        title: "Pets",
+        _type: "edition",
+        _id: "/topic/animal-welfare/pets"
+      }.to_json
+    ].join("\n")
+  end
+
+  def no_specialist_sectors_elasticsearch_post_response
+    {
+      items: [
+        {
+          index: {
+            _index: "mainstream_test-2016-01-04t14:17:28z-00000000-0000-0000-0000-000000000000",
+            _type: "edition",
+            _id: "/topic/animal-welfare/pets",
+            status: 200
+          }
+        }
+      ]
+    }.to_json
+  end
+
+  def specialist_sectors_post_response
+    {
+      items: [
+        {
+          index: {
+            _index: "mainstream_test-2016-01-04t14:17:28z-00000000-0000-0000-0000-000000000000",
+            _type: "edition",
+            _id: "/topic/animal-welfare/pets",
+            status: 200
+          }
+        }
+      ]
+    }.to_json
+  end
+
+  def pets_search_result
+    {
+      _index: "mainstream_test-2016-01-04t14:17:28z-00000000-0000-0000-0000-000000000000",
+      _type: "edition",
+      _id: "/topic/animal-welfare/pets",
+      found: true,
+      _source: {
+        slug: "animal-welfare/pets",
+        description: "Info about pets.",
+        format: "specialist_sector",
+        link: "/topic/animal-welfare/pets",
+        title: "Pets",
+        _type: "edition",
+        _id: "/topic/animal-welfare/pets"
+      }
+    }.to_json
+  end
+end


### PR DESCRIPTION
Currently, changes to topics and other tags in content-tagger don't cause the search index (accessed via rummager) to be updated correspondingly. We want such changes to be reflected as soon as possible in the search index.

Part of: https://trello.com/c/lRnxI2x5/472-make-rummager-index-the-tags-in-the-links-hash
