### PR TITLE
Bump `tilt` and `rack-protection`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 
 gem "unicorn", "4.6.2"
-gem "tilt", "1.3.3"
-gem "rack-protection", "1.5.0"
 gem "sinatra", "1.4.7"
 gem "rake", "~> 10.5"
 gem "rack", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     rack-logstasher (0.0.3)
       logstash-event
       rack
-    rack-protection (1.5.0)
+    rack-protection (1.5.3)
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
@@ -161,7 +161,7 @@ GEM
       tilt (>= 1.3, < 3)
     slop (3.4.5)
     statsd-ruby (1.2.1)
-    tilt (1.3.3)
+    tilt (2.0.2)
     timecop (0.8.0)
     timers (4.0.4)
       hitimes
@@ -202,7 +202,6 @@ DEPENDENCIES
   plek (= 1.12.0)
   rack (~> 1.6)
   rack-logstasher (= 0.0.3)
-  rack-protection (= 1.5.0)
   rack-test
   rake (~> 10.5)
   redis-namespace (= 1.3.1)
@@ -214,7 +213,6 @@ DEPENDENCIES
   simplecov-rcov
   sinatra (= 1.4.7)
   slop (= 3.4.5)
-  tilt (= 1.3.3)
   timecop (= 0.8.0)
   turn
   unf (= 0.1.4)

--- a/app.rb
+++ b/app.rb
@@ -23,6 +23,9 @@ require_relative "helpers"
 require "routes/content"
 
 class Rummager < Sinatra::Application
+  # Stop double slashes in URLs (even escaped ones) being flattened to single ones
+  set :protection, except: [:path_traversal, :escaped_params, :frame_options]
+
   def search_server
     settings.search_config.search_server
   end

--- a/config.ru
+++ b/config.ru
@@ -26,9 +26,6 @@ else
     extra_request_headers: { "GOVUK-Request-Id" => "govuk_request_id", "x-varnish" => "varnish_id" }
 end
 
-# Stop double slashes in URLs (even escaped ones) being flattened to single ones
-set :protection, except: [:path_traversal, :escaped_params, :frame_options]
-
 enable :dump_errors, :raise_errors
 
 run Rummager


### PR DESCRIPTION
No longer need to specify the values of `tilt` and `rack-protection` in the Gemfile.

To get `rack-protection` working properly again, configuration had to be moved from `config.ru` to `app.rb`

Part of: https://trello.com/c/1mXjOji6/565-upgrade-rummager-dependencies
