### PR TITLE
Rename link type: alpha_taxons to taxons

### DIFF
--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -73,7 +73,7 @@ module Indexer
         content_item['base_path'].sub('/government/organisations/', '')
       end
 
-      links_with_slugs["taxons"] = links["alpha_taxons"].to_a.map do |content_item|
+      links_with_slugs["taxons"] = links["taxons"].to_a.map do |content_item|
         content_item['content_id']
       end
 

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -68,7 +68,7 @@ class TaglookupDuringIndexingTest < IntegrationTest
             "base_path" => "/government/organisations/my-org/1",
           }
         ],
-        alpha_taxons: [
+        taxons: [
           {
             "content_id" => "TAXON-1",
             "base_path" => "/alpha-taxonomy/my-taxon-1"


### PR DESCRIPTION
Reverts alphagov/rummager#684

When we started experimenting with new taxonomy we used alpha_taxonomy as the link type.
Now that we're no longer in alpha we'd like to be consistent in using the link type.

Trello: https://trello.com/c/tt0UdAV3/35-use-taxons-as-link-type-everywhere
2349d27
