### PR TITLE
Remove duplicated field definitions from schema config

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -411,12 +411,6 @@
   "tribunal_decision_judges_name": {
     "type": "searchable_identifiers"
   },
-  "tribunal_decision_categories": {
-    "type": "identifiers"
-  },
-  "tribunal_decision_categories_name": {
-    "type": "searchable_identifiers"
-  },
   "tribunal_decision_category": {
     "type": "identifier"
   },


### PR DESCRIPTION
Remove duplicated field definitions for `tribunal_decision_categories` and `tribunal_decision_categories_name` from field_definitions.json config.

The duplicated fields are defined elsewhere in the file here: https://github.com/ministryofjustice/rummager/blob/remove-duplicated-field-definitions/config/schema/field_definitions.json#L393-L398

Currently there is a problem filtering on tribunal decision categories for UTAAC decisions that may or may not be related to the definitions being duplicated.
