### PR TITLE
Index collections-publisher tags

### DIFF
--- a/lib/index_documents.rb
+++ b/lib/index_documents.rb
@@ -6,6 +6,7 @@ class IndexDocuments
     businesssupportfinder
     calculators
     calendars
+    collections-publisher
     hmrc-manuals-api
     licencefinder
     policy-publisher


### PR DESCRIPTION
collections-publisher pages will be taggable with https://github.com/alphagov/content-tagger/pull/25.
