### PR TITLE
Add dfid_review_status

### DIFF
--- a/config/schema/document_types/dfid_research_output.json
+++ b/config/schema/document_types/dfid_research_output.json
@@ -2,9 +2,20 @@
   "fields": [
     "country",
     "first_published_at",
-    "dfid_authors"
+    "dfid_authors",
+    "dfid_review_status"
   ],
   "expanded_search_result_fields": {
+    "dfid_review_status": [
+      {
+        "value": "unreviewed",
+        "label": "Unreviewed"
+      },
+      {
+        "value": "peer_reviewed",
+        "label": "Peer reviewed"
+      }
+    ],
     "country": [
       {
         "value": "VA",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -461,5 +461,9 @@
   "dfid_authors": {
     "description": "A set of author names, which aren't selected from a predefined list and don't repeat",
     "type": "searchable_identifiers"
+  },
+  "dfid_review_status": {
+    "description": "Whether or not this item is peer reviewed (a code)",
+    "type": "identifier"
   }
 }


### PR DESCRIPTION
`dfid_review_status` is a single `identifier` that can have either of the values `unreviewed` or `peer_reviewed`.

It still uses the deprecated `expand_search_result_fields` Rummager feature. Two more facets will use that feature, but we have a [ticket](https://www.pivotaltracker.com/n/projects/1573681) to address this work during our next sprint.

Add a general integration test to smoke test multiple DFID finder query types in the face of automapping uncertainty.
## Related PRs
- https://github.com/alphagov/govuk-content-schemas/pull/341
- https://github.com/alphagov/specialist-publisher-rebuild/pull/818
