### PR TITLE
[WIP - do not merge] Rake tasks for snapshot restore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "gds-api-adapters", "~> 28.1.0"
 gem "rack-logstasher", "0.0.3"
 gem 'airbrake', '4.0.0'
 gem "unf", "0.1.3"
+gem 'aws-sdk', '~> 2'
 
 group :test do
   gem "shoulda-context"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,12 @@ GEM
     ast (2.2.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
+    aws-sdk (2.2.19)
+      aws-sdk-resources (= 2.2.19)
+    aws-sdk-core (2.2.19)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.2.19)
+      aws-sdk-core (= 2.2.19)
     builder (3.1.3)
     bunny (2.2.2)
       amq-protocol (>= 2.0.1)
@@ -47,6 +53,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.6.0)
+    jmespath (1.1.3)
     json (1.8.1)
     kgio (2.8.0)
     link_header (0.0.8)
@@ -175,6 +182,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.0.0)
+  aws-sdk (~> 2)
   ci_reporter (= 1.7.1)
   gds-api-adapters (~> 28.1.0)
   govuk-lint (~> 0.6.1)

--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,14 @@ def search_server
   search_config.search_server
 end
 
+def bucket
+  search_server.snapshot_bucket
+end
+
+def elasticsearch_uri
+  SearchConfig.new.elasticsearch["base_uri"]
+end
+
 def index_names
   case ENV["RUMMAGER_INDEX"]
   when "all"

