### PR TITLE
Add a withdrawn field to all document types

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For the most up to date query syntax and API output:
 - [docs/unified-search-api.md](docs/unified-search-api.md) for the unified search
   endpoint (`/unified-search.json`).
 - [docs/content-api.md](docs/content-api.md) for the `/content/*` endpoint.
+- [docs/documents.md](docs/documents.md) for the `*/documents/` endpoint.
 
 ### Additional Docs
 

--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -5,6 +5,7 @@
     "description",
     "format",
     "indexable_content",
+    "is_withdrawn",
     "latest_change_note",
     "link",
     "mainstream_browse_pages",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -308,6 +308,11 @@
     "type": "boolean"
   },
 
+  "is_withdrawn": {
+    "description": "If the content has been published but then withdrawn",
+    "type": "boolean"
+  },
+
   "government_name": {
     "description": "The name of the Government that first published this document, eg, '1970 to 1974 Conservative government'",
     "type": "unsearchable_text"

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -1,0 +1,38 @@
+## Rummager Documents API
+
+### `POST /:index/documents`
+
+Insert or overwrite a document.
+
+There must be a link attribute in the JSON body.
+
+Any fields which are not part of the schema for the document type you are posting
+will be silently ignored (see config/schema).
+
+#### Example request and response
+
+```json
+{
+    "organisations": [
+      "department-for-transport",
+      "driver-and-vehicle-licensing-agency"
+    ],
+    "public_timestamp": "2014-12-09T16:21:03+00:00",
+    "description": "Renew or tax your vehicle for the first time, apply online, by phone or at the Post Office",
+    "format": "transaction",
+    "link": "/vehicle-tax",
+    "mainstream_browse_pages": [
+      "driving/car-tax-discs"
+    ],
+    "title": "Tax your vehicle",
+    "_type": "edition",
+    "_id": "/vehicle-tax",
+    "specialist_sectors": []
+}
+```
+
+```json
+{
+  "result": "OK"
+}
+```

--- a/lib/elasticsearch/advanced_search_query_builder.rb
+++ b/lib/elasticsearch/advanced_search_query_builder.rb
@@ -128,7 +128,12 @@ module Elasticsearch
     end
 
     def filter_query_hash
+      # Withdrawn documents should never be part of advanced search
+      withdrawn_query = {"not" => { "term" => {"is_withdrawn" => true } } }
+
       filters = filters_hash
+      filters << withdrawn_query
+
       if filters.size > 1
         filters = {"and" => filters}
       else

--- a/lib/elasticsearch/queries.rb
+++ b/lib/elasticsearch/queries.rb
@@ -1,0 +1,45 @@
+module Elasticsearch
+  # Mixin for building elasticsearch queries
+  module Queries
+  private
+
+    # Combine filters using an operator
+    #
+    # `filters` should be a sequence of filters. nil filters are ignored.
+    # `op` should be :and or :or
+    #
+    # If 0 non-nil filters are supplied, returns nil.  Otherwise returns the
+    # elasticsearch query required to match the filters
+    def combine_filters(filters, op)
+      filters = filters.compact
+      if filters.length == 0
+        nil
+      elsif filters.length == 1
+        filters.first
+      else
+        {op => filters}
+      end
+    end
+
+    def terms_filter(field_name, values)
+      return nil if values.size == 0
+
+      {"terms" => { field_name => values } }
+    end
+
+    def term_filter(field_name, value)
+      {"term" => { field_name => value } }
+    end
+
+    def date_filter(field_name, value)
+      {
+        "range" => {
+          field_name => {
+            "from" => value["from"].iso8601,
+            "to" => value["to"].iso8601,
+          }.reject { |_, v| v.nil? }
+        }
+      }
+    end
+  end
+end

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -299,6 +299,10 @@ private
         options[:new_weighting] = true
       when "explain"
         options[:explain] = true
+      when "include_withdrawn"
+        # Withdrawn content is excluded from regular searches but is useful for
+        # content audits
+        options[:include_withdrawn] = true
       else
         @errors << %{Unknown debug option "#{option}"}
       end

--- a/lib/query_components/filter.rb
+++ b/lib/query_components/filter.rb
@@ -1,102 +1,52 @@
+require "query_components/user_filter"
+require "query_components/visibility_filter"
+require 'elasticsearch/queries'
+
 module QueryComponents
   class Filter < BaseComponent
-    def payload(excluding = [])
-      rejects = []
-      filters = []
+    include Elasticsearch::Queries
 
-      param_filters = search_params.filters.reject do |filter|
-        excluding.include?(filter.field_name)
-      end
+    def payload(excluded_field_names = [])
+      user_filter = QueryComponents::UserFilter.new(search_params)
+      visibility_filter = QueryComponents::VisibilityFilter.new(search_params)
 
-      param_filters.each do |filter|
-        if filter.reject
-          rejects << filter_hash(filter)
-        else
-          filters << filter_hash(filter)
-        end
-      end
+      user_rejected = combine_filters(
+        user_filter.rejected_queries(excluded_field_names),
+        :and
+      )
+      visibility_rejected = combine_filters(
+        visibility_filter.rejected_queries,
+        :and
+      )
+      all_rejected_queries = [user_rejected, visibility_rejected]
 
-      filters = combine_filters(filters, :and)
-      rejects = combine_filters(rejects, :and)
+      # *all* filters must be true to *include* in the result
+      selected = combine_filters(user_filter.selected_queries(excluded_field_names), :and)
 
-      if filters
-        if rejects
+      # *any* rejects can be true to *exclude* from the result
+      rejected = combine_filters(all_rejected_queries, :or)
+
+
+      if selected
+        if rejected
           {
             bool: {
-              must: filters,
-              must_not: rejects,
+              must: selected,
+              must_not: rejected,
             }
           }
         else
-          filters
+          selected
         end
       else
-        if rejects
+        if rejected
           {
-            not: rejects
+            not: rejected
           }
         else
           nil
         end
       end
-    end
-
-    private
-
-    # Combine filters using an operator
-    #
-    # `filters` should be a sequence of filters. nil filters are ignored.
-    # `op` should be :and or :or
-    #
-    # If 0 non-nil filters are supplied, returns nil.  Otherwise returns the
-    # elasticsearch query required to match the filters
-    def combine_filters(filters, op)
-      filters = filters.compact
-      if filters.length == 0
-        nil
-      elsif filters.length == 1
-        filters.first
-      else
-        {op => filters}
-      end
-    end
-
-    def filter_hash(filter)
-      es_filters = []
-
-      if filter.include_missing
-        es_filters << {"missing" => { field: filter.field_name } }
-      end
-
-      case filter.type
-      when "string"
-        es_filters << terms_filter(filter)
-      when "date"
-        es_filters << date_filter(filter)
-      else
-        raise "Filter type not supported"
-      end
-
-      combine_filters(es_filters, :or)
-    end
-
-    def terms_filter(filter)
-      if filter.values.size > 0
-        {"terms" => { filter.field_name => filter.values } }
-      end
-    end
-
-    def date_filter(filter)
-      value = filter.values.first
-
-      {
-        "range" => {
-          filter.field_name => {
-            "from" => value["from"].iso8601,
-            "to" => value["to"].iso8601,
-          }.reject { |_, v| v.nil? }
-        }
-      }
     end
   end
 end

--- a/lib/query_components/user_filter.rb
+++ b/lib/query_components/user_filter.rb
@@ -1,0 +1,64 @@
+require 'elasticsearch/queries'
+
+module QueryComponents
+  class UserFilter < BaseComponent
+    include Elasticsearch::Queries
+
+    attr_reader :rejects, :filters
+
+    def initialize(search_params = SearchParameters.new)
+      super
+
+      @rejects = []
+      @filters = []
+
+      search_params.filters.each do |filter|
+        if filter.reject
+          @rejects << filter
+        else
+          @filters << filter
+        end
+      end
+    end
+
+    def selected_queries(excluding = [])
+      remaining = exclude_fields_from_filters(excluding, filters)
+      remaining.map {|filter| filter_hash(filter)}
+    end
+
+    def rejected_queries(excluding = [])
+      remaining = exclude_fields_from_filters(excluding, rejects)
+      remaining.map {|filter| filter_hash(filter)}
+    end
+
+  private
+
+    def filter_hash(filter)
+      es_filters = []
+
+      if filter.include_missing
+        es_filters << {"missing" => { field: filter.field_name } }
+      end
+
+      field_name = filter.field_name
+      values = filter.values
+
+      case filter.type
+      when "string"
+        es_filters << terms_filter(field_name, values)
+      when "date"
+        es_filters << date_filter(field_name, values.first)
+      else
+        raise "Filter type not supported"
+      end
+
+      combine_filters(es_filters, :or)
+    end
+
+    def exclude_fields_from_filters(excluded_field_names, filters)
+      filters.reject do |filter|
+        excluded_field_names.include?(filter.field_name)
+      end
+    end
+  end
+end

--- a/lib/query_components/visibility_filter.rb
+++ b/lib/query_components/visibility_filter.rb
@@ -1,0 +1,13 @@
+require 'elasticsearch/queries'
+
+module QueryComponents
+  class VisibilityFilter < BaseComponent
+    include Elasticsearch::Queries
+
+    def rejected_queries
+      return [] if search_params.debug[:include_withdrawn]
+
+      [term_filter("is_withdrawn", true)]
+    end
+  end
+end

--- a/test/integration/unified_search_test.rb
+++ b/test/integration/unified_search_test.rb
@@ -413,6 +413,34 @@ class UnifiedSearchTest < IntegrationTest
     assert result_links.include? "/mainstream-1"
   end
 
+  def test_withdrawn_content
+    reset_content_indexes
+
+    commit_document("mainstream_test",
+      title: "I am the result",
+      description: "This is a test search result",
+      link: "/some-nice-link",
+      is_withdrawn: true
+    )
+
+    get "/unified_search?q=test"
+    assert_equal 0, parsed_response.fetch("total")
+  end
+
+  def test_withdrawn_content_with_flag
+    reset_content_indexes
+
+    commit_document("mainstream_test",
+      title: "I am the result",
+      description: "This is a test search result",
+      link: "/some-nice-link",
+      is_withdrawn: true
+    )
+
+    get "/unified_search?q=test&debug=include_withdrawn"
+    assert_equal 1, parsed_response.fetch("total")
+  end
+
   private
 
   def first_result

--- a/test/unit/elasticsearch/advanced_search_query_builder_test.rb
+++ b/test/unit/elasticsearch/advanced_search_query_builder_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+require "elasticsearch/advanced_search_query_builder"
+
+class AdvancedSearchQueryBuilderTest < MiniTest::Unit::TestCase
+  include Fixtures::DefaultMappings
+
+  def build_builder(keywords = "", filter_params = {}, sort_order = {}, mappings = default_mappings)
+    Elasticsearch::AdvancedSearchQueryBuilder.new(keywords, filter_params, sort_order, mappings)
+  end
+
+  def test_builder_excludes_withdrawn
+    builder = build_builder
+    query_hash = builder.filter_query_hash
+
+    assert_equal(
+      query_hash,
+      {
+        "filter" => {
+          "not" => { "term" => {"is_withdrawn" => true} }
+        }
+      }
+    )
+  end
+
+
+  def test_builder_single_filters
+    builder = build_builder("how to drive", {"format" => "organisation"})
+    query_hash = builder.filter_query_hash
+
+    assert_equal(
+      query_hash,
+      {
+        "filter" => {
+          "and" => [
+            { "term" => {"format" => "organisation"} },
+            { "not" => { "term" => {"is_withdrawn" => true} } }
+          ]
+        }
+      }
+    )
+  end
+
+  def test_builder_multiple_filters
+    builder = build_builder("how to drive", {"format" => "organisation", "specialist_sectors" => "driving"})
+    query_hash = builder.filter_query_hash
+
+    assert_equal(
+      query_hash,
+      {
+        "filter" => {
+          "and" => [
+            { "term" => {"format" => "organisation"} },
+            { "term" => {"specialist_sectors" => "driving"} },
+            { "not" => { "term" => {"is_withdrawn" => true} } }
+          ]
+        }
+      }
+    )
+  end
+end

--- a/test/unit/query_components/facets_test.rb
+++ b/test/unit/query_components/facets_test.rb
@@ -2,11 +2,19 @@ require "test_helper"
 require "unified_search_builder"
 
 class FacetsTest < ShouldaUnitTestCase
+  def make_search_params(facets:, filters: [])
+    SearchParameters.new(
+      filters: filters, facets: facets, debug: { include_withdrawn: true }
+    )
+  end
+
   context "search with facet" do
     should "have correct facet in payload" do
-      builder = QueryComponents::Facets.new(search_query_params(
-        facets: { "organisations" => { requested: 10, scope: :exclude_field_filter } },
-      ))
+      builder = QueryComponents::Facets.new(
+        make_search_params(
+          facets: { "organisations" => { requested: 10, scope: :exclude_field_filter } },
+        )
+      )
 
       result = builder.payload
 
@@ -28,8 +36,8 @@ class FacetsTest < ShouldaUnitTestCase
   context "search with facet and filter on same field" do
     setup do
       @builder = QueryComponents::Facets.new(
-        SearchParameters.new(
-          filters: [ text_filter("organisations", ["hm-magic"]) ],
+        make_search_params(
+          filters: [text_filter("organisations", ["hm-magic"])],
           facets: {"organisations" => {requested: 10, scope: :exclude_field_filter}},
         )
       )
@@ -53,8 +61,8 @@ class FacetsTest < ShouldaUnitTestCase
   context "search with facet and filter on same field, and scope set to all_filters" do
     setup do
       @builder = QueryComponents::Facets.new(
-        SearchParameters.new(
-          filters: [ text_filter("organisations", ["hm-magic"]) ],
+        make_search_params(
+          filters: [text_filter("organisations", ["hm-magic"])],
           facets: {"organisations" => {requested: 10, scope: :all_filters}},
         )
       )
@@ -81,8 +89,8 @@ class FacetsTest < ShouldaUnitTestCase
   context "search with facet and filter on different field" do
     setup do
       @builder = QueryComponents::Facets.new(
-        SearchParameters.new(
-          filters: [ text_filter("mainstream_browse_pages", "levitation") ],
+        make_search_params(
+          filters: [text_filter("mainstream_browse_pages", "levitation")],
           facets: {"organisations" => {requested: 10, scope: :exclude_field_filter}},
         )
       )

--- a/test/unit/query_components/filter_test.rb
+++ b/test/unit/query_components/filter_test.rb
@@ -2,10 +2,14 @@ require "test_helper"
 require "unified_search_builder"
 
 class FilterTest < ShouldaUnitTestCase
+  def make_search_params(filters, include_withdrawn: true)
+    SearchParameters.new(filters: filters, debug: {include_withdrawn: include_withdrawn})
+  end
+
   context "search with one filter" do
     should "append the correct text filters" do
       builder = QueryComponents::Filter.new(
-        SearchParameters.new(filters: [ text_filter("organisations", ["hm-magic"]) ])
+        make_search_params([text_filter("organisations", ["hm-magic"])])
       )
 
       result = builder.payload
@@ -18,14 +22,14 @@ class FilterTest < ShouldaUnitTestCase
 
     should "append the correct date filters" do
       builder = QueryComponents::Filter.new(
-        SearchParameters.new(filters: [ make_date_filter_param("field_with_date", ["from:2014-04-01 00:00,to:2014-04-02 00:00"]) ])
+        make_search_params([make_date_filter_param("field_with_date", ["from:2014-04-01 00:00,to:2014-04-02 00:00"])])
       )
 
       result = builder.payload
 
       assert_equal(
         result,
-        {"range"=>{"field_with_date"=>{"from"=>"2014-04-01", "to"=>"2014-04-02"}}}
+        {"range" => {"field_with_date" => {"from" => "2014-04-01", "to" => "2014-04-02"}}}
       )
     end
 
@@ -37,7 +41,7 @@ class FilterTest < ShouldaUnitTestCase
   context "search with a filter with multiple options" do
     should "have correct filter" do
       builder = QueryComponents::Filter.new(
-        SearchParameters.new(filters: [ text_filter("organisations", ["hm-magic", "hmrc"]) ],)
+        make_search_params([text_filter("organisations", ["hm-magic", "hmrc"])])
       )
 
       result = builder.payload
@@ -52,8 +56,8 @@ class FilterTest < ShouldaUnitTestCase
   context "search with a filter and rejects" do
     should "have correct filter" do
       builder = QueryComponents::Filter.new(
-        SearchParameters.new(
-          filters: [
+        make_search_params(
+          [
             text_filter("organisations", ["hm-magic", "hmrc"]),
             reject_filter("mainstream_browse_pages", ["benefits"]),
           ]
@@ -75,8 +79,8 @@ class FilterTest < ShouldaUnitTestCase
   context "search with multiple filters" do
     should "have correct filter" do
       builder = QueryComponents::Filter.new(
-        SearchParameters.new(
-          filters: [
+        make_search_params(
+          [
             text_filter("organisations", ["hm-magic", "hmrc"]),
             text_filter("mainstream_browse_pages", ["levitation"]),
           ],
@@ -87,10 +91,12 @@ class FilterTest < ShouldaUnitTestCase
 
       assert_equal(
         result,
-        {:and => [
-          {"terms" => {"organisations" => ["hm-magic", "hmrc"]}},
-          {"terms" => {"mainstream_browse_pages" => ["levitation"]}},
-        ].compact}
+        {
+          and: [
+            {"terms" => {"organisations" => ["hm-magic", "hmrc"]}},
+            {"terms" => {"mainstream_browse_pages" => ["levitation"]}},
+          ].compact
+        }
       )
     end
 


### PR DESCRIPTION
This will allow us to include withdrawn documents when we do content audits.
https://trello.com/c/RkrlGszq/473-keep-items-in-search-index-when-withdrawn-but-not-redirected

If `is_withdrawn` is set on a content item, it is not returned by searches, except if a debug flag is passed in.

When we do a basic search, the elasticsearch query is built up in parts. I've refactored the `Filter` component so that it delegates to a `UserFilter` and a `VisibilityFilter`, where `VisibilityFilter` contains a query to exclude the withdrawn content.

`UserFilter` is responsible for building up filters from the search params. There was a bunch of reusable code here that used to be private methods of this component. They all manipulate hashes that are serialised into JSON for the elasticsearch request. I've moved them out into a mixin in the elasticsearch module so I can reuse them in `Filter` and `VisibilityFilter`. If there is a better place for this let me know. I suspect there might be some duplication with the advanced search logic, which has its own builder class.

`#filter_hash` is slightly different, because this operates on another class object representing a filter that is created in the search parameter parser. I've left this as a private method of the UserFilter for now but it may make sense to move this method to the filter object itself.

I still need to have a look at advanced searches as they are handled differently.
