### PR TITLE
Also index tags from contacts-admin

### DIFF
--- a/lib/index_documents.rb
+++ b/lib/index_documents.rb
@@ -7,6 +7,7 @@ class IndexDocuments
     calculators
     calendars
     collections-publisher
+    contacts-admin
     hmrc-manuals-api
     licencefinder
     policy-publisher


### PR DESCRIPTION
contacts-admin has been migrated since https://github.com/alphagov/contacts-admin/pull/231.

Trello: https://trello.com/c/afa0Mfa4
