### PR TITLE
Wait for snapshot completion

### DIFF
--- a/docs/snapshot-restore.md
+++ b/docs/snapshot-restore.md
@@ -173,3 +173,22 @@ Where `snapshot_max_age` defaults to 24 hours.
 
 There is a nightly jenkins job to rebuild the search indexes. This is also
 responsible for cleaning up out of date snapshots.
+
+## FAQ
+
+### Why does elasticsearch return 5xx errors?
+
+```
+Elasticsearch::Transport::Transport::Errors::InternalServerError: [500] {"error":"ElasticsearchIllegalStateException[trying to modify or unregister repository that is currently used ]","status":500}
+```
+
+```
+Elasticsearch::Transport::Transport::Errors::ServiceUnavailable: [503] {"error":"ConcurrentSnapshotExecutionException[[repo:snapshot] a snapshot is already running]","status":503}
+```
+
+Both of these errors mean we are trying to execute two snapshots at once,
+which is not possible.
+
+When we run a snapshot we ensure the repository is created first. If another
+snapshot is running at the same time, elasticsearch can fail before even running
+the snapshot request.

--- a/lib/snapshot/snapshot_repository.rb
+++ b/lib/snapshot/snapshot_repository.rb
@@ -28,8 +28,9 @@ module Snapshot
     #
     # Raises a ServiceUnavailable exception if elasticsearch is already taking
     # another snapshot.
-    def create_snapshot(snapshot_name, index_names)
+    def create_snapshot(snapshot_name, index_names, wait_for_completion: false)
       client.create(
+        wait_for_completion: wait_for_completion,
         repository: repository_name,
         snapshot: snapshot_name,
         body: {

--- a/lib/tasks/snapshot.rake
+++ b/lib/tasks/snapshot.rake
@@ -24,14 +24,17 @@ namespace :rummager do
       repo = Snapshot::SnapshotRepository.new(
         base_uri: elasticsearch_uri,
         repository_name: repository_name,
+
+        # The first snapshot of a large index can take a long time
+        request_timeout: 20 * 60,
       )
 
       puts snapshot_name
-      puts repo.create_snapshot(snapshot_name, indices)
+      puts repo.create_snapshot(snapshot_name, indices, wait_for_completion: true)
     end
 
     desc "Get the status of a snapshot, e.g. SUCCESS"
-    task :check, [:repository_name, :snapshot_name] do |_, args|
+    task :check, [:snapshot_name, :repository_name] do |_, args|
       raise "A 'snapshot_name' must be supplied" unless args.snapshot_name
       repository_name = args.repository_name || search_config.repository_name
 


### PR DESCRIPTION
When running a snapshot, pass the wait for completion flag.
The timeout needs to be increased because this can take a long time
if there are no previous snapshots (e.g. around 10 minutes for all indices)

Reverse the arguments on the check task since the second one is optional.

Added some notes about possible elasticsearch failures.

This will allow us to use locking around our snapshot related tasks - see https://github.com/alphagov/govuk-puppet/pull/4196#discussion_r56490715
