### PR TITLE
Lock down `activesupport` to 3.2.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 source "https://rubygems.org"
 
 gem "unicorn", "5.1.0"
+
+# We have been experiencing `ActiveSupport::Deprecation::MethodWrapper` errors
+# when deploying versions of this app with activesupport 4.0.13. Pin to this
+# version for now until we've upgraded other apps and fixed the issue.
+gem "activesupport", "3.2.12"
+
 gem "sinatra", "1.4.7"
 gem "rake", "~> 10.5"
 gem "rack", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,6 @@ GEM
     amq-protocol (2.0.1)
     ansi (1.5.0)
     ast (2.2.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
     aws-sdk (2.2.31)
       aws-sdk-resources (= 2.2.31)
     aws-sdk-core (2.2.31)
@@ -161,7 +159,6 @@ GEM
       tilt (>= 1.3, < 3)
     slop (3.4.5)
     statsd-ruby (1.3.0)
-    thread_safe (0.3.5)
     tilt (2.0.2)
     timecop (0.8.0)
     timers (4.0.4)
@@ -169,7 +166,6 @@ GEM
     turn (0.9.7)
       ansi
       minitest (~> 4)
-    tzinfo (0.3.48)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -188,6 +184,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (= 3.2.12)
   airbrake (~> 4.3.6)
   aws-sdk (~> 2.2.29)
   ci_reporter (= 1.7.1)


### PR DESCRIPTION
We have been experiencing `ActiveSupport::Deprecation::MethodWrapper` errors when deploying versions of this app with activesupport 4.0.13. Pin to this version for now until we've upgraded other apps and fixed the issue.

Also removes some gems from the Gemfile.lock that were in there because of manual editing (https://github.com/alphagov/rummager/pull/615).

Related: https://github.com/alphagov/rummager/pull/596
