### PR TITLE
Remove notification to Airbrake in doc prepration

### DIFF
--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -6,7 +6,6 @@ module Indexer
     end
 
     def prepared(doc_hash, popularities, is_content_index)
-      warn_if_links_present_in(doc_hash)
       if is_content_index
         doc_hash = copy_legacy_topic_to_policy_area(doc_hash)
         doc_hash = prepare_popularity_field(doc_hash, popularities)
@@ -22,13 +21,6 @@ module Indexer
   private
 
     class UnexpectedLinksError < StandardError
-    end
-
-    def warn_if_links_present_in(doc_hash)
-      unexpected_links = %w{ mainstream_browse_pages organisations specialist_sectors }
-      if doc_hash.keys.any? { |key| unexpected_links.include?(key) }
-        Airbrake.notify_or_ignore(UnexpectedLinksError.new, parameters: doc_hash)
-      end
     end
 
     def prepare_popularity_field(doc_hash, popularities)

--- a/test/unit/indexer/document_preparer_test.rb
+++ b/test/unit/indexer/document_preparer_test.rb
@@ -13,18 +13,5 @@ describe Indexer::DocumentPreparer do
         assert_equal %w(a b), updated_doc_hash["policy_areas"]
       end
     end
-
-    it "warns via Airbake if the doc contains any links we no longer expect" do
-      stub_tagging_lookup
-      doc_hash = {
-        "link" => "/some-link",
-        "specialist_sectors" => %w(foo bar)
-      }
-
-      Airbrake.expects(:notify_or_ignore).with(
-        Indexer::DocumentPreparer::UnexpectedLinksError.new, parameters: doc_hash
-      )
-      Indexer::DocumentPreparer.new("fake_client").prepared(doc_hash, nil, true)
-    end
   end
 end


### PR DESCRIPTION
This was added in https://github.com/alphagov/rummager/pull/659:

> We're in the process of updating Rummager client apps to not send
> mainstream browse pages, specialist sectors and organisation links.
> This commit adds an Airbrake message if links of this type are
> encountered when preparing a document for indexing.

We've now realised that when we do the nightly re-index, this would send 250.000 messages to Airbrake since all documents have `organisations`, `mainstream_browse_pages` and `specialist_sectors`.

What we _actually_ wanted to test is that clients are no longer sending this information to the Rummager API. A replacement for that feature would probably need to live closer to the sinatra app.
