### PR TITLE
Fix suggestion health check

### DIFF
--- a/lib/health_check/suggestion_check.rb
+++ b/lib/health_check/suggestion_check.rb
@@ -46,7 +46,7 @@ module HealthCheck
         if expected_result_empty?
           "'#{search_term}' should not be corrected but corrects to '#{suggested_query}'"
         else
-          "'#{search_term}' should be be corrected to '#{expected_result}' but #{suggested_query.nil? ? 'does not correct' : "corrects to '#{suggested_query}'"}"
+          "'#{search_term}' should be corrected to '#{expected_result}' but #{suggested_query.nil? ? 'does not correct' : "corrects to '#{suggested_query}'"}"
         end
       end
     end

--- a/lib/health_check/suggestion_checker.rb
+++ b/lib/health_check/suggestion_checker.rb
@@ -15,7 +15,7 @@ module HealthCheck
       calculator = Calculator.new
 
       parsed_checks.each do |search_term, expected_result|
-        suggested_queries = @search_client.search(search_term, count: 0)[:suggested_queries]
+        suggested_queries = @search_client.search(search_term, count: 0, suggest: 'spelling')[:suggested_queries]
 
         check = SuggestionCheck.new(
           search_term: search_term,

--- a/test/unit/health_check/suggestion_checker_test.rb
+++ b/test/unit/health_check/suggestion_checker_test.rb
@@ -25,7 +25,7 @@ other-thing,,
         }
 
         responses.each do |term, suggestions|
-          stub_request(:get, "https://www.gov.uk/api/search.json?count=0&q=#{term}").
+          stub_request(:get, "https://www.gov.uk/api/search.json?count=0&q=#{term}&suggest=spelling").
             to_return(body: JSON.dump(results: [], suggested_queries: suggestions))
         end
 


### PR DESCRIPTION
The search suggestion health check measures how good rummager is in suggesting spelling corrections to the user. 

A rummager API change months ago (https://github.com/alphagov/rummager/pull/515) caused the health check to stop working.

Fixes: https://trello.com/c/wae6TIdZ
