### PR TITLE
Add a filterable "first_published_at" field

### DIFF
--- a/config/schema/document_types/dfid_research_output.json
+++ b/config/schema/document_types/dfid_research_output.json
@@ -1,6 +1,7 @@
 {
   "fields": [
-    "country"
+    "country",
+    "first_published_at"
   ],
   "expanded_search_result_fields": {
     "country": [


### PR DESCRIPTION
This needs to be separate and distinct from the publishing platform's
 "Published" date field, which is updated in lockstep with major updates
and will not appear when items are `bulk_published`. There is already
 a "first_published_at" field in rummager, so we just use this.

This gives editors the opportunity to enter the real published date
of a research output.
## Related PRs

https://github.com/alphagov/dfid-transition/pull/25
https://github.com/alphagov/specialist-publisher-rebuild/pull/767