--- a/docs/snapshot-restore.md
+++ b/docs/snapshot-restore.md
@@ -1,0 +1,142 @@
+# Snapshot and Restore Tasks
+
+Rummager defines several rake tasks to assist in
+
+  * restoring the search indexes to an earlier state
+  * rebuilding indexes with updated popularity data
+  * mirroring the search indexes between environments
+
+This is built on top of elasticsearch's snapshot/restore functionality,
+documented at <https://www.elastic.co/guide/en/elasticsearch/reference/1.4/modules-snapshots.html>
+
+You can use these snapshots to set up a local copy of rummager with production
+data.
+
+## How snapshot/restore works in elasticsearch
+
+The Elasticsearch API allows us to create snapshots of one or more
+indexes.
+
+The snapshots live in a `repository`, which maps to some remote data store,
+such as a location in the file system, or in our case an AWS S3 bucket.
+
+Each snapshot is incremental, so successive snapshots don't necessarily use
+up extra storage, but there will be redundancy in the stored data, due to things
+like elasticsearch merging shards over time, or us rebuilding an index entirely.
+Because of this, we regularly delete old snapshots.
+
+### Index aliases
+
+Aliases are like symbolic links to one or more indices, and can be changed
+atomically.
+
+Rummager uses aliases to avoid downtime when restoring a snapshot or rebuilding
+an index.
+
+For example, during a restore operation, we follow the following steps:
+
+1. `mainstream` -> `mainstream-2016-02-25t17:07:13z-8efbb505-759a-4a34-ae0e-85aad065932d`
+2. Restore mainstream from a snapshot to a new index, `restored-mainstream-2016-02-25t17:11:04z-6d2a7dc4-a3b7-4572-b388-c59dc2c40be5`
+3. Wait for the restore to complete. Searches will continue to use the old
+index.
+3. Switch the alias: `mainstream` -> `restored-mainstream-2016-02-25t17:11:04z-6d2a7dc4-a3b7-4572-b388-c59dc2c40be5`
+4. Searches now use the new index.
+
+## Repository setup
+
+> If you wish to make an apple pie from scratch, you must first invent the universe.
+>
+> -- Carl Sagan
+
+If you have an S3 bucket set up, you can create a snapshot repository yourself
+by running:
+
+```
+rake rummager:snapshot:create_repository[repository_name]
+```
+
+This assumes you have some environment variables available:
+
+- AWS_ACCESS_KEY_ID
+- AWS_ACCESS_SECRET_ACCESS_KEY
+
+The name of the bucket to be used is configured in `elasticsearch.yml`.
+
+If you want to create your own repository (e.g. for development), you might
+want to create a filesystem backed repository instead. This is documented in
+the [elasticsearch documentation for snapshot restore](https://www.elastic.co/guide/en/elasticsearch/reference/1.4/modules-snapshots.html).
+
+You won't be able to use the `rummager:snapshot:list` and `rummager:snapshot:latest`
+tasks without an S3 bucket, but the basic snapshot/restore can work with any
+repository type.
+
+## Start a snapshot
+You can initiate a snapshot by running:
+
+```shell
+rake rummager:snapshot:run[repository_name,snapshot_name]
+```
+
+If the repository does not exist, or elasticsearch is unable to process the
+request, the task exits with a non zero code and prints a stack trace.
+
+Otherwise, it will print an API response. TODO: fix this
+
+
+## Monitoring snapshots
+### Check if a snapshot has completed yet
+```shell
+rake rummager:snapshot:check[repository_name,snapshot_name]
+```
+This returns the status of a snapshot operation, e.g. "SUCCESS".
+
+### Find the last successful snapshot
+```shell
+# Print the name of the latest snapshot
+rake rummager:snapshot:latest[repository_name]
+
+# Print the last snapshot excluding any after Jan 1st 2016
+rake 'rummager:snapshot:latest[repository_name, 2016-01-01 00:00:00]
+```
+
+### List all snapshots in the S3 bucket
+```shell
+# Includes in-progress snapshots
+rake rummager:snapshot:list[repository]
+```
+
+## Restore the latest snapshot
+```shell
+INDEX_NAMES=all rake rummager:snapshot:restore[repository_name,snapshot_name]
+```
+Prints the names of the indexes that will be created.
+
+Exits with a non-zero code and prints a stack trace if elasticsearch is
+unable to handle a request. Only one restore operation should happen at a time.
+
+## Monitor a restore from snapshot
+```shell
+rake rummager:check_recovery[index_name]
+```
+Prints "true" or "false". TODO: make this better.
+
+## Switch an index alias to a restored index
+
+Once an index has been successfully restored from a snapshot, you can switch
+over the alias:
+```shell
+INDEX_NAMES=mainstream rake rummager:switch_to_named_index[new_index_name]
+```
+
+## Nightly rebuild process
+
+There is a nightly jenkins job to rebuild the search indexes. This is also
+responsible for cleaning up out of date snapshots.
+
+## FAQ
+### Open questions
+Key rotation - when we rotate keys we need to ensure the create repository step is rerun.
+
+Can we add a repository in read-only mode to another env based on the live bucket?
+
+If not, how does a member of the public use the bucket?

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -4,6 +4,7 @@ auxiliary_index_names: ["page-traffic", "metasearch"]
 registry_index: "government"
 metasearch_index_name: "metasearch"
 popularity_rank_offset: 10
+snapshot_bucket_name: "govuk-api-elasticsearch-snapshots-integration"
 
 # When doing spell checking, which indices to use?
 spelling_index_names:

--- a/lib/elasticsearch/bucket.rb
+++ b/lib/elasticsearch/bucket.rb
@@ -1,0 +1,35 @@
+require 'time'
+
+module Elasticsearch
+  class Bucket
+    def initialize(bucket_name:, client: Aws::S3::Client.new(region: 'eu-west-1'))
+      @aws_client = client
+      @bucket_name = bucket_name
+    end
+
+    def repository_prefix(repository_name)
+      "#{repository_name}/metadata-"
+    end
+
+    # List names of all available snapshots, ignoring status.
+    # This information is not always visible in the elasticsearch API,
+    # so we go directly to the backing store (S3)
+    # Ordered by modification date ascending.
+    def list_snapshots(repository_name, before_time:)
+      prefix = repository_prefix(repository_name)
+
+      all_snapshots = @aws_client.list_objects({
+          bucket: @bucket_name,
+          prefix: prefix
+      }).contents
+
+      all_snapshots.select! { |snapshot| snapshot.last_modified <= before_time }
+
+      all_snapshots.sort_by!(&:last_modified)
+
+      all_snapshots.map do |snapshot|
+        snapshot.key.gsub(prefix, "")
+      end
+    end
+  end
+end

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -296,6 +296,15 @@ module Elasticsearch
       end
     end
 
+    def self.index_recovered?(base_uri:, index_name:)
+      # Check if an index has recovered all its shards.
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html
+      # If something goes wrong, a shard may get stuck and never reach the DONE state.
+      client = Client.new("#{base_uri}/#{index_name}/")
+      index_info = JSON(client.get("_recovery"))[index_name]
+      index_info["shards"].all? { |shard_info|  shard_info["stage"] == "DONE"}
+    end
+
   private
 
     # Parse an elasticsearch error message to determine whether it's caused by

--- a/lib/elasticsearch/index.rb
+++ b/lib/elasticsearch/index.rb
@@ -302,7 +302,7 @@ module Elasticsearch
       # If something goes wrong, a shard may get stuck and never reach the DONE state.
       client = Client.new("#{base_uri}/#{index_name}/")
       index_info = JSON(client.get("_recovery"))[index_name]
-      index_info["shards"].all? { |shard_info|  shard_info["stage"] == "DONE"}
+      index_info["shards"].all? { |shard_info| shard_info["stage"] == "DONE" }
     end
 
   private

--- a/lib/elasticsearch/index_group.rb
+++ b/lib/elasticsearch/index_group.rb
@@ -13,12 +13,20 @@ module Elasticsearch
   #
   # One of these indexes is aliased to the group name itself.
   class IndexGroup
+
     def initialize(base_uri, name, schema, search_config)
       @base_uri = base_uri
       @client = Client.new(base_uri)
       @name = name
       @schema = schema
       @search_config = search_config
+    end
+
+    def find_index(real_name)
+      # TODO: validate this against the API to make sure it actually exists
+      Elasticsearch::Index.new(
+        @base_uri, real_name, @name, mappings, @search_config
+      )
     end
 
     def create_index

--- a/lib/elasticsearch/index_group.rb
+++ b/lib/elasticsearch/index_group.rb
@@ -13,7 +13,6 @@ module Elasticsearch
   #
   # One of these indexes is aliased to the group name itself.
   class IndexGroup
-
     def initialize(base_uri, name, schema, search_config)
       @base_uri = base_uri
       @client = Client.new(base_uri)

--- a/lib/elasticsearch/search_server.rb
+++ b/lib/elasticsearch/search_server.rb
@@ -46,7 +46,7 @@ module Elasticsearch
 
     def snapshot_bucket
       Bucket.new(
-          bucket_name: search_config.snapshot_bucket_name
+        bucket_name: search_config.snapshot_bucket_name
       )
     end
 

--- a/lib/elasticsearch/search_server.rb
+++ b/lib/elasticsearch/search_server.rb
@@ -44,6 +44,12 @@ module Elasticsearch
       end
     end
 
+    def snapshot_bucket
+      Bucket.new(
+          bucket_name: search_config.snapshot_bucket_name
+      )
+    end
+
   private
 
     def validate_index_name!(index_name)

--- a/lib/elasticsearch/snapshot_repository.rb
+++ b/lib/elasticsearch/snapshot_repository.rb
@@ -4,7 +4,6 @@ require "logging"
 require "json"
 
 module Elasticsearch
-
   class SnapshotRepositoryBusy < Exception
   end
 
@@ -54,7 +53,7 @@ module Elasticsearch
       snapshot = response["snapshots"].first
 
       logger.info(
-        "Snapshot #{snapshot["snapshot"]}: #{snapshot["state"]}"
+        "Snapshot #{snapshot['snapshot']}: #{snapshot['state']}"
       )
       logger.debug(snapshot["shards_stats"].to_s)
 
@@ -63,8 +62,8 @@ module Elasticsearch
 
     def in_progress_snapshots
       snapshots = JSON(@client.get("_status"))["snapshots"]
-      snapshots.reject! {|snapshot| snapshot.fetch("state") == "SUCCESS"}
-      snapshots.map {|snapshot| snapshot.fetch("snapshot")}
+      snapshots.reject! { |snapshot| snapshot.fetch("state") == "SUCCESS" }
+      snapshots.map { |snapshot| snapshot.fetch("snapshot") }
     end
 
     def last_successful_snapshot(snapshots)
@@ -119,6 +118,7 @@ module Elasticsearch
     end
 
   private
+
     def logger
       Logging.logger[self]
     end

--- a/lib/elasticsearch/snapshot_repository.rb
+++ b/lib/elasticsearch/snapshot_repository.rb
@@ -1,0 +1,130 @@
+require "elasticsearch/client"
+require 'pry'
+require "logging"
+require "json"
+
+module Elasticsearch
+
+  class SnapshotRepositoryBusy < Exception
+  end
+
+  class SnapshotRepository
+    def initialize(base_uri:, repository_name:)
+      @client = Client.new(url_for(base_uri, repository_name))
+      @repository_name = repository_name
+    end
+
+    # Create a snapshot repository
+    # The verify param requires delete permissions on the underlying data store
+    def create_repository(type, settings)
+      response = @client.put(
+        "?verify=false",
+        {
+          "type" => type,
+          "settings" => settings
+        }.to_json
+      )
+      JSON(response)
+    end
+
+    # Start a snapshot of one or more indices.
+    # snapshot_name is assumed to be unique.
+    def snapshot(snapshot_name, index_names)
+      begin
+        response = @client.put(
+          snapshot_name,
+          {
+            "indices" => index_names.join(","),
+            "include_global_state" => false
+          }.to_json
+        )
+      rescue RestClient::ServiceUnavailable
+        # API goes unresponsive when a snapshot is in progress.
+        raise SnapshotRepositoryBusy
+      end
+
+      JSON(response)
+    end
+
+    # Get the status of a previously started snapshot
+    def check_snapshot(snapshot_name)
+      response = JSON(
+        @client.get("#{snapshot_name}/_status")
+      )
+      snapshot = response["snapshots"].first
+
+      logger.info(
+        "Snapshot #{snapshot["snapshot"]}: #{snapshot["state"]}"
+      )
+      logger.debug(snapshot["shards_stats"].to_s)
+
+      snapshot["state"]
+    end
+
+    def in_progress_snapshots
+      snapshots = JSON(@client.get("_status"))["snapshots"]
+      snapshots.reject! {|snapshot| snapshot.fetch("state") == "SUCCESS"}
+      snapshots.map {|snapshot| snapshot.fetch("snapshot")}
+    end
+
+    def last_successful_snapshot(snapshots)
+      (snapshots - in_progress_snapshots).last
+    end
+
+    def restore_indexes(snapshot_name, index_groups)
+      # Restore the requested indexes from a snapshot.
+      # The snapshot contains indexes with their "real" names, e.g.:
+      # mainstream-2016-02-25t17:14:51z-7f3aa400-76a0-4247-ba8a-1a1f3cac513c
+      #
+      # We restore them to new indices, which we can point the aliases to
+      # once the recovery has completed.
+      # The new names contain the current timestamp and a "restored" prefix.
+      indices = JSON(@client.get(snapshot_name))["snapshots"].first["indices"]
+      indices = self.class.select_indices_from_groups(indices, index_groups)
+
+      uuid = SecureRandom.uuid
+      restore_time = Time.now.utc.iso8601
+      rename_pattern = '(.+)-\d{4}-\d{2}-\d{2}t\d{2}:\d{2}:\d{2}z-[0-9a-f][-0-9a-f]*\Z'
+      rename_replacement = "restored-$1-#{restore_time}-#{uuid}".downcase
+
+      begin
+        @client.post("#{snapshot_name}/_restore", {
+          "indices" => indices.values.join(","),
+          "rename_pattern" => rename_pattern,
+          "rename_replacement" => rename_replacement
+        }.to_json)
+      rescue RestClient::ServiceUnavailable
+        # API goes unresponsive when a restore is in progress.
+        raise SnapshotRepositoryBusy
+      end
+
+      # Work out the index names elasticsearch will create for us, because the
+      # request doesn't return them.
+      indices.values.map do |index|
+        index.gsub(Regexp.new(rename_pattern)) do
+          "restored-#{$1}-#{restore_time}-#{uuid}".downcase
+        end
+      end
+    end
+
+    # Create a hash from group names to "real" index names
+    def self.select_indices_from_groups(indices, index_groups)
+      indices.each_with_object({}) do |index, indices_for_groups|
+        index_groups.each do |index_group|
+          if index.start_with?(index_group)
+            indices_for_groups[index_group] = index
+          end
+        end
+      end
+    end
+
+  private
+    def logger
+      Logging.logger[self]
+    end
+
+    def url_for(base_uri, repository_name)
+      "#{base_uri}/_snapshot/#{CGI.escape(repository_name)}/"
+    end
+  end
+end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -11,6 +11,7 @@ class SearchConfig
     auxiliary_index_names
     content_index_names
     spelling_index_names
+    snapshot_bucket_name
   ].each do |config_method|
     define_method config_method do
       elasticsearch.fetch(config_method)
