### PR TITLE
Message queue: only listen to link changes

### DIFF
--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -12,11 +12,14 @@ namespace :message_queue do
     require 'govuk_message_queue_consumer'
     require 'indexer/index_documents'
 
-    # routing_key is defaulted to '#'
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "rummager_to_be_indexed",
       exchange_name: "published_documents",
       processor: Indexer::IndexDocuments.new,
+
+      # Only listen to "links" updates, which the publishing-api sends after
+      # something updates the links hash.
+      routing_key: '*.links',
     ).run
   end
 end


### PR DESCRIPTION
The publishing-api sends a message when the content item changes: on a `publish` call and a `patch links` call.

It sends the message with a "routing key" in the form of "format.update_type". The update type can be major, minor or republish (when the content has changed), or `links` when somebody patches the
links.

Rummager is only interested in the changing links, so we can restrict the consumer to listen to a specific pattern. You can read more about it here:

https://www.rabbitmq.com/tutorials/tutorial-five-python.html

By restricting this rummager will have to do less work, because less messages will come in.

Trello: https://trello.com/c/MC4qYvTV
