### PR TITLE
Clarify what `manual` attribute means

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -275,7 +275,8 @@
   },
 
   "manual": {
-    "type": "identifier"
+    "type": "identifier",
+    "description": "Base path of the manual this document belongs to. Eg `/service-manual` or `/hmrc-internal-manuals/air-passenger-duty`"
   },
 
   "hmrc_manual_section_id": {


### PR DESCRIPTION
This should be a base path to the manual, otherwise scoped search won’t work.

@AndrewVos 
