### PR TITLE
Sync tags of pages by travel advice publisher

### DIFF
--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -14,6 +14,7 @@ module Indexer
       licencefinder
       policy-publisher
       smartanswers
+      travel-advice-publisher
     }
 
     EXCLUDED_FORMATS = %{


### PR DESCRIPTION
This commit adds travel-advice-publisher to the list of apps that have been migrated. After this is deployed, tags sent to the publishing-api (from content-tagger for example) will be copied into the rummager index.

Part of: https://trello.com/c/Unia7Z0B