@@ -35,11 +36,12 @@ class SearchConfig
     content_index_names + auxiliary_index_names
   end
 
-private
-
   def elasticsearch
     @elasticsearch ||= config_for("elasticsearch")
   end
+
+
+private
 
   def config_path
     File.expand_path("../config/schema", File.dirname(__FILE__))

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -50,6 +50,23 @@ You should run this task if the index schema has changed.
     end
   end
 
+  desc "Switches an index group to a specific index WITHOUT transferring data"
+  task :switch_to_named_index, [:new_index_name] do |_, args|
+    # This makes no assumptions on the contents of the new index.
+    # If it has been restored from a snapshot, you should check that the
+    # index is fully recovered first. See :check_recovery.
+
+    new_index_name = args[:new_index_name] or raise "The new index name must be supplied"
+
+    index_names.each do |index_name|
+      if new_index_name.include?(index_name)
+        puts "Switching #{index_name} -> #{new_index_name}"
+        index_group = search_server.index_group(index_name)
+        index_group.switch_to(index_group.find_index(new_index_name))
+      end
+    end
+  end
+
   desc "Migrates from an index with the actual index name to an alias"
   task :migrate_from_unaliased_index do
     # WARNING: this is potentially dangerous, and will leave the search
@@ -67,5 +84,18 @@ You should run this task if the index schema has changed.
     index_names.each do |index_name|
       search_server.index_group(index_name).clean
     end
