### PR TITLE
Don't try and spell correct 'chilcot'

### DIFF
--- a/config/suggest/ignore.yml
+++ b/config/suggest/ignore.yml
@@ -1,3 +1,4 @@
+- chilcot
 - brexit
 - bodrum
 - frem


### PR DESCRIPTION
Add chilcot to the blacklist so no spelling suggestions are provided by
elasticsearch.
