### PR TITLE
Remove `unified_search` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can read how to use the API in the blog post: ["Use the search API to get us
 
 Rummager is a Sinatra application that interfaces with Elasticsearch.
 
-It provides a [search API](docs/unified-search-api.md) that is used by multiple
+It provides a [search API](docs/search-api.md) that is used by multiple
 applications, and is publicly available at
 [gov.uk/api/search.json](https://www.gov.uk/api/search.json?q=taxes).
 
@@ -85,7 +85,7 @@ If you're not running the GDS development VM:
     ./startup.sh
 
 Rummager should then be available at
-[rummager.dev.gov.uk](http://rummager.dev.gov.uk/unified_search.json?q=taxes).
+[rummager.dev.gov.uk](http://rummager.dev.gov.uk/search.json?q=taxes).
 
 Rummager uses Sidekiq to manage index workers in a separate process. To run
 this in the development VM, you need to run both of these commands:
@@ -116,8 +116,8 @@ After changing the schema, you'll need to migrate the index.
 
 For the most up to date query syntax and API output:
 
-- [docs/unified-search-api.md](docs/unified-search-api.md) for the unified
-	search endpoint (`/unified-search.json`).
+- [docs/search-api.md](docs/search-api.md) for the search
+	endpoint (`/search.json`).
 - [docs/content-api.md](docs/content-api.md) for the `/content/*` endpoint.
 - [docs/documents.md](docs/documents.md) for the `*/documents/` endpoint.
 

--- a/app.rb
+++ b/app.rb
@@ -110,8 +110,8 @@ class Rummager < Sinatra::Application
 
   # Return results for the GOV.UK site search
   #
-  # For details, see docs/unified-search-api.md
-  ["/unified_search.?:request_format?", "/search.?:request_format?"].each do |path|
+  # For details, see docs/search-api.md
+  ["/search.?:request_format?"].each do |path|
     get path do
       json_only
 

--- a/docs/search-api.md
+++ b/docs/search-api.md
@@ -1,16 +1,16 @@
-# Unified Search API
+# Search API
 
 This API is the main endpoint for performing searches on GOV.UK.  It supports
 keyword searching, ordering by relevance or date fields, filtering and
 faceting.
 
 At the time of writing, there is one other endpoint, the `advanced_search`
-endpoint, which is slowly being replaced by the `unified_search` endpoint.  The
+endpoint, which is slowly being replaced by the `search` endpoint.  The
 `advanced_search` endpoint shouldn't be used by new code.
 
 ## Parameters
 
-The unified search API supports many query string parameters.  It validates
+The search API supports many query string parameters.  It validates
 parameters strictly - any unknown parameters, or parameters with invalid
 options, will cause an HTTP 422 error.  This makes it likely that typos do not
 result in silently returning the wrong results, and also makes it easier to
@@ -172,7 +172,7 @@ The parameters supported are:
 
 For example:
 
-    /unified_search.json?
+    /search.json?
      q=foo&
      start=0&
      count=20&

--- a/test/integration/indexer/migration_test.rb
+++ b/test/integration/indexer/migration_test.rb
@@ -51,7 +51,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     # Test that a reindex re-adds all the documents with new
     # stemming settings
 
-    get "/unified_search?q=directive"
+    get "/search?q=directive"
     assert_equal 2, parsed_response["results"].length
 
     @stemmer["rules"] = ["directive => directive"]
@@ -64,10 +64,10 @@ class ElasticsearchMigrationTest < IntegrationTest
     # Ensure the indexes have actually been switched.
     refute_equal original_index_name, index_group.current_real.real_name
 
-    get "/unified_search?q=directive"
+    get "/search?q=directive"
     assert_result_links "/important"
 
-    get "/unified_search?q=direct"
+    get "/search?q=direct"
     assert_result_links "/aliens"
   end
 
@@ -85,7 +85,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     index_group.current_real.bulk_index(extra_documents)
     commit_index
 
-    get "/unified_search?q=directive"
+    get "/search?q=directive"
     assert_equal 2, parsed_response["results"].length
 
     @stemmer["rules"] = ["directive => directive"]
@@ -98,13 +98,13 @@ class ElasticsearchMigrationTest < IntegrationTest
     # Ensure the indexes have actually been switched.
     refute_equal original_index_name, index_group.current_real.real_name
 
-    get "/unified_search?q=directive"
+    get "/search?q=directive"
     assert_result_links "/important"
 
-    get "/unified_search?q=direct"
+    get "/search?q=direct"
     assert_result_links "/aliens"
 
-    get "/unified_search?q=Document&count=100"
+    get "/search?q=Document&count=100"
     assert_equal test_batch_size + 5, parsed_response["results"].length
   end
 
@@ -113,7 +113,7 @@ class ElasticsearchMigrationTest < IntegrationTest
 
     SearchIndices::Index.any_instance.stubs(:bulk_index).raises(SearchIndices::IndexLocked)
 
-    get "/unified_search?q=directive"
+    get "/search?q=directive"
     assert_equal 2, parsed_response["results"].length
 
     @stemmer["rules"] = ["directive => directive"]
@@ -128,7 +128,7 @@ class ElasticsearchMigrationTest < IntegrationTest
     # Ensure the the indexes haven't been swapped
     assert_equal original_index_name, index_group.current_real.real_name
 
-    get "/unified_search?q=directive"
+    get "/search?q=directive"
     assert_equal 2, parsed_response["results"].length
   end
 

--- a/test/integration/search/best_bets_test.rb
+++ b/test/integration/search/best_bets_test.rb
@@ -29,7 +29,7 @@ class BestBetsTest < IntegrationTest
       position: 1,
     )
 
-    links = get_links "/unified_search?q=a+forced+best+bet"
+    links = get_links "/search?q=a+forced+best+bet"
 
     assert_equal ["/the-link-that-should-surface", "/an-organic-result"], links
   end
@@ -47,7 +47,7 @@ class BestBetsTest < IntegrationTest
       position: 1,
     )
 
-    links = get_links "/unified_search?q=shown"
+    links = get_links "/search?q=shown"
 
     refute links.include?("/we-never-show-this")
   end
@@ -64,7 +64,7 @@ class BestBetsTest < IntegrationTest
       position: 1,
     )
 
-    links = get_links "/unified_search?q=best+bet+and+such"
+    links = get_links "/search?q=best+bet+and+such"
 
     assert_equal ["/the-link-that-should-surface"], links
   end
@@ -82,7 +82,7 @@ class BestBetsTest < IntegrationTest
     )
 
     # note that we're searching for "bests bet", not "best bet" here.
