### PR TITLE
Amend to field defs to support changes to MOJ asylum doc

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -431,13 +431,13 @@
     "type": "searchable_identifiers"
   },
   "tribunal_decision_category": {
-    "type": "identifier"
+    "type": "identifiers"
   },
   "tribunal_decision_category_name": {
     "type": "searchable_identifier"
   },
   "tribunal_decision_sub_category": {
-    "type": "identifier"
+    "type": "identifiers"
   },
   "tribunal_decision_sub_category_name": {
     "type": "searchable_identifier"


### PR DESCRIPTION
An amend has been made to the MOJ Asylum schema fields so that the category and subcategory fields support an array format.

Associated changes have been made to the specialist publisher and govuk-content-schema repos
