### PR TITLE
Remove topics field, keep policy_areas

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -141,7 +141,7 @@ class Rummager < Sinatra::Application
   # Arbitrary "filter parameters", anything which is defined in the mappings
   # for the index is allowed. Examples:
   #   search_format_types[]        - eg "consultation"
-  #   topics[]                     - eg "climate-change"
+  #   policy_areas[]               - eg "climate-change"
   #   organisations[]              - eg "cabinet-office"
   #   relevant_to_local_government - eg "1"
   #

--- a/config/schema/document_types/edition.json
+++ b/config/schema/document_types/edition.json
@@ -29,7 +29,6 @@
     "slug",
     "specialist_sectors",
     "statistics_announcement_state",
-    "topics",
     "world_locations"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -53,7 +53,7 @@
   },
 
   "policy_areas": {
-    "description": "Policy areas are managed in Whitehall. They're an old grouping of policies, which we're expecting to deprecate soon.",
+    "description": "Policy areas are managed in Whitehall. They're an old grouping of policies, which we're expecting to deprecate soon. Formally known as 'topics'.",
     "type": "identifiers"
   },
 
@@ -158,11 +158,6 @@
 
   "statistics_announcement_state": {
     "type": "identifier"
-  },
-
-  "topics": {
-    "description": "The policy areas that the document is associated with.  Nothing to do with \"specialist sectors\"",
-    "type": "identifiers"
   },
 
   "world_locations": {

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -8,7 +8,6 @@ module Indexer
     def prepared(doc_hash, popularities, is_content_index)
       warn_if_links_present_in(doc_hash)
       if is_content_index
-        doc_hash = copy_legacy_topic_to_policy_area(doc_hash)
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_format_field(doc_hash)
         doc_hash = prepare_tags_field(doc_hash)
@@ -50,14 +49,6 @@ module Indexer
       else
         doc_hash
       end
-    end
-
-    def copy_legacy_topic_to_policy_area(doc_hash)
-      if doc_hash["topics"]
-        doc_hash["policy_areas"] = doc_hash["topics"]
-      end
-
-      doc_hash
     end
 
     # If a document is a best bet, and is using the stemmed_query field, we

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -92,7 +92,6 @@ class BaseParameterParser
     slug
     specialist_sectors
     title
-    topics
     policy_areas
     world_locations
   ).freeze

--- a/lib/search/presenters/entity_expander.rb
+++ b/lib/search/presenters/entity_expander.rb
@@ -24,7 +24,6 @@ module Search
       'document_series' => :document_series,
       'document_collections' => :document_collections,
       'organisations' => :organisations,
-      'topics' => :topics,
       'policy_areas' => :policy_areas,
       'world_locations' => :world_locations,
       'specialist_sectors' => :specialist_sectors,

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -10,7 +10,6 @@ module Search
       @registries ||= {
         organisations: organisations,
         specialist_sectors: specialist_sectors,
-        topics: registry_for_document_format('topic'),
 
         # Whitehall has a thing called `topic`, which is being renamed to "policy
         # area", because there already are seven things called "topic". Until

--- a/test/unit/indexer/document_preparer_test.rb
+++ b/test/unit/indexer/document_preparer_test.rb
@@ -3,15 +3,19 @@ require "indexer"
 
 describe Indexer::DocumentPreparer do
   describe "#prepared" do
-    describe "policy areas migration" do
-      it "copies topics to policy areas" do
-        stub_tagging_lookup
+    it "populates popularities" do
+      stub_tagging_lookup
 
-        doc_hash = { "link" => "/some-link", "topics" => %w(a b) }
-        updated_doc_hash = Indexer::DocumentPreparer.new("fake_client").prepared(doc_hash, nil, true)
+      doc_hash = {
+        "link" => "/some-link",
+      }
 
-        assert_equal %w(a b), updated_doc_hash["policy_areas"]
-      end
+      updated_doc_hash = Indexer::DocumentPreparer.new("fake_client").prepared(
+        doc_hash,
+        { "/some-link" => 0.5 }, true
+      )
+
+      assert_equal 0.5, updated_doc_hash["popularity"]
     end
 
     it "warns via Airbake if the doc contains any links we no longer expect" do

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -34,7 +34,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
       "fields" => {
         "title" => "Dairy farming and schemes",
         "link" => "/dairy-farming-and-schemes",
-        "topics" => ["farming"],
+        "policy_areas" => ["farming"],
       },
     }]
   end
