### PR TITLE
s/taxons/alpha_taxons for expanded-links

### DIFF
--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -73,7 +73,7 @@ module Indexer
         content_item['base_path'].sub('/government/organisations/', '')
       end
 
-      links_with_slugs["taxons"] = links["taxons"].to_a.map do |content_item|
+      links_with_slugs["taxons"] = links["alpha_taxons"].to_a.map do |content_item|
         content_item['content_id']
       end
 

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -68,7 +68,7 @@ class TaglookupDuringIndexingTest < IntegrationTest
             "base_path" => "/government/organisations/my-org/1",
           }
         ],
-        taxons: [
+        alpha_taxons: [
           {
             "content_id" => "TAXON-1",
             "base_path" => "/alpha-taxonomy/my-taxon-1"


### PR DESCRIPTION
The publishing api/content store still refers to these links
as "alpha taxons". We plan to rename or copy this to taxons sometime in the future
so we're just going to leave it as "taxons" in rummager.

trello https://trello.com/c/fG3pFItN/11-show-popular-content-from-education-in-search
paired with @rubenarakelyan 
