### PR TITLE
Update name for Democratic Republic of the Congo

### DIFF
--- a/config/schema/document_types/international_development_fund.json
+++ b/config/schema/document_types/international_development_fund.json
@@ -33,7 +33,7 @@
         "value": "burma"
       },
       {
-        "label": "Democratic Republic of Congo",
+        "label": "Democratic Republic of the Congo",
         "value": "democratic-republic-of-congo"
       },
       {


### PR DESCRIPTION
**trello**: https://trello.com/c/rxjklHjL/191-country-name-change-democratic-republic-of-the-congo

> The country formerly known as 'Democratic Republic of Congo' is now officially called 'Democratic Republic of **the** Congo'
