### PR TITLE
Correctly self-tag organisations

### DIFF
--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -11,6 +11,7 @@ module Indexer
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_format_field(doc_hash)
         doc_hash = prepare_tags_field(doc_hash)
+        doc_hash = add_self_to_organisations_links(doc_hash)
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
@@ -80,6 +81,24 @@ module Indexer
       analyzed_query["tokens"].map { |token_info|
         token_info["token"]
       }.join(" ")
+    end
+
+    def add_self_to_organisations_links(doc_hash)
+      # Consider an organisation page to linked to itself.
+      # This means that when filtering on an organisation,
+      # the organisation page gets included in the search results.
+      #
+      # This deliberately doesn't match up with the canonical representation
+      # of the organisation in the publishing api, since self-linking has
+      # a very fuzzy meaning: ids in links can mean both the thing (HMRC)
+      # and the content representing the thing (the HMRC home page).
+      if doc_hash["format"] == "organisation" && doc_hash["slug"]
+        doc_hash["organisations"] ||= []
+        doc_hash["organisations"] << doc_hash["slug"]
+        doc_hash["organisations"].uniq!
+      end
+
+      doc_hash
     end
   end
 end

--- a/lib/indexer/tag_lookup.rb
+++ b/lib/indexer/tag_lookup.rb
@@ -14,7 +14,6 @@ module Indexer
       artefact = find_document_from_content_api(doc_hash["link"])
       return doc_hash unless artefact
       add_tags_from_artefact(artefact, doc_hash)
-      add_self_links(doc_hash)
     end
 
   private
@@ -26,23 +25,6 @@ module Indexer
       rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
         nil
       end
-    end
-
-    def add_self_links(doc_hash)
-      # Consider an organisation page to linked to itself.
-      # This means that when filtering on an organisation,
-      # the organisation page gets included in the search results.
-      #
-      # This deliberately doesn't match up with the canonical representation
-      # of the organisation in the publishing api, since self-linking has
-      # a very fuzzy meaning: ids in links can mean both the thing (HMRC)
-      # and the content representing the thing (the HMRC home page).
-      if doc_hash["format"] == "organisation" && doc_hash["slug"]
-        doc_hash["organisations"] << doc_hash["slug"]
-        doc_hash["organisations"].uniq!
-      end
-
-      doc_hash
     end
 
     def add_tags_from_artefact(artefact, doc_hash)

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -46,6 +46,23 @@ class ElasticsearchIndexingTest < IntegrationTest
     })
   end
 
+  def test_adding_a_document_to_the_search_index_with_organisation_self_tagging
+    stub_tagging_lookup
+
+    post "/documents", {
+      'title' => 'HMRC',
+      'link' => '/government/organisations/hmrc',
+      'slug' => 'hmrc',
+      'format' => 'organisation',
+      'organisations' => [],
+    }.to_json
+
+    assert_document_is_in_rummager({
+      "link" => "/government/organisations/hmrc",
+      "organisations" => ["hmrc"],
+    })
+  end
+
   def test_adding_a_document_to_the_search_index_with_queue
     stub_tagging_lookup
 

--- a/test/unit/indexer/tag_lookup_test.rb
+++ b/test/unit/indexer/tag_lookup_test.rb
@@ -57,39 +57,6 @@ describe Indexer::TagLookup do
       assert_equal %w(foo baz bar), result["specialist_sectors"]
     end
 
-    it 'adds self-tags to organisation pages' do
-      content_api_has_an_artefact("organisations/land-registry", {
-        "tags" => []
-      })
-
-      result = Indexer::TagLookup.prepare_tags(
-        {
-          "link" => "/organisations/land-registry",
-          "slug" => "land-registry",
-          "format" => "organisation",
-        }
-      )
-
-      assert_equal %w(land-registry), result["organisations"]
-    end
-
-    it 'doesnt duplicate self-tags if passed in' do
-      content_api_has_an_artefact("organisations/land-registry", {
-        "tags" => []
-      })
-
-      result = Indexer::TagLookup.prepare_tags(
-        {
-          "link" => "/organisations/land-registry",
-          "slug" => "land-registry",
-          "format" => "organisation",
-          "organisations" => %w(land-registry)
-        }
-      )
-
-      assert_equal %w(land-registry), result["organisations"]
-    end
-
     it 'removes magic tags' do
       content_api_has_an_artefact("foo/bar", { "owning_app" => "travel-advice-publisher", "format" => "travel-advice", "tags" => [] })
 


### PR DESCRIPTION
This fixes a bug that prevented the "self-tagging" introduced in https://github.com/alphagov/rummager/pull/648 to work properly.

Because `organisations` do not have an artefact in content-api, the tags would never be added because the tag lookup bailed at `return doc_hash unless artefact`.