-    links = get_links "/unified_search?q=bests+bet"
+    links = get_links "/search?q=bests+bet"
 
     assert_equal ["/the-link-that-should-surface"], links
   end
@@ -100,7 +100,7 @@ class BestBetsTest < IntegrationTest
     )
 
     # note that we're searching for "bet best", not "best bet" here.
-    links = get_links "/unified_search?q=bet+best"
+    links = get_links "/search?q=bet+best"
 
     refute links.include?("/only-shown-for-exact-matches")
   end

--- a/test/integration/search/booster_test.rb
+++ b/test/integration/search/booster_test.rb
@@ -29,7 +29,7 @@ class BoosterTest < IntegrationTest
       link: "/can-we-be-agile",
     )
 
-    get "/unified_search?q=agile"
+    get "/search?q=agile"
 
     assert_equal ["Can we be agile?", "Agile is good", "Being agile is good"],
       result_titles

--- a/test/integration/search/expands_values_from_schema_test.rb
+++ b/test/integration/search/expands_values_from_schema_test.rb
@@ -17,7 +17,7 @@ class ExpandsValuesFromSchemaTest < IntegrationTest
       "_type" => "cma_case",
     })
 
-    get "/unified_search?filter_document_type=cma_case&fields=case_type,description,title"
+    get "/search?filter_document_type=cma_case&fields=case_type,description,title"
     first_result = parsed_response["results"].first
 
     assert_equal [{ "label" => "Mergers", "value" => "mergers" }], first_result["case_type"]

--- a/test/integration/search/quoted_and_unquoted_searches_test.rb
+++ b/test/integration/search/quoted_and_unquoted_searches_test.rb
@@ -20,56 +20,56 @@ class QuotedAndUnquotedSearchTest < IntegrationTest
   #
   def test_new_weighting_three_matches_found_for_london
     commit_london_transport_docs
-    get "/unified_search?q=london&debug=new_weighting"
+    get "/search?q=london&debug=new_weighting"
     assert_equal 200, last_response.status
     assert_equal 3, parsed_response["results"].size
   end
 
   def test_new_weighting_three_matches_found_for_transport
     commit_london_transport_docs
