### PR TITLE
Return all available fields by default

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -80,26 +80,6 @@ class BaseParameterParser
   #            the query and filters
   ALLOWED_EXAMPLE_SCOPES = [:global, :query].freeze
 
-  # The fields which are returned by default for search results.
-  DEFAULT_RETURN_FIELDS = %w(
-    description
-    display_type
-    document_series
-    format
-    link
-    organisations
-    public_timestamp
-    slug
-    specialist_sectors
-    title
-    policy_areas
-    world_locations
-    topic_content_ids
-    expanded_topics
-    organisation_content_ids
-    expanded_organisations
-  ).freeze
-
   # Default order in which facet results are sorted
   DEFAULT_FACET_SORT = [
     [:filtered, 1],

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -102,18 +102,10 @@ private
     [SORT_MAPPINGS.fetch(field, field), dir]
   end
 
-  # Get a list of the fields to request in results from elasticsearch
   def return_fields
     fields = character_separated_param("fields")
-    if fields.empty?
-      return DEFAULT_RETURN_FIELDS
-    end
-    disallowed_fields = fields - allowed_return_fields
-    fields = fields - disallowed_fields
+    return [] if fields.empty?
 
-    if disallowed_fields.any?
-      @errors << "Some requested fields are not valid return fields: #{disallowed_fields}"
-    end
     fields
   end
 

--- a/lib/search/presenters/result_presenter.rb
+++ b/lib/search/presenters/result_presenter.rb
@@ -17,7 +17,7 @@ module Search
     end
 
     def present
-      result = raw_result['fields'] || {}
+      result = raw_result['fields'] || raw_result['_source'] || {}
 
       if schema
         result = convert_elasticsearch_array_fields(result)
@@ -64,7 +64,7 @@ module Search
       result.each do |field_name, values|
         next if field_name[0] == '_'
         next if document_schema.fields.fetch(field_name).type.multivalued
-        result[field_name] = values.first
+        result[field_name] = values.is_a?(Array) ? values.first : values
       end
       result
     end
@@ -109,6 +109,8 @@ module Search
     end
 
     def only_return_explicitely_requested_values(result)
+      return result if search_params.return_fields.empty?
+
       result.slice(*search_params.return_fields)
     end
 

--- a/lib/search/presenters/result_set_presenter.rb
+++ b/lib/search/presenters/result_set_presenter.rb
@@ -56,7 +56,15 @@ module Search
 
     def presented_results
       es_response["hits"]["hits"].map do |raw_result|
-        ResultPresenter.new(raw_result.to_hash, @registries, @schema, search_params).present
+        results_hash = raw_result.to_hash
+        results_hash['fields'] ||= results_hash.delete('_source')
+
+        ResultPresenter.new(
+          results_hash,
+          @registries,
+          @schema,
+          search_params
+        ).present
       end
     end
 

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -21,28 +21,17 @@ module Search
     end
 
     def payload
-      hash_without_blank_values(
+      hash_without_blank_values({
         from: search_params.start,
         size: search_params.count,
-        fields: fields.uniq,
         query: query,
         filter: filter,
         sort: sort,
         facets: facets,
         highlight: highlight,
         explain: search_params.debug[:explain],
+      }
       )
-    end
-
-    # `title`, `description` always needed to potentially populate virtual
-    # fields. If not explicitly requested they will not be sent to the user.
-    # The same applies to all `*_content_ids` in order to be able to expand
-    # their corresponding fields without having to request both fields
-    # explicitly.
-    def fields
-      search_params.return_fields +
-        %w[title description organisation_content_ids topic_content_ids
-           mainstream_browse_page_content_ids]
     end
 
     def query

--- a/test/unit/parameter_parser/search_parameter_parser_test.rb
+++ b/test/unit/parameter_parser/search_parameter_parser_test.rb
@@ -9,7 +9,7 @@ class SearchParameterParserTest < ShouldaUnitTestCase
       count: 10,
       query: nil,
       order: nil,
-      return_fields: BaseParameterParser::DEFAULT_RETURN_FIELDS,
+      return_fields: [],
       filters: [],
       facets: {},
       debug: {},
@@ -704,14 +704,6 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     assert_equal("", p.error)
     assert p.valid?
     assert_equal(expected_params({ return_fields: %w(title description) }), p.parsed_params)
-  end
-
-  should "complain about invalid fields parameters" do
-    p = SearchParameterParser.new({ "fields" => %w(title waffle) }, @schema)
-
-    assert_equal("Some requested fields are not valid return fields: [\"waffle\"]", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({ return_fields: ["title"] }), p.parsed_params)
   end
 
   should "understand the debug parameter" do

--- a/test/unit/search/query_builder_test.rb
+++ b/test/unit/search/query_builder_test.rb
@@ -14,7 +14,7 @@ class QueryBuilderTest < ShouldaUnitTestCase
 
       assert_equal 11, result[:from]
       assert_equal 34, result[:size]
-      assert result[:fields].include?('a_field')
+      assert_nil result[:fields]
       assert result.key?(:query)
     end
   end


### PR DESCRIPTION
Rummager used to do field filtering by default when no fields were
specified.  I found that behaviour a bit confusing when working on a
feature that touched this functionality. The difference in output
between `search-admin` and the search API was also a bit confusing,
making it harder to get up to speed with how rummager filters fields.

This change aims at simplifying things by always returning all fields
from ElasticSearch when no specific fields have been requested.

When specific fields have been requested, we fetch all fields from
ElasticSearch and only keep the fields we are interested in, which is
the current behaviour.

This means we don't need to add extra fields such as title and
description to make sure virtual fields (e.g. highlights) work. Because
each result includes all fields, we are able to enrich the response and
further down the line remove unwanted fields.

What do you think? 
