### PR TITLE
Ignore non-existing links in links hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "sidekiq-statsd", "0.1.5"
 # pin to version that includes security vulnerability fix
 gem "redis-namespace", "1.3.1"
 gem "plek", "1.11.0"
-gem "gds-api-adapters", "~> 28.0.2"
+gem "gds-api-adapters", "~> 28.1.0"
 gem "rack-logstasher", "0.0.3"
 gem 'airbrake', '4.0.0'
 gem "unf", "0.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.9.0)
-    gds-api-adapters (28.0.2)
+    gds-api-adapters (28.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -174,7 +174,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.0.0)
   ci_reporter (= 1.7.1)
-  gds-api-adapters (~> 28.0.2)
+  gds-api-adapters (~> 28.1.0)
   govuk-lint (~> 0.6.1)
   govuk_message_queue_consumer (~> 2.0.1)
   logging (= 1.8.1)

--- a/lib/index_documents.rb
+++ b/lib/index_documents.rb
@@ -24,6 +24,7 @@ class IndexDocuments
   end
 
 private
+
   def index_links_from_message(message)
     return unless publishing_app_migrated?(message)
     raw_links = links_from_payload(message)

--- a/lib/index_documents.rb
+++ b/lib/index_documents.rb
@@ -1,5 +1,5 @@
 require_relative "../app"