+  end
+
+  desc "Check whether a restored index has recovered"
+  task :check_recovery, [:index_name] do |_, args|
+
+    index_name = args.index_name or raise "An 'index_name' must be supplied"
+
+    require 'elasticsearch/index'
+
+    puts Elasticsearch::Index.index_recovered?(
+      base_uri: elasticsearch_uri,
+      index_name: index_name
+    )
   end
 end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -55,14 +55,13 @@ You should run this task if the index schema has changed.
     # This makes no assumptions on the contents of the new index.
     # If it has been restored from a snapshot, you should check that the
     # index is fully recovered first. See :check_recovery.
-
-    new_index_name = args[:new_index_name] or raise "The new index name must be supplied"
+    raise "The new index name must be supplied" unless args.new_index_name
 
     index_names.each do |index_name|
       if new_index_name.include?(index_name)
         puts "Switching #{index_name} -> #{new_index_name}"
         index_group = search_server.index_group(index_name)
-        index_group.switch_to(index_group.find_index(new_index_name))
+        index_group.switch_to(index_group.find_index(args.new_index_name))
       end
     end
   end
@@ -88,14 +87,13 @@ You should run this task if the index schema has changed.
 
   desc "Check whether a restored index has recovered"
   task :check_recovery, [:index_name] do |_, args|
