### PR TITLE
Bump `sinatra` to v1.4.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
 
 gem "unicorn", "4.6.2"
-gem "sinatra", "1.3.4"
+gem "tilt", "1.3.3"
+gem "rack-protection", "1.5.0"
+gem "sinatra", "1.4.7"
 gem "rake", "~> 10.5"
 gem "rack", "~> 1.6"
 gem "rest-client", "1.8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     rack-logstasher (0.0.3)
       logstash-event
       rack
-    rack-protection (1.3.2)
+    rack-protection (1.5.0)
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
@@ -155,10 +155,10 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    sinatra (1.3.4)
-      rack (~> 1.4)
-      rack-protection (~> 1.3)
-      tilt (~> 1.3, >= 1.3.3)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     slop (3.4.5)
     statsd-ruby (1.2.1)
     tilt (1.3.3)
@@ -202,6 +202,7 @@ DEPENDENCIES
   plek (= 1.12.0)
   rack (~> 1.6)
   rack-logstasher (= 0.0.3)
+  rack-protection (= 1.5.0)
   rack-test
   rake (~> 10.5)
   redis-namespace (= 1.3.1)
@@ -211,8 +212,9 @@ DEPENDENCIES
   sidekiq-statsd (= 0.1.5)
   simplecov (~> 0.10.0)
   simplecov-rcov
-  sinatra (= 1.3.4)
+  sinatra (= 1.4.7)
   slop (= 3.4.5)
+  tilt (= 1.3.3)
   timecop (= 0.8.0)
   turn
   unf (= 0.1.4)

--- a/lib/indexer/workers/base_worker.rb
+++ b/lib/indexer/workers/base_worker.rb
@@ -40,7 +40,7 @@ module Indexer
   private
 
     def index(index_name)
-      settings.search_config.search_server.index(index_name)
+      Rummager.settings.search_config.search_server.index(index_name)
     end
   end
 end

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -38,7 +38,7 @@ module Search
 
     def specialist_sectors
       BaseRegistry.new(
-        search_server.index_for_search(settings.search_config.content_index_names),
+        search_server.index_for_search(Rummager.settings.search_config.content_index_names),
         field_definitions,
         "specialist_sector"
       )
@@ -49,7 +49,7 @@ module Search
     end
 
     def index
-      search_server.index_for_search([settings.search_config.registry_index])
+      search_server.index_for_search([Rummager.settings.search_config.registry_index])
     end
 
     def field_definitions


### PR DESCRIPTION
Changes in `sinatra` means that, eg, `settings` becomes `Rummager.settings`.

Leave `tilt`, and small bump for `rack-protection`: bumping these two further cause test failures. That will be fixed in the next PR.

The following work on the development vm:
- all tests pass
- `RUMMAGER_INDEX=all bundle exec rake rummager:migrate_index` works
- `bundle exec bin/health_check --type=suggestions` runs
- `http://rummager.dev.gov.uk/unified_search.json?q=child%20benefit` returns sensible output
