### PR TITLE
Don't abort snapshot:clean if snapshot isn't found

### DIFF
--- a/lib/tasks/snapshot.rake
+++ b/lib/tasks/snapshot.rake
@@ -156,7 +156,9 @@ namespace :rummager do
             snapshot_name,
           )
         rescue Elasticsearch::Transport::Transport::Errors::NotFound
-          raise "Attempted to delete snapshot that doesn't exist"
+          # Sometimes elasticsearch (1.4) returns 404 for the delete operation.
+          # In this case we want to just move onto the next snapshot.
+          $stderr.puts "Attempted to delete snapshot that doesn't exist"
         end
       end
     end


### PR DESCRIPTION
I shouldn't have made this an exception in my last PR.

Sometimes elasticsearch returns 404 from the delete operation even though the snapshot used to exist. As far as I can tell this is fine to ignore.

```
Found 721 old snapshots...
Deleting mainstream-detailed-government-service-manual-page-traffic-metasearch-2016-03-10t06:55:03z-402a0848-65d2-4f44-869f-e96a48001bb1

[....]

Elasticsearch::Transport::Transport::Errors::NotFound: [404] {"error":"RemoteTransportException[[api-elasticsearch-2.api.integration.publishing.service.gov.uk][inet[/10.1.4.26:9300]][cluster:admin/snapshot/delete]]; nested: SnapshotMissingException[[rummager-snapshots:mainstream-detailed-government-service-manual-page-traffic-metasearch-2016-03-10t06:55:03z-402a0848-65d2-4f44-869f-e96a48001bb1] is missing]; nested: FileNotFoundException[Blob object [snapshot-mainstream-detailed-government-service-manual-page-traffic-metasearch-2016-03-10t06:55:03z-402a0848-65d2-4f44-869f-e96a48001bb1] not found: The specified key does not exist. (Service: Amazon S3; Status Code: 404; Error Code: NoSuchKey; Request ID: 11224B40358F2D29)]; ","status":404}
```
