### PR TITLE
Use the correct document_id when indexing docs

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -166,17 +166,17 @@ module SearchIndices
       response
     end
 
-    def amend(link, updates)
-      Indexer::Amender.new(self).amend(link, updates)
+    def amend(document_id, updates)
+      Indexer::Amender.new(self).amend(document_id, updates)
     end
 
-    def amend_queued(link, updates)
-      queue.queue_amend(link, updates)
+    def amend_queued(document_id, updates)
+      queue.queue_amend(document_id, updates)
     end
 
-    def get(link)
+    def get_document_by_id(document_id)
       begin
-        response = @client.get("_all/#{CGI.escape(link)}")
+        response = @client.get("_all/#{CGI.escape(document_id)}")
         document_from_hash(JSON.parse(response.body)["_source"])
       rescue RestClient::ResourceNotFound
         nil

--- a/lib/indexer/amender.rb
+++ b/lib/indexer/amender.rb
@@ -8,7 +8,7 @@ module Indexer
 
     def amend(document_id, updates)
       if updates.include?("link")
-        raise ArgumentError, "Cannot change document the `link` attribute of a document."
+        raise ArgumentError, "Cannot change the `link` attribute of a document."
       end
 
       document = index.get_document_by_id(document_id)

--- a/lib/indexer/amender.rb
+++ b/lib/indexer/amender.rb
@@ -6,15 +6,16 @@ module Indexer
       @index = index
     end
 
-    def amend(link, updates)
+    def amend(document_id, updates)
       if updates.include?("link")
         raise ArgumentError, "Cannot change document the `link` attribute of a document."
       end
 
-      document = index.get(link)
+      document = index.get_document_by_id(document_id)
 
       unless document
-        raise SearchIndices::DocumentNotFound, "`Index#get` can't find #{link}"
+        raise SearchIndices::DocumentNotFound,
+          "Can't find document with _id #{document_id}"
       end
 
       updates.each do |key, value|

--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -49,19 +49,17 @@ module Indexer
     end
 
     def update_index(base_path, links)
-      indices_with_base_path(base_path).map do |index|
-        index.amend(base_path, links)
-      end
+      index = get_index_for_document_with_path(base_path)
+      index.amend(base_path, links)
     end
 
-    def indices_with_base_path(document_base_path)
+    def get_index_for_document_with_path(document_base_path)
       indices_to_search = search_server.index_for_search(search_config.content_index_names)
       results = indices_to_search.raw_search(query: { term: { link: document_base_path } })
 
-      results["hits"]["hits"].map do |hit|
-        index = SearchIndices::Index.strip_alias_from_index_name(hit["_index"])
-        search_server.index(index) if index
-      end
+      hit = results["hits"]["hits"].first
+      index = SearchIndices::Index.strip_alias_from_index_name(hit["_index"])
+      search_server.index(index)
     end
 
     def search_server

--- a/lib/legacy_client/index_for_search.rb
+++ b/lib/legacy_client/index_for_search.rb
@@ -31,6 +31,17 @@ module LegacyClient
       JSON.parse(@client.get_with_payload(path, json_payload))
     end
 
+    def get_document_by_link(link)
+      results = raw_search(query: { term: { link: link } }, size: 1)
+      raw_result = results['hits']['hits'].first
+
+      if raw_result
+        raw_result['real_index_name'] = SearchIndices::Index.strip_alias_from_index_name(raw_result['_index'])
+      end
+
+      raw_result
+    end
+
     def msearch(bodies)
       header_json = "{}"
       payload = bodies.map { |body|

--- a/lib/routes/content.rb
+++ b/lib/routes/content.rb
@@ -22,8 +22,7 @@ class Rummager < Sinatra::Application
 private
 
   def find_result_by_link(link)
-    results = unified_index.raw_search(query: { term: { link: link } }, size: 1)
-    raw_result = results['hits']['hits'].first
+    raw_result = unified_index.get_document_by_link(link)
 
     unless raw_result
       halt 404, "No document found with link #{link}."
@@ -33,8 +32,7 @@ private
   end
 
   def delete_result_from_index(raw_result)
-    index_name = SearchIndices::Index.strip_alias_from_index_name(raw_result['_index'])
-    index = search_server.index(index_name)
+    index = search_server.index(raw_result['real_index_name'])
     index.delete(raw_result['_type'], raw_result['_id'])
   end
 end


### PR DESCRIPTION
Currently this indexer assumes that a document's `_id` and `link` are the same. This causes tag updates for the `contacts` app to fail because they aren't the same (the _id has no leading slash).

Best reviewed per-commit, as some refactoring was necessary to prevent this from happening again.

https://trello.com/c/lRnxI2x5 https://trello.com/c/afa0Mfa4
