### PR TITLE
Don't try to index links from email-signup pages

### DIFF
--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -55,7 +55,7 @@ module Indexer
     def get_document_for_base_path(document_base_path)
       unified_index = search_server.index_for_search(search_config.content_index_names)
       document = unified_index.get_document_by_link(document_base_path)
-      document || raise(UnknownDocumentError, "#{document_base_path} not found in index")
+      document || raise(UnknownDocumentError, "Document not found in index")
     end
 
     def search_server

--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -16,6 +16,10 @@ module Indexer
       smartanswers
     }
 
+    EXCLUDED_FORMATS = %{
+      email_alert_signup
+    }
+
     def process(message)
       $stdout.puts "Processing message: #{message.payload.inspect}"
       index_links_from_message(message)
@@ -32,7 +36,7 @@ module Indexer
   private
 
     def index_links_from_message(message)
-      return unless publishing_app_migrated?(message)
+      return unless should_index_document?(message.payload)
 
       base_path = message.payload.fetch("base_path")
       document = get_document_for_base_path(base_path)
@@ -44,8 +48,9 @@ module Indexer
       index.amend(document['_id'], links)
     end
 
-    def publishing_app_migrated?(message)
-      MIGRATED_TAGGING_APPS.include? message.payload["publishing_app"]
+    def should_index_document?(content_item)
+      MIGRATED_TAGGING_APPS.include?(content_item.fetch("publishing_app")) &&
+        !EXCLUDED_FORMATS.include?(content_item.fetch("document_type"))
     end
 
     def links_from_payload(message)

--- a/test/integration/indexer/index_documents_test.rb
+++ b/test/integration/indexer/index_documents_test.rb
@@ -23,6 +23,7 @@ class Indexer::IndexDocumentsTest < IntegrationTest
 
     message = GovukMessageQueueConsumer::MockMessage.new({
       "base_path" => "/my-page",
+      "document_type" => "some_format",
       "publishing_app" => "policy-publisher",
       "links" => {
         "topics" => ["my-topic-id"],
@@ -50,6 +51,7 @@ class Indexer::IndexDocumentsTest < IntegrationTest
 
     message = GovukMessageQueueConsumer::MockMessage.new({
       "base_path" => "/my-page",
+      "document_type" => "some_format",
       "publishing_app" => "policy-publisher",
       "links" => {
         "topics" => ["MY-ID"],
@@ -66,6 +68,7 @@ class Indexer::IndexDocumentsTest < IntegrationTest
 
     message = GovukMessageQueueConsumer::MockMessage.new({
       "base_path" => "/my-page",
+      "document_type" => "some_format",
       "publishing_app" => "unmigrated-app",
       "links" => {
         "topics" => ["my-topic-id"],
@@ -94,6 +97,7 @@ class Indexer::IndexDocumentsTest < IntegrationTest
 
     message = GovukMessageQueueConsumer::MockMessage.new({
       "base_path" => "/my-tagged-page",
+      "document_type" => "some_format",
       "publishing_app" => "policy-publisher",
       "links" => {}
     })
@@ -120,6 +124,7 @@ class Indexer::IndexDocumentsTest < IntegrationTest
     message = GovukMessageQueueConsumer::MockMessage.new({
       "base_path" => "/my-tagged-page",
       "publishing_app" => "policy-publisher",
+      "document_type" => "some_format",
       "links" => {
         "topics" => ['a-topic-uid']
       }
@@ -137,6 +142,7 @@ class Indexer::IndexDocumentsTest < IntegrationTest
     message = GovukMessageQueueConsumer::MockMessage.new({
       "base_path" => "/an-unknown-page",
       "publishing_app" => "policy-publisher",
+      "document_type" => "some_format",
       "links" => {
         "topics" => ['a-topic-uid']
       }
@@ -145,6 +151,21 @@ class Indexer::IndexDocumentsTest < IntegrationTest
     Indexer::IndexDocuments.new.process(message)
 
     assert message.discarded?
+  end
+
+  def test_ignore_messages_with_some_formats
+    message = GovukMessageQueueConsumer::MockMessage.new({
+      "base_path" => "/an-unknown-page",
+      "publishing_app" => "policy-publisher",
+      "document_type" => "email_alert_signup",
+      "links" => {
+        "topics" => ['a-topic-uid']
+      }
+    })
+
+    Indexer::IndexDocuments.new.process(message)
+
+    assert message.acked?
   end
 
 private


### PR DESCRIPTION
These pages are not in search, and shouldn't be. This commit makes it
that we don't index things with this document_type (formerly `format`).