-    get "/unified_search?q=transport&debug=new_weighting"
+    get "/search?q=transport&debug=new_weighting"
     assert_equal 200, last_response.status
     assert_equal 3, parsed_response["results"].size
   end
 
   def test_new_weighting_three_matches_found_for_unquoted_london_transport
     commit_london_transport_docs
-    get "/unified_search?q=london+transport&debug=new_weighting"
+    get "/search?q=london+transport&debug=new_weighting"
     assert_equal 200, last_response.status
     assert_equal 3, parsed_response["results"].size
   end
 
   def test_new_weighting_one_match_found_for_quoted_london_transport
     commit_london_transport_docs
-    get "/unified_search?q=%22london+transport%22&debug=new_weighting"
+    get "/search?q=%22london+transport%22&debug=new_weighting"
     assert_equal 200, last_response.status
     assert_equal 1, parsed_response["results"].size
   end
 
   def test_new_weighting_synonyms_are_returned_with_unquoted_phrases
     commit_synonym_documents
-    get "/unified_search?q=driving+abroad&debug=new_weighting"
+    get "/search?q=driving+abroad&debug=new_weighting"
     assert_equal 200, last_response.status
     assert_equal 2, parsed_response["results"].size
   end
 
   def test_new_weighting_synonyms_are_not_returned_with_quoted_phrases
     commit_synonym_documents
-    get "/unified_search?q=%22driving+abroad%22&debug=new_weighting"
+    get "/search?q=%22driving+abroad%22&debug=new_weighting"
     assert_equal 200, last_response.status
     assert_equal 1, parsed_response["results"].size
   end
 
   def test_new_weighting_stemming_is_in_place_for_unquoted_phrases
     commit_stemming_documents
-    get "/unified_search?q=dog&debug=new_weighting"
+    get "/search?q=dog&debug=new_weighting"
     assert_equal 200, last_response.status
     assert_equal 2, parsed_response["results"].size
   end
 
   def test_new_weighting_stemming_is_still_in_place_even_for_quoted_phrases
     commit_stemming_documents
-    get "/unified_search?q=%22dog%22&debug=new_weighting"
+    get "/search?q=%22dog%22&debug=new_weighting"
     assert_equal 200, last_response.status
     assert_equal 2, parsed_response["results"].size
   end
@@ -79,49 +79,49 @@ class QuotedAndUnquotedSearchTest < IntegrationTest
   #
   def test_old_weighting_three_matches_found_for_london
     commit_london_transport_docs
-    get "/unified_search?q=london"
+    get "/search?q=london"
     assert_equal 200, last_response.status
     assert_equal 3, parsed_response["results"].size
   end
 
   def test_old_weighting_three_matches_found_for_transport
     commit_london_transport_docs
-    get "/unified_search?q=transport"
+    get "/search?q=transport"
     assert_equal 200, last_response.status
     assert_equal 3, parsed_response["results"].size
   end
 
   def test_old_weighting_three_matches_found_for_unquoted_london_transport
     commit_london_transport_docs
-    get "/unified_search?q=london+transport"
+    get "/search?q=london+transport"
     assert_equal 200, last_response.status
     assert_equal 3, parsed_response["results"].size
   end
 
   def test_old_weighting_one_match_found_for_quoted_london_transport
     commit_london_transport_docs
-    get "/unified_search?q=%22london+transport%22"
+    get "/search?q=%22london+transport%22"
     assert_equal 200, last_response.status
     assert_equal 1, parsed_response["results"].size
   end
 
   def test_old_weighting_synonyms_are_returned_with_unquoted_phrases
     commit_synonym_documents
-    get "/unified_search?q=driving+abroad"
+    get "/search?q=driving+abroad"
     assert_equal 200, last_response.status
     assert_equal 2, parsed_response["results"].size
   end
 
   def test_old_weighting_stemming_is_in_place_for_unquoted_phrases
     commit_stemming_documents
-    get "/unified_search?q=dog"
+    get "/search?q=dog"
     assert_equal 200, last_response.status
     assert_equal 2, parsed_response["results"].size
   end
 
   def test_old_weighting_stemming_is_still_in_place_even_for_quoted_phrases
     commit_stemming_documents
-    get "/unified_search?q=%22dog%22"
+    get "/search?q=%22dog%22"
     assert_equal 200, last_response.status
     assert_equal 2, parsed_response["results"].size
   end

