### PR TITLE
Correct lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,12 +21,6 @@ Style/ClosingParenthesisIndentation:
 Style/IfUnlessModifier:
   Enabled: false
 
-# We shouldn't inherit from Struct, but existing violations are quite difficult
-# to refactor. We'll disable this cop for known occurences so no new violations
-# will be introduced.
-Style/StructInheritance:
-  Enabled: false
-
 # The class vars in these two files are acceptable because
 # they aren't inherited.
 Style/ClassVars:

--- a/lib/health_check/basic_auth_credentials.rb
+++ b/lib/health_check/basic_auth_credentials.rb
@@ -4,7 +4,7 @@ module HealthCheck
   #
   # Because this is a Struct, the object can be passed into a Net::HTTP::Get
   # request's #basic_auth method with the splat operator.
-  class BasicAuthCredentials < Struct.new(:user, :password)
+  BasicAuthCredentials = Struct.new(:user, :password) do
     # Since we've got to provide a `call` method for Slop, let's make that the
     # only way to instantiate this class.
     private_class_method :new

--- a/lib/health_check/search_check.rb
+++ b/lib/health_check/search_check.rb
@@ -1,7 +1,7 @@
 require "health_check/search_check_result"
 
 module HealthCheck
-  class SearchCheck < Struct.new(:search_term, :imperative, :path, :minimum_rank, :weight)
+  SearchCheck = Struct.new(:search_term, :imperative, :path, :minimum_rank, :weight) do
     def valid_imperative?
       ["should", "should not"].include?(imperative)
     end

--- a/lib/search/presenters/spell_check_presenter.rb
+++ b/lib/search/presenters/spell_check_presenter.rb
@@ -1,5 +1,5 @@
 module Search
-  class SpellCheckPresenter < Struct.new(:es_response)
+  SpellCheckPresenter = Struct.new(:es_response) do
     def present
       return [] unless any_suggestions?
       es_response['suggest']['spelling_suggestions'].first['options'].map { |option| option['text'] }

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -1,7 +1,7 @@
 require_relative "registry"
 
 module Search
-  class Registries < Struct.new(:search_server, :search_config)
+  Registries = Struct.new(:search_server, :search_config) do
     def [](name)
       as_hash[name]
     end

--- a/lib/search/spell_check_fetcher.rb
+++ b/lib/search/spell_check_fetcher.rb
@@ -16,7 +16,7 @@ require_relative 'suggestion_blacklist'
 # Our solution is to run a separate query to fetch the suggestions, only using
 # the indices we want.
 module Search
-  class SpellCheckFetcher < Struct.new(:search_params, :registries)
+  SpellCheckFetcher = Struct.new(:search_params, :registries) do
     def es_response
       return unless should_correct_query?
       search_client.raw_search(elasticsearch_query)['suggest']

--- a/lib/search/suggestion_blacklist.rb
+++ b/lib/search/suggestion_blacklist.rb
@@ -2,7 +2,7 @@ require_relative 'matcher_set'
 require_relative 'registry'
 
 module Search
-  class SuggestionBlacklist < Struct.new(:registries)
+  SuggestionBlacklist = Struct.new(:registries) do
     STRINGS_WITH_DIGITS = /\d/
 
     def should_correct?(string)


### PR DESCRIPTION
Remove the unnecessary level from the inheritance hierarchy. See https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new
