### PR TITLE
Stop magic tags from being indexed

### DIFF
--- a/lib/indexer/tag_lookup.rb
+++ b/lib/indexer/tag_lookup.rb
@@ -47,6 +47,13 @@ module Indexer
       doc_hash["mainstream_browse_pages"].uniq!
       doc_hash["specialist_sectors"].uniq!
 
+      # Content API adds two "magic tags" to artefacts when requesting an
+      # artefact over the API. Prevent these tags from ending up in Rummager.
+      if artefact["owning_app"] == "travel-advice-publisher" && artefact["format"] == "travel-advice"
+        doc_hash["mainstream_browse_pages"].delete("abroad/living-abroad")
+        doc_hash["mainstream_browse_pages"].delete("abroad/travel-abroad")
+      end
+
       doc_hash
     end
   end

--- a/test/unit/indexer/tag_lookup_test.rb
+++ b/test/unit/indexer/tag_lookup_test.rb
@@ -56,5 +56,13 @@ describe Indexer::TagLookup do
 
       assert_equal %w(foo baz bar), result["specialist_sectors"]
     end
+
+    it 'removes magic tags' do
+      content_api_has_an_artefact("foo/bar", { "owning_app" => "travel-advice-publisher", "format" => "travel-advice", "tags" => [] })
+
+      result = Indexer::TagLookup.prepare_tags({ "link" => "/foo/bar", "mainstream_browse_pages" => %w(foo abroad/living-abroad) })
+
+      assert_equal %w(foo), result["mainstream_browse_pages"]
+    end
   end
 end


### PR DESCRIPTION
Content API adds two "magic tags" to artefacts when requesting an artefact over the API. Prevent these tags from ending up in Rummager. These are not tags that the user has chosen, but automatically added things that cause an extra navigation to show up on the page. For reference:

https://github.com/alphagov/govuk_content_api/blob/b74a48dd9c43f56120893e5b2000c1da2c473da0/govuk_content_api.rb#L686-L691

When we initially started indexing links from the content-api, we started inadvertently indexing these tags too. This caused initial problems on the browse pages, which we solved by excluding the format from the browse pages (https://github.com/alphagov/collections/pull/170).

This commit solves the original sin and removes these rogue tags from the search-index at indexing time.

We need this now because we want publishing-api to be in sync with rummager.

https://trello.com/c/UidTGyou
