### PR TITLE
Handle malformed messages better

### DIFF
--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -48,6 +48,8 @@ module Indexer
 
       index = search_server.index(document['real_index_name'])
       index.amend(document['_id'], links)
+    rescue KeyError => e
+      raise MalformedMessage, "Content item attribute missing. #{e.message}"
     end
 
     def should_index_document?(content_item)
@@ -77,6 +79,9 @@ module Indexer
     end
 
     class UnknownDocumentError < ProcessingError
+    end
+
+    class MalformedMessage < ProcessingError
     end
   end
 end

--- a/test/integration/indexer/index_documents_test.rb
+++ b/test/integration/indexer/index_documents_test.rb
@@ -168,6 +168,20 @@ class Indexer::IndexDocumentsTest < IntegrationTest
     assert message.acked?
   end
 
+  def test_ignore_messages_with_missing_values
+    message = GovukMessageQueueConsumer::MockMessage.new({
+      "base_path" => "/an-unknown-page",
+      "publishing_app" => "policy-publisher",
+      "links" => {
+        "topics" => ['a-topic-uid']
+      }
+    })
+
+    Indexer::IndexDocuments.new.process(message)
+
+    assert message.discarded?
+  end
+
 private
 
   def stub_publishing_api_get_content(content_id, body)


### PR DESCRIPTION
When deploying rummager to staging, we noticed that there are a number of messages waiting in the queue without the `document_format` attribute in the payload.

This commit makes sure we discard any of these messages, because there is no way to reliably process them. `ProcessingError` do get reported to errbit so we can take appropriate actions.
