### PR TITLE
Upgrade Airbrake to latest 4.X version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "redis-namespace", "1.3.1"
 gem "plek", "1.12.0"
 gem "gds-api-adapters", "~> 30.0"
 gem "rack-logstasher", "0.0.3"
-gem 'airbrake', '4.0.0'
+gem "airbrake", "~> 4.3.6"
 gem "unf", "0.1.4"
 gem 'aws-sdk', '~> 2.2.29'
 gem 'elasticsearch', '~> 1.0.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (~> 0.6)
       multi_json (~> 1.0)
     addressable (2.4.0)
-    airbrake (4.0.0)
+    airbrake (4.3.6)
       builder
       multi_json
     amq-protocol (2.0.1)
@@ -20,7 +20,7 @@ GEM
       jmespath (~> 1.0)
     aws-sdk-resources (2.2.31)
       aws-sdk-core (= 2.2.31)
-    builder (3.1.3)
+    builder (3.2.2)
     bunny (2.2.2)
       amq-protocol (>= 2.0.1)
     celluloid (0.16.0)
@@ -89,7 +89,7 @@ GEM
       rb-fsevent (>= 0.9)
       rb-inotify (>= 0.8)
       unicorn (>= 4.5)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     netrc (0.10.3)
     nokogiri (1.6.7.2)
@@ -187,7 +187,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (= 4.0.0)
+  airbrake (~> 4.3.6)
   aws-sdk (~> 2.2.29)
   ci_reporter (= 1.7.1)
   elasticsearch (~> 1.0.15)


### PR DESCRIPTION
We can't upgrade to Airbrake 5.X because it is probably not compatible with Errbit. In the meantime we should be on the latest version of 4.
