### PR TITLE
Index selected links for published documents sent to publishing api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,3 +38,4 @@ group :development do
 end
 
 gem "pry-byebug", group: [:development, :test]
+gem "govuk_message_queue_consumer", "~> 2.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,11 @@ GEM
     airbrake (4.0.0)
       builder
       multi_json
+    amq-protocol (2.0.1)
     ansi (1.4.3)
     builder (3.1.3)
+    bunny (2.2.2)
+      amq-protocol (>= 2.0.1)
     byebug (8.2.0)
     celluloid (0.14.1)
       timers (>= 1.0.0)
@@ -32,6 +35,8 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
+    govuk_message_queue_consumer (2.0.0)
+      bunny (~> 2.2.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.6.0)
@@ -147,6 +152,7 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   ci_reporter (= 1.7.1)
   gds-api-adapters (= 26.7.0)
+  govuk_message_queue_consumer (~> 2.0.0)
   logging (= 1.8.1)
   minitest (= 4.6.1)
   mocha

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 worker: bundle exec sidekiq -C ./config/sidekiq.yml
+publishing-api-document-indexer: bundle exec rake message_queue:index_documents_from_publishing_api

--- a/lib/index_documents.rb
+++ b/lib/index_documents.rb
@@ -1,0 +1,96 @@
+require_relative "../app"
+require 'gds_api/publishing_api_v2'
+
+class IndexDocuments
+  MIGRATED_TAGGING_APPS = %w{
+    businesssupportfinder
+    calculators
+    calendars
+    hmrc-manuals-api
+    licencefinder
+    policy-publisher
+    smartanswers
+  }
+
+  def process(message)
+    if publishing_app_migrated?(message)
+      raw_links = links_from_payload(message)
+
+      unless raw_links.empty?
+        links = rummager_fields_from_links(raw_links)
+        base_path = document_base_path(message)
+        update_index(base_path, links)
+      end
+    end
+
+    message.ack
+  end
+
+private
+  def publishing_app_migrated?(message)
+    MIGRATED_TAGGING_APPS.include? message.payload["publishing_app"]
+  end
+
+  def links_from_payload(message)
+    message.payload.fetch("links", {})
+  end
+
+  def rummager_fields_from_links(links)
+    results = {}
+    rummager_field_mappers.each { |field_name, mapper|
+      field_values = mapper.call(links)
+      if field_values
+        results[field_name] = field_values
+      end
+    }
+    results
+  end
+
+  def rummager_field_mappers
+    {
+      "mainstream_browse_pages" => lambda { |links| sorted_link_paths(links, "mainstream_browse_pages") },
+      "organisations" => lambda { |links| (sorted_link_paths(links, "lead_organisations") + sorted_link_paths(links, "organisations")).uniq },
+      "specialist_sectors" => lambda { |links| sorted_link_paths(links, "topics") },
+    }
+  end
+
+  def sorted_link_paths(links, link_types)
+    links.fetch(link_types, []).map { |content_id| base_path(content_id) }.compact.sort
+  end
+
+  def document_base_path(message)
+    message.payload.fetch("base_path")
+  end
+
+  def base_path(content_id)
+    publishing_api.get_content(content_id)["base_path"]
+  end
+
+  def update_index(base_path, links)
+    indices_with_base_path(base_path).map do |index|
+      index.amend(base_path, links)
+    end
+  end
+
+  def indices_with_base_path(document_base_path)
+    indices_to_search = search_server.index_for_search(search_config.content_index_names)
+    results = indices_to_search.raw_search(query: {term: {link: document_base_path}})
+
+    indices = results["hits"]["hits"].map do |hit|
+      index = Elasticsearch::Index.strip_alias_from_index_name(hit["_index"])
+      search_server.index(index) if index
+    end
+  end
+
+  def publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(Plek.current.find('publishing-api'))
+  end
+
+  def search_server
+    @search_server ||= search_config.search_server
+  end
+
+  def search_config
+    @search_config ||= Rummager.settings.search_config
+  end
+end

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -1,0 +1,20 @@
+namespace :message_queue do
+  desc "Index documents that are published to the publishing-api"
+  task :index_documents_from_publishing_api do
+    # The following environment variables need to be set
+    # RABBITMQ_HOSTS
+    # RABBITMQ_VHOST
+    # RABBITMQ_USER
+    # RABBITMQ_PASSWORD
+
+    require 'govuk_message_queue_consumer'
+    require_relative '../index_documents'
+
+    # routing_key is defaulted to '#'
+    GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "rummager_to_be_indexed",
+      exchange_name: "published_documents",
+      processor: IndexDocuments.new,
+    ).run
+  end
+end

