### PR TITLE
Fix bug in indexing

### DIFF
--- a/lib/indexer/change_notification_processor.rb
+++ b/lib/indexer/change_notification_processor.rb
@@ -17,14 +17,12 @@ module Indexer
     end
 
     def self.find_document(content_item)
-      @document ||= begin
-        # Note that in the future the publishing-api may allow items without
-        # `base_path`. When that starts we should bail out here instead of
-        # crashing.
-        document_base_path = content_item.fetch("base_path")
-        index = IndexFinder.content_index
-        index.get_document_by_link(document_base_path)
-      end
+      # Note that in the future the publishing-api may allow items without
+      # `base_path`. When that starts we should bail out here instead of
+      # crashing.
+      document_base_path = content_item.fetch("base_path")
+      index = IndexFinder.content_index
+      index.get_document_by_link(document_base_path)
     end
 
     def self.trigger_indexing_of_document(document)

--- a/test/integration/indexer/change_notification_processor_test.rb
+++ b/test/integration/indexer/change_notification_processor_test.rb
@@ -1,0 +1,57 @@
+require "integration_test_helper"
+require "indexer/change_notification_processor"
+
+class ChangeNotificationProcessorTest < IntegrationTest
+  def setup
+    stub_elasticsearch_settings
+    create_test_indexes
+  end
+
+  def teardown
+    clean_test_indexes
+  end
+
+  def test_triggering_a_reindex
+    publishing_api_has_lookups(
+      "/foo" => "DOCUMENT-CONTENT-ID"
+    )
+
+    publishing_api_has_expanded_links(
+      content_id: "DOCUMENT-CONTENT-ID",
+      expanded_links: {},
+    )
+
+    post "/documents", {
+      'title' => 'Foo',
+      'link' => '/foo',
+    }.to_json
+
+    commit_index
+
+    assert_document_is_in_rummager({
+      "link" => "/foo",
+      "mainstream_browse_pages" => [],
+    })
+
+    publishing_api_has_expanded_links(
+      content_id: "DOCUMENT-CONTENT-ID",
+      expanded_links: {
+        mainstream_browse_pages: [{
+          title: "Bla",
+          base_path: "/browse/my-browse"
+        }]
+      },
+    )
+
+    Indexer::ChangeNotificationProcessor.trigger({
+      "base_path" => "/foo"
+    })
+
+    commit_index
+
+    assert_document_is_in_rummager({
+      "link" => "/foo",
+      "mainstream_browse_pages" => ['my-browse'],
+    })
+  end
+end


### PR DESCRIPTION
This method was caching the result of the `get_document_by_link`. This means that after the first run, it would always re-index the same document, causing tagging not to work for most documents.

The integration test would not have caught the issue, but I've added it anyway because there wasn't a proper end-to-end test for this procedure.