--- a/test/integration/search/results_with_highlighting_test.rb
+++ b/test/integration/search/results_with_highlighting_test.rb
@@ -17,7 +17,7 @@ class ResultsWithHighlightingTest < IntegrationTest
       link: "/some-nice-link",
     )
 
-    get "/unified_search?q=result&fields[]=title_with_highlighting"
+    get "/search?q=result&fields[]=title_with_highlighting"
 
     refute first_search_result.key?('title')
     assert_equal "I am the <mark>result</mark>",
@@ -31,7 +31,7 @@ class ResultsWithHighlightingTest < IntegrationTest
       link: "/some-nice-link",
     )
 
-    get "/unified_search?q=result&fields[]=title_with_highlighting"
+    get "/search?q=result&fields[]=title_with_highlighting"
 
     refute first_search_result.key?('title')
     assert_equal "Thing without",
@@ -44,7 +44,7 @@ class ResultsWithHighlightingTest < IntegrationTest
       description: "This is a test search result of many results."
     )
 
-    get "/unified_search?q=result&fields[]=description_with_highlighting"
+    get "/search?q=result&fields[]=description_with_highlighting"
 
     refute first_search_result.key?('description')
     assert_equal "This is a test search <mark>result</mark> of many <mark>results</mark>.",
@@ -58,7 +58,7 @@ class ResultsWithHighlightingTest < IntegrationTest
       description: "Escape & highlight the description as well."
     )
 
-    get "/unified_search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
+    get "/search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
 
     assert_equal "Escape &amp; <mark>highlight</mark> the description as well.",
       first_search_result['description_with_highlighting']
@@ -72,7 +72,7 @@ class ResultsWithHighlightingTest < IntegrationTest
       description: "word " + ("something " * 200)
     )
 
-    get "/unified_search?q=word&fields[]=description_with_highlighting"
+    get "/search?q=word&fields[]=description_with_highlighting"
     description = first_search_result['description_with_highlighting']
 
     assert description.starts_with?("<mark>word</mark>")
@@ -85,7 +85,7 @@ class ResultsWithHighlightingTest < IntegrationTest
       description: ("something " * 200) + " word"
     )
 
-    get "/unified_search?q=word&fields[]=description_with_highlighting"
+    get "/search?q=word&fields[]=description_with_highlighting"
     description = first_search_result['description_with_highlighting']
 
     assert description.starts_with?("…")
@@ -98,7 +98,7 @@ class ResultsWithHighlightingTest < IntegrationTest
       description: ("something " * 200) + " word " + ("something " * 200)
     )
 
-    get "/unified_search?q=word&fields[]=description_with_highlighting"
+    get "/search?q=word&fields[]=description_with_highlighting"
     description = first_search_result['description_with_highlighting']
 
     assert description.ends_with?("…")

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -17,7 +17,7 @@ class SearchTest < IntegrationTest
   def test_returns_success
     reset_content_indexes
 
-    get "/unified_search?q=important"
+    get "/search?q=important"
 
     assert last_response.ok?
   end
@@ -36,12 +36,12 @@ class SearchTest < IntegrationTest
 
     )
 
-    get "/unified_search?q=p+60&debug=use_id_codes"
+    get "/search?q=p+60&debug=use_id_codes"
 
     assert_equal(parsed_response['results'].size, 1)
     assert_equal(parsed_response["results"][0]["link"], "/get-paye-forms-p45-p60")
 
-    get "/unified_search?q=p+60"
+    get "/search?q=p+60"
     assert_equal(parsed_response['results'].size, 0)
   end
 
@@ -54,7 +54,7 @@ class SearchTest < IntegrationTest
       link: "/some-nice-link"
     )
 
-    get "/unified_search?q=serch&suggest=spelling"
+    get "/search?q=serch&suggest=spelling"
 
     assert_equal ['search'], parsed_response['suggested_queries']
   end
@@ -62,7 +62,7 @@ class SearchTest < IntegrationTest
   def test_spell_checking_without_typo
     reset_content_indexes_with_content(section_count: 1)
 
-    get "/unified_search?q=milliband"
+    get "/search?q=milliband"
 
     assert_equal [], parsed_response['suggested_queries']
   end
@@ -70,7 +70,7 @@ class SearchTest < IntegrationTest
   def test_returns_docs_from_all_indexes
     reset_content_indexes_with_content(section_count: 1)
 
