### PR TITLE
Add option to log instead of raise timeouts

### DIFF
--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -9,11 +9,7 @@ module Indexer
       if is_content_index
         doc_hash = prepare_popularity_field(doc_hash, popularities)
         doc_hash = prepare_format_field(doc_hash)
-
-        unless ENV['SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS'] == '1'
-          doc_hash = prepare_tags_field(doc_hash)
-        end
-
+        doc_hash = prepare_tags_field(doc_hash)
         doc_hash = add_self_to_organisations_links(doc_hash)
       end
 
@@ -37,6 +33,12 @@ module Indexer
 
     def prepare_tags_field(doc_hash)
       Indexer::LinksLookup.prepare_tags(doc_hash)
+    rescue GdsApi::TimedOutException => e
+      if ENV['LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE'] == '1'
+        puts "Unable to lookup links for link: #{doc_hash['link']}"
+      else
+        raise e
+      end
     end
 
     def prepare_format_field(doc_hash)


### PR DESCRIPTION
We're currently skipping the links-indexing during nightly reindex
(performed by the search-analytics[1] scripts).

This means that rummager links are not being synced up with the
publishing platform unless a page is republished. There are a lot
of cases where these links are known to be wrong; for example,
the old content api integration used to only append to tags, and
never remove old ones. This means there is a lot of links data
in rummager that is wrong.

Publishing API is supposed to be authoritive so we should pull as much data
as we can from it. The reason we disabled the nightly sync in the first
place is because of performance issues with the get-expanded-links call,
which affects a subset of content, depending on the amount of links
pointing to/from it. We have made some improvements but this is not
entirely fixed.

This change ensures that links are overriden from publishing api if
possible, but we fall back to the existing links otherwise.

[1]
https://github.com/alphagov/search-analytics/blob/master/nightly-run.sh
