### PR TITLE
Allow tagging for service-manual-publisher

### DIFF
--- a/lib/indexer/index_documents.rb
+++ b/lib/indexer/index_documents.rb
@@ -5,7 +5,6 @@ module Indexer
   class IndexDocuments
     NON_MIGRATED_APPS = %w(
       publisher
-      service-manual-publisher
       specialist-publisher
       whitehall
       non-migrated-app


### PR DESCRIPTION
Service manual publisher has been migrated to the new tagging mechanism.

See https://trello.com/c/FSo3C9Qf/591-allow-tagging-for-service-manual-publisher

Other blacklists:
https://github.com/alphagov/panopticon/pull/343
https://github.com/alphagov/content-tagger/pull/57
