### PR TITLE
Enable scripts to skip links indexing

### DIFF
--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -10,7 +10,11 @@ module Indexer
         doc_hash = copy_legacy_topic_to_policy_area(doc_hash)
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_format_field(doc_hash)
-        doc_hash = prepare_tags_field(doc_hash)
+
+        unless ENV['SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS'] == '1'
+          doc_hash = prepare_tags_field(doc_hash)
+        end
+
         doc_hash = add_self_to_organisations_links(doc_hash)
       end
 


### PR DESCRIPTION
This commit enables us to set a flag that will prevent the document preparer from doing links lookup in the publishing-api. It is a stopgap while we are waiting for the publishing-api to get faster, and it should be removed soon.

We need to do this now to allow the fetch-search-analytics job to run again. It's been broken for a week and a half, so the search doesn't reflect current document popularity.

It should/must/can only be used when doing an index migration, like the fetch-search-analytics job does[1]. 

In that case, it will not touch the existing links (because `migrate_index` uses existing data).

[1] https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb#L33-L37

Trello: https://trello.com/c/kAm186hM
