### PR TITLE
Adds Alan Turing to ignore.yml

### DIFF
--- a/config/suggest/ignore.yml
+++ b/config/suggest/ignore.yml
@@ -40,6 +40,9 @@
 - stgo
 - swmp
 
+# Never try to correct full names of honoured people
+- alan turing
+
 # Never try to correct full names of cabinet members. These can be removed in
 # the future when elasticsearch has "learned" that their names are correct
 # because they are found often in government/mainstream indices.

--- a/test/unit/search/suggestion_blacklist_test.rb
+++ b/test/unit/search/suggestion_blacklist_test.rb
@@ -28,8 +28,12 @@ class Search::SuggestionBlacklistTest < ShouldaUnitTestCase
       refute blacklist.should_correct?("86asrdv")
     end
 
-    should "correct words in ignore.txt" do
+    should "not correct words added to ignore.yml" do
       refute blacklist.should_correct?("bodrum")
+    end
+
+    should "not correct names added to ignore.yml" do
+      refute blacklist.should_correct?("Alan Turing")
     end
 
     should "correct words in the organization" do


### PR DESCRIPTION
We don't want to wrongly suggest his name during search.
#### Before

<img width="958" alt="screen shot 2016-05-24 at 13 37 31" src="https://cloud.githubusercontent.com/assets/136777/15503996/b48543d8-21b4-11e6-8ef2-03cfb6c42882.png">
#### After

<img width="958" alt="screen shot 2016-05-24 at 13 37 14" src="https://cloud.githubusercontent.com/assets/136777/15504005/c3ec889a-21b4-11e6-9b4e-619a70b240ff.png">
