### PR TITLE
Emit a stat to track rejected index requests

### DIFF
--- a/lib/indexer/change_notification_processor.rb
+++ b/lib/indexer/change_notification_processor.rb
@@ -8,12 +8,13 @@ require 'index_finder'
 # a "re-index", which means that the document will go through the DocumentPreparer
 # process and will look up the tags for the document again.
 module Indexer
-  class ChangeNotificationProcessor
+  module ChangeNotificationProcessor
     # Gets called with a content-item from the publishing-api message queue.
     def self.trigger(content_item)
       document = find_document(content_item)
-      return unless document
+      return :rejected unless document
       trigger_indexing_of_document(document)
+      :accepted
     end
 
     def self.find_document(content_item)

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -20,7 +20,7 @@ namespace :message_queue do
 
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "rummager_to_be_indexed",
-      processor: Indexer::MessageProcessor.new,
+      processor: Indexer::MessageProcessor.new(statsd_client),
       statsd_client: statsd_client,
     ).run
   end


### PR DESCRIPTION
We want to count messages we receive from the rabbit
queue but choose not to process. At present, the only reason
to reject index requests is if the document is not in Rummager.

This might help track down a discrepancy in the counts of the
messages hitting the rabbit queue vs the messages hitting the
sidekiq queue.

@benhyland and @davidslv
