### PR TITLE
[WIP] Add support for “more like this” queries

### DIFF
--- a/lib/search/query_components/sort.rb
+++ b/lib/search/query_components/sort.rb
@@ -3,9 +3,13 @@ module QueryComponents
     # Get a list describing the sort order (or nil)
     def payload
       if search_params.order.nil?
+        # Disable sorting when searching for "similar" documents because these
+        # are already sorted in order of "similarity".
+        if !search_params.similar_to.nil?
+          return nil
         # Sort by popularity when there's no explicit ordering, and there's no
         # query (so there's no relevance scores).
-        if search_term.nil? && !search_params.disable_popularity?
+        elsif search_term.nil? && !search_params.disable_popularity?
           return [{ "popularity" => { order: "desc" } }]
         else
           return nil

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -1,8 +1,8 @@
 module Search
   # Value object that holds the parsed parameters for a search.
   class QueryParameters
-    attr_accessor :query, :order, :start, :count, :return_fields, :facets,
-                  :filters, :debug, :suggest, :is_quoted_phrase
+    attr_accessor :query, :similar_to, :order, :start, :count, :return_fields,
+                  :facets, :filters, :debug, :suggest, :is_quoted_phrase
 
     # starts and ends with quotes with no quotes in between, with or without
     # leading or trailing whitespace

--- a/test/integration/search/more_like_this_test.rb
+++ b/test/integration/search/more_like_this_test.rb
@@ -1,0 +1,54 @@
+require "integration_test_helper"
+
+class MoreLikeThisTest < IntegrationTest
+  def setup
+    # `@@registries` are set in Rummager and is *not* reset between tests. To
+    # prevent caching issues we manually clear them here to make a "new" app.
+    Rummager.class_variable_set(:'@@registries', nil)
+
+    stub_elasticsearch_settings
+    create_meta_indexes
+  end
+
+  def teardown
+    clean_meta_indexes
+  end
+
+  def test_returns_success
+    reset_content_indexes
+
+    get "/search?similar_to=/mainstream-1"
+
+    assert last_response.ok?
+  end
+
+  def test_returns_similar_docs
+    # We need at least 5 documents in the index for "more like this"
+    # queries to work (default value of `min_doc_freq` in Elasticsearch)
+    reset_content_indexes_with_content(section_count: 5)
+
+    get "/search?similar_to=/mainstream-1"
+
+    # All mainstream documents (excluding the one we're using for comparison)
+    # should be returned, but none of the government ones, since they're not
+    # "similar" enough
+    assert result_links.include? "/mainstream-2"
+    assert result_links.include? "/mainstream-3"
+    assert result_links.include? "/mainstream-4"
+    assert result_links.include? "/mainstream-5"
+    refute result_links.include? "/mainstream-1"
+    refute result_links.include? "/government-1"
+    refute result_links.include? "/government-2"
+    refute result_links.include? "/government-3"
+    refute result_links.include? "/government-4"
+    refute result_links.include? "/government-5"
+  end
+
+private
+
+  def result_links
+    @_result_links ||= parsed_response["results"].map do |result|
+      result["link"]
+    end
+  end
+end

--- a/test/unit/search/query_components/more_like_this_query_test.rb
+++ b/test/unit/search/query_components/more_like_this_query_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+require "search/query_builder"
+
+class MoreLikeThisQueryTest < ShouldaUnitTestCase
+  context "more like this" do
+    should "call the payload for a more like this query" do
+      params = search_query_params(similar_to: %{"/hello-world"})
+      builder = QueryComponents::Query.new(params)
+      builder.expects(:more_like_this_query_hash).once
+
+      builder.payload
+    end
+  end
+end

--- a/test/unit/search/query_components/sort_test_test.rb
+++ b/test/unit/search/query_components/sort_test_test.rb
@@ -47,4 +47,14 @@ class SortTest < ShouldaUnitTestCase
       )
     end
   end
+
+  context "more like this query" do
+    should "not explicitly order" do
+      builder = QueryComponents::Sort.new(Search::QueryParameters.new(similar_to: ["/hello-world"]))
+
+      result = builder.payload
+
+      assert_nil result
+    end
+  end
 end


### PR DESCRIPTION
This commit adds support in rummager for “more like this” queries to be sent to Elasticsearch. “More like this” queries allow searching using an existing indexed document as a starting point, and returning a set of documents that are “similar” to it content-wise.

A “more like this” search can be carried out using the existing rummager search endpoint with the new `similar_to` option, which takes a base path as its value (more correctly, the ID of the document in the Elasticsearch index). These searches cannot be combined with a text query (using the `q` option) and they also cannot be custom sorted (they are already sorted by similarity).