### PR TITLE
Add debug option to show query

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.3
+
 # Don't care about single/double quotes inside interpolation
 Style/StringLiteralsInInterpolation:
   Enabled: false

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -309,6 +309,8 @@ private
         options[:include_withdrawn] = true
       when "use_id_codes"
         options[:use_id_codes] = true
+      when "show_query"
+        options[:show_query] = true
       else
         @errors << %{Unknown debug option "#{option}"}
       end

--- a/lib/search/presenters/result_set_presenter.rb
+++ b/lib/search/presenters/result_set_presenter.rb
@@ -20,7 +20,8 @@ module Search
                    es_response:,
                    registries: {},
                    facet_examples: {},
-                   schema: nil)
+                   schema: nil,
+                   query_payload: {})
 
       @es_response = es_response
       @facets = es_response["facets"]
@@ -28,16 +29,23 @@ module Search
       @registries = registries
       @facet_examples = facet_examples
       @schema = schema
+      @query_payload = query_payload
     end
 
     def present
-      {
+      response = {
         results: presented_results,
         total: es_response["hits"]["total"],
         start: search_params.start,
         facets: presented_facets,
         suggested_queries: suggested_queries
       }
+
+      if search_params.show_query?
+        response['elasticsearch_query'] = @query_payload
+      end
+
+      response
     end
 
   private

--- a/lib/search/presenters/result_set_presenter.rb
+++ b/lib/search/presenters/result_set_presenter.rb
@@ -16,11 +16,11 @@ module Search
     # `facet_examples` is {field_name => {facet_value => {total: count, examples: [{field: value}, ...]}}}
     # ie: a hash keyed by field name, containing hashes keyed by facet value with
     # values containing example information for the value.
-    def initialize(search_params,
-                   es_response,
-                   registries = {},
-                   facet_examples = {},
-                   schema = nil)
+    def initialize(search_params:,
+                   es_response:,
+                   registries: {},
+                   facet_examples: {},
+                   schema: nil)
 
       @es_response = es_response
       @facets = es_response["facets"]

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -17,7 +17,8 @@ module Search
     # Search and combine the indices and return a hash of ResultSet objects
     def run(search_params)
       builder = QueryBuilder.new(search_params)
-      es_response = index.raw_search(builder.payload)
+      payload = builder.payload
+      es_response = index.raw_search(payload)
 
       example_fetcher = FacetExampleFetcher.new(index, es_response, search_params, builder)
       facet_examples = example_fetcher.fetch
@@ -32,7 +33,8 @@ module Search
         es_response: es_response,
         registries: registries,
         facet_examples: facet_examples,
-        schema: index.schema
+        schema: index.schema,
+        query_payload: payload
       ).present
     end
 

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -28,11 +28,11 @@ module Search
       end
 
       ResultSetPresenter.new(
-        search_params,
-        es_response,
-        registries,
-        facet_examples,
-        index.schema
+        search_params: search_params,
+        es_response: es_response,
+        registries: registries,
+        facet_examples: facet_examples,
+        schema: index.schema
       ).present
     end
 

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -42,6 +42,10 @@ module Search
       debug[:use_id_codes]
     end
 
+    def show_query?
+      debug[:show_query]
+    end
+
     def suggest_spelling?
       query && suggest.include?('spelling')
     end

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -464,6 +464,14 @@ class SearchTest < IntegrationTest
     assert_equal 1, parsed_response.fetch("total")
   end
 
+  def test_show_the_query
+    reset_content_indexes
+
+    get "/unified_search?q=test&debug=show_query"
+
+    assert parsed_response.fetch("elasticsearch_query")
+  end
+
 private
 
   def first_result


### PR DESCRIPTION
This is useful for debugging and understanding the query.

For example:

http://www.gov.uk/api/search.json?count=0&debug=show_query
