### PR TITLE
Don't rely on publishing-api when deploying

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -31,14 +31,21 @@ namespace :publishing_api do
     ]
 
     routes.each do |route|
-      publisher.publish(
-        route.merge(
+      begin
+        payload = route.merge(
           format: "special_route",
           publishing_app: "rummager",
           rendering_app: "rummager",
           public_updated_at: Time.now.iso8601,
           update_type: "major",
-        ))
+        )
+
+        publisher.publish(payload)
+      rescue GdsApi::TimedOutException
+        puts "WARNING: publishing-api timed out when trying to publish route #{payload.inspect}"
+      rescue GdsApi::HTTPServerError => e
+        puts "WARNING: publishing-api errored out when trying to publish route #{payload.inspect}\n\nError: #{e.inspect}"
+      end
     end
   end
 end


### PR DESCRIPTION
On each deploy, capistrano runs the rake task:

```
rake publishing_api:publish_special_routes
```

When publishing-api is unavailable this causes the deploy to fail. These pages are republished each deploy for convenience, so that we don't have to remember to republish them each time we change them. In most cases they won't send anything new to the publishing pipeline, so we're fine with giving a warning when the request fails.

Fixes: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/4441/console
