### PR TITLE
Add frontmatter to /docs pages

### DIFF
--- a/docs/adding-new-fields.md
+++ b/docs/adding-new-fields.md
@@ -1,4 +1,6 @@
-## Adding new fields to rummager
+---
+title: Adding new fields to rummager
+---
 
 ### The schema
 

--- a/docs/content-api.md
+++ b/docs/content-api.md
@@ -1,4 +1,6 @@
-## Rummager Content API
+---
+title: Rummager Content API
+---
 
 ### `GET /content/?link=/a-link`
 

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -1,4 +1,6 @@
-## Rummager Documents API
+---
+title: Rummager Documents API
+---
 
 ### `POST /:index/documents`
 

--- a/docs/health-check.md
+++ b/docs/health-check.md
@@ -1,4 +1,6 @@
-## Health check
+---
+title: Health check
+---
 
 As we work on rummager we want some objective metrics of the performance of search. That's what the health check is for.
 

--- a/docs/popularity.md
+++ b/docs/popularity.md
@@ -1,4 +1,6 @@
-### Popularity information
+---
+title: Popularity information
+---
 
 The gov.uk search uses page popularity information extracted from Google
 Analytics as one of the factors in weighting search results.  This is extracted

--- a/docs/search-api.md
+++ b/docs/search-api.md
@@ -1,4 +1,6 @@
-# Search API
+---
+title: Search API
+---
 
 This API is the main endpoint for performing searches on GOV.UK.  It supports
 keyword searching, ordering by relevance or date fields, filtering and


### PR DESCRIPTION
This will probably cause them to show up in the table of contents on

http://alphagov.github.io/rummager/
