### PR TITLE
Remove DFID 'Questionnaire' document type

### DIFF
--- a/config/schema/document_types/dfid_research_output.json
+++ b/config/schema/document_types/dfid_research_output.json
@@ -916,10 +916,6 @@
         "label": "Protocol"
       },
       {
-        "value": "questionnaire",
-        "label": "Questionnaire"
-      },
-      {
         "value": "research_paper",
         "label": "Research Paper"
       },


### PR DESCRIPTION
- No longer in use as of last week
