### PR TITLE
Send the bearer token to publishing-api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "sidekiq-statsd", "0.1.5"
 # pin to version that includes security vulnerability fix
 gem "redis-namespace", "1.3.1"
 gem "plek", "1.11.0"
-gem "gds-api-adapters", "26.7.0"
+gem "gds-api-adapters", "28.0.0"
 gem "rack-logstasher", "0.0.3"
 gem 'airbrake', '4.0.0'
 gem "unf", "0.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,11 +28,11 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.9.0)
-    gds-api-adapters (26.7.0)
+    gds-api-adapters (28.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     govuk_message_queue_consumer (2.0.0)
@@ -78,7 +78,7 @@ GEM
       byebug (~> 8.0)
       pry (~> 0.10)
     rack (1.6.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.0)
       rack (>= 0.4)
     rack-logstasher (0.0.3)
       logstash-event
@@ -151,7 +151,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.0.0)
   ci_reporter (= 1.7.1)
-  gds-api-adapters (= 26.7.0)
+  gds-api-adapters (= 28.0.0)
   govuk_message_queue_consumer (~> 2.0.0)
   logging (= 1.8.1)
   minitest (= 4.6.1)

--- a/lib/index_documents.rb
+++ b/lib/index_documents.rb
@@ -83,7 +83,10 @@ private
   end
 
   def publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(Plek.current.find('publishing-api'))
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
   end
 
   def search_server


### PR DESCRIPTION
The publishing-api expects a bearer token. This wasn't set when initialising this object.

`PUBLISHING_API_BEARER_TOKEN` is already available to rummager.

Trello: https://trello.com/c/lRnxI2x5
Follow up to: https://github.com/alphagov/rummager/pull/555
