### PR TITLE
[See other PRs] Migrate trade tariff tags to publishing api

### DIFF
--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -14,6 +14,7 @@ module Indexer
       licencefinder
       policy-publisher
       smartanswers
+      tariff
       travel-advice-publisher
     }
 


### PR DESCRIPTION
Trade tariff tags are now handled by publishing api and content tagger

Part of: https://trello.com/c/Aqvwgl1G/558-migrate-the-trade-tariff-page-to-new-tagging-infrastructure

Should be deployed with
- https://github.com/alphagov/panopticon/pull/333
- https://github.com/alphagov/content-tagger/pull/50
- https://github.com/alphagov/tagging-migration-verifier/pull/14
