### PR TITLE
Offload reindexing to Sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:concurrency:  2
+:concurrency:  16
 :require: ./app.rb
 :logfile: ./log/sidekiq.log
 :queues:

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -145,14 +145,6 @@ module SearchIndices
       Indexer::Amender.new(self).amend(document_id, updates)
     end
 
-    # Adding an existing document to the index will overwrite the current
-    # document and has side effects such as looking up the links in the
-    # publishing-api again.
-    def trigger_document_reindex(document_id)
-      document = get_document_by_id(document_id)
-      add([document])
-    end
-
     def get_document_by_id(document_id)
       begin
         response = @client.get("_all/#{CGI.escape(document_id)}")

--- a/lib/indexer/change_notification_processor.rb
+++ b/lib/indexer/change_notification_processor.rb
@@ -13,7 +13,10 @@ module Indexer
     def self.trigger(content_item)
       document = find_document(content_item)
       return :rejected unless document
-      trigger_indexing_of_document(document)
+      index_name = document['real_index_name']
+      document_id = document['_id']
+      updates = {}
+      Indexer::AmendWorker.perform_async(index_name, document_id, updates)
       :accepted
     end
 
@@ -24,11 +27,6 @@ module Indexer
       document_base_path = content_item.fetch("base_path")
       index = IndexFinder.content_index
       index.get_document_by_link(document_base_path)
-    end
-
-    def self.trigger_indexing_of_document(document)
-      index = IndexFinder.by_name(document['real_index_name'])
-      index.trigger_document_reindex(document['_id'])
     end
   end
 end


### PR DESCRIPTION
This offloads reindexing to Sidekiq to make the indexing faster. Also bump Sidekiq's concurrency to 16, which seems to be a fine number for integration.
