### PR TITLE
Rename `allowed_values`

### DIFF
--- a/config/schema/README.md
+++ b/config/schema/README.md
@@ -84,12 +84,28 @@ The document type files contain JSON object with the following keys:
  - `fields`: An array of field names which are allowed in documents of this
    type.  The field names must be defined in the `field_definitions.json` file.
 
- - `allowed_values`: Details of allowed values for fields in the document. This
-   is an object, keyed by field name.  If a field is not mentioned in this
-   object, any syntactically valid value is allowed.  The allowed values are
-   specified as an array of objects, in which the `value` key defines the
-   allowed value, and an additional `label` value contains a displayable
-   version of the value.
+ - `expanded_search_result_fields`: DEPRECATED. Sets up field "expansion" for a
+    field. This is used by the search result presenter to replace a raw value.
+
+    For example:
+
+    ```
+    "expanded_search_result_fields": {
+      "fault_type": [
+        {
+          "label": "Recall",
+          "value": "recall"
+        },
+        {
+          "label": "Non-urgent fault",
+          "value": "non_urgent_fault"
+        }
+      ],
+    ```
+
+    Will return make the presenter replace the `fault_type` with value `recall`
+    with the hash `{ "label": "Recall", "value": "recall" }`. This can be used
+    when displaying the search results.
 
 ## Indexes
 