-
-    index_name = args.index_name or raise "An 'index_name' must be supplied"
+    raise "An 'index_name' must be supplied" unless args.index_name
 
     require 'elasticsearch/index'
 
     puts Elasticsearch::Index.index_recovered?(
       base_uri: elasticsearch_uri,
-      index_name: index_name
+      index_name: args.index_name
     )
   end
 end

--- a/lib/tasks/snapshot.rake
+++ b/lib/tasks/snapshot.rake
@@ -7,32 +7,30 @@ require "date"
 
 namespace :rummager do
   namespace :snapshot do
-
     desc "Start a snapshot of the public elasticsearch indices."
     task :run, [:repository_name, :snapshot_name] do |_, args|
-
-      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
-      snapshot_name = args.snapshot_name or raise "A 'snapshot_name' must be supplied"
+      raise "A 'repository_name' must be supplied" unless args.repository_name
+      raise "A 'snapshot_name' must be supplied" unless args.snapshot_name
 
       repo = Elasticsearch::SnapshotRepository.new(
         base_uri: elasticsearch_uri,
-        repository_name: repository_name,
+        repository_name: args.repository_name,
       )
 
-      puts repo.snapshot(snapshot_name, index_names)
+      puts repo.snapshot(args.snapshot_name, index_names)
     end
 
     desc "Get the status of a snapshot, e.g. SUCCESS"
     task :check, [:repository_name, :snapshot_name] do |_, args|
-      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
-      snapshot_name = args.snapshot_name or raise "A 'snapshot_name' must be supplied"
+      raise "A 'repository_name' must be supplied" unless args.repository_name
+      raise "A 'snapshot_name' must be supplied" unless args.snapshot_name
 
       begin
         repo = Elasticsearch::SnapshotRepository.new(
           base_uri: elasticsearch_uri,
-          repository_name: repository_name,
+          repository_name: args.repository_name,
         )
