### PR TITLE
Introduce elasticsearch gem and rake tasks for snapshot restore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem "gds-api-adapters", "~> 29.4"
 gem "rack-logstasher", "0.0.3"
 gem 'airbrake', '4.0.0'
 gem "unf", "0.1.3"
+gem 'aws-sdk', '~> 2.2.19'
+gem 'elasticsearch', '~> 1.0.15'
 
 group :test do
   gem "shoulda-context"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,12 @@ GEM
     ast (2.2.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
+    aws-sdk (2.2.19)
+      aws-sdk-resources (= 2.2.19)
+    aws-sdk-core (2.2.19)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.2.19)
+      aws-sdk-core (= 2.2.19)
     builder (3.1.3)
     bunny (2.2.2)
       amq-protocol (>= 2.0.1)
@@ -30,6 +36,16 @@ GEM
     docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
+    elasticsearch (1.0.15)
+      elasticsearch-api (= 1.0.15)
+      elasticsearch-transport (= 1.0.15)
+    elasticsearch-api (1.0.15)
+      multi_json
+    elasticsearch-transport (1.0.15)
+      faraday
+      multi_json
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.0)
     gds-api-adapters (29.4.0)
       link_header
@@ -47,6 +63,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.6.0)
+    jmespath (1.1.3)
     json (1.8.1)
     kgio (2.8.0)
     link_header (0.0.8)
@@ -73,6 +90,7 @@ GEM
       rb-inotify (>= 0.8)
       unicorn (>= 4.5)
     multi_json (1.11.0)
+    multipart-post (2.0.0)
     netrc (0.10.3)
     nokogiri (1.5.5)
     null_logger (0.0.1)
@@ -175,7 +193,9 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.0.0)
+  aws-sdk (~> 2.2.19)
   ci_reporter (= 1.7.1)
+  elasticsearch (~> 1.0.15)
   gds-api-adapters (~> 29.4)
   govuk-lint (~> 0.6.1)
   govuk_message_queue_consumer (~> 2.0.1)

--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,10 @@ def search_server
   search_config.search_server
 end
 
+def elasticsearch_uri
+  SearchConfig.new.elasticsearch["base_uri"]
+end
+
 def index_names
   case ENV["RUMMAGER_INDEX"]
   when "all"

