### PR TITLE
Don't block search requests based on referrer

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,8 +27,16 @@ require "indexer/workers/delete_worker"
 require "indexer/workers/amend_worker"
 
 class Rummager < Sinatra::Application
-  # Stop double slashes in URLs (even escaped ones) being flattened to single ones
-  set :protection, except: [:path_traversal, :escaped_params, :frame_options]
+  # - Stop double slashes in URLs (even escaped ones) being flattened to single ones
+  #
+  # - Explicitly allow requests that are referred from other domains so we can link
+  #   to the search API.
+  #   JsonCsrf requires the referer to match this domain. This is one way to prevent
+  #   browsers from being tricked into making a request that returns sensitive
+  #   information or performs some dangerous action.
+  #   In our case the only public API is search and there is no sensitive or
+  #   personalised information in the response.
+  set :protection, except: [:path_traversal, :escaped_params, :frame_options, :json_csrf]
 
   def search_server
     settings.search_config.search_server


### PR DESCRIPTION
We recently [blogged about the search API](https://gdsdata.blog.gov.uk/2016/05/26/use-the-search-api-to-get-useful-information-about-gov-uk-content/), but none of the links are clickable, because
rummager returns 403 for requests that have a referer header from another domain :(

This is caused by this middleware: https://github.com/sinatra/rack-protection/blob/master/lib/rack/protection/json_csrf.rb

The reason for having this check is that if a GET request was protected by a session, you can trick
a victim's browser into making a request using that session, and extract sensitive
information from the response (eg by combining with a javascript injection)

For more details see: http://stackoverflow.com/questions/10509774/sinatra-and-rack-protection-setting

In our case the only API we expose is search, which returns no sensitive information,
so we can just switch this off.

Trello: https://trello.com/c/jT2dkcMx/643-api-search-json-sometimes-returns-forbidden-waiting-for-bug-to-happen-again
