### PR TITLE
Improve error handling to reduce Errbit errors

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -204,24 +204,10 @@ class Rummager < Sinatra::Application
 
   # Update an existing document
   post "/?:index?/documents/*" do
-    unless request.form_data?
-      halt(
-        415,
-        { "Content-Type" => "text/plain" },
-        "Amendments require application/x-www-form-urlencoded data"
-      )
-    end
-
-    begin
-      document_id = params["splat"].first
-      updates = request.POST
-      Indexer::AmendWorker.perform_async(index_name, document_id, updates)
-      json_result 202, "Queued"
-    rescue ArgumentError => e
-      text_error e.message
-    rescue SearchIndices::DocumentNotFound
-      halt 404
-    end
+    document_id = params["splat"].first
+    updates = request.POST
+    Indexer::AmendWorker.perform_async(index_name, document_id, updates)
+    json_result 202, "Queued"
   end
 
   delete "/?:index?/documents" do

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -13,7 +13,6 @@ require "indexer/amender"
 require "document"
 
 module SearchIndices
-  class DocumentNotFound < RuntimeError; end
   class IndexLocked < RuntimeError; end
 
   class Index

--- a/lib/indexer/amender.rb
+++ b/lib/indexer/amender.rb
@@ -13,10 +13,7 @@ module Indexer
 
       document = index.get_document_by_id(document_id)
 
-      unless document
-        raise SearchIndices::DocumentNotFound,
-          "Can't find document with _id #{document_id}"
-      end
+      return unless document
 
       updates.each do |key, value|
         if document.has_field?(key)

--- a/test/integration/indexer/amendment_test.rb
+++ b/test/integration/indexer/amendment_test.rb
@@ -51,36 +51,4 @@ class ElasticsearchAmendmentTest < IntegrationTest
 
     assert_equal 202, last_response.status
   end
-
-  def test_rejects_unknown_fields
-    commit_document("mainstream_test", {
-      "title" => "The old title",
-      "link" => "/an-example-answer",
-    })
-
-    post "/documents/%2Fan-example-answer", "fish=Trout"
-
-    assert 403, last_response.status
-    assert_equal "Unrecognised field 'fish'", last_response.body
-  end
-
-  def test_returns_not_found_correctly
-    post "/documents/%2Fsome-non-existing-document", "title=A+new+title"
-
-    assert 404, last_response.status
-  end
-
-  def test_should_fail_to_amend_link
-    commit_document("mainstream_test", {
-      "title" => "The title",
-      "link" => "/an-example-answer",
-    })
-
-    post "/documents/%2Fan-example-answer", "link=/wibble"
-
-    assert_document_is_in_rummager({
-      "title" => "The title",
-      "link" => "/an-example-answer",
-    })
-  end
 end


### PR DESCRIPTION
This PR removes some spurious error handling and removes the `DocumentNotFound` exception. 

This should reduce the number of errors sent to Errbit.

Successor to https://github.com/alphagov/rummager/pull/664

Trello: https://trello.com/c/7PtlldZZ
