### PR TITLE
Sync tags from contacts

### DIFF
--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -8,6 +8,7 @@ module Indexer
       calculators
       calendars
       collections-publisher
+      contacts
       contacts-admin
       hmrc-manuals-api
       licencefinder


### PR DESCRIPTION
contacts-admin sends the data to publishing-api as `contacts`, not `contacts-admin`.

https://trello.com/c/afa0Mfa4
