### PR TITLE
Rescue all exceptions in message queue worker

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -83,7 +83,7 @@ class Rummager < Sinatra::Application
     halt(422, env['sinatra.error'].message)
   end
 
-  error SearchIndices::BulkIndexFailure do
+  error Indexer::BulkIndexFailure do
     halt(500, env['sinatra.error'].message)
   end
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -18,15 +18,6 @@ module SearchIndices
   class DocumentNotFound < RuntimeError; end
   class IndexLocked < RuntimeError; end
 
-  class BulkIndexFailure < RuntimeError
-    attr_reader :failed_keys
-
-    def initialize(failed_items)
-      super "Failed inserts: #{failed_items.map { |id, error| "#{id} (#{error})" }.join(', ')}"
-      @failed_keys = failed_items.map { |id, _| id }
-    end
-  end
-
   class Index
     include Search::Escaping
 
@@ -155,7 +146,7 @@ module SearchIndices
           # TODO This error should include the error messages from
           # elasticsearch, not just the IDs of the documents that weren't
           # inserted
-          raise BulkIndexFailure.new(failed_items.map { |item|
+          raise Indexer::BulkIndexFailure.new(failed_items.map { |item|
             [
               item["index"]["_id"],
               item["index"]["error"],

--- a/lib/indexer.rb
+++ b/lib/indexer.rb
@@ -1,6 +1,7 @@
 require 'indexer/popularity_lookup'
 require 'indexer/bulk_payload_generator'
 require 'indexer/document_preparer'
+require 'indexer/exceptions'
 require 'indexer/tag_lookup'
 
 module Indexer

--- a/lib/indexer/exceptions.rb
+++ b/lib/indexer/exceptions.rb
@@ -1,0 +1,10 @@
+module Indexer
+  class BulkIndexFailure < RuntimeError
+    attr_reader :failed_keys
+
+    def initialize(failed_items)
+      super "Failed inserts: #{failed_items.map { |id, error| "#{id} (#{error})" }.join(', ')}"
+      @failed_keys = failed_items.map { |id, _| id }
+    end
+  end
+end

--- a/lib/indexer/exceptions.rb
+++ b/lib/indexer/exceptions.rb
@@ -1,10 +1,7 @@
 module Indexer
   class BulkIndexFailure < RuntimeError
-    attr_reader :failed_keys
-
     def initialize(failed_items)
       super "Failed inserts: #{failed_items.map { |id, error| "#{id} (#{error})" }.join(', ')}"
-      @failed_keys = failed_items.map { |id, _| id }
     end
   end
 end

--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -35,6 +35,11 @@ module Indexer
     rescue ProcessingError => e
       Airbrake.notify_or_ignore(e, parameters: message.payload)
       message.discard
+    rescue StandardError => e
+      $stderr.puts "Unknown Exception: #{e.message}"
+      Airbrake.notify_or_ignore(e, parameters: message.payload)
+      sleep 1
+      message.retry
     end
 
   private

--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -26,7 +26,7 @@ module Indexer
 
     def process(message)
       $stdout.puts "Processing message: #{message.payload.inspect}"
-      index_links_from_message(message)
+      index_links_from_message(message.payload)
       message.ack
     rescue GdsApi::HTTPServerError => e
       $stderr.puts "An error occurred!"
@@ -44,28 +44,28 @@ module Indexer
 
   private
 
-    def index_links_from_message(message)
-      return unless should_index_document?(message.payload)
+    def index_links_from_message(payload)
+      return unless should_index_document?(payload)
 
-      base_path = message.payload.fetch("base_path")
+      base_path = payload.fetch("base_path")
       document = get_document_for_base_path(base_path)
 
-      raw_links = links_from_payload(message)
+      raw_links = payload.fetch("links", {})
       links = Indexer::LinksLookup.new.rummager_fields_from_links(raw_links)
 
-      index = search_server.index(document['real_index_name'])
-      index.amend(document['_id'], links)
+      update_document_in_search_index(document, links)
     rescue KeyError => e
       raise MalformedMessage, "Content item attribute missing. #{e.message}"
+    end
+
+    def update_document_in_search_index(document, links)
+      index = search_server.index(document['real_index_name'])
+      index.amend(document['_id'], links)
     end
 
     def should_index_document?(content_item)
       MIGRATED_TAGGING_APPS.include?(content_item.fetch("publishing_app")) &&
         !EXCLUDED_FORMATS.include?(content_item.fetch("document_type"))
-    end
-
-    def links_from_payload(message)
-      message.payload.fetch("links", {})
     end
 
     def get_document_for_base_path(document_base_path)

--- a/test/integration/indexer/closing_test.rb
+++ b/test/integration/indexer/closing_test.rb
@@ -2,6 +2,7 @@ require "integration_test_helper"
 
 class ElasticsearchClosingTest < IntegrationTest
   def setup
+    stub_tagging_lookup
     stub_elasticsearch_settings
     create_test_index
   end
@@ -14,7 +15,7 @@ class ElasticsearchClosingTest < IntegrationTest
     index = search_server.index_group(DEFAULT_INDEX_NAME).current
     index.close
 
-    assert_raises SearchIndices::BulkIndexFailure do
+    assert_raises Indexer::BulkIndexFailure do
       index.add([sample_document])
     end
   end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -108,7 +108,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     begin
       @index.add(documents)
       flunk("No exception raised")
-    rescue SearchIndices::BulkIndexFailure => e
+    rescue Indexer::BulkIndexFailure => e
       assert_equal "Failed inserts: /foo/baz (stuff)", e.message
       assert_equal ["/foo/baz"], e.failed_keys
     end

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -110,7 +110,6 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       flunk("No exception raised")
     rescue Indexer::BulkIndexFailure => e
       assert_equal "Failed inserts: /foo/baz (stuff)", e.message
-      assert_equal ["/foo/baz"], e.failed_keys
     end
   end
 


### PR DESCRIPTION
During development of the message queue processor we've experienced multiple times that some unknown exception in the code is triggered.

Currently this will crash the worker, after which it is restarted by `upstart`. This sometimes happens very quickly, causing the message queue processor to try the same thing many times, causing other load
troubles.

This commit makes the consumer more resilient by rescuing any errors and waiting one second before trying again. It also reports the error to Airbrake itself so that we have access to the offending payload.

Trello: https://trello.com/c/MC4qYvTV
