### PR TITLE
Add alpha taxons to rummager schema

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -1,6 +1,7 @@
 {
   "fields": [
     "all_searchable_text",
+    "taxons",
     "content_id",
     "description",
     "format",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -66,6 +66,10 @@
     "type": "identifiers"
   },
 
+  "taxons": {
+    "type": "identifiers"
+  },
+
   "updated_at": {
     "type": "date"
   },

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -73,6 +73,10 @@ module Indexer
         content_item['base_path'].sub('/government/organisations/', '')
       end
 
+      links_with_slugs["taxons"] = links["taxons"].to_a.map do |content_item|
+        content_item['content_id']
+      end
+
       links_with_slugs
     end
   end

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -68,6 +68,12 @@ class TaglookupDuringIndexingTest < IntegrationTest
             "base_path" => "/government/organisations/my-org/1",
           }
         ],
+        taxons: [
+          {
+            "content_id" => "TAXON-1",
+            "base_path" => "/alpha-taxonomy/my-taxon-1"
+          }
+        ],
       }
     )
 
@@ -80,6 +86,7 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "specialist_sectors" => ["my-topic/a", "my-topic/b"],
       "mainstream_browse_pages" => ["my-browse/1"],
       "organisations" => ["my-org/1"],
+      "taxons" => ["TAXON-1"],
     )
   end
 

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -498,6 +498,46 @@ class SearchTest < IntegrationTest
     end
   end
 
+  def test_taxonomy_can_be_returned
+    reset_content_indexes
+
+    commit_document("mainstream_test",
+      title: "I am the result",
+      description: "This is a test search result",
+      link: "/some-nice-link",
+      taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
+    )
+
+    get "/unified_search?q=test&fields[]=taxons"
+    assert_equal 1, parsed_response.fetch("total")
+
+    taxons = parsed_response.dig("results", 0, "taxons")
+    assert_equal ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"], taxons
+  end
+
+  def test_taxonomy_can_be_filtered
+    reset_content_indexes
+
+    commit_document("mainstream_test",
+      title: "I am the result",
+      description: "This is a test search result",
+      link: "/some-nice-link",
+      taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
+    )
+
+    get "/unified_search?filter_taxons=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
+
+    assert last_response.ok?
+    assert_equal 1, parsed_response.fetch("total")
+    assert_equal(
+      hash_including(
+        "title" => "I am the result",
+        "link" => "/some-nice-link",
+      ),
+      parsed_response.fetch("results").fetch(0),
+    )
+  end
+
 private
 
   def first_result

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -3,3 +3,4 @@ require "app"
 require "search_server"
 require "sidekiq/testing/inline" # Make all queued jobs run immediately
 require "support/integration_test"
+require "pry-byebug"


### PR DESCRIPTION
This will help us highlight popular information tagged to a taxon (eg education).

https://trello.com/c/fG3pFItN/11-show-popular-content-from-education-in-search

Paired with @rubenarakelyan 
