### PR TITLE
Allow multiple categories for administrative appeals tribunal decisions

### DIFF
--- a/config/schema/document_types/utaac_decision.json
+++ b/config/schema/document_types/utaac_decision.json
@@ -1,11 +1,11 @@
 {
   "fields": [
-    "tribunal_decision_category",
-    "tribunal_decision_category_name",
+    "tribunal_decision_categories",
+    "tribunal_decision_categories_name",
     "tribunal_decision_decision_date",
     "tribunal_decision_judges",
     "tribunal_decision_judges_name",
-    "tribunal_decision_sub_category",
-    "tribunal_decision_sub_category_name"
+    "tribunal_decision_sub_categories",
+    "tribunal_decision_sub_categories_name"
   ]
 }


### PR DESCRIPTION
Domain experts have confirmed they want to be able to set multiple tribunal decision categories and sub-categories for administrative appeals tribunal decisions.

Rename `tribunal_decision_category` to `tribunal_decision_categories`.

Rename `tribunal_decision_sub_category` to `tribunal_decision_sub_categories`.

**Must be merged at same time as this specialist-publisher PR: https://github.com/alphagov/specialist-publisher/pull/671**
