### PR TITLE
Fix which value is indexed from message queue

### DIFF
--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -13,8 +13,8 @@ module Indexer
     # is turned into:
     #
     # {
-    #   "mainstream_browse_pages" => ['/a-base-path'],
-    #   "specialist_sectors" => ['/some-other-path']
+    #   "mainstream_browse_pages" => ['some/browse-slug'],
+    #   "specialist_sectors" => ['some/topic-slug']
     # }
     def rummager_fields_from_links(links)
       results = {}
@@ -42,7 +42,11 @@ module Indexer
     end
 
     def base_path(content_id)
-      publishing_api.get_content!(content_id)["base_path"]
+      base_path = publishing_api.get_content!(content_id)["base_path"]
+      base_path
+        .gsub('/government/organisations/', '')
+        .gsub('/topic/', '')
+        .gsub('/browse/', '')
     rescue GdsApi::HTTPNotFound
       # Content items in the links hash may not exist yet.
       nil

--- a/test/unit/indexer/links_lookup_test.rb
+++ b/test/unit/indexer/links_lookup_test.rb
@@ -4,17 +4,25 @@ require "indexer/links_lookup"
 describe Indexer::LinksLookup do
   describe "#rummager_fields_from_links" do
     it "returns transformed links" do
-      stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/b6b7d71f-ecf3-4ff0-8fee-f19041cbe6b5").
-        to_return(body: { base_path: "/hela" }.to_json)
+      stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/MSBP-CONTENT-ID").
+        to_return(body: { base_path: "/browse/working/time-off" }.to_json)
+
+      stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/ORG-CONTENT-ID").
+        to_return(body: { base_path: "/government/organisations/accelerated-access-review" }.to_json)
+
+      stub_request(:get, "http://publishing-api.dev.gov.uk/v2/content/TOPIC-CONTENT-ID").
+        to_return(body: { base_path: "/topic/schools-colleges-childrens-services/adoption-fostering" }.to_json)
 
       rummager_links = rummager_links_for({
-        "topics" => ["b6b7d71f-ecf3-4ff0-8fee-f19041cbe6b5"]
+        "topics" => ["TOPIC-CONTENT-ID"],
+        "mainstream_browse_pages" => ["MSBP-CONTENT-ID"],
+        "organisations" => ["ORG-CONTENT-ID"]
       })
 
       assert_equal rummager_links, {
-        "mainstream_browse_pages" => [],
-        "organisations" => [],
-        "specialist_sectors" => ["/hela"]
+        "mainstream_browse_pages" => ["working/time-off"],
+        "organisations" => ["accelerated-access-review"],
+        "specialist_sectors" => ["schools-colleges-childrens-services/adoption-fostering"]
       }
     end
 


### PR DESCRIPTION
Currently `IndexDocuments` indexes the entire base_path of the topic, organisation or browse page. This should be the slug only.

https://trello.com/c/lRnxI2x5
