### PR TITLE
[Don't merge] Add `rummager_document_type` as alias for `_type`

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -21,6 +21,12 @@ class BaseParameterParser
   # Incoming filter fields will have their names transformed according to the
   # following mapping. Fields not listed here will be passed through unchanged.
   FILTER_NAME_MAPPING = {
+    # The term `document_type` is also used by the publishing-api, but they are
+    # not the same. To prevent confusion, we're renaming it here in Rummager.
+    # https://trello.com/c/KlVeVW91.
+    "rummager_document_type" => "_type",
+
+    # DEPRECATED. Use `rummager_document_type`.
     "document_type" => "_type",
   }.freeze
 

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -158,9 +158,9 @@ private
   end
 
   def allowed_filter_fields
-    # document_type is a special case, because it's an alias for the internal
-    # "_type" field.
-    ["document_type"] + @schema.allowed_filter_fields
+    # rummager_document_type is a special case, because it's an alias for the
+    # internal "_type" field.
+    %w[rummager_document_type document_type] + @schema.allowed_filter_fields
   end
 
   def allowed_return_fields

--- a/lib/search/presenters/result_presenter.rb
+++ b/lib/search/presenters/result_presenter.rb
@@ -92,7 +92,10 @@ module Search
         result[:_explanation] = raw_result["_explanation"]
       end
 
+      # TODO: only return these values if they're actually requested by the user.
       result[:document_type] = raw_result["_type"]
+      result[:rummager_document_type] = raw_result["_type"]
+
       result
     end
 


### PR DESCRIPTION
The term `document_type` is also used by the publishing-api, but they are not the same. To prevent confusion, we're renaming it here in Rummager.

https://trello.com/c/KlVeVW91

I'm not a 100% convinced about the name. Perhaps people have other suggestions?
- `internal_type`
- `elasticsearch_type`
- `internal_document_type`