--- a/test/integration/index_documents_test.rb
+++ b/test/integration/index_documents_test.rb
@@ -1,0 +1,131 @@
+require "integration_test_helper"
+require 'govuk_message_queue_consumer'
+require 'govuk_message_queue_consumer/test_helpers'
+require './lib/index_documents'
+
+class IndexDocumentsTest < IntegrationTest
+  include IndexDocumentsTestHelpers
+
+  def setup
+    stub_elasticsearch_settings
+    create_test_indexes
+    stub_tagging_lookup
+    stub_calls_for_index_documents_test
+  end
+
+  def teardown
+    clean_test_indexes
+  end
+
+  def test_populated_tags_get_indexed_from_publishing_api
+    Elasticsearch::Amender.any_instance.expects(:amend)
+      .with('/topic/animal-welfare/pets', {
+              "mainstream_browse_pages" => ['/path/2'],
+              "organisations" => ['/path/3'],
+              "specialist_sectors" => ['/path/1'],
+            })
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_with_tags)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def test_empty_tags_get_indexed_from_publishing_api
+    Elasticsearch::Amender.any_instance.expects(:amend)
+      .with('/topic/animal-welfare/pets', {
+              "mainstream_browse_pages" => [],
+              "organisations" => [],
+              "specialist_sectors" => [],
+            })
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_empty_tags)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def test_no_tags_no_update
+    Elasticsearch::Amender.any_instance.expects(:amend).never
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_no_tags)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def test_no_links_no_update
+    Elasticsearch::Amender.any_instance.expects(:amend).never
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_no_links)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def test_migrated_publishing_app_sorts_links
+    Elasticsearch::Amender.any_instance.expects(:amend)
+      .with('/topic/animal-welfare/pets', {
+              "mainstream_browse_pages" => [],
+              "organisations" => [],
+              "specialist_sectors" => sorted_links,
+            })
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_migrated_publishing_app)
+    IndexDocuments.new.process(m)
+  end
+
+  def test_non_migrated_publishing_app_no_update
+    Elasticsearch::Amender.any_instance.expects(:amend).never
+
+    m = GovukMessageQueueConsumer::MockMessage.new(payload_non_migrated_publishing_app)
+    IndexDocuments.new.process(m)
+
+    assert m.acked?
+  end
+
+  def sorted_links
+    ['/path/1', '/path/2', '/path/3']
+  end
+
+
+  def payload_non_migrated_publishing_app
+    payload_no_tags.merge({
+                            "publishing_app" => "other-app",
+                          })
+  end
+
+  def payload_migrated_publishing_app
+    payload_with_tags.merge({
+                              "links" => {
+                                "topics" => ["uuid-3", "uuid-2", "uuid-1"],
+                              }
+                            })
+  end
+
+  def payload_with_tags
+    payload_empty_tags.merge({ "links" => {
+                                   "topics" => ["uuid-1"],
+                                   "mainstream_browse_pages" => ["uuid-2"],
+                                   "organisations" => ["uuid-3"],
+                                 }})
+  end
+
+  def payload_empty_tags
+    payload_no_tags.merge({ "links" => {
+                                "topics" => [],
+                                "mainstream_browse_page" => [],
+                                "organisations" => [],
+                              }})
+  end
+
+  def payload_no_tags
+    payload_no_links.merge({"links" => {}})
+  end
+
+  def payload_no_links
+    {
+      "base_path" => "/topic/animal-welfare/pets",
+      "publishing_app" => "policy-publisher",
+    }
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -3,3 +3,4 @@ require "app"
 require "elasticsearch/search_server"
 require "sidekiq/testing/inline"  # Make all queued jobs run immediately
 require "support/integration_test"
+require "support/index_document_test_helpers"

