### PR TITLE
Perfom link expansion via content ids

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -94,6 +94,10 @@ class BaseParameterParser
     title
     policy_areas
     world_locations
+    topic_content_ids
+    expanded_topics
+    organisation_content_ids
+    expanded_organisations
   ).freeze
 
   # Default order in which facet results are sorted

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -1,7 +1,12 @@
 require_relative "base_parameter_parser"
 
 class SearchParameterParser < BaseParameterParser
-  VIRTUAL_FIELDS = %w[title_with_highlighting description_with_highlighting].freeze
+  VIRTUAL_FIELDS = %w[
+    title_with_highlighting
+    description_with_highlighting
+    expanded_topics
+    expanded_organisations
+  ].freeze
   MAX_RESULTS = 1000
 
   def initialize(params, schema)

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -24,9 +24,7 @@ module Search
       hash_without_blank_values(
         from: search_params.start,
         size: search_params.count,
-        # `title` and `description` always needed to potentially populate virtual
-        # fields. If not explicitly requested they will not be sent to the user.
-        fields: search_params.return_fields + %w[title description],
+        fields: fields.uniq,
         query: query,
         filter: filter,
         sort: sort,
@@ -34,6 +32,17 @@ module Search
         highlight: highlight,
         explain: search_params.debug[:explain],
       )
+    end
+
+    # `title`, `description` always needed to potentially populate virtual
+    # fields. If not explicitly requested they will not be sent to the user.
+    # The same applies to all `*_content_ids` in order to be able to expand
+    # their corresponding fields without having to request both fields
+    # explicitly.
+    def fields
+      search_params.return_fields +
+        %w[title description organisation_content_ids topic_content_ids
+           mainstream_browse_page_content_ids]
     end
 
     def query

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -9,7 +9,9 @@ module Search
     def as_hash
       @registries ||= {
         organisations: organisations,
+        organisation_content_ids: organisations,
         specialist_sectors: specialist_sectors,
+        topic_content_ids: specialist_sectors,
 
         # Whitehall has a thing called `topic`, which is being renamed to "policy
         # area", because there already are seven things called "topic". Until

--- a/lib/search/registry.rb
+++ b/lib/search/registry.rb
@@ -20,6 +20,10 @@ module Search
       @cache.get
     end
 
+    def by_content_id(content_id)
+      all.find { |o| o['content_id'] == content_id }
+    end
+
     def [](slug)
       all.find { |o| o['slug'] == slug }
     end

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -493,6 +493,30 @@ class SearchTest < IntegrationTest
     assert(first_result['expanded_organisations'])
   end
 
+  def test_filter_by_organisation_content_ids_works
+    reset_content_indexes
+
+    commit_document(
+      "mainstream_test",
+      title: 'Advice on Treatment of Dragons',
+      link: '/dragon-guide',
+      organisation_content_ids: ['organisation-content-id']
+    )
+
+    commit_document(
+      "government_test",
+      content_id: 'organisation-content-id',
+      slug: '/ministry-of-magic',
+      title: 'Ministry of Magic',
+      link: '/ministry-of-magic-site',
+      format: 'organisation'
+    )
+
+    get "/search.json?filter_organisation_content_ids[]=organisation-content-id"
+
+    assert(first_result['expanded_organisations'])
+  end
+
   def test_expandinging_of_topics
     reset_content_indexes
 
@@ -528,6 +552,28 @@ class SearchTest < IntegrationTest
 
     # Keeps the topic content ids
     assert_equal(first_result['topic_content_ids'], ['topic-content-id'])
+  end
+
+  def test_filter_by_topic_content_ids_works
+    reset_content_indexes
+
+    commit_document("mainstream_test",
+      title: 'Advice on Treatment of Dragons',
+      link: '/dragon-guide',
+      topic_content_ids: ['topic-content-id']
+    )
+
+    commit_document("government_test",
+      content_id: 'topic-content-id',
+      slug: 'topic-magic',
+      title: 'Magic topic',
+      link: '/magic-topic-site',
+      # TODO: we should rename this format to `topic` and update all apps
+      format: 'specialist_sector'
+    )
+    get "/search.json?filter_topic_content_ids[]=topic-content-id"
+
+    assert(first_result['expanded_topics'])
   end
 
   def test_id_search

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -469,6 +469,30 @@ class SearchTest < IntegrationTest
     )
   end
 
+  def test_search_for_expanded_organisations_works
+    reset_content_indexes
+
+    commit_document(
+      "mainstream_test",
+      title: 'Advice on Treatment of Dragons',
+      link: '/dragon-guide',
+      organisation_content_ids: ['organisation-content-id']
+    )
+
+    commit_document(
+      "government_test",
+      content_id: 'organisation-content-id',
+      slug: '/ministry-of-magic',
+      title: 'Ministry of Magic',
+      link: '/ministry-of-magic-site',
+      format: 'organisation'
+    )
+
+    get "/search.json?q=dragons&fields[]=expanded_organisations"
+
+    assert(first_result['expanded_organisations'])
+  end
+
   def test_expandinging_of_topics
     reset_content_indexes
 

--- a/test/unit/search/base_registry_test.rb
+++ b/test/unit/search/base_registry_test.rb
@@ -11,6 +11,7 @@ class BaseRegistryTest < MiniTest::Unit::TestCase
 
   def example_document
     {
+      "content_id" => "example-content-id",
       "slug" => "example-document",
       "link" => "/government/example-document",
       "title" => "Example document"
@@ -63,5 +64,16 @@ class BaseRegistryTest < MiniTest::Unit::TestCase
     # we don't need to worry about cache expiry tests here.
     Search::TimedCache.any_instance.expects(:get).with.returns([example_document])
     assert @base_registry["example-document"]
+  end
+
+  def test_find_by_content_id
+    @index.stubs(:documents_by_format)
+      .with("example-format", anything)
+      .returns([example_document])
+
+    assert_equal(
+      @base_registry.by_content_id("example-content-id"),
+      example_document
+    )
   end
 end


### PR DESCRIPTION
We are changing the way we are storing and expanding information on links.
Before, there would be one field per link type (e.g. `organisations`), which
would hold a list of `slugs` in ElasticSearch. When that document was being
served, we would expand those `slugs` into a Hash of attributes in the same
`organisations` field.

We are changing to use 2 fields per link type instead. One containing the
`content_ids` and another containing the expanded version of the links.

So, for the example above, we would have both `organisation_content_ids` and
`expanded_organisations`.

This PR expands the new fields `expanded_organsiations` and `expanded_topics` based on their content IDs. It also adds these fields to the search results so we can have access to them.

Trello: https://trello.com/c/12ijjlxN/209-change-the-way-rummager-refers-to-other-documents
