### PR TITLE
Allow misspelled ID codes to return relevant results

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -289,7 +289,8 @@ private
     debug_options = character_separated_param("debug")
 
     options = {}
-    debug_options.each { |option|
+
+    debug_options.each do |option|
       case option
       when ""
       when "disable_best_bets"
@@ -306,10 +307,13 @@ private
         # Withdrawn content is excluded from regular searches but is useful for
         # content audits
         options[:include_withdrawn] = true
+      when "use_id_codes"
+        options[:use_id_codes] = true
       else
         @errors << %{Unknown debug option "#{option}"}
       end
-    }
+    end
+
     options
   end
 end

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -63,7 +63,11 @@ module QueryComponents
     end
 
     def must_conditions
-      [all_searchable_text_query]
+      if @search_params.enable_id_codes?
+        [all_searchable_text_query]
+      else
+        [query_string_query]
+      end
     end
 
     def should_conditions

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -63,11 +63,23 @@ module QueryComponents
     end
 
     def must_conditions
-      [query_string_query]
+      [all_searchable_text_query]
     end
 
     def should_conditions
       exact_field_boosts + [exact_match_boost, shingle_token_filter_boost]
+    end
+
+    def all_searchable_text_query
+      # Return the highest weight obtained by searching for the text when
+      # analyzed in different ways (with a small bonus if it matches in
+      # multiple of these ways).
+      queries = []
+
+      queries << query_string_query
+      queries << match_query("all_searchable_text.id_codes", search_term, minimum_should_match: "1")
+
+      dis_max_query(queries, tie_breaker: 0.1)
     end
 
     def query_string_query

--- a/lib/search/query_components/query.rb
+++ b/lib/search/query_components/query.rb
@@ -39,15 +39,14 @@ module QueryComponents
     end
 
     def base_query
-      if search_term.nil?
-        return { match_all: {} }
-      end
+      return { match_all: {} } if search_term.nil?
 
       if search_params.enable_new_weighting?
         core_query = QueryComponents::TextQuery.new(search_params).payload
       else
         core_query = QueryComponents::CoreQuery.new(search_params).payload
       end
+
       boosted_query = QueryComponents::Booster.new(search_params).wrap(core_query)
       QueryComponents::Popularity.new(search_params).wrap(boosted_query)
     end

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -38,6 +38,10 @@ module Search
       debug[:disable_best_bets]
     end
 
+    def enable_id_codes?
+      debug[:use_id_codes]
+    end
+
     def suggest_spelling?
       query && suggest.include?('spelling')
     end

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -22,6 +22,29 @@ class SearchTest < IntegrationTest
     assert last_response.ok?
   end
 
+  def test_id_code_with_space
+    # when debug mode includes "use_id_codes" and it searches for
+    # "P 60" instead of "P60" a P60 document should be found!
+
+    reset_content_indexes
+
+    commit_document(
+      "mainstream_test",
+      title: "Get P45, P60 and other forms for your employees",
+      description: "Get PAYE forms from HMRC including P45, P60, starter checklist (which replaced the P46), P11D(b)",
+      link: "/get-paye-forms-p45-p60"
+
+    )
+
+    get "/unified_search?q=p+60&debug=use_id_codes"
+
+    assert_equal(parsed_response['results'].size, 1)
+    assert_equal(parsed_response["results"][0]["link"], "/get-paye-forms-p45-p60")
+
+    get "/unified_search?q=p+60"
+    assert_equal(parsed_response['results'].size, 0)
+  end
+
   def test_spell_checking_with_typo
     reset_content_indexes
 


### PR DESCRIPTION
Often people search for ID codes (eg forms or reports) which may or may not contain spaces or punctuation. They only see the relevant results when they use exactly same spelling as the content, this often frustrates users for not getting the results they are looking for.

This commit aims to solve this problem without changing too much of the existing weight system, by applying a match query on `all_searchable_text.id_codes` fields.

Related with: https://trello.com/c/lrYj5PdF/516-enable-searching-for-id-codes-with-or-without-spaces-punctuation
