### PR TITLE
[DO NOT MERGE] Proof of concept for including organisation pages in an organisation search

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -220,8 +220,6 @@ private
       case field_name
       when "organisations"
         "organisation"
-      else
-        nil
       end
     end
   end

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -215,6 +215,15 @@ private
     def valid?
       errors.empty?
     end
+
+    def associated_document_type
+      case field_name
+      when "organisations"
+        "organisation"
+      else
+        nil
+      end
+    end
   end
 
   class DateFieldFilter < Filter

--- a/lib/search/query_components/user_filter.rb
+++ b/lib/search/query_components/user_filter.rb
@@ -52,6 +52,18 @@ module QueryComponents
         raise "Filter type not supported"
       end
 
+      associated_document_type = filter.associated_document_type
+      if associated_document_type
+        associated_document_filter = combine_filters(
+          [
+            terms_filter("slug", values),
+            term_filter("format", associated_document_type)
+          ],
+          :and
+        )
+        es_filters << associated_document_filter
+      end
+
       combine_filters(es_filters, :or)
     end
 

--- a/test/unit/search/query_components/facets_test.rb
+++ b/test/unit/search/query_components/facets_test.rb
@@ -12,7 +12,7 @@ class FacetsTest < ShouldaUnitTestCase
     should "have correct facet in payload" do
       builder = QueryComponents::Facets.new(
         make_search_params(
-          facets: { "organisations" => { requested: 10, scope: :exclude_field_filter } },
+          facets: { "specialist_sectors" => { requested: 10, scope: :exclude_field_filter } },
         )
       )
 
