### PR TITLE
Don't rescue `Elasticsearch::DocumentNotFound`

### DIFF
--- a/lib/elasticsearch/amender.rb
+++ b/lib/elasticsearch/amender.rb
@@ -10,7 +10,7 @@ module Elasticsearch
       document = index.get(link)
 
       unless document
-        raise Elasticsearch::DocumentNotFound.new, link
+        raise Elasticsearch::DocumentNotFound, "`Index#get` can't find #{link}"
       end
 
       if updates.include? "link"

--- a/lib/index_documents.rb
+++ b/lib/index_documents.rb
@@ -49,11 +49,7 @@ private
 
   def update_index(base_path, links)
     indices_with_base_path(base_path).map do |index|
-      begin
-        index.amend(base_path, links)
-      rescue Elasticsearch::DocumentNotFound => e
-        Airbrake.notify_or_ignore(e)
-      end
+      index.amend(base_path, links)
     end
   end
 


### PR DESCRIPTION
Currently this app rescues & sends an Airbrake whenever `Elasticsearch::DocumentNotFound` is encountered. This was added because I thought that this meant that the document in question wasn't in the index.

But there is something else going on here. At this place in the code, `Elasticsearch::DocumentNotFound` means that the document _does_ exist in elasticsearch (it's found via `IndexDocuments#indices_with_base_path` - which returns the index that contains this document). But because of a bug in the `Elasticsearch::Index` class, the Amender will still fail and raise this error.

The bug is that https://github.com/alphagov/rummager/blob/master/lib/elasticsearch/index.rb#L291-L300 returns the wrong `_type` for some documents.

This commit removes the rescue so that we don't `ack` messages which we couldn't process because of a bug. It also changes the exception message to be slightly more accurate.

A follow up PR will be raised to fix the actual bug.
