### PR TITLE
Add dfid_authors to rummager

### DIFF
--- a/config/schema/document_types/dfid_research_output.json
+++ b/config/schema/document_types/dfid_research_output.json
@@ -1,7 +1,8 @@
 {
   "fields": [
     "country",
-    "first_published_at"
+    "first_published_at",
+    "dfid_authors"
   ],
   "expanded_search_result_fields": {
     "country": [

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -457,5 +457,8 @@
   },
   "tribunal_decision_reference_number": {
     "type": "identifier"
+  },
+  "dfid_authors": {
+    "type": "searchable_identifiers"
   }
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -459,6 +459,7 @@
     "type": "identifier"
   },
   "dfid_authors": {
+    "description": "A set of author names, which aren't selected from a predefined list and don't repeat",
     "type": "searchable_identifiers"
   }
 }


### PR DESCRIPTION
A metadata field to hold a collection of authors for a research output
## Related PRs
- https://github.com/alphagov/specialist-publisher-rebuild/pull/809
- https://github.com/alphagov/dfid-transition/pull/33
