### PR TITLE
Downweight dfid research docs

### DIFF
--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -40,8 +40,9 @@ module QueryComponents
         "contact" => 0.3,
 
         # Should appear below mainstream content
-        "hmrc_manual_section" => 0.2,
         "aaib_report" => 0.2,
+        "dfid_research_output" => 0.2,
+        "hmrc_manual_section" => 0.2,
 
         # Hide mainstream browse pages for now.
         "mainstream_browse_page" => 0,

--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -31,8 +31,9 @@ class BoosterTest < ShouldaUnitTestCase
             { filter: { term: { format: "document_collection" } },    boost_factor: 1.3 },
             { filter: { term: { format: "operational_field" } },      boost_factor: 1.5 },
             { filter: { term: { format: "contact" } },                boost_factor: 0.3 },
-            { filter: { term: { format: "hmrc_manual_section" } },    boost_factor: 0.2 },
             { filter: { term: { format: "aaib_report" } },            boost_factor: 0.2 },
+            { filter: { term: { format: "dfid_research_output" } },   boost_factor: 0.2 },
+            { filter: { term: { format: "hmrc_manual_section" } },    boost_factor: 0.2 },
             { filter: { term: { format: "mainstream_browse_page" } }, boost_factor: 0 },
             { filter: { term: { search_format_types: "announcement" } },
               script_score: {


### PR DESCRIPTION
Finder content and manuals are added to the 'mainstream' index, so they're unintentionally weighted higher than whitehall content, because the whole 'government' index is downweighted.

https://trello.com/c/QImDkMg0/79-downweight-dfid-finder-items-in-search
