### PR TITLE
Handle slow publishing api requests a bit better

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -7,7 +7,12 @@ module Services
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
 
       # The cache is not threadsafe so using it can cause bulk imports to break
-      disable_cache: true
+      disable_cache: true,
+
+      # Currently, expanded-links consistently takes a long time for some
+      # content. This is required for indexing, so it's better to wait for this
+      # to complete than abort the request.
+      timeout: 20
     )
   end
 end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -36,8 +36,7 @@ You should run this task if the index schema has changed.
     require 'indexer/bulk_loader'
 
     index_names.each do |index_name|
-      # Batch concurrency reduced from 12 to 3 until publishing api can handle the load.
-      Indexer::BulkLoader.new(search_config, index_name, batch_concurrency: 3).load_from_current_index
+      Indexer::BulkLoader.new(search_config, index_name).load_from_current_index
     end
   end
 

--- a/test/unit/indexer/links_lookup_test.rb
+++ b/test/unit/indexer/links_lookup_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+require "indexer/links_lookup"
+require "gds_api/test_helpers/publishing_api_v2"
+
+class LinkslookupTest < MiniTest::Unit::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  def test_retry_links_on_timeout
+    content_id = "DOCUMENT_CONTENT_ID"
+    endpoint = Plek.current.find('publishing-api') + '/v2'
+    expanded_links_url = endpoint + "/expanded-links/" + content_id
+    stub_request(:get, expanded_links_url).to_timeout
+
+    assert_raises(GdsApi::TimedOutException) do
+      Indexer::LinksLookup.prepare_tags({
+        "content_id" => content_id,
+        "link" => "/my-base-path",
+      })
+    end
+
+    assert_requested :get, expanded_links_url, times: 5
+  end
+end


### PR DESCRIPTION
Expanded links requests are timing out at the moment and this is breaking our nightly jenkins job.
https://trello.com/c/kAm186hM/687-jenkins-rake-task-to-update-the-index-based-on-google-analytics-is-failing
- Increase timeout for publishing api (this is only used during indexing)
- Add some logging so we can investigate the content involved (if it's still an issue)

This is not worth merging until I've run through the job successfully. I'll deploy the branch to integration as this is a better test than my dev VM.
