### PR TITLE
Don't send `InvalidQuery` exceptions to Errbit

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -79,7 +79,7 @@ class Rummager < Sinatra::Application
     halt(503, "Redis queue timed out")
   end
 
-  error SearchIndices::InvalidQuery do
+  error LegacySearch::InvalidQuery do
     halt(422, env['sinatra.error'].message)
   end
 

--- a/config.rb
+++ b/config.rb
@@ -21,5 +21,6 @@ Dir[initializers_path].each { |f| require f }
 
 configure do
   Airbrake.configuration.ignore << "Sinatra::NotFound"
+  Airbrake.configuration.ignore << "LegacySearch::InvalidQuery"
   use Airbrake::Sinatra
 end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -14,7 +14,6 @@ require "document"
 require "indexer/index_queue"
 
 module SearchIndices
-  class InvalidQuery < ArgumentError; end
   class DocumentNotFound < RuntimeError; end
   class IndexLocked < RuntimeError; end
 

--- a/lib/legacy_search/advanced_search.rb
+++ b/lib/legacy_search/advanced_search.rb
@@ -1,6 +1,9 @@
 require "legacy_search/advanced_search_query_builder"
 
 module LegacySearch
+  class InvalidQuery < ArgumentError
+  end
+
   class AdvancedSearch
     def initialize(mappings, document_types, client)
       @mappings = mappings
@@ -11,7 +14,7 @@ module LegacySearch
     def result_set(params)
       logger.info "params:#{params.inspect}"
       if params["per_page"].nil? || params["page"].nil?
-        raise SearchIndices::InvalidQuery.new("Pagination params are required.")
+        raise LegacySearch::InvalidQuery, "Pagination params are required."
       end
 
       # Delete params that we don't want to be passed as filter_params
@@ -21,7 +24,10 @@ module LegacySearch
       page      = params.delete("page").to_i
 
       query_builder = AdvancedSearchQueryBuilder.new(keywords, params, order, @mappings)
-      raise SearchIndices::InvalidQuery.new(query_builder.error) unless query_builder.valid?
+
+      unless query_builder.valid?
+        raise LegacySearch::InvalidQuery, query_builder.error
+      end
 
       starting_index = page <= 1 ? 0 : (per_page * (page - 1))
       payload = {

--- a/test/unit/legacy_search/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/legacy_search/elasticsearch_index_advanced_search_test.rb
@@ -203,7 +203,7 @@ class IndexerIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def assert_rejected_search(expected_error, search_args)
-    e = assert_raises(SearchIndices::InvalidQuery) do
+    e = assert_raises(LegacySearch::InvalidQuery) do
       @wrapper.advanced_search(search_args)
     end
     assert_equal expected_error, e.message


### PR DESCRIPTION
This exception is triggered by a user error and should not be sent to errbit. Currently it is, causing unnecessary emails to developers and error-blindness.

Ignores errors like:

https://errbit.publishing.service.gov.uk/apps/539849ba0da115be230008b7/problems/56fd109165786342b80e1a00

Trello: https://trello.com/c/MC4qYvTV
