### PR TITLE
Ignore redirects in message queue

### DIFF
--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -18,6 +18,7 @@ module Indexer
 
     EXCLUDED_FORMATS = %{
       email_alert_signup
+      redirect
     }
 
     def process(message)


### PR DESCRIPTION
These documents can't be tagged, so ignore them.
