### PR TITLE
Downgrade rack-cache to 1.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       byebug (~> 8.0)
       pry (~> 0.10)
     rack (1.6.4)
-    rack-cache (1.6.0)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-logstasher (0.0.3)
       logstash-event


### PR DESCRIPTION
1.6 has been yanked for unknown reasons.