-    get "/unified_search?q=important"
+    get "/search?q=important"
 
     assert result_links.include? "/government-1"
     assert result_links.include? "/mainstream-1"
@@ -79,7 +79,7 @@ class SearchTest < IntegrationTest
   def test_sort_by_date_ascending
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?q=important&order=public_timestamp"
+    get "/search?q=important&order=public_timestamp"
 
     assert_equal ["/government-1", "/government-2"],
       result_links.take(2)
@@ -88,7 +88,7 @@ class SearchTest < IntegrationTest
   def test_sort_by_date_descending
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?q=important&order=-public_timestamp"
+    get "/search?q=important&order=-public_timestamp"
 
     # The government links have dates, so appear before all the other links.
     # The other documents have no dates, so appear in an undefined order
@@ -99,7 +99,7 @@ class SearchTest < IntegrationTest
   def test_sort_by_title_ascending
     reset_content_indexes_with_content(section_count: 1)
 
-    get "/unified_search?order=title"
+    get "/search?order=title"
     lowercase_titles = result_titles.map(&:downcase)
 
     assert_equal lowercase_titles, lowercase_titles.sort
@@ -108,7 +108,7 @@ class SearchTest < IntegrationTest
   def test_filter_by_field
     reset_content_indexes_with_content(section_count: 1)
 
-    get "/unified_search?filter_mainstream_browse_pages=1"
+    get "/search?filter_mainstream_browse_pages=1"
 
     assert_equal ["/government-1", "/mainstream-1"],
       result_links.sort
@@ -117,7 +117,7 @@ class SearchTest < IntegrationTest
   def test_reject_by_field
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?reject_mainstream_browse_pages=1"
+    get "/search?reject_mainstream_browse_pages=1"
 
     assert_equal ["/government-2", "/mainstream-2"],
       result_links.sort
@@ -126,7 +126,7 @@ class SearchTest < IntegrationTest
   def test_can_filter_for_missing_field
     reset_content_indexes_with_content(section_count: 1)
 
-    get "/unified_search?filter_specialist_sectors=_MISSING"
+    get "/search?filter_specialist_sectors=_MISSING"
 
     assert_equal ["/government-1", "/mainstream-1"],
       result_links.sort
@@ -135,7 +135,7 @@ class SearchTest < IntegrationTest
   def test_can_filter_for_missing_or_specific_value_in_field
     reset_content_indexes_with_content(section_count: 1)
 
-    get "/unified_search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
+    get "/search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
 
     assert_equal ["/government-1", "/mainstream-1"],
       result_links.sort