--- a/docs/snapshot-restore.md
+++ b/docs/snapshot-restore.md
@@ -1,0 +1,144 @@
+# Snapshot and Restore Tasks
+
+Rummager defines several rake tasks to assist in
+
+  * restoring the search indexes to an earlier state
+  * rebuilding indexes with updated popularity data
+  * mirroring the search indexes between environments
+
+This is built on top of elasticsearch's snapshot/restore functionality,
+documented at <https://www.elastic.co/guide/en/elasticsearch/reference/1.4/modules-snapshots.html>
+
+## How snapshot/restore works in elasticsearch
+
+The Elasticsearch API allows us to create snapshots of one or more
+indexes.
+
+The snapshots live in a `repository`, which maps to some remote data store,
+such as a location in the file system, or in our case an AWS S3 bucket.
+
+Each snapshot is incremental, so successive snapshots don't necessarily use
+up extra storage, but there will be redundancy in the stored data, due to things
+like elasticsearch merging shards over time, or us rebuilding an index entirely.
+Because of this, we regularly delete old snapshots.
+
+### Index aliases
+
+Aliases are like symbolic links to one or more indices, and can be changed
+atomically.
+
+Rummager uses aliases to avoid downtime when restoring a snapshot or rebuilding
+an index.
+
+For example, during a restore operation, we follow the following steps:
+
+1. `mainstream` -> `mainstream-2016-02-25t17:07:13z-8efbb505-759a-4a34-ae0e-85aad065932d`
+2. Restore mainstream from a snapshot to a new index, `restored-mainstream-2016-02-25t17:11:04z-6d2a7dc4-a3b7-4572-b388-c59dc2c40be5`
+3. Wait for the restore to complete. Searches will continue to use the old
+index.
+3. Switch the alias: `mainstream` -> `restored-mainstream-2016-02-25t17:11:04z-6d2a7dc4-a3b7-4572-b388-c59dc2c40be5`
+4. Searches now use the new index.
+
+## Repository setup
+
+If you have an S3 bucket set up, you can create a snapshot repository yourself
+by running:
+
+```
+rake rummager:snapshot:create_repository
+```
+
+This assumes you have some environment variables available:
+
+- AWS_ACCESS_KEY_ID
+- AWS_ACCESS_SECRET_ACCESS_KEY
+- AWS_BUCKET_NAME
+- AWS_BUCKET_REGION
+
+The name of the bucket to be used is configured in `elasticsearch.yml`.
+
+If you want to create your own repository (e.g. for development), you might
+want to create a filesystem backed repository instead. This is documented in
+the [elasticsearch documentation for snapshot restore](https://www.elastic.co/guide/en/elasticsearch/reference/1.4/modules-snapshots.html).
+
+You won't be able to use the `rummager:snapshot:list` and `rummager:snapshot:latest`
+tasks without an S3 bucket, but the basic snapshot/restore can work with any
+repository type.
+
+## Start a snapshot
+Normally, snapshots are triggered regularly from a cron job.
+
+You can initiate a snapshot manually by running:
+
+```shell
+rake rummager:snapshot:run[repository_name,snapshot_name]
+```
+
+As above, you will need to ensure that AWS environment variables are set.
+
+If snapshot_name is left out, Rummager generates one based on the current time.
+
+If the repository does not exist, or elasticsearch is unable to process the
+request, the task exits with a non zero code and prints a stack trace.
+
+Otherwise the exit code will be zero.
+
+## Monitoring snapshots
+### Check if a snapshot has completed yet
+```shell
+rake rummager:snapshot:check[snapshot_name]
+```
+This returns the status of a snapshot operation, e.g. "SUCCESS".
+
+### Find the last successful snapshot
+```shell
+# Print the name of the latest snapshot
+rake rummager:snapshot:latest
+
+# Print the last snapshot excluding any after Jan 1st 2016
+rake 'rummager:snapshot:latest[2016-01-01 00:00:00]'
+```
+
+These require access to the S3 bucket, so all of the AWS environment variables
+must be set.
+
+### List all snapshots in the S3 bucket
+
+```shell
+# Includes in-progress snapshots
+rake rummager:snapshot:list
+```
+
+This command also requires AWS environment variables to be set.
+
+## Restore the latest snapshot
+```shell
+INDEX_NAMES=all rake rummager:snapshot:restore[snapshot_name]
+```
+Prints the names of the indexes that will be created.
+
+Exits with a non-zero code and prints a stack trace if elasticsearch is
+unable to handle a request. Only one restore operation can happen at a time.
+
+## Monitor a restore from snapshot
+```shell
+rake rummager:check_recovery[new_index_name]
+```
+Prints "true" or "false", depending on whether the restore is complete.
+
+Where `new_index_name` is the name that was printed by the `rummager:snapshot:restore`
+task. If in doubt, the [elasticsearch recovery API](https://www.elastic.co/guide/en/elasticsearch/reference/1.4/indices-recovery.html) can list all restored
+indexes.
+
+## Switch an index alias to a restored index
+
+Once an index has been successfully restored from a snapshot, you can switch
+over the alias:
+```shell
+INDEX_NAMES=mainstream rake rummager:switch_to_named_index[new_index_name]
+```
+
+## Nightly rebuild process
+
+There is a nightly jenkins job to rebuild the search indexes. This is also
+responsible for cleaning up out of date snapshots.

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -4,6 +4,7 @@ auxiliary_index_names: ["page-traffic", "metasearch"]
 registry_index: "government"
 metasearch_index_name: "metasearch"
 popularity_rank_offset: 10
+repository_name: rummager-snapshots
 
 # When doing spell checking, which indices to use?
 spelling_index_names:

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -5,6 +5,7 @@ registry_index: "government"
 metasearch_index_name: "metasearch"
 popularity_rank_offset: 10
 repository_name: rummager-snapshots
+snapshot_max_age_days: 1
 
 # When doing spell checking, which indices to use?
 spelling_index_names:

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -296,6 +296,15 @@ module SearchIndices
       end
     end
 
+    def self.index_recovered?(base_uri:, index_name:)
+      # Check if an index has recovered all its shards.
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html
+      # If something goes wrong, a shard can get stuck and not reach the DONE state.
+      client = Elasticsearch::Client.new(host: base_uri).indices
+      index_info = client.recovery(index: index_name)[index_name]
+      index_info["shards"].all? { |shard_info| shard_info["stage"] == "DONE" }
+    end
+
   private
 
     # Parse an elasticsearch error message to determine whether it's caused by

--- a/lib/index_group.rb
+++ b/lib/index_group.rb
@@ -21,6 +21,12 @@ module SearchIndices
       @search_config = search_config
     end
 
+    def index_for_name(real_name)
+      SearchIndices::Index.new(
+        @base_uri, real_name, @name, mappings, @search_config
+      )
+    end
+
     def create_index
       index_name = generate_name
       index_payload = {

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -12,6 +12,7 @@ class SearchConfig
     content_index_names
     spelling_index_names
     repository_name
+    snapshot_max_age_days
   ].each do |config_method|
     define_method config_method do
       elasticsearch.fetch(config_method)

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -11,6 +11,7 @@ class SearchConfig
     auxiliary_index_names
     content_index_names
     spelling_index_names
+    repository_name
   ].each do |config_method|
     define_method config_method do
       elasticsearch.fetch(config_method)
@@ -35,11 +36,12 @@ class SearchConfig
     content_index_names + auxiliary_index_names
   end
 
-private
-
   def elasticsearch
     @elasticsearch ||= config_for("elasticsearch")
   end
+
+
+private
 
   def config_path
     File.expand_path("../config/schema", File.dirname(__FILE__))

--- a/lib/snapshot/bucket.rb
+++ b/lib/snapshot/bucket.rb
@@ -1,0 +1,33 @@
+module Snapshot
+  class Bucket
+    def initialize(bucket_name:, client:)
+      @aws_client = client
+      @bucket_name = bucket_name
+    end
+
+    def repository_prefix(repository_name)
+      "#{repository_name}/metadata-"
+    end
+
+    # List names of all available snapshots, ignoring status.
+    # This information is not always visible in the elasticsearch API,
+    # so we go directly to the backing store (S3)
+    # Ordered by modification date ascending.
+    def list_snapshots(repository_name, before_time:)
+      prefix = repository_prefix(repository_name)
+
+      all_snapshots = @aws_client.list_objects({
+          bucket: @bucket_name,
+          prefix: prefix
+      }).contents
+
+      all_snapshots.select! { |snapshot| snapshot.last_modified <= before_time }
+
+      all_snapshots.sort_by!(&:last_modified)
+
+      all_snapshots.map do |snapshot|
+        snapshot.key.sub(prefix, "")
+      end
+    end
+  end
+end

--- a/lib/snapshot/snapshot_repository.rb
+++ b/lib/snapshot/snapshot_repository.rb
@@ -1,0 +1,159 @@
+require 'elasticsearch'
+require "logging"
+require "json"
+
+module Snapshot
+  class SnapshotRepository
+    attr_reader :repository_name
+
+    def initialize(base_uri:, repository_name:)
+      @client = Elasticsearch::Client.new(host: base_uri).snapshot
+      @repository_name = repository_name
+    end
+
+    # Create a snapshot repository
+    # The verify param requires delete permissions on the underlying data store
+    def create_repository(type, settings)
+      client.create_repository(
+        repository: "#{repository_name}",
+        body: {
+          type: type,
+          settings: settings
+        }
+      )
+    end
+
+    # Start a snapshot of one or more indices.
+    # snapshot_name is assumed to be unique.
+    #
+    # Raises a ServiceUnavailable exception if elasticsearch is already taking
+    # another snapshot.
+    def create_snapshot(snapshot_name, index_names)
+      client.create(
+        repository: repository_name,
+        snapshot: snapshot_name,
+        body: {
+          indices: index_names.join(","),
+          include_global_state: false
+        }
+      )
+    end
+
+    # Get the status of a previously started snapshot
+    def check_snapshot(snapshot_name)
+      response = client.status(
+        repository: repository_name,
+        snapshot: snapshot_name,
+      )
+      snapshot = response["snapshots"].first
+
+      logger.info(
+        "Snapshot #{snapshot['snapshot']}: #{snapshot['state']}"
+      )
+      logger.debug(snapshot["shards_stats"].to_s)
+
+      snapshot["state"]
+    end
+
+    def in_progress_snapshots
+      client.status(repository: repository_name)["snapshots"]
+        .reject { |snapshot| snapshot.fetch("state") == "SUCCESS" }
+        .map { |snapshot| snapshot.fetch("snapshot") }
+    end
+
+    def last_successful_snapshot(snapshots)
+      (snapshots - in_progress_snapshots).last
+    end
+
+    # Restore the indexes matching the specified group names
+    # The snapshot contains indexes with their "real" names, e.g.:
+    # mainstream-2016-02-25t17:14:51z-7f3aa400-76a0-4247-ba8a-1a1f3cac513c
+    def restore_indexes(snapshot_name, index_groups)
+      response = client.get(
+        repository: repository_name,
+        snapshot: snapshot_name
+      )
+      all_indices = response["snapshots"].first["indices"]
+      selected_indices = select_indices_from_groups(all_indices, index_groups)
+
+      Restorer.new(
+        client: client,
+        repository_name: repository_name,
+        snapshot_name: snapshot_name,
+        snapshot_indices: selected_indices
+      ).run
+    end
+
+  private
+
+    attr_reader :client
+
+    def logger
+      Logging.logger[self]
+    end
+
+    # Select only the indices matching one of our requested groups
+    def select_indices_from_groups(indices, index_groups)
+      indices.select do |index|
+        index_groups.any? do |index_group|
+          index.include?(index_group)
+        end
+      end
+    end
+  end
+
+  class Restorer
+    RENAME_PATTERN = '(restored-)*(.+)-\d{4}-\d{2}-\d{2}t\d{2}:\d{2}:\d{2}z-[0-9a-f][-0-9a-f]*\Z'
+
+    def initialize(client:, repository_name:, snapshot_name:, snapshot_indices:)
+      @client = client
+      @snapshot_name = snapshot_name
+      @snapshot_indices = snapshot_indices
+      @uuid = SecureRandom.uuid
+      @restore_time = Time.now.utc.iso8601
+      @repository_name = repository_name
+    end
+
+    # Restore to new indices, which we can point the aliases to once the
+    # recovery has completed.
+    # The new names contain the current timestamp and a "restored" prefix.
+
+    # Raises a ServiceUnavailable exception if elasticsearch is already
+    # restoring another snapshot.
+    def run
+      client.restore(
+        repository: repository_name,
+        snapshot: snapshot_name,
+        body: {
+          indices: snapshot_indices.join(","),
+          rename_pattern: RENAME_PATTERN,
+          rename_replacement: "#{prefix}$2#{suffix}".downcase
+        }
+      )
+
+      restored_index_names
+    end
+
+    # Work out the index names elasticsearch will create for us.
+    # This is not returned by the request itself.
+    def restored_index_names
+      snapshot_indices.map do |index|
+        index.gsub(Regexp.new(RENAME_PATTERN)) do
+          "#{prefix}#{$2}#{suffix}".downcase
+        end
+      end
+    end
+
+  private
+
+    attr_reader :client, :repository_name, :snapshot_name, :snapshot_indices
+
+    def prefix
+      "restored-"
+    end
+
+    def suffix
+      "-#{@restore_time}-#{@uuid}"
+    end
+  end
+end

--- a/lib/snapshot/snapshot_repository.rb
+++ b/lib/snapshot/snapshot_repository.rb
@@ -6,8 +6,8 @@ module Snapshot
   class SnapshotRepository
     attr_reader :repository_name
 
-    def initialize(base_uri:, repository_name:)
-      @client = Elasticsearch::Client.new(host: base_uri).snapshot
+    def initialize(base_uri:, repository_name:, **client_opts)
+      @client = Elasticsearch::Client.new(host: base_uri, **client_opts).snapshot
       @repository_name = repository_name
     end
 
@@ -53,6 +53,10 @@ module Snapshot
       logger.debug(snapshot["shards_stats"].to_s)
 
       snapshot["state"]
+    end
+
+    def delete_snapshot(snapshot_name)
+      client.delete(repository: repository_name, snapshot: snapshot_name)
     end
 
     def in_progress_snapshots

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -50,6 +50,24 @@ You should run this task if the index schema has changed.
     end
   end
 
+  desc "Switches an index group to a specific index WITHOUT transferring data"
+  task :switch_to_named_index, [:new_index_name] do |_, args|
+    # This makes no assumptions on the contents of the new index.
+    # If it has been restored from a snapshot, you should check that the
+    # index is fully recovered first. See :check_recovery.
+    raise "The new index name must be supplied" unless args.new_index_name
+
+    new_index_name = args.new_index_name
+
+    index_names.each do |index_name|
+      if new_index_name.include?(index_name)
+        puts "Switching #{index_name} -> #{args.new_index_name}"
+        index_group = search_server.index_group(index_name)
+        index_group.switch_to(index_group.index_for_name(new_index_name))
+      end
+    end
+  end
+
   desc "Migrates from an index with the actual index name to an alias"
   task :migrate_from_unaliased_index do
     # WARNING: this is potentially dangerous, and will leave the search
@@ -67,5 +85,17 @@ You should run this task if the index schema has changed.
     index_names.each do |index_name|
       search_server.index_group(index_name).clean
     end
+  end
+
+  desc "Check whether a restored index has recovered"
+  task :check_recovery, [:index_name] do |_, args|
+    raise "An 'index_name' must be supplied" unless args.index_name
+
+    require 'index'
+
+    puts SearchIndices::Index.index_recovered?(
+      base_uri: elasticsearch_uri,
+      index_name: args.index_name
+    )
   end
 end

--- a/lib/tasks/snapshot.rake
+++ b/lib/tasks/snapshot.rake
@@ -1,0 +1,139 @@
+require "snapshot/snapshot_repository"
+require "snapshot/bucket"
+require "rest-client"
+require "aws-sdk"
+require "date"
+require "time"
+
+# Generate a snapshot name based on the current time
+def generate_name(indices)
+  "#{indices.join('-')}-#{Time.now.utc.iso8601}-#{SecureRandom.uuid}".downcase
+end
+
+namespace :rummager do
+  namespace :snapshot do
+    desc "Start a snapshot of the public elasticsearch indices."
+    task :run, [:snapshot_name, :repository_name] do |_, args|
+      repository_name = args.repository_name || search_config.repository_name
+
+      indices = index_names
+      snapshot_name = args.snapshot_name || generate_name(indices)
+
+      Rake::Task["rummager:snapshot:create_repository"].invoke(repository_name)
+
+      repo = Snapshot::SnapshotRepository.new(
+        base_uri: elasticsearch_uri,
+        repository_name: repository_name,
+      )
+
+      puts snapshot_name
+      puts repo.create_snapshot(snapshot_name, indices)
+    end
+
+    desc "Get the status of a snapshot, e.g. SUCCESS"
+    task :check, [:repository_name, :snapshot_name] do |_, args|
+      raise "A 'snapshot_name' must be supplied" unless args.snapshot_name
+      repository_name = args.repository_name || search_config.repository_name
+
+      begin
+        repo = Snapshot::SnapshotRepository.new(
+          base_uri: elasticsearch_uri,
+          repository_name: repository_name,
+        )
+        puts repo.check_snapshot(args.snapshot_name)
+      rescue RestClient::ResourceNotFound
+        puts "Missing repository or snapshot. Try rummager:snapshot:list"
+      end
+    end
+
+    desc "Create or update a snapshot repository backed by S3"
+    task :create_repository, [:repository_name] do |_, args|
+      repository_name = args.repository_name || search_config.repository_name
+
+      validate_env(%w(
+        AWS_BUCKET_NAME
+        AWS_ACCESS_KEY_ID
+        AWS_BUCKET_REGION
+        AWS_SECRET_ACCESS_KEY
+      ))
+
+      client = Snapshot::SnapshotRepository.new(
+        base_uri: elasticsearch_uri,
+        repository_name: repository_name,
+      )
+      settings = {
+         region: ENV["AWS_BUCKET_REGION"],
+         bucket: ENV["AWS_BUCKET_NAME"],
+         access_key: ENV["AWS_ACCESS_KEY_ID"],
+         secret_key: ENV["AWS_SECRET_ACCESS_KEY"],
+         base_path: repository_name,
+      }
+      acknowledged = client.create_repository("s3", settings)["acknowledged"]
+
+      raise "Snapshot not acknowledged" unless acknowledged
+    end
+
+    desc "List all snapshots in the repository"
+    task :list, [:repository_name] do |_, args|
+      repository_name = args.repository_name || search_config.repository_name
+
+      puts bucket.list_snapshots(repository_name, before_time: Time.now)
+    end
+
+    desc "Get latest snapshot.
+    You can optionally pass a datetime parameter to filter out any snapshots
+    created afterwards.
+
+    If you don't pass it, it will default to the time in which the rake task is run.
+
+    This is used to monitor the ongoing snapshot process and make sure our
+    repository is keeping up to date.
+    "
+    task :latest, [:before_time, :repository_name] do |_, args|
+      repository_name = args.repository_name || search_config.repository_name
+
+      if args.before_time
+        before_time = DateTime.parse(before_time).to_time
+      else
+        before_time = Time.now
+      end
+
+      snapshots = bucket.list_snapshots(repository_name, before_time: before_time)
+
+      snapshot_repository = Snapshot::SnapshotRepository.new(
+        base_uri: elasticsearch_uri,
+        repository_name: repository_name,
+      )
+
+      puts snapshot_repository.last_successful_snapshot(snapshots) || "No snapshots present."
+    end
+
+    desc "Start restoring a snapshot and print the new index names"
+    task :restore, [:snapshot_name, :repository_name] do |_, args|
+      raise "A 'snapshot_name' must be supplied" unless args.snapshot_name
+      repository_name = args.repository_name || search_config.repository_name
+
+      snapshot_repository = Snapshot::SnapshotRepository.new(
+        base_uri: elasticsearch_uri,
+        repository_name: repository_name,
+      )
+      puts "Restored to indices:"
+      puts snapshot_repository.restore_indexes(args.snapshot_name, index_names)
+    end
+  end
+
+  def bucket
+    validate_env(%w(AWS_BUCKET_NAME AWS_BUCKET_REGION))
+
+    Snapshot::Bucket.new(
+      bucket_name: ENV["AWS_BUCKET_NAME"],
+      client: Aws::S3::Client.new(region: ENV["AWS_BUCKET_REGION"])
+    )
+  end
+
+  def validate_env(required_names)
+    unless required_names.all? { |name| ENV[name] }
+      raise "#{required_names.join(", ")} must be set as environment variables"
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ require "pp"
 require "shoulda-context"
 require "logging"
 require "timecop"
-require "pry"
+require "pry-byebug"
 
 require "webmock/minitest"
 

--- a/test/unit/snapshot/bucket_test.rb
+++ b/test/unit/snapshot/bucket_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "snapshot/bucket"
+require "aws-sdk"
+require 'time'
+
+class BucketTest < MiniTest::Unit::TestCase
+  def setup
+    @client = Minitest::Mock.new
+    @response = Minitest::Mock.new
+    @response.expect(:contents, [
+      Aws::S3::Types::Object.new(key: "my-repository/metadata-snap2000", last_modified: Time.new(2000)),
+      Aws::S3::Types::Object.new(key: "my-repository/metadata-snap2003", last_modified: Time.new(2003)),
+      Aws::S3::Types::Object.new(key: "my-repository/metadata-snap2001", last_modified: Time.new(2001)),
+    ])
+    @client.expect(:list_objects, @response, [{ bucket: "bucket", prefix: "my-repository/metadata-" }])
+  end
+
+  def test_returns_snapshots_ordered_by_date
+    bucket = Snapshot::Bucket.new(bucket_name: "bucket", client: @client)
+    names = bucket.list_snapshots("my-repository", before_time: Time.now)
+
+    assert_equal(names, %w(snap2000 snap2001 snap2003))
+  end
+
+  def test_returns_snapshots_filtered_by_date
+    bucket = Snapshot::Bucket.new(bucket_name: "bucket", client: @client)
+    names = bucket.list_snapshots("my-repository", before_time: Time.new(2001))
+
+    assert_equal(names, %w(snap2000 snap2001))
+  end
+end

--- a/test/unit/snapshot/snapshot_repository_test.rb
+++ b/test/unit/snapshot/snapshot_repository_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+require "snapshot/snapshot_repository"
+
+class SnapshotRepositoryTest < MiniTest::Unit::TestCase
+  def setup
+    @snapshot_repository = Snapshot::SnapshotRepository.new(
+      base_uri: "localhost:9000/repository/",
+      repository_name: "test-repository",
+    )
+  end
+
+  def test_last_successful_snapshot
+    @snapshot_repository.stub :in_progress_snapshots, ["in-progress-1", "in-progress-2"] do
+      all_snapshots = ["completed-1", "completed-2", "in-progress-1", "in-progress-2"]
+      assert @snapshot_repository.last_successful_snapshot(all_snapshots) == "completed-2"
+    end
+  end
+
+  def test_select_indices_from_groups
+    groups = %w(mainstream government)
+    indices = ["mainstream-2016-01-01....", "government-2016-01-01....", "service-manual-2016-01-01..."]
+    result = @snapshot_repository.send(:select_indices_from_groups, indices, groups)
+    assert_equal(
+      result,
+      [indices[0], indices[1]]
+    )
+  end
+end
+
+class SnapshotRestorerTest < MiniTest::Unit::TestCase
+  def create_restorer(indices)
+    Timecop.freeze(DateTime.new(2016, 4, 1)) do
+      SecureRandom.stub(:uuid, "123abc") do
+        @restorer = Snapshot::Restorer.new(
+          client: Minitest::Mock.new,
+          repository_name: "test-repository",
+          snapshot_name: "test-snapshot",
+          snapshot_indices: indices
+        )
+      end
+    end
+  end
+
+  def test_rename_pattern
+    restorer = create_restorer(["mainstream-2016-03-04t12:20:43z-bef6d9dd-0b71-4c93-a613-757352fd3826"])
+    result = restorer.restored_index_names
+    assert_equal(
+      result,
+      ["restored-mainstream-2016-04-01t00:00:00z-123abc"]
+    )
+  end
+
+  def test_restore_a_restore
+    restorer = create_restorer(["restored-mainstream-2016-03-04t12:20:43z-bef6d9dd-0b71-4c93-a613-757352fd3826"])
+    result = restorer.restored_index_names
+    assert_equal(
+      result,
+      ["restored-mainstream-2016-04-01t00:00:00z-123abc"]
+    )
+  end
+
+  def test_restore_hyphenated_index
+    restorer = create_restorer(["service-manual-2016-03-04t12:20:43z-bef6d9dd-0b71-4c93-a613-757352fd3826"])
+    result = restorer.restored_index_names
+    assert_equal(
+      result,
+      ["restored-service-manual-2016-04-01t00:00:00z-123abc"]
+    )
+  end
+end


### PR DESCRIPTION
- Start snapshot
- Monitor snapshot
- List snapshots in bucket
- Get latest snapshot
- Restore a named snapshot
- Monitor a restore
- Switch aliases to a restored index

The ongoing snapshot process will be managed from a cron or jenkins job,
and we plan to add a jenkins job for restoring as well.
We always create repository before snapshotting (this is idempotent), so settings
get updated when keys are rotated.

In addition to this we already have a nightly job that rebuilds the
indexes, which will be extended to clean up old snapshots.

Elasticsearch's APIs don't handle multiple snapshot/restore operations
at the same time. If we are unable to take a snapshot for this reason, we
will just let the job fail.

Ultimately, we will ensure we always have a useable snapshot by using
snapshots to refresh staging/integration and monitoring this.
