### PR TITLE
Fix links indexing for courts and tribunals

### DIFF
--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -70,7 +70,7 @@ module Indexer
       end
 
       links_with_slugs["organisations"] = links["organisations"].to_a.map do |content_item|
-        content_item['base_path'].sub('/government/organisations/', '')
+        content_item['base_path'].sub('/government/organisations/', '').sub('/courts-tribunals/', '')
       end
 
       links_with_slugs["taxons"] = links["taxons"].to_a.map do |content_item|

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -66,6 +66,10 @@ class TaglookupDuringIndexingTest < IntegrationTest
           {
             "content_id" => "ORG-1",
             "base_path" => "/government/organisations/my-org/1",
+          },
+          {
+            "content_id" => "ORG-2",
+            "base_path" => "/courts-tribunals/my-court",
           }
         ],
         taxons: [
@@ -85,7 +89,7 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "link" => "/foo/bar",
       "specialist_sectors" => ["my-topic/a", "my-topic/b"],
       "mainstream_browse_pages" => ["my-browse/1"],
-      "organisations" => ["my-org/1"],
+      "organisations" => ["my-org/1", "my-court"],
       "taxons" => ["TAXON-1"],
     )
   end


### PR DESCRIPTION
Content can be tagged to organisations. In most cases the organisation has a URL in the form of

https://www.gov.uk/government/organisations/cabinet-office

Rummager internally uses a concept of `slug` to refer to other pages in the index (in the future it should use `content_ids`, but soit).

The slug for above URL is `cabinet-office`, so the code that copies the links from the publishing-api just strips `/government/organisations/` off the base_path. However, we didn't realise that there are organisations with a slightly different slug, namely the courts & tribunals, that live at:

https://www.gov.uk/courts-tribunals/administrative-court

This PR makes sure we persist the proper slug in elasticsearch for the courts tribunals.

https://trello.com/c/BCzbVwRw