@@ -144,7 +144,7 @@ class SearchTest < IntegrationTest
   def test_can_filter_and_reject
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?reject_mainstream_browse_pages=1&filter_specialist_sectors[]=farming"
+    get "/search?reject_mainstream_browse_pages=1&filter_specialist_sectors[]=farming"
 
     assert_equal [
       "/government-2",
@@ -155,7 +155,7 @@ class SearchTest < IntegrationTest
   def test_only_contains_fields_which_are_present
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?q=important&order=public_timestamp"
+    get "/search?q=important&order=public_timestamp"
 
     results = parsed_response["results"]
     refute_includes results[0].keys, "specialist_sectors"
@@ -165,7 +165,7 @@ class SearchTest < IntegrationTest
   def test_facet_counting
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?q=important&facet_mainstream_browse_pages=2"
+    get "/search?q=important&facet_mainstream_browse_pages=2"
 
     assert_equal 4, parsed_response["total"]
 
@@ -190,12 +190,12 @@ class SearchTest < IntegrationTest
   def test_facet_counting_with_filter_on_field_and_exclude_field_filter_scope
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?q=important&facet_mainstream_browse_pages=2"
+    get "/search?q=important&facet_mainstream_browse_pages=2"
 
     assert_equal 4, parsed_response["total"]
     facets_without_filter = parsed_response["facets"]
 
-    get "/unified_search?q=important&facet_mainstream_browse_pages=2&filter_mainstream_browse_pages=1"
+    get "/search?q=important&facet_mainstream_browse_pages=2&filter_mainstream_browse_pages=1"
     assert_equal 2, parsed_response["total"]
 
     facets_with_filter = parsed_response["facets"]
@@ -207,7 +207,7 @@ class SearchTest < IntegrationTest
   def test_facet_counting_missing_options
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?q=important&facet_mainstream_browse_pages=1"
+    get "/search?q=important&facet_mainstream_browse_pages=1"
 
     assert_equal 4, parsed_response["total"]
     facets = parsed_response["facets"]
@@ -227,7 +227,7 @@ class SearchTest < IntegrationTest
   def test_facet_counting_with_filter_on_field_and_all_filters_scope
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?q=important&facet_mainstream_browse_pages=2,scope:all_filters&filter_mainstream_browse_pages=1"
+    get "/search?q=important&facet_mainstream_browse_pages=2,scope:all_filters&filter_mainstream_browse_pages=1"
 
     assert_equal 2, parsed_response["total"]
     facets = parsed_response["facets"]
@@ -248,7 +248,7 @@ class SearchTest < IntegrationTest
   def test_facet_examples
     reset_content_indexes_with_content(section_count: 2)
 
-    get "/unified_search?q=important&facet_mainstream_browse_pages=1,examples:5,example_scope:global,example_fields:link:title:mainstream_browse_pages"
+    get "/search?q=important&facet_mainstream_browse_pages=1,examples:5,example_scope:global,example_fields:link:title:mainstream_browse_pages"
 
     assert_equal(
       ["/government-1", "/mainstream-1"],
@@ -259,7 +259,7 @@ class SearchTest < IntegrationTest
   def test_validates_integer_params
     reset_content_indexes
 
-    get "/unified_search?start=a"
+    get "/search?start=a"
 
     assert_equal last_response.status, 422
     assert_equal parsed_response, { "error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)" }
@@ -268,7 +268,7 @@ class SearchTest < IntegrationTest
   def test_allows_integer_params_leading_zeros
     reset_content_indexes
 
-    get "/unified_search?start=09"
+    get "/search?start=09"
 
     assert last_response.ok?
   end
@@ -276,7 +276,7 @@ class SearchTest < IntegrationTest
   def test_validates_unknown_params
     reset_content_indexes
 
-    get "/unified_search?foo&bar=1"
+    get "/search?foo&bar=1"
 
     assert_equal last_response.status, 422
     assert_equal parsed_response, { "error" => "Unexpected parameters: foo, bar" }
@@ -285,7 +285,7 @@ class SearchTest < IntegrationTest
   def test_debug_explain_returns_explanations
     reset_content_indexes_with_content(section_count: 1)
 
-    get "/unified_search?debug=explain"
+    get "/search?debug=explain"
 
     first_hit_explain = parsed_response["results"].first["_explanation"]
     refute_nil first_hit_explain
@@ -298,7 +298,7 @@ class SearchTest < IntegrationTest
     reset_content_indexes
     commit_document("mainstream_test", cma_case_attributes)
 
-    get "/unified_search?filter_document_type=cma_case"
+    get "/search?filter_document_type=cma_case"
 
     assert last_response.ok?
     assert_equal 1, parsed_response.fetch("total")
@@ -316,7 +316,7 @@ class SearchTest < IntegrationTest
     reset_content_indexes
     commit_document("mainstream_test", cma_case_attributes)
 
-    get "/unified_search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
+    get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
 
     assert last_response.ok?
     assert_equal 1, parsed_response.fetch("total")
@@ -333,7 +333,7 @@ class SearchTest < IntegrationTest
     reset_content_indexes
     commit_document("mainstream_test", cma_case_attributes)
 
-    get "/unified_search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
+    get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
 
     assert last_response.ok?
     assert_equal 1, parsed_response.fetch("total")
@@ -350,7 +350,7 @@ class SearchTest < IntegrationTest
     reset_content_indexes
     commit_document("mainstream_test", cma_case_attributes)
 
-    get "/unified_search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
+    get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
 
     assert last_response.ok?
     assert_equal 1, parsed_response.fetch("total")
@@ -367,7 +367,7 @@ class SearchTest < IntegrationTest
     reset_content_indexes
     commit_document("mainstream_test", cma_case_attributes)
 
-    get "/unified_search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
+    get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
 
     assert last_response.ok?
     assert_equal 1, parsed_response.fetch("total")
@@ -383,7 +383,7 @@ class SearchTest < IntegrationTest
   def test_cannot_provide_date_filter_key_multiple_times
     reset_content_indexes
 
-    get "/unified_search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
+    get "/search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
 
     assert_equal 422, last_response.status
     assert_equal(
@@ -395,7 +395,7 @@ class SearchTest < IntegrationTest
   def test_cannot_provide_invalid_dates_for_date_filter
     reset_content_indexes
 
-    get "/unified_search?filter_document_type=cma_case&filter_opened_date=from:not-a-date"
+    get "/search?filter_document_type=cma_case&filter_opened_date=from:not-a-date"
 
     assert_equal 422, last_response.status
     assert_equal(
@@ -420,7 +420,7 @@ class SearchTest < IntegrationTest
       format: 'organisation'
     )
 
-    get "/unified_search.json?q=dragons"
+    get "/search.json?q=dragons"
 
     assert_equal first_result['organisations'],
       [{ "slug" => "/ministry-of-magic",
@@ -431,7 +431,7 @@ class SearchTest < IntegrationTest
   def test_id_search
     reset_content_indexes_with_content(section_count: 1)
 
-    get "/unified_search?q=id1&debug=new_weighting"
+    get "/search?q=id1&debug=new_weighting"
 
     assert result_links.include? "/mainstream-1"
   end
@@ -446,7 +446,7 @@ class SearchTest < IntegrationTest
       is_withdrawn: true
     )
 
-    get "/unified_search?q=test"
+    get "/search?q=test"
     assert_equal 0, parsed_response.fetch("total")
   end
 
@@ -460,7 +460,7 @@ class SearchTest < IntegrationTest
       is_withdrawn: true
     )
 
-    get "/unified_search?q=test&debug=include_withdrawn&fields[]=is_withdrawn"
+    get "/search?q=test&debug=include_withdrawn&fields[]=is_withdrawn"
     assert_equal 1, parsed_response.fetch("total")
     assert_equal true, parsed_response.dig("results", 0, "is_withdrawn")
   end
@@ -468,7 +468,7 @@ class SearchTest < IntegrationTest
   def test_show_the_query
     reset_content_indexes
 
-    get "/unified_search?q=test&debug=show_query"
+    get "/search?q=test&debug=show_query"
 
     assert parsed_response.fetch("elasticsearch_query")
   end
@@ -483,7 +483,7 @@ class SearchTest < IntegrationTest
     )
 
     facet_queries.each do |filter_query|
-      get "/unified_search?filter_document_type=dfid_research_output&#{filter_query}"
+      get "/search?filter_document_type=dfid_research_output&#{filter_query}"
 
       assert last_response.ok?
       assert_equal 1, parsed_response.fetch("total"), "Failure to search by #{filter_query}"
@@ -508,7 +508,7 @@ class SearchTest < IntegrationTest
       taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
     )
 
-    get "/unified_search?q=test&fields[]=taxons"
+    get "/search?q=test&fields[]=taxons"
     assert_equal 1, parsed_response.fetch("total")
 
     taxons = parsed_response.dig("results", 0, "taxons")
@@ -525,7 +525,7 @@ class SearchTest < IntegrationTest
       taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
     )
 
