### PR TITLE
Expand policy_areas

### DIFF
--- a/lib/entity_expander.rb
+++ b/lib/entity_expander.rb
@@ -24,6 +24,7 @@ class EntityExpander
     'document_collections' => :document_collections,
     'organisations' => :organisations,
     'topics' => :topics,
+    'policy_areas' => :policy_areas,
     'world_locations' => :world_locations,
     'specialist_sectors' => :specialist_sectors,
     'people' => :people,

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -93,6 +93,7 @@ class BaseParameterParser
     specialist_sectors
     title
     topics
+    policy_areas
     world_locations
   )
 

--- a/lib/registries.rb
+++ b/lib/registries.rb
@@ -10,6 +10,13 @@ class Registries < Struct.new(:search_server, :search_config)
       organisations: organisations,
       specialist_sectors: specialist_sectors,
       topics: registry_for_document_format('topic'),
+
+      # Whitehall has a thing called `topic`, which is being renamed to "policy
+      # area", because there already are seven things called "topic". Until
+      # Whitehall publishes the policy areas with format "policy_area" rather
+      # than "topic", we will expand `policy_areas` with data from documents
+      # with format `topic`.
+      policy_areas: registry_for_document_format('topic'),
       document_series: registry_for_document_format('document_series'),
       document_collections: registry_for_document_format('document_collection'),
       world_locations: registry_for_document_format('world_location'),


### PR DESCRIPTION
The `topics` field will be renamed to `policy_areas` (see https://github.com/alphagov/rummager/pull/557). Currently we copy `topics` to `policy_areas` during the indexing.

To make rummager return the same data for both fields, we need to expand the field as well. We still have to use the `topic` format for this, because Whitehall will keep sending policy area docs with this
format name (https://github.com/alphagov/whitehall/blob/master/app/models/classifica
tion.rb#L7-L12).

https://trello.com/c/bDFlehc5
