### PR TITLE
Improve error handling

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -23,6 +23,9 @@ configure do
   Airbrake.configuration.ignore << "Sinatra::NotFound"
   Airbrake.configuration.ignore << "LegacySearch::InvalidQuery"
 
+  # DocumentNotFound is inevitable since we process deletes and amends in parallel
+  Airbrake.configuration.ignore << "SearchIndices::DocumentNotFound"
+
   # We manually send `Indexer::BulkIndexFailure` to Airbrake with extra
   # parameters for debugging. Ignore it here so that we don't send them twice.
   Airbrake.configuration.ignore << "Indexer::BulkIndexFailure"


### PR DESCRIPTION
Don't send DocumentNotFound errors to errbit
With the current design which parallelises deletes and amends, they are not avoidable.

We have better ways of seeing whether there is an unwanted difference
in content in rummager and publishing-api.

If we are worried about bugs which induce large numbers of these, we
should count them with a stat and monitor with icinga, rather than clutter errbit.

Also, tidy up bulk_index error handling.

This allows us to detect locked indexes on elasticsearch responses
which contain a 'create' field as well as those which contain an 'index' field.

Does any reviewer know whether we should be handling both 'locked index' and 'other' errors, or whether they are mutually exclusive?
