### PR TITLE
Allow rendering_app & publishing_app to be set

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -13,6 +13,8 @@
     "policies",
     "popularity",
     "public_timestamp",
+    "publishing_app",
+    "rendering_app",
     "specialist_sectors",
     "spelling_text",
     "title",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -47,9 +47,19 @@
     "type": "identifiers"
   },
 
+  "publishing_app": {
+    "description": "Application that published this page",
+    "type": "identifier"
+  },
+
   "policy_areas": {
     "description": "Policy areas are managed in Whitehall. They're an old grouping of policies, which we're expecting to deprecate soon.",
     "type": "identifiers"
+  },
+
+  "rendering_app": {
+    "description": "Application that renders this page",
+    "type": "identifier"
   },
 
   "mainstream_browse_pages": {


### PR DESCRIPTION
This is interesting information when we will start migrating rummager to use the message queue. We’ll slowly migrate apps to send this information.