-    get "/unified_search?filter_taxons=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
+    get "/search?filter_taxons=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
 
     assert last_response.ok?
     assert_equal 1, parsed_response.fetch("total")

--- a/test/unit/health_check/json_search_client_test.rb
+++ b/test/unit/health_check/json_search_client_test.rb
@@ -5,7 +5,7 @@ Logging.logger.root.appenders = nil
 
 module HealthCheck
   class JsonSearchClientTest < ShouldaUnitTestCase
-    def unified_search_response_body
+    def search_response_body
       {
         "results" => [
           {
@@ -21,14 +21,14 @@ B)
       }
     end
 
-    def stub_unified_search(search_term)
+    def stub_search(search_term)
       stub_request(:get, "http://www.gov.uk/api/search.json?q=#{CGI.escape(search_term)}").
         with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
-        to_return(status: 200, body: unified_search_response_body.to_json)
+        to_return(status: 200, body: search_response_body.to_json)
     end
 
     should "support the unified search format" do
-      stub_unified_search("cheese")
+      stub_search("cheese")
       expected = { results: ["/a", "/b"], suggested_queries: %w[A B] }
       base_url = URI.parse("http://www.gov.uk/api/search.json")
       assert_equal expected, JsonSearchClient.new(base_url: base_url).search("cheese")


### PR DESCRIPTION
All alphagov apps have now been changed to use the new `search` endpoint for rummager, hence this commit removes the `unified_search` endpoint.

Trello: https://trello.com/c/cj8UX2jX
