### PR TITLE
Opt in to gds-api-adapters request tracing middleware

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -26,6 +26,10 @@ else
     extra_request_headers: { "GOVUK-Request-Id" => "govuk_request_id", "x-varnish" => "varnish_id" }
 end
 
+require "gds_api/middleware/govuk_header_sniffer"
+use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_REQUEST_ID'
+use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_ORIGINAL_URL'
+
 enable :dump_errors, :raise_errors
 
 run Rummager

--- a/lib/legacy_client/client.rb
+++ b/lib/legacy_client/client.rb
@@ -1,5 +1,6 @@
 require "logging"
 require "rest-client"
+require "gds_api/govuk_headers"
 
 module LegacyClient
   class Client
@@ -96,6 +97,8 @@ module LegacyClient
       if headers == {}
         headers[:content_type] = "application/json"
       end
+
+      headers = headers.merge(GdsApi::GovukHeaders.headers)
 
       logging_exception_body do
         args = {

--- a/lib/legacy_client/client.rb
+++ b/lib/legacy_client/client.rb
@@ -106,7 +106,7 @@ module LegacyClient
           url: url_for(path),
         }
         args[:payload] = payload if payload
-        args[:headers] = headers if headers
+        args[:headers] = headers
         args[:timeout] = @timeout if @timeout
         args[:open_timeout] = @open_timeout if @open_timeout
         logger.debug(args.reject { |k| k == :payload })


### PR DESCRIPTION
Pass the two headers on to all downstream requests, including elasticsearch.

We currently run a local nginx on the search hosts that does some load balancing and proxies to elasticsearch.
Long term, we can remove this, since the elasticsearch gem can do its own load balancing.

For now though, it would be useful to be able to trace requests back to the original request. The nginx logs currently don't contain any identifible information about the request, because the query string is part of the GET body rather than the URL.

We will also pass through the request id to downstream requests made through gds-api-adapters,
eg content api when indexing.