--- a/test/support/index_document_test_helpers.rb
+++ b/test/support/index_document_test_helpers.rb
@@ -1,0 +1,146 @@
+module IndexDocumentsTestHelpers
+  # There are quite a few api calls made when expanding/indexing
+  # data when topics are updated.
+
+  # Hide the stub requests in this helper
+  def stub_calls_for_index_documents_test
+    stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/uuid-1").
+      to_return(status: 200, body: { id: 1111, base_path: "/path/1" }.to_json)
+
+    stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/uuid-2").
+      to_return(status: 200, body: { id: 2222, base_path: "/path/2" }.to_json)
+
+    stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/uuid-3").
+      to_return(status: 200, body: { id: 3333, base_path: "/path/3" }.to_json)
+
+    stub_request(:get, "http://localhost:9200/mainstream_test,government_test/_search").
+      with(body: {query: {term: {link: "/topic/animal-welfare/pets"}}}.to_json).
+      to_return(status: 200, body: pet_topic_search_response_data)
+
+    stub_request(:get, "http://localhost:9200/mainstream_test/edition/%2Ftopic%2Fanimal-welfare%2Fpets").
+      to_return(status: 200, body: pets_search_result)
+
+    stub_request(:post, "http://localhost:9200/mainstream_test/_bulk").
+      with(body: post_no_specialist_sectors_to_elasticsearch).
+      to_return(status: 200, body: no_specialist_sectors_elasticsearch_post_response)
+
+    stub_request(:post, "http://localhost:9200/mainstream_test/_bulk").
+      with(body: post_specialist_sectors_to_elasticsearch).
+      to_return(status: 200, body: specialist_sectors_post_response)
+  end
+
+  def pet_topic_search_response_data
+    {
+      hits: {
+        hits: [
+          {
+            _index: "mainstream_test-2016-01-04t14:17:28z-00000000-0000-0000-0000-000000000000",
+            _type: "edition",
+            _id: "/topic/animal-welfare/pets",
+            _source: {
+              slug: "animal-welfare/pets",
+              description: "Info about pets.",
+              format: "specialist_sector",
+              link: "/topic/animal-welfare/pets",
+              title: "Pets",
+              _type: "edition",
+              _id: "/topic/animal-welfare/pets"
+            }
+          }
+        ]
+      }
+    }.to_json
+  end
+
+  def post_specialist_sectors_to_elasticsearch
+    # bulk operation receives multiple JSON objects joined by newlines
+    [
+      {
+        index: {
+          _type: "edition",
+          _id: "/topic/animal-welfare/pets"
+        }
+      }.to_json,
+      {
+        slug: "animal-welfare/pets",
+        specialist_sectors: ["/path/1"],
+        description: "Info about pets.",
+        format: "specialist_sector",
+        link: "/topic/animal-welfare/pets",
+        title: "Pets",
+        _type: "edition",
+        _id: "/topic/animal-welfare/pets"
+      }.to_json
+    ].join("\n")
+  end
+
+  def post_no_specialist_sectors_to_elasticsearch
+    # bulk operation receives multiple JSON objects joined by newlines
+    [
+      {
+        index: {
+          _type: "edition",
+          _id: "/topic/animal-welfare/pets"
+        }
+      }.to_json,
+      {
+        popularity: "5.6085249579360626e-05",
+        slug: "animal-welfare/pets",
+        description: "Info about pets.",
+        format: "specialist_sector",
+        link: "/topic/animal-welfare/pets",
+        title: "Pets",
+        _type: "edition",
+        _id: "/topic/animal-welfare/pets"
+      }.to_json
+    ].join("\n")
+  end
+
+  def no_specialist_sectors_elasticsearch_post_response
+    {
+      items: [
+        {
+          index: {
+            _index: "mainstream_test-2016-01-04t14:17:28z-00000000-0000-0000-0000-000000000000",
+            _type: "edition",
+            _id: "/topic/animal-welfare/pets",
+            status: 200
+          }
+        }
+      ]
+    }.to_json
+  end
+
+  def specialist_sectors_post_response
+    {
+      items: [
+        {
+          index: {
+            _index: "mainstream_test-2016-01-04t14:17:28z-00000000-0000-0000-0000-000000000000",
+            _type: "edition",
+            _id: "/topic/animal-welfare/pets",
+            status: 200
+          }
+        }
+      ]
+    }.to_json
+  end
+
+  def pets_search_result
+    {
+      _index: "mainstream_test-2016-01-04t14:17:28z-00000000-0000-0000-0000-000000000000",
+      _type: "edition",
+      _id: "/topic/animal-welfare/pets",
+      found: true,
+      _source: {
+        slug: "animal-welfare/pets",
+        description: "Info about pets.",
+        format: "specialist_sector",
+        link: "/topic/animal-welfare/pets",
+        title: "Pets",
+        _type: "edition",
+        _id: "/topic/animal-welfare/pets"
+      }
+    }.to_json
+  end
+end


### PR DESCRIPTION
Currently, changes to topics and other tags in content-tagger don't cause the search index (accessed via rummager) to be updated correspondingly. We want such changes to be reflected as soon as possible in the search index.

Part of: https://trello.com/c/lRnxI2x5/472-make-rummager-index-the-tags-in-the-links-hash