-        puts repo.check_snapshot(snapshot_name)
+        puts repo.check_snapshot(args.snapshot_name)
       rescue RestClient::ResourceNotFound
         puts "Missing repository or snapshot. Try rummager:snapshot:list[#{repository_name}]"
       end
@@ -40,29 +38,27 @@ namespace :rummager do
 
     desc "Create or update a snapshot repository backed by S3"
     task :create_repository, [:repository_name] do |_, args|
-
-      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
+      raise "A 'repository_name' must be supplied" unless args.repository_name
 
       client = Elasticsearch::SnapshotRepository.new(
         base_uri: elasticsearch_uri,
-        repository_name: repository_name,
+        repository_name: args.repository_name,
       )
       settings = {
          region: "eu-west-1",
          bucket: search_config.snapshot_bucket_name,
          access_key: ENV["AWS_ACCESS_KEY_ID"],
          secret_key: ENV["AWS_SECRET_ACCESS_KEY"],
-         base_path: repository_name,
+         base_path: args.repository_name,
       }
       puts client.create_repository("s3", settings)
     end
 
     desc "List all snapshots in the repository"
     task :list, [:repository_name] do |_, args|
+      raise "A 'repository_name' must be supplied" unless args.repository_name
 
-      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
-
-      puts bucket.list_snapshots(args[:repository_name], before_time: Time.now)
+      puts bucket.list_snapshots(args.repository_name, before_time: Time.now)
     end
 
     desc "Get latest snapshot.
@@ -75,8 +71,7 @@ namespace :rummager do
     repository is keeping up to date.
     "
     task :latest, [:repository_name, :before_time] do |_, args|
-
-      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
+      raise "A 'repository_name' must be supplied" unless args.repository_name
 
       if args.before_time
         before_time = DateTime.parse(before_time).to_time
@@ -84,11 +79,11 @@ namespace :rummager do
         before_time = Time.now
       end
 
-      snapshots = bucket.list_snapshots(repository_name, before_time: before_time)
+      snapshots = bucket.list_snapshots(args.repository_name, before_time: before_time)
 
       snapshot_repository = Elasticsearch::SnapshotRepository.new(
         base_uri: elasticsearch_uri,
-        repository_name: repository_name,
+        repository_name: args.repository_name,
       )
 
       puts snapshot_repository.last_successful_snapshot(snapshots) || "No snapshots present."
@@ -96,15 +91,14 @@ namespace :rummager do
 
     desc "Start restoring a snapshot and print the new index names"
     task :restore, [:repository_name, :snapshot_name] do |_, args|
-
-      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
-      snapshot_name   = args.snapshot_name or raise "A 'snapshot_name' must be supplied"
+      raise "A 'repository_name' must be supplied" unless args.repository_name
+      raise "A 'snapshot_name' must be supplied" unless args.snapshot_name
 
       snapshot_repository = Elasticsearch::SnapshotRepository.new(
         base_uri: elasticsearch_uri,
-        repository_name: repository_name,
+        repository_name: args.repository_name,
       )
-      puts snapshot_repository.restore_indexes(snapshot_name, index_names)
+      puts snapshot_repository.restore_indexes(args.snapshot_name, index_names)
     end
   end
 end

