### PR TITLE
Safely remove old workers

### DIFF
--- a/lib/indexer/workers/amend_worker.rb
+++ b/lib/indexer/workers/amend_worker.rb
@@ -17,21 +17,3 @@ module Indexer
     end
   end
 end
-
-module Elasticsearch
-  class AmendWorker < Indexer::BaseWorker
-    notify_of_failures
-
-    def perform(index_name, document_link, updates)
-      logger.info "Amending document '#{document_link}' in '#{index_name}'"
-      logger.info "Amending fields #{updates.keys.join(', ')}"
-      logger.debug "Amendments: #{updates}"
-      begin
-        index(index_name).amend(document_link, updates)
-      rescue SearchIndices::IndexLocked
-        logger.info "Index #{index_name} is locked; rescheduling"
-        self.class.perform_in(LOCK_DELAY, index_name, document_link, updates)
-      end
-    end
-  end
-end

--- a/lib/indexer/workers/bulk_index_worker.rb
+++ b/lib/indexer/workers/bulk_index_worker.rb
@@ -17,21 +17,3 @@ module Indexer
     end
   end
 end
-
-module Elasticsearch
-  class BulkIndexWorker < Indexer::BaseWorker
-    notify_of_failures
-
-    def perform(index_name, document_hashes)
-      noun = document_hashes.size > 1 ? "documents" : "document"
-      logger.info "Indexing #{document_hashes.size} queued #{noun} into #{index_name}"
-
-      begin
-        index(index_name).bulk_index(document_hashes)
-      rescue SearchIndices::IndexLocked
-        logger.info "Index #{index_name} is locked; rescheduling"
-        self.class.perform_in(LOCK_DELAY, index_name, document_hashes)
-      end
-    end
-  end
-end

--- a/lib/indexer/workers/delete_worker.rb
+++ b/lib/indexer/workers/delete_worker.rb
@@ -21,25 +21,3 @@ module Indexer
     end
   end
 end
-
-module Elasticsearch
-  class DeleteWorker < Indexer::BaseWorker
-    notify_of_failures
-
-    def perform(index_name, document_type, document_id = nil)
-      # Handle previous method signature to cope with leftover queued jobs when
-      # we deploy.
-      if document_id.nil?
-        document_type, document_id = index(index_name).link_to_type_and_id(document_type)
-      end
-
-      logger.info "Deleting #{document_type} document '#{document_id}' from '#{index_name}'"
-      begin
-        index(index_name).delete(document_type, document_id)
-      rescue SearchIndices::IndexLocked
-        logger.info "Index #{index_name} is locked; rescheduling"
-        self.class.perform_in(LOCK_DELAY, index_name, document_type, document_id)
-      end
-    end
-  end
-end


### PR DESCRIPTION
These workers were added in https://github.com/alphagov/rummager/pull/573 to allow us to safely change the class name of the workers. Now that all old messages have gone from the queue, we can delete the old ones.

cc @MatMoore 
