### PR TITLE
Remove “unified search” from more files

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -39,7 +39,7 @@ class HealthCheckCLI
       on 'h', 'help', "Show this message"
       on 'limit=', "Limit to the first n tests", as: Integer
       on 'a', 'auth=', "Basic auth credentials (of the form 'user:pass'", as: HealthCheck::BasicAuthCredentials
-      on 'j', 'json=', "Connect to a Rummager unified search endpoint at the the given url (default) (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
+      on 'j', 'json=', "Connect to a Rummager search endpoint at the the given url (default) (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
       on 'v', 'verbose', "Show verbose logging output"
       on 'type=', "Which tests to run. 'suggestions' or 'results' (default)"
       run(health_checker)

--- a/test/unit/health_check/json_search_client_test.rb
+++ b/test/unit/health_check/json_search_client_test.rb
@@ -27,7 +27,7 @@ B)
         to_return(status: 200, body: search_response_body.to_json)
     end
 
-    should "support the unified search format" do
+    should "support the search format" do
       stub_search("cheese")
       expected = { results: ["/a", "/b"], suggested_queries: %w[A B] }
       base_url = URI.parse("http://www.gov.uk/api/search.json")


### PR DESCRIPTION
Following on from https://github.com/alphagov/rummager/pull/698, this commit removes “unified search” from a couple of places where they were missed last time.

Trello: https://trello.com/c/cj8UX2jX
