### PR TITLE
in? comes from activesupport, we should avoid it

### DIFF
--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -26,7 +26,7 @@ module Indexer
 
     def warn_if_links_present_in(doc_hash)
       unexpected_links = %w{ mainstream_browse_pages organisations specialist_sectors }
-      if doc_hash.keys.any? { |key| key.in?(unexpected_links) }
+      if doc_hash.keys.any? { |key| unexpected_links.include?(key) }
         Airbrake.notify_or_ignore(UnexpectedLinksError.new, parameters: doc_hash)
       end
     end


### PR DESCRIPTION
Rummager is a sinatra app.

activesupport is not required automatically, and this method call only works elsewhere because
some of our gems depend on active support.

http://guides.rubyonrails.org/active_support_core_extensions.html#in-questionmark

Currently breaks some rake tasks - eg https://deploy.publishing.service.gov.uk/job/search-fetch-analytics-data/331/console
This was not obvious because the job has been failing for other reasons.
