### PR TITLE
Add fields for links expansion

### DIFF
--- a/config/schema/base_document_type.json
+++ b/config/schema/base_document_type.json
@@ -11,8 +11,10 @@
     "link",
     "mainstream_browse_pages",
     "mainstream_browse_page_content_ids",
+    "expanded_mainstream_browse_pages",
     "organisations",
     "organisation_content_ids",
+    "expanded_organisations",
     "policies",
     "popularity",
     "public_timestamp",
@@ -20,6 +22,7 @@
     "rendering_app",
     "specialist_sectors",
     "topic_content_ids",
+    "expanded_topics",
     "spelling_text",
     "title",
     "updated_at"

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -35,11 +35,17 @@
   },
 
   "organisations": {
-    "type": "identifiers"
+    "type": "identifiers",
+    "description": "This field includes slugs from organisations, which are expanded on presentation, returning a list of expanded organisations. This will be replaced by \"expanded_organisations\" in the future."
   },
 
   "organisation_content_ids": {
-    "description": "As opposed to \"organisations\", this will include the \"content_ids\" of each organisation rather than the slug. It will eventually replace \"organisations\".",
+    "description": "As opposed to \"organisations\", this will include the \"content_ids\" of each organisation rather than the slug.",
+    "type": "identifiers"
+  },
+
+  "expanded_organisations": {
+    "description": "As opposed to \"organisations\", this will include organisations expanded via content_ids instead of slugs. It will eventually replace \"organisations\".",
     "type": "identifiers"
   },
 
@@ -49,7 +55,12 @@
   },
 
   "topic_content_ids": {
-    "description": "The navigation \"topics\" that the document is assigned to. Nothing to do with \"policy areas\". As opposed to \"specialist_sectors\", this will include the \"content_ids\" of each topic rather than the slug. It will eventually replace \"specialist_sectors\".",
+    "description": "The navigation \"topics\" that the document is assigned to. Nothing to do with \"policy areas\". As opposed to \"specialist_sectors\", this will include the \"content_ids\" of each topic rather than the slug.",
+    "type": "identifiers"
+  },
+
+  "expanded_topics": {
+    "description": "As opposed to \"specialist_sectors\", this will include topics expanded via content_ids instead of slugs. It will eventually replace \"specialist_sectors\".",
     "type": "identifiers"
   },
 
@@ -73,11 +84,17 @@
   },
 
   "mainstream_browse_pages": {
+    "description": "This field includes slugs from mainstream browse pages, which are expanded on presentation, returning a list of expanded mainstream browse pages. This will be replaced by \"expanded_mainstream_browse_pages\" in the future.",
     "type": "identifiers"
   },
 
   "mainstream_browse_page_content_ids": {
     "description": "As opposed to \"mainstream_browse_pages\", this will include the \"content_ids\" of each mainstream browse pagerather than the slug. It will eventually replace \"mainstream_browse_pages\".",
+    "type": "identifiers"
+  },
+
+  "expanded_mainstream_browse_pages": {
+    "description": "As opposed to \"mainstream_browse_pages\", this will include mainstream browse pages expanded via content_ids instead of slugs. It will eventually replace \"mainstream_browse_pages\".",
     "type": "identifiers"
   },
 


### PR DESCRIPTION
The commit 646d64f252a5393d8d30b0319361b8548bf49d12 added extra fields in order
to hold `content_ids` of links for a given document.

The next step in the process is to expand links based on those content IDs. In
order to do that transparently, this commit adds 3 new fields to each document:
- `expanded_topics`
- `expanded_organisations`
- `expanded_mainstream_browse_pages`

These new fields are meant to replace, in the future, the following fields:
- `specialist_sectors`
- `organisations`
- `mainstream_browse_pages`

For now we will be expanding the new fields, which will allow us to migrate
existing applications to use the new behaviour.

When all applications have been moved across, we can deprecate the fields
mentioned above.
