### PR TITLE
Improve error handling in message queue consumer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "sidekiq-statsd", "0.1.5"
 # pin to version that includes security vulnerability fix
 gem "redis-namespace", "1.3.1"
 gem "plek", "1.11.0"
-gem "gds-api-adapters", "~> 28.1.0"
+gem "gds-api-adapters", "~> 29.4"
 gem "rack-logstasher", "0.0.3"
 gem 'airbrake', '4.0.0'
 gem "unf", "0.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.9.0)
-    gds-api-adapters (28.1.0)
+    gds-api-adapters (29.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -176,7 +176,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.0.0)
   ci_reporter (= 1.7.1)
-  gds-api-adapters (~> 28.1.0)
+  gds-api-adapters (~> 29.4)
   govuk-lint (~> 0.6.1)
   govuk_message_queue_consumer (~> 2.0.1)
   logging (= 1.8.1)

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -41,8 +41,8 @@ module Indexer
         .gsub('/government/organisations/', '')
         .gsub('/topic/', '')
         .gsub('/browse/', '')
-    rescue GdsApi::HTTPNotFound
-      # Content items in the links hash may not exist yet.
+    rescue GdsApi::HTTPNotFound, # Items in the links hash may not exist yet.
+           GdsApi::HTTPUnauthorized # Items may be access limited.
       nil
     end
 

--- a/test/integration/indexer/index_documents_test.rb
+++ b/test/integration/indexer/index_documents_test.rb
@@ -114,6 +114,20 @@ class Indexer::IndexDocumentsTest < IntegrationTest
     })
   end
 
+  def test_document_does_not_exist_in_elasticsearch
+    message = GovukMessageQueueConsumer::MockMessage.new({
+      "base_path" => "/an-unknown-page",
+      "publishing_app" => "policy-publisher",
+      "links" => {
+        "topics" => ['a-topic-uid']
+      }
+    })
+
+    Indexer::IndexDocuments.new.process(message)
+
+    assert message.discarded?
+  end
+
 private
 
   def stub_publishing_api_get_content(content_id, body)


### PR DESCRIPTION
When consuming from the message queue we've encountered two new edge-cases. 

The first one is that the document on the queue doesn't exist in the search index (which can happen, not all pages are in search). In this case we handle the error gracefully but send a Airbrake message for us to inspect. Once we've established that the pages are missing from search legitimately we'll remove that error notification.

The second is where a document is tagged to a access-limited document. When we request the item from the publishing-api it will return a `401 Unauthorised`. In this case we'll just ignore the linked document.

https://trello.com/c/lRnxI2x5
