### PR TITLE
Add styling to documentation pages

### DIFF
--- a/docs/adding-new-fields.md
+++ b/docs/adding-new-fields.md
@@ -1,5 +1,6 @@
 ---
 title: Adding new fields to rummager
+layout: default
 ---
 
 ### The schema

--- a/docs/content-api.md
+++ b/docs/content-api.md
@@ -1,5 +1,6 @@
 ---
 title: Rummager Content API
+layout: default
 ---
 
 ### `GET /content/?link=/a-link`

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -1,5 +1,6 @@
 ---
 title: Rummager Documents API
+layout: default
 ---
 
 ### `POST /:index/documents`

--- a/docs/health-check.md
+++ b/docs/health-check.md
@@ -1,5 +1,6 @@
 ---
 title: Health check
+layout: default
 ---
 
 As we work on rummager we want some objective metrics of the performance of search. That's what the health check is for.

--- a/docs/popularity.md
+++ b/docs/popularity.md
@@ -1,5 +1,6 @@
 ---
 title: Popularity information
+layout: default
 ---
 
 The gov.uk search uses page popularity information extracted from Google

--- a/docs/search-api.md
+++ b/docs/search-api.md
@@ -1,5 +1,6 @@
 ---
 title: Search API
+layout: default
 ---
 
 This API is the main endpoint for performing searches on GOV.UK.  It supports


### PR DESCRIPTION
Currently pages like this don't have a layout:

http://alphagov.github.io/rummager/adding-new-fields.html
