### PR TITLE
Move self-linking of organisations from whitehall

### DIFF
--- a/lib/indexer/tag_lookup.rb
+++ b/lib/indexer/tag_lookup.rb
@@ -14,6 +14,7 @@ module Indexer
       artefact = find_document_from_content_api(doc_hash["link"])
       return doc_hash unless artefact
       add_tags_from_artefact(artefact, doc_hash)
+      add_self_links(doc_hash)
     end
 
   private
@@ -25,6 +26,23 @@ module Indexer
       rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
         nil
       end
+    end
+
+    def add_self_links(doc_hash)
+      # Consider an organisation page to linked to itself.
+      # This means that when filtering on an organisation,
+      # the organisation page gets included in the search results.
+      #
+      # This deliberately doesn't match up with the canonical representation
+      # of the organisation in the publishing api, since self-linking has
+      # a very fuzzy meaning: ids in links can mean both the thing (HMRC)
+      # and the content representing the thing (the HMRC home page).
+      if doc_hash["format"] == "organisation" && doc_hash["slug"]
+        doc_hash["organisations"] << doc_hash["slug"]
+        doc_hash["organisations"].uniq!
+      end
+
+      doc_hash
     end
 
     def add_tags_from_artefact(artefact, doc_hash)

--- a/test/unit/indexer/tag_lookup_test.rb
+++ b/test/unit/indexer/tag_lookup_test.rb
@@ -57,6 +57,39 @@ describe Indexer::TagLookup do
       assert_equal %w(foo baz bar), result["specialist_sectors"]
     end
 
+    it 'adds self-tags to organisation pages' do
+      content_api_has_an_artefact("organisations/land-registry", {
+        "tags" => []
+      })
+
+      result = Indexer::TagLookup.prepare_tags(
+        {
+          "link" => "/organisations/land-registry",
+          "slug" => "land-registry",
+          "format" => "organisation",
+        }
+      )
+
+      assert_equal %w(land-registry), result["organisations"]
+    end
+
+    it 'doesnt duplicate self-tags if passed in' do
+      content_api_has_an_artefact("organisations/land-registry", {
+        "tags" => []
+      })
+
+      result = Indexer::TagLookup.prepare_tags(
+        {
+          "link" => "/organisations/land-registry",
+          "slug" => "land-registry",
+          "format" => "organisation",
+          "organisations" => %w(land-registry)
+        }
+      )
+
+      assert_equal %w(land-registry), result["organisations"]
+    end
+
     it 'removes magic tags' do
       content_api_has_an_artefact("foo/bar", { "owning_app" => "travel-advice-publisher", "format" => "travel-advice", "tags" => [] })
 


### PR DESCRIPTION
This logic was previously in whitehall, so will be lost at the point we start indexing based on the publishing api exchange.

We tag organisations to themselves so that the organisation home page shoes up in search results filtered by organisations.

I'd like to do some further testing on integration to make sure this uses the correct fields.

https://trello.com/c/aOTMr3WJ/640-whitehall-organisations-tagged-to-itself
