### PR TITLE
Add sigdump gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "airbrake", "~> 4.3.6"
 gem "unf", "~> 0.1.4"
 gem "aws-sdk", "~> 2.2.29"
 gem "elasticsearch", "~> 1.0.15"
+gem "sigdump", "~> 0.2.4"
 
 if ENV["MESSAGE_QUEUE_CONSUMER_DEV"]
   gem "govuk_message_queue_consumer", path: "../govuk_message_queue_consumer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
       activesupport
       sidekiq (>= 2.6)
       statsd-ruby (>= 1.1.0)
+    sigdump (0.2.4)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -222,6 +223,7 @@ DEPENDENCIES
   shoulda-context (~> 1.2.1)
   sidekiq (~> 3.5.4)
   sidekiq-statsd (= 0.1.5)
+  sigdump (~> 0.2.4)
   simplecov (~> 0.10.0)
   simplecov-rcov (~> 0.2.3)
   sinatra (= 1.4.7)

--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require "sinatra"
 require "json"
 require "csv"
 require "redis"
+require "sigdump/setup"
 
 %w[ . lib ].each do |path|
   $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)


### PR DESCRIPTION
This allows us to generate thread dumps by sending a signal to the process,
which can be useful for debugging.

Require it in app.rb as this is the entry point for the app. This is also
required by the sidekiq worker.