--- a/lib/tasks/snapshot.rake
+++ b/lib/tasks/snapshot.rake
@@ -1,0 +1,110 @@
+require "elasticsearch/snapshot_repository"
+require "elasticsearch/bucket"
+require "rest-client"
+require "pry-byebug"
+require "aws-sdk"
+require "date"
+
+namespace :rummager do
+  namespace :snapshot do
+
+    desc "Start a snapshot of the public elasticsearch indices."
+    task :run, [:repository_name, :snapshot_name] do |_, args|
+
+      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
+      snapshot_name = args.snapshot_name or raise "A 'snapshot_name' must be supplied"
+
+      repo = Elasticsearch::SnapshotRepository.new(
+        base_uri: elasticsearch_uri,
+        repository_name: repository_name,
+      )
+
+      puts repo.snapshot(snapshot_name, index_names)
+    end
+
+    desc "Get the status of a snapshot, e.g. SUCCESS"
+    task :check, [:repository_name, :snapshot_name] do |_, args|
+      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
+      snapshot_name = args.snapshot_name or raise "A 'snapshot_name' must be supplied"
+
+      begin
+        repo = Elasticsearch::SnapshotRepository.new(
+          base_uri: elasticsearch_uri,
+          repository_name: repository_name,
+        )
+        puts repo.check_snapshot(snapshot_name)
+      rescue RestClient::ResourceNotFound
+        puts "Missing repository or snapshot. Try rummager:snapshot:list[#{repository_name}]"
+      end
+    end
+
+    desc "Create or update a snapshot repository backed by S3"
+    task :create_repository, [:repository_name] do |_, args|
+
+      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
+
+      client = Elasticsearch::SnapshotRepository.new(
+        base_uri: elasticsearch_uri,
+        repository_name: repository_name,
+      )
+      settings = {
+         region: "eu-west-1",
+         bucket: search_config.snapshot_bucket_name,
+         access_key: ENV["AWS_ACCESS_KEY_ID"],
+         secret_key: ENV["AWS_SECRET_ACCESS_KEY"],
+         base_path: repository_name,
+      }
+      puts client.create_repository("s3", settings)
+    end
+
+    desc "List all snapshots in the repository"
+    task :list, [:repository_name] do |_, args|
+
+      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
+
+      puts bucket.list_snapshots(args[:repository_name], before_time: Time.now)
+    end
+
+    desc "Get latest snapshot.
+    You can optionally pass a datetime parameter to filter out any snapshots
+    created afterwards.
+
+    If you don't pass it, it will default to the time in which the rake task is run.
+
+    This is used to monitor the ongoing snapshot process and make sure our
+    repository is keeping up to date.
+    "
+    task :latest, [:repository_name, :before_time] do |_, args|
+
+      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
+
+      if args.before_time
+        before_time = DateTime.parse(before_time).to_time
+      else
+        before_time = Time.now
+      end
+
+      snapshots = bucket.list_snapshots(repository_name, before_time: before_time)
+
+      snapshot_repository = Elasticsearch::SnapshotRepository.new(
+        base_uri: elasticsearch_uri,
+        repository_name: repository_name,
+      )
+
+      puts snapshot_repository.last_successful_snapshot(snapshots) || "No snapshots present."
+    end
+
+    desc "Start restoring a snapshot and print the new index names"
+    task :restore, [:repository_name, :snapshot_name] do |_, args|
+
+      repository_name = args.repository_name or raise "A 'repository_name' must be supplied"
+      snapshot_name   = args.snapshot_name or raise "A 'snapshot_name' must be supplied"
+
+      snapshot_repository = Elasticsearch::SnapshotRepository.new(
+        base_uri: elasticsearch_uri,
+        repository_name: repository_name,
+      )
+      puts snapshot_repository.restore_indexes(snapshot_name, index_names)
+    end
+  end
+end

--- a/test/unit/elasticsearch/bucket_test.rb
+++ b/test/unit/elasticsearch/bucket_test.rb
@@ -13,20 +13,20 @@ class BucketTest < MiniTest::Unit::TestCase
       Aws::S3::Types::Object.new(key: "my-repository/metadata-snap2003", last_modified: Time.new(2003)),
       Aws::S3::Types::Object.new(key: "my-repository/metadata-snap2001", last_modified: Time.new(2001)),
     ])
-    @client.expect(:list_objects, @response, [{:bucket=>"bucket", :prefix=>"my-repository/metadata-"}])
+    @client.expect(:list_objects, @response, [{ bucket: "bucket", prefix: "my-repository/metadata-" }])
   end
 
   def test_returns_snapshots_ordered_by_date
     bucket = Elasticsearch::Bucket.new(bucket_name: "bucket", client: @client)
     names = bucket.list_snapshots("my-repository", before_time: Time.now)
 
-    assert_equal(names, ["snap2000", "snap2001", "snap2003"])
+    assert_equal(names, %w(snap2000 snap2001 snap2003))
   end
 
   def test_returns_snapshots_filtered_by_date
     bucket = Elasticsearch::Bucket.new(bucket_name: "bucket", client: @client)
     names = bucket.list_snapshots("my-repository", before_time: Time.new(2001))
 
-    assert_equal(names, ["snap2000", "snap2001"])
+    assert_equal(names, %w(snap2000 snap2001))
   end
 end

