### PR TITLE
Base spell checking on government index

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -7,5 +7,4 @@ popularity_rank_offset: 10
 
 # When doing spell checking, which indices to use?
 spelling_index_names:
-  - mainstream
   - government

--- a/test/unit/search/spell_check_fetcher_test.rb
+++ b/test/unit/search/spell_check_fetcher_test.rb
@@ -7,7 +7,7 @@ class Search::SpellCheckFetcherTest < ShouldaUnitTestCase
     should "return the raw elasticsearch response" do
       Search::SuggestionBlacklist.any_instance.stubs(should_correct?: true)
 
-      stub_request(:get, "http://localhost:9200/mainstream,government/_search")
+      stub_request(:get, "http://localhost:9200/government/_search")
         .to_return(body: JSON.dump(suggest: { spelling_suggestions: 'a-hash' }))
 
       es_response = Search::SpellCheckFetcher.new(Search::QueryParameters.new(query: 'bolo'), stub('registries')).es_response


### PR DESCRIPTION
This solves the problem of incorrect spelling suggestions of words that only appear in government index. We'll evaluate this change soon.

https://trello.com/c/iDCoSabY