@@ -60,7 +60,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
     }
   end
 
-  def sample_facet_data_with_topics
+  def sample_facet_data_with_policy_areas
     {
       "organisations" => {
         "terms" => [
@@ -69,7 +69,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
         ],
         "missing" => 8,
       },
-      "topics" => {
+      "policy_areas" => {
         "terms" => [
           { "term" => "farming", "count" => 4 },
           { "term" => "unknown_topic", "count" => 5 },
@@ -227,7 +227,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
 
   context "results with a registry" do
     setup do
-      topic_registry = {
+      policy_area_registry = {
         "farming" => {
           "link" => "/government/topics/farming",
           "title" => "Farming"
@@ -235,9 +235,9 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
       }
 
       @output = Search::ResultSetPresenter.new(
-        search_params: Search::QueryParameters.new(start: 0, return_fields: %w[topics]),
+        search_params: Search::QueryParameters.new(start: 0, return_fields: %w[policy_areas]),
         es_response: sample_es_response,
-        registries: { topics: topic_registry },
+        registries: { policy_areas: policy_area_registry },
       ).present
     end
 
@@ -277,7 +277,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
         "link" => "/government/topics/farming",
         "title" => "Farming",
         "slug" => "farming",
-      }], result["topics"])
+      }], result["policy_areas"])
     end
   end
 
@@ -557,9 +557,9 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
       @output = Search::ResultSetPresenter.new(
         search_params: Search::QueryParameters.new(
           start: 0,
-          facets: { "organisations" => facet_params(1), "topics" => facet_params(1) },
+          facets: { "organisations" => facet_params(1), "policy_areas" => facet_params(1) },
         ),
-        es_response: sample_es_response("facets" => sample_facet_data_with_topics),
+        es_response: sample_es_response("facets" => sample_facet_data_with_policy_areas),
         registries: { organisations: org_registry },
       ).present
     end
@@ -574,7 +574,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
 
     should "have correct number of facet values" do
       assert_equal 1, @output[:facets]["organisations"][:options].length
-      assert_equal 1, @output[:facets]["topics"][:options].length
+      assert_equal 1, @output[:facets]["policy_areas"][:options].length
     end
 
     should "have org facet value expanded" do
@@ -592,22 +592,22 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
       assert_equal({
         value: { "slug" => "unknown_topic" },
         documents: 5,
-      }, @output[:facets]["topics"][:options][0])
+      }, @output[:facets]["policy_areas"][:options][0])
     end
 
     should "have correct number of documents with no value" do
       assert_equal(8, @output[:facets]["organisations"][:documents_with_no_value])
-      assert_equal(3, @output[:facets]["topics"][:documents_with_no_value])
+      assert_equal(3, @output[:facets]["policy_areas"][:documents_with_no_value])
     end
 
     should "have correct total number of options" do
       assert_equal(2, @output[:facets]["organisations"][:total_options])
-      assert_equal(2, @output[:facets]["topics"][:total_options])
+      assert_equal(2, @output[:facets]["policy_areas"][:total_options])
     end
 
     should "have correct number of missing options" do
       assert_equal(1, @output[:facets]["organisations"][:missing_options])
-      assert_equal(1, @output[:facets]["topics"][:missing_options])
+      assert_equal(1, @output[:facets]["policy_areas"][:missing_options])
     end
   end
 


### PR DESCRIPTION
This removes the deprecated topics field to avoid confusion with specialist sectors,
which are also called topics.

Before merging, we should ensure that
- [x] The topics field is not being used for filtering or faceting - policy_areas should be used instead (https://github.com/alphagov/whitehall/pull/2629)
- [x] All existing documents with topics contain the same data in the policy_areas field
- [x] Whitehall is using the policy_areas field when indexing (https://github.com/alphagov/whitehall/pull/2630)
