### PR TITLE
Allow `content_id` to be added to documents

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -1,6 +1,7 @@
 {
   "fields": [
     "all_searchable_text",
+    "content_id",
     "description",
     "format",
     "indexable_content",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -8,6 +8,11 @@
     "type": "identifier"
   },
 
+  "content_id": {
+    "description": "The content_id of the item. This will not be present for all items, as most application do not send it.",
+    "type": "identifier"
+  },
+
   "title": {
     "type": "searchable_sortable_text"
   },

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -32,7 +32,7 @@ module Search
         index,
         field_definitions,
         "organisation",
-        %w{slug link title acronym organisation_type organisation_state}
+        %w{slug content_id link title acronym organisation_type organisation_state}
       )
     end
 

--- a/lib/search/registry.rb
+++ b/lib/search/registry.rb
@@ -4,7 +4,7 @@ module Search
   class BaseRegistry
     CACHE_LIFETIME = 300 # 5 minutes
 
-    def initialize(index, field_definitions, format, fields = %w{slug link title}, clock = Time)
+    def initialize(index, field_definitions, format, fields = %w{slug link title content_id}, clock = Time)
       @cache = TimedCache.new(self.class::CACHE_LIFETIME, clock) { fetch }
 
       @field_definitions = fields.reduce({}) { |result, field|

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -29,6 +29,7 @@ class ElasticsearchIndexingTest < IntegrationTest
     })
 
     post "/documents", {
+      "content_id" => "6b965b82-2e33-4587-a70c-60204cbb3e29",
       "title" => "TITLE",
       "format" => "answer",
       "link" => "/an-example-answer",
@@ -37,6 +38,7 @@ class ElasticsearchIndexingTest < IntegrationTest
 
     assert last_response.ok?
     assert_document_is_in_rummager({
+      "content_id" => "6b965b82-2e33-4587-a70c-60204cbb3e29",
       "title" => "TITLE",
       "format" => "answer",
       "link" => "/an-example-answer",

--- a/test/unit/search/base_registry_test.rb
+++ b/test/unit/search/base_registry_test.rb
@@ -35,7 +35,7 @@ class BaseRegistryTest < MiniTest::Unit::TestCase
 
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
-      .with("example-format", sample_field_definitions(%w{slug link title}))
+      .with("example-format", sample_field_definitions(%w{slug link title content_id}))
 
     @base_registry["example-document"]
   end

--- a/test/unit/search/specialist_sector_registry_test.rb
+++ b/test/unit/search/specialist_sector_registry_test.rb
@@ -27,7 +27,7 @@ class SpecialistSectorRegistryTest < MiniTest::Unit::TestCase
 
   def test_only_required_fields_are_requested_from_index
     @index.expects(:documents_by_format)
-      .with("specialist_sector", sample_field_definitions(%w{link slug title}))
+      .with("specialist_sector", sample_field_definitions(%w{link slug title content_id}))
       .returns([])
     @specialist_sector_registry["oil-and-gas/licensing"]
   end


### PR DESCRIPTION
In the future, Rummager will be looking up the tags for an item at indexing time. This will replace the current implementation where it [looks up content in content-api](https://github.com/alphagov/rummager/blob/cb87092842772632b7f560e932a5656be651e098/lib/indexer/document_preparer.rb#L13).

The publishing-api currently just exposes a unexpanded links-hash like:

``` json
{
  "topics": ["bf9683e6-b584-425c-923b-dd5ed925e8d8"]
}
```

At indexing time we need to translate these content_ids into a base_path, which is how the links are currently stored in rummager. To ease that lookup, we will be sending the content_id of organisations,
topics and browse pages to rummager. This means we can do a simple search in elasticsearch and use the `link` of the document.

Trello: https://trello.com/c/ppe8Upar