-require 'gds_api/publishing_api_v2'
+require 'indexer/links_lookup'
 
 class IndexDocuments
   MIGRATED_TAGGING_APPS = %w{
@@ -24,13 +24,12 @@ class IndexDocuments
   end
 
 private
-
   def index_links_from_message(message)
     return unless publishing_app_migrated?(message)
     raw_links = links_from_payload(message)
 
     unless raw_links.empty?
-      links = rummager_fields_from_links(raw_links)
+      links = Indexer::LinksLookup.new.rummager_fields_from_links(raw_links)
       base_path = document_base_path(message)
       update_index(base_path, links)
     end
@@ -44,35 +43,8 @@ private
     message.payload.fetch("links", {})
   end
 
-  def rummager_fields_from_links(links)
-    results = {}
-    rummager_field_mappers.each { |field_name, mapper|
-      field_values = mapper.call(links)
-      if field_values
-        results[field_name] = field_values
-      end
-    }
-    results
-  end
-
-  def rummager_field_mappers
-    {
-      "mainstream_browse_pages" => lambda { |links| sorted_link_paths(links, "mainstream_browse_pages") },
-      "organisations" => lambda { |links| (sorted_link_paths(links, "lead_organisations") + sorted_link_paths(links, "organisations")).uniq },
-      "specialist_sectors" => lambda { |links| sorted_link_paths(links, "topics") },
-    }
-  end
-
-  def sorted_link_paths(links, link_types)
-    links.fetch(link_types, []).map { |content_id| base_path(content_id) }.compact.sort
-  end
-
   def document_base_path(message)
     message.payload.fetch("base_path")
-  end
-
-  def base_path(content_id)
-    publishing_api.get_content(content_id)["base_path"]
   end
 
   def update_index(base_path, links)
@@ -93,13 +65,6 @@ private
       index = Elasticsearch::Index.strip_alias_from_index_name(hit["_index"])
       search_server.index(index) if index
     end
-  end
-
-  def publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(
-      Plek.new.find('publishing-api'),
-      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
-    )
   end
 
   def search_server

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -28,6 +28,7 @@ module Indexer
     end
 
   private
+
     def rummager_field_mappers
       {
         "mainstream_browse_pages" => lambda { |links| sorted_link_paths(links, "mainstream_browse_pages") },
@@ -41,7 +42,10 @@ module Indexer
     end
 
     def base_path(content_id)
-      publishing_api.get_content(content_id)["base_path"]
+      publishing_api.get_content!(content_id)["base_path"]
+    rescue GdsApi::HTTPNotFound
+      # Content items in the links hash may not exist yet.
+      nil
     end
 
     def publishing_api

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -1,0 +1,54 @@
+require 'gds_api/publishing_api_v2'
+
+module Indexer
+  class LinksLookup
+    # Given a "links hash" from the publishing-api, return a hash of links in
+    # "rummager-style". For example:
+    #
+    # {
+    #  "mainstream_browse_pages" => ["953a0469-1284-48ef-932f-354cc7099e7e"],
+    #  "topics" => ["974a8fdc-3306-4dd5-b349-34dc00b12ac2"]
+    # }
+    #
+    # is turned into:
+    #
+    # {
+    #   "mainstream_browse_pages" => ['/a-base-path'],
+    #   "specialist_sectors" => ['/some-other-path']
+    # }
+    def rummager_fields_from_links(links)
+      results = {}
+      rummager_field_mappers.each do |field_name, mapper|
+        field_values = mapper.call(links)
+        if field_values
+          results[field_name] = field_values
+        end
+      end
+      results
+    end
+
+  private
+    def rummager_field_mappers
+      {
+        "mainstream_browse_pages" => lambda { |links| sorted_link_paths(links, "mainstream_browse_pages") },
+        "organisations" => lambda { |links| (sorted_link_paths(links, "lead_organisations") + sorted_link_paths(links, "organisations")).uniq },
+        "specialist_sectors" => lambda { |links| sorted_link_paths(links, "topics") },
+      }
+    end
+
+    def sorted_link_paths(links, link_types)
+      links.fetch(link_types, []).map { |content_id| base_path(content_id) }.compact.sort
+    end
+
+    def base_path(content_id)
+      publishing_api.get_content(content_id)["base_path"]
+    end
+
+    def publishing_api
+      @publishing_api ||= GdsApi::PublishingApiV2.new(
+        Plek.new.find('publishing-api'),
+        bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+      )
+    end
+  end
+end

--- a/test/unit/indexer/links_lookup_test.rb
+++ b/test/unit/indexer/links_lookup_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "indexer/links_lookup"
+
+describe Indexer::LinksLookup do
+  describe "#rummager_fields_from_links" do
+    it "returns transformed links" do
+      stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/b6b7d71f-ecf3-4ff0-8fee-f19041cbe6b5").
+        to_return(body: { base_path: "/hela" }.to_json)
+
+      rummager_links = rummager_links_for({
+        "topics" => ["b6b7d71f-ecf3-4ff0-8fee-f19041cbe6b5"]
+      })
+
+      assert_equal rummager_links, {
+        "mainstream_browse_pages" => [],
+        "organisations"=>[],
+        "specialist_sectors" => ["/hela"]
+      }
+    end
+
+    def rummager_links_for(links)
+      Indexer::LinksLookup.new.rummager_fields_from_links(links)
+    end
+  end
+end

--- a/test/unit/indexer/links_lookup_test.rb
+++ b/test/unit/indexer/links_lookup_test.rb
@@ -13,8 +13,23 @@ describe Indexer::LinksLookup do
 
       assert_equal rummager_links, {
         "mainstream_browse_pages" => [],
-        "organisations"=>[],
+        "organisations" => [],
         "specialist_sectors" => ["/hela"]
+      }
+    end
+
+    it "returns transformed links when non-existing items are linked" do
+      stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/4da67807").
+        to_return(status: 404, body: {}.to_json)
+
+      rummager_links = rummager_links_for({
+        "topics" => ["4da67807"]
+      })
+
+      assert_equal rummager_links, {
+        "mainstream_browse_pages" => [],
+        "organisations" => [],
+        "specialist_sectors" => []
       }
     end
 


### PR DESCRIPTION
In certain situations, the content_ids found in the links hash will not exist in the publishing-api. This is correct behaviour. When this happens, we should ignore the item.

One of the valid cases I found is collections-publisher. For any parent topic, this puts the children in the links hash (`children` key):

https://github.com/alphagov/collections-publisher/blob/7846746aa4b5e62139c7e199c841c938515c18e3/app/presenters/topic_presenter.rb#L25

But these may not have been sent to the publishing-api, thus causing this issue.

Trello: https://trello.com/c/lRnxI2x5