--- a/test/unit/elasticsearch/bucket_test.rb
+++ b/test/unit/elasticsearch/bucket_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "elasticsearch/bucket"
+require "minitest/mock"
+require "aws-sdk"
+require 'time'
+
+class BucketTest < MiniTest::Unit::TestCase
+  def setup
+    @client = Minitest::Mock.new
+    @response = Minitest::Mock.new
+    @response.expect(:contents, [
+      Aws::S3::Types::Object.new(key: "my-repository/metadata-snap2000", last_modified: Time.new(2000)),
+      Aws::S3::Types::Object.new(key: "my-repository/metadata-snap2003", last_modified: Time.new(2003)),
+      Aws::S3::Types::Object.new(key: "my-repository/metadata-snap2001", last_modified: Time.new(2001)),
+    ])
+    @client.expect(:list_objects, @response, [{:bucket=>"bucket", :prefix=>"my-repository/metadata-"}])
+  end
+
+  def test_returns_snapshots_ordered_by_date
+    bucket = Elasticsearch::Bucket.new(bucket_name: "bucket", client: @client)
+    names = bucket.list_snapshots("my-repository", before_time: Time.now)
+
+    assert_equal(names, ["snap2000", "snap2001", "snap2003"])
+  end
+
+  def test_returns_snapshots_filtered_by_date
+    bucket = Elasticsearch::Bucket.new(bucket_name: "bucket", client: @client)
+    names = bucket.list_snapshots("my-repository", before_time: Time.new(2001))
+
+    assert_equal(names, ["snap2000", "snap2001"])
+  end
+end

--- a/test/unit/elasticsearch/snapshot_repository_test.rb
+++ b/test/unit/elasticsearch/snapshot_repository_test.rb
@@ -5,7 +5,10 @@ require "minitest/mock"
 
 class SnapshotRepositoryTest < MiniTest::Unit::TestCase
   def setup
-    @snapshot_repository = Elasticsearch::SnapshotRepository.new(base_uri: "localhost:9000/repository/", repository_name: "test-repository")
+    @snapshot_repository = Elasticsearch::SnapshotRepository.new(
+      base_uri: "localhost:9000/repository/",
+      repository_name: "test-repository",
+    )
   end
 
   def test_last_successful_snapshot
@@ -16,12 +19,12 @@ class SnapshotRepositoryTest < MiniTest::Unit::TestCase
   end
 
   def test_select_indices_from_groups
-    groups = ["mainstream", "government"]
+    groups = %w(mainstream government)
     indices = ["mainstream-2016-01-01....", "government-2016-01-01....", "service-manual-2016-01-01..."]
     result = Elasticsearch::SnapshotRepository.select_indices_from_groups(indices, groups)
     assert_equal(
       result,
-      {groups[0] => indices[0], groups[1] => indices[1]}
+      { groups[0] => indices[0], groups[1] => indices[1] }
     )
   end
 end

--- a/test/unit/elasticsearch/snapshot_repository_test.rb
+++ b/test/unit/elasticsearch/snapshot_repository_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+require "elasticsearch/snapshot_repository"
+require "minitest/mock"
+
+
+class SnapshotRepositoryTest < MiniTest::Unit::TestCase
+  def setup
+    @snapshot_repository = Elasticsearch::SnapshotRepository.new(base_uri: "localhost:9000/repository/", repository_name: "test-repository")
+  end
+
+  def test_last_successful_snapshot
+    @snapshot_repository.stub :in_progress_snapshots, ["in-progress-1", "in-progress-2"] do
+      all_snapshots = ["completed-1", "completed-2", "in-progress-1", "in-progress-2"]
+      assert @snapshot_repository.last_successful_snapshot(all_snapshots) == "completed-2"
+    end
+  end
+
+  def test_select_indices_from_groups
+    groups = ["mainstream", "government"]
+    indices = ["mainstream-2016-01-01....", "government-2016-01-01....", "service-manual-2016-01-01..."]
+    result = Elasticsearch::SnapshotRepository.select_indices_from_groups(indices, groups)
+    assert_equal(
+      result,
+      {groups[0] => indices[0], groups[1] => indices[1]}
+    )
+  end
+end


### PR DESCRIPTION
- Start snapshot
- Monitor snapshot
- List snapshots in bucket
- Get latest snapshot
- Restore a named snapshot
- Monitor a restore
- Switch aliases to a restored index

The ongoing snapshot process will be managed from a cron or jenkins job,
and we plan to add a jenkins job for restoring as well.

In addition to this we already have a nightly job that rebuilds the indexes,
which will be extended to clean up old snapshots.

Elasticsearch's APIs don't handle multiple snapshot/restore operations at
the same time. If we are unable to take a snapshot for this reason, we will just
let the job the fail. Snapshot freshness will be monitored by icinga.
