### PR TITLE
Weigh down HMRC manuals results

### DIFF
--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -39,6 +39,9 @@ module QueryComponents
         "operational_field" => 1.5,
         "contact" => 0.3,
 
+        # Should appear below mainstream content
+        "hmrc_manual_section" => 0.2,
+
         # Hide mainstream browse pages for now.
         "mainstream_browse_page" => 0,
       }

--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -31,6 +31,7 @@ class BoosterTest < ShouldaUnitTestCase
             { filter: { term: { format: "document_collection" } },    boost_factor: 1.3 },
             { filter: { term: { format: "operational_field" } },      boost_factor: 1.5 },
             { filter: { term: { format: "contact" } },                boost_factor: 0.3 },
+            { filter: { term: { format: "hmrc_manual_section" } },    boost_factor: 0.2 },
             { filter: { term: { format: "mainstream_browse_page" } }, boost_factor: 0 },
             { filter: { term: { search_format_types: "announcement" } },
               script_score: {


### PR DESCRIPTION
We should reduce HMRC manuals relevancy score, so that they don't appear above more relevant results.
Ticket: https://trello.com/c/fF7yDgRL/585-weighting-of-hmrc-manuals-in-search
