### PR TITLE
Don't try to spell correct "brexit"

### DIFF
--- a/config/suggest/ignore.yml
+++ b/config/suggest/ignore.yml
@@ -1,3 +1,4 @@
+- brexit
 - bodrum
 - frem
 - hotmail


### PR DESCRIPTION
`brexit` is a word that's not used a lot in GOV.UK content, so elasticsearch will provide spelling suggestions for it.

This adds it to the blacklist, so that no suggestion will be shown.
