### PR TITLE
Service manual formats

### DIFF
--- a/config/schema/document_types/service_manual_guide.json
+++ b/config/schema/document_types/service_manual_guide.json
@@ -1,0 +1,5 @@
+{
+  "fields": [
+    "manual"
+  ]
+}

--- a/config/schema/document_types/service_manual_topic.json
+++ b/config/schema/document_types/service_manual_topic.json
@@ -1,0 +1,5 @@
+{
+  "fields": [
+    "manual"
+  ]
+}

--- a/config/schema/indexes/mainstream.json
+++ b/config/schema/indexes/mainstream.json
@@ -19,6 +19,8 @@
     "medical_safety_alert",
     "policy",
     "raib_report",
+    "service_manual_guide",
+    "service_manual_topic",
     "tax_tribunal_decision",
     "utaac_decision",
     "vehicle_recalls_and_faults_alert"

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -24,18 +24,20 @@ module QueryComponents
     def boosted_formats
       {
         # Mainstream formats
-        "smart-answer"      => 1.5,
-        "transaction"       => 1.5,
+        "service_manual_guide" => 0.3,
+        "service_manual_topic" => 0.3,
+        "smart-answer" => 1.5,
+        "transaction" => 1.5,
 
         # Inside Gov formats
-        "topical_event"     => 1.5,
-        "minister"          => 1.7,
-        "organisation"      => 2.5,
-        "topic"             => 1.5,
-        "document_series"   => 1.3,
+        "topical_event" => 1.5,
+        "minister" => 1.7,
+        "organisation" => 2.5,
+        "topic" => 1.5,
+        "document_series" => 1.3,
         "document_collection" => 1.3,
         "operational_field" => 1.5,
-        "contact"           => 0.3,
+        "contact" => 0.3,
 
         # Hide mainstream browse pages for now.
         "mainstream_browse_page" => 0,

--- a/test/integration/search/booster_test.rb
+++ b/test/integration/search/booster_test.rb
@@ -1,0 +1,43 @@
+require "integration_test_helper"
+
+class BoosterTest < IntegrationTest
+  def setup
+    stub_elasticsearch_settings
+    reset_content_indexes
+    create_meta_indexes
+  end
+
+  def teardown
+    clean_test_indexes
+  end
+
+  def test_service_manual_formats_are_weighted_down
+    commit_document("mainstream_test",
+      title: "Agile is good",
+      link: "/agile-is-good",
+      format: "service_manual_guide",
+    )
+
+    commit_document("mainstream_test",
+      title: "Being agile is good",
+      link: "/being-agile-is-good",
+      format: "service_manual_topic",
+    )
+
+    commit_document("mainstream_test",
+      title: "Can we be agile?",
+      link: "/can-we-be-agile",
+    )
+
+    get "/unified_search?q=agile"
+
+    assert_equal ["Can we be agile?", "Agile is good", "Being agile is good"],
+      result_titles
+  end
+
+  def result_titles
+    parsed_response['results'].map do |result|
+      result['title']
+    end
+  end
+end

--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+require "search/query_builder"
+
+class BoosterTest < ShouldaUnitTestCase
+  should "add a function score to the query" do
+    Timecop.freeze("2016-03-11 16:00".to_time) do
+      builder = QueryComponents::Booster.new(search_query_params)
+      result = builder.wrap({ some: 'query' })
+
+      expected = {
+        function_score: {
+          boost_mode: :multiply,
+          score_mode: "multiply",
+          query: {
+            bool: {
+              should: [
+                { some: "query" }
+              ]
+            }
+          },
+          functions: [
+            { filter: { term: { format: "service_manual_guide" } },   boost_factor: 0.3 },
+            { filter: { term: { format: "service_manual_topic" } },   boost_factor: 0.3 },
+            { filter: { term: { format: "smart-answer" } },           boost_factor: 1.5 },
+            { filter: { term: { format: "transaction" } },            boost_factor: 1.5 },
+            { filter: { term: { format: "topical_event" } },          boost_factor: 1.5 },
+            { filter: { term: { format: "minister" } },               boost_factor: 1.7 },
+            { filter: { term: { format: "organisation" } },           boost_factor: 2.5 },
+            { filter: { term: { format: "topic" } },                  boost_factor: 1.5 },
+            { filter: { term: { format: "document_series" } },        boost_factor: 1.3 },
+            { filter: { term: { format: "document_collection" } },    boost_factor: 1.3 },
+            { filter: { term: { format: "operational_field" } },      boost_factor: 1.5 },
+            { filter: { term: { format: "contact" } },                boost_factor: 0.3 },
+            { filter: { term: { format: "mainstream_browse_page" } }, boost_factor: 0 },
+            { filter: { term: { search_format_types: "announcement" } },
+              script_score: {
+                script: "((0.05 / ((3.16*pow(10,-11)) * abs(now - doc['public_timestamp'].date.getMillis()) + 0.05)) + 0.12)",
+                params: { now: 1457712000000 }
+              }
+            },
+            { filter: { term: { organisation_state: "closed" } }, boost_factor: 0.2 },
+            { filter: { term: { organisation_state: "devolved" } }, boost_factor: 0.3 },
+            { filter: { term: { is_historic: true } }, boost_factor: 0.5 }
+          ]
+        }
+      }
+
+      assert_equal expected, result
+    end
+  end
+end


### PR DESCRIPTION
The original service manual, which is being replaced, currently uses it's own index service-manual. The deploy process for the original service manual purges the service-manual index and rebuilds it via a rake task.

We have started publishing from the new service manual publisher and we have been adding to the same service-manual index. When the original service manual is deployed we are going to lose our recently published stuff from search.

Here is the related PR from the publisher: https://github.com/alphagov/service-manual-publisher/pull/191
Here is the script that purges and rebuilds the service-manual index if you're interested: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_jenkins/templates/jobs/service_manual_rebuild_search_index.yaml.erb
