### PR TITLE
Add test for `is_withdrawn` type

### DIFF
--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -460,8 +460,9 @@ class SearchTest < IntegrationTest
       is_withdrawn: true
     )
 
-    get "/unified_search?q=test&debug=include_withdrawn"
+    get "/unified_search?q=test&debug=include_withdrawn&fields[]=is_withdrawn"
     assert_equal 1, parsed_response.fetch("total")
+    assert_equal true, parsed_response.dig("results", 0, "is_withdrawn")
   end
 
   def test_show_the_query


### PR DESCRIPTION
There's some confusion about the type of `is_withdrawn`:

https://github.com/alphagov/finding-things-migration-checker/pull/57#discussion-diff-66598952

This adds a test that confirms that Rummager returns booleans as booleans, not as strings.