@@ -20,9 +20,9 @@ class FacetsTest < ShouldaUnitTestCase
 
       assert_equal(
         {
-          "organisations" => {
+          "specialist_sectors" => {
             terms: {
-              field: "organisations",
+              field: "specialist_sectors",
               order: "count",
               size: 100000,
             },
@@ -37,8 +37,8 @@ class FacetsTest < ShouldaUnitTestCase
     setup do
       @builder = QueryComponents::Facets.new(
         make_search_params(
-          filters: [text_filter("organisations", ["hm-magic"])],
-          facets: { "organisations" => { requested: 10, scope: :exclude_field_filter } },
+          filters: [text_filter("specialist_sectors", ["magic"])],
+          facets: { "specialist_sectors" => { requested: 10, scope: :exclude_field_filter } },
         )
       )
     end
@@ -46,9 +46,9 @@ class FacetsTest < ShouldaUnitTestCase
     should "have correct facet in payload" do
       assert_equal(
         {
-          "organisations" => {
+          "specialist_sectors" => {
             terms: {
-              field: "organisations",
+              field: "specialist_sectors",
               order: "count",
               size: 100000,
             },
@@ -62,8 +62,8 @@ class FacetsTest < ShouldaUnitTestCase
     setup do
       @builder = QueryComponents::Facets.new(
         make_search_params(
-          filters: [text_filter("organisations", ["hm-magic"])],
-          facets: { "organisations" => { requested: 10, scope: :all_filters } },
+          filters: [text_filter("specialist_sectors", ["magic"])],
+          facets: { "specialist_sectors" => { requested: 10, scope: :all_filters } },
         )
       )
     end
@@ -71,14 +71,14 @@ class FacetsTest < ShouldaUnitTestCase
     should "have correct facet in payload" do
       assert_equal(
         {
-          "organisations" => {
+          "specialist_sectors" => {
             terms: {
-              field: "organisations",
+              field: "specialist_sectors",
               order: "count",
               size: 100000,
             },
             facet_filter: {
-              "terms" => { "organisations" => ["hm-magic"] }
+              "terms" => { "specialist_sectors" => ["magic"] }
             },
           },
         },
@@ -91,7 +91,7 @@ class FacetsTest < ShouldaUnitTestCase
       @builder = QueryComponents::Facets.new(
         make_search_params(
           filters: [text_filter("mainstream_browse_pages", "levitation")],
-          facets: { "organisations" => { requested: 10, scope: :exclude_field_filter } },
+          facets: { "specialist_sectors" => { requested: 10, scope: :exclude_field_filter } },
         )
       )
     end
@@ -99,9 +99,9 @@ class FacetsTest < ShouldaUnitTestCase
     should "have facet with facet_filter in payload" do
       assert_equal(
         {
-          "organisations" => {
+          "specialist_sectors" => {
             terms: {
-              field: "organisations",
+              field: "specialist_sectors",
               order: "count",
               size: 100000,
             },

--- a/test/unit/search/query_components/filter_test.rb
+++ b/test/unit/search/query_components/filter_test.rb
@@ -138,5 +138,4 @@ class FilterTest < ShouldaUnitTestCase
       )
     end
   end
-
 end

--- a/test/unit/search/query_components/filter_test.rb
+++ b/test/unit/search/query_components/filter_test.rb
@@ -21,14 +21,14 @@ class FilterTest < ShouldaUnitTestCase
   context "search with one filter" do
     should "append the correct text filters" do
       builder = QueryComponents::Filter.new(
-        make_search_params([text_filter("organisations", ["hm-magic"])])
+        make_search_params([text_filter("specialist_sectors", ["magic"])])
       )
 
       result = builder.payload
 
       assert_equal(
         result,
-        { "terms" => { "organisations" => ["hm-magic"] } }
+        { "terms" => { "specialist_sectors" => ["magic"] } }
       )
     end
 
@@ -49,14 +49,14 @@ class FilterTest < ShouldaUnitTestCase
   context "search with a filter with multiple options" do
     should "have correct filter" do
       builder = QueryComponents::Filter.new(
-        make_search_params([text_filter("organisations", ["hm-magic", "hmrc"])])
+        make_search_params([text_filter("specialist_sectors", ["magic", "air-travel"])])
       )
 
       result = builder.payload
 
       assert_equal(
         result,
-        { "terms" => { "organisations" => ["hm-magic", "hmrc"] } }
+        { "terms" => { "specialist_sectors" => ["magic", "air-travel"] } }
       )
     end
   end
@@ -66,7 +66,7 @@ class FilterTest < ShouldaUnitTestCase
       builder = QueryComponents::Filter.new(
         make_search_params(
           [
-            text_filter("organisations", ["hm-magic", "hmrc"]),
+            text_filter("specialist_sectors", ["magic", "air-travel"]),
             reject_filter("mainstream_browse_pages", ["benefits"]),
           ]
         )
@@ -77,7 +77,7 @@ class FilterTest < ShouldaUnitTestCase
       assert_equal(
         result,
         { bool: {
-          must: { "terms" => { "organisations" => ["hm-magic", "hmrc"] } },
+          must: { "terms" => { "specialist_sectors" => ["magic", "air-travel"] } },
           must_not: { "terms" => { "mainstream_browse_pages" => ["benefits"] } },
         } }
       )
@@ -89,7 +89,7 @@ class FilterTest < ShouldaUnitTestCase
       builder = QueryComponents::Filter.new(
         make_search_params(
           [
-            text_filter("organisations", ["hm-magic", "hmrc"]),
+            text_filter("specialist_sectors", ["magic", "air-travel"]),
             text_filter("mainstream_browse_pages", ["levitation"]),
           ],
         )
@@ -101,11 +101,42 @@ class FilterTest < ShouldaUnitTestCase
         result,
         {
           and: [
-            { "terms" => { "organisations" => ["hm-magic", "hmrc"] } },
+            { "terms" => { "specialist_sectors" => ["magic", "air-travel"] } },
             { "terms" => { "mainstream_browse_pages" => ["levitation"] } },
           ].compact
         }
       )
     end
   end
+
+  context "search with tag filter" do
+    should "include the topic itself" do
+      builder = QueryComponents::Filter.new(
+        make_search_params(
+          [
+            text_filter("organisations", ["hmrc"]),
+          ],
+        )
+      )
+
+      result = builder.payload
+
+      assert_equal(
+        result,
+        {
+          or: [
+            { "terms" => { "organisations" => ["hmrc"] } },
+
+            {
+              and: [
+                { "terms" => { "slug" => ["hmrc"] } },
+                { "term" => { "format" => "organisation" } },
+              ]
+            }
+          ].compact
+        }
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
When filtering by organisation, we expect to see the organisation page itself in the results.
Right now, we achieve this by automatically adding the organisation page to its
own organisations field - i.e. tagging the page to itself.

Publishing api doesn't know about this tagging, and we need to make the two
consistent. This PR is one possible way of doing this without changing the behaviour
in rummager. The alternative is to have whitehall send organisation self-tags into
publishing api.

This isn't intended to be mergeable, I just want to see if this is an approach is worth continuing with. Thoughts?

Further discussion on https://trello.com/c/aOTMr3WJ/640-whitehall-organisations-tagged-to-itself
cc @alphagov/team-finding-things 
