### PR TITLE
Don't index "gone" documents

### DIFF
--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -19,6 +19,7 @@ module Indexer
 
     EXCLUDED_FORMATS = %{
       email_alert_signup
+      gone
       redirect
     }
 


### PR DESCRIPTION
These documents are generally not in the search index. We can ignore them when indexing the links.

This will help in reducing the load in elasticsearch when indexing a bunch of documents.

https://trello.com/c/0FKSqAkK