--- a/config/schema/document_types/aaib_report.json
+++ b/config/schema/document_types/aaib_report.json
@@ -8,7 +8,7 @@
     "location"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "aircraft_category": [
       {
         "label": "Commercial - fixed wing",

--- a/config/schema/document_types/cma_case.json
+++ b/config/schema/document_types/cma_case.json
@@ -8,7 +8,7 @@
     "closed_date"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "case_type": [
       {
         "label": "CA98 and civil cartels",

--- a/config/schema/document_types/countryside_stewardship_grant.json
+++ b/config/schema/document_types/countryside_stewardship_grant.json
@@ -6,7 +6,7 @@
     "funding_amount"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "grant_type": [
       {
         "label": "Option",

--- a/config/schema/document_types/drug_safety_update.json
+++ b/config/schema/document_types/drug_safety_update.json
@@ -4,7 +4,7 @@
     "first_published_at"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "therapeutic_area": [
       {
         "label": "Anaesthesia and intensive care",

--- a/config/schema/document_types/european_structural_investment_fund.json
+++ b/config/schema/document_types/european_structural_investment_fund.json
@@ -7,7 +7,7 @@
     "closing_date"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "fund_state": [
       {
         "label": "Open",

--- a/config/schema/document_types/international_development_fund.json
+++ b/config/schema/document_types/international_development_fund.json
@@ -7,7 +7,7 @@
     "value_of_funding"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "fund_state": [
       {
         "label": "Open",

--- a/config/schema/document_types/maib_report.json
+++ b/config/schema/document_types/maib_report.json
@@ -5,7 +5,7 @@
     "date_of_occurrence"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "vessel_type": [
       {
         "label": "Merchant vessel 100 gross tons or over",

--- a/config/schema/document_types/medical_safety_alert.json
+++ b/config/schema/document_types/medical_safety_alert.json
@@ -5,7 +5,7 @@
     "issued_date"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "alert_type": [
       {
         "label": "Drug alert",

--- a/config/schema/document_types/raib_report.json
+++ b/config/schema/document_types/raib_report.json
@@ -5,7 +5,7 @@
     "date_of_occurrence"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "railway_type": [
       {
         "label": "Heavy rail",

--- a/config/schema/document_types/vehicle_recalls_and_faults_alert.json
+++ b/config/schema/document_types/vehicle_recalls_and_faults_alert.json
@@ -10,7 +10,7 @@
     "build_end_date"
   ],
 
-  "allowed_values": {
+  "expanded_search_result_fields": {
     "fault_type": [
       {
         "label": "Recall",

--- a/lib/schema/combined_index_schema.rb
+++ b/lib/schema/combined_index_schema.rb
@@ -17,10 +17,9 @@ class CombinedIndexSchema
   # Get a hash from field_name to FieldDefinition object, for all fields
   # allowed in any document type in the indexes.
   #
-  # Since FieldDefinitions can contain an "allowed_values" member, and this
+  # Since FieldDefinitions can contain an "expanded_search_result_fields" member, and this
   # may differ between document types, the definitions returned here will
-  # have combined "allowed_values" fields, containing all the allowed values
-  # for the field across all document types.
+  # have combined "expanded_search_result_fields" fields.
   def field_definitions
     @field_definitions ||= each_field_with_object({}) { |field_name, field_definition, results|
       results[field_name] = field_definition.merge(results[field_name])

--- a/lib/schema/field_definitions.rb
+++ b/lib/schema/field_definitions.rb
@@ -1,20 +1,20 @@
 require "json"
 require "schema/field_types"
 
-FieldDefinition = Struct.new("FieldDefinition", :name, :type, :es_config, :description, :children, :allowed_values)
+FieldDefinition = Struct.new("FieldDefinition", :name, :type, :es_config, :description, :children, :expanded_search_result_fields)
 
 class FieldDefinition
   # Merge this field definition with another one.
   #
   # Assumes that the definitions are for the same field (but probably for a
   # different document type).  Therefore, the only thing that can differ is the
-  # allowed_values setting, so we only have to do anything if allowed_values
+  # expanded_search_result_fields setting, so we only have to do anything if expanded_search_result_fields
   # are set.
   def merge(other)
     unless other.nil?
-      if other.allowed_values
+      if other.expanded_search_result_fields
         result = self.clone
-        result.allowed_values = ((result.allowed_values || []) + other.allowed_values).uniq
+        result.expanded_search_result_fields = ((result.expanded_search_result_fields || []) + other.expanded_search_result_fields).uniq
         return result
       end
     end

--- a/lib/search/presenters/result_presenter.rb
+++ b/lib/search/presenters/result_presenter.rb
@@ -21,7 +21,7 @@ module Search
 
       if schema
         result = convert_elasticsearch_array_fields(result)
-        result = expand_allowed_values(result)
+        result = expand_fields_from_schema(result)
       end
 
       result = add_virtual_fields(result)
@@ -39,15 +39,15 @@ module Search
       EntityExpander.new(registries).new_result(result)
     end
 
-    def expand_allowed_values(result)
+    def expand_fields_from_schema(result)
       params_to_expand = result.select do |k, _|
-        document_schema.allowed_values.include?(k)
+        document_schema.expanded_search_result_fields.include?(k)
       end
 
       expanded_params = params_to_expand.reduce({}) do |params, (field_name, values)|
         params.merge(
           field_name => Array(values).map { |raw_value|
-            document_schema.allowed_values[field_name].find { |allowed_value|
+            document_schema.expanded_search_result_fields[field_name].find { |allowed_value|
               allowed_value.fetch("value") == raw_value
             }
           }

--- a/test/integration/search/expands_values_from_schema_test.rb
+++ b/test/integration/search/expands_values_from_schema_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class SearchExpandsAllowedValuesTest < IntegrationTest
+class ExpandsValuesFromSchemaTest < IntegrationTest
   def setup
     stub_elasticsearch_settings
     reset_content_indexes

--- a/test/unit/schema/combined_index_schema_test.rb
+++ b/test/unit/schema/combined_index_schema_test.rb
@@ -22,8 +22,8 @@ class CombinedIndexSchemaTest < MiniTest::Unit::TestCase
     # The location field is defined in both the
     # international_development_fund document type, and in the
     # european_structural_investment_fund document type, with different
-    # allowed_values.  Check that allowed values from both lists are present.
-    locations = @combined_schema.field_definitions["location"].allowed_values
+    # expanded_search_result_fields.  Check that expansion values from both lists are present.
+    locations = @combined_schema.field_definitions["location"].expanded_search_result_fields
     assert locations.include?({ "label" => "Afghanistan", "value" => "afghanistan" })
     assert locations.include?({ "label" => "North East", "value" => "north-east" })
   end

--- a/test/unit/schema/document_types_test.rb
+++ b/test/unit/schema/document_types_test.rb
@@ -11,7 +11,7 @@ class DocumentTypesTest < ShouldaUnitTestCase
     File.expand_path('../../../config/schema', File.dirname(__FILE__))
   end
 
-  def cma_case_allowed_values
+  def cma_case_expanded_search_result_fields
     [
       {
         "label" => "Open",
@@ -60,21 +60,21 @@ class DocumentTypesTest < ShouldaUnitTestCase
       )
     end
 
-    should "not specify allowed_values for the `organisations` field" do
-      assert_nil @types["manual_section"].fields["organisations"].allowed_values
+    should "not specify expanded_search_result_fields for the `organisations` field" do
+      assert_nil @types["manual_section"].fields["organisations"].expanded_search_result_fields
     end
 
-    should "include allowed_values in the cma_case `case_state` field" do
+    should "include expanded_search_result_fields in the cma_case `case_state` field" do
       assert_equal(
-        cma_case_allowed_values,
-        @types["cma_case"].fields["case_state"].allowed_values
+        cma_case_expanded_search_result_fields,
+        @types["cma_case"].fields["case_state"].expanded_search_result_fields
       )
     end
 
-    should "allowed_values on a field should also be available from the document type" do
+    should "expanded_search_result_fields on a field should also be available from the document type" do
       assert_equal(
-        @types["cma_case"].fields["case_state"].allowed_values,
-        @types["cma_case"].allowed_values["case_state"]
+        @types["cma_case"].fields["case_state"].expanded_search_result_fields,
+        @types["cma_case"].expanded_search_result_fields["case_state"]
       )
     end
   end
@@ -105,11 +105,11 @@ class DocumentTypesTest < ShouldaUnitTestCase
       assert_raises_message(%{Unknown keys (unknown), in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
 
-    should "fail if allowed values are specified in base type" do
+    should "fail if `expanded_search_result_fields` are specified in base type" do
       DocumentTypeParser.any_instance.stubs(:load_json).returns({
         "fields" => ["case_state"],
-        "allowed_values" => {
-          "case_state" => cma_case_allowed_values,
+        "expanded_search_result_fields" => {
+          "case_state" => cma_case_expanded_search_result_fields,
         },
       })
       base_type = @parser.parse
@@ -117,18 +117,18 @@ class DocumentTypesTest < ShouldaUnitTestCase
       subtype_parser = DocumentTypeParser.new("/config/path/subtype.json", base_type, @definitions)
       DocumentTypeParser.any_instance.stubs(:load_json).returns({ "fields" => [] })
 
-      assert_raises_message(%{Specifying `allowed_values` in base document type is not supported, in document type definition in "/config/path/subtype.json"}) { subtype_parser.parse }
+      assert_raises_message(%{Specifying `expanded_search_result_fields` in base document type is not supported, in document type definition in "/config/path/subtype.json"}) { subtype_parser.parse }
     end
 
-    should "fail if allowed_values are set for fields which aren't known" do
+    should "fail if expanded_search_result_fields are set for fields which aren't known" do
       DocumentTypeParser.any_instance.stubs(:load_json).returns({
         "fields" => ["case_state"],
-        "allowed_values" => {
-          "unknown_field" => cma_case_allowed_values,
+        "expanded_search_result_fields" => {
+          "unknown_field" => cma_case_expanded_search_result_fields,
         },
       })
 
-      assert_raises_message(%{Field "unknown_field" set in "allowed_values", but not in "fields", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
+      assert_raises_message(%{Field "unknown_field" set in "expanded_search_result_fields", but not in "fields", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
   end
 end

--- a/test/unit/schema/field_definitions_test.rb
+++ b/test/unit/schema/field_definitions_test.rb
@@ -37,7 +37,7 @@ class FieldDefinitionsTest < ShouldaUnitTestCase
 
       assert_equal "foo", merged.name
       assert_equal "string", merged.type
-      assert_equal [value1, value2, value3], merged.allowed_values.sort_by { |item| item["value"] }
+      assert_equal [value1, value2, value3], merged.expanded_search_result_fields.sort_by { |item| item["value"] }
     end
   end
 end


### PR DESCRIPTION
`allowed_values` is misnamed because it implies that this performs some kind of validation of input, which it doesn't.

`expanded_search_result_fields` is more descriptive, because its purpose is to replace certain values in the search results.

Paired with @mobaig on the new naming.
