### PR TITLE
Rename contact_group to contact_groups

### DIFF
--- a/config/schema/document_types/contact.json
+++ b/config/schema/document_types/contact.json
@@ -1,5 +1,5 @@
 {
   "fields": [
-    "contact_group"
+    "contact_groups"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -247,8 +247,8 @@
     "type": "date"
   },
 
-  "contact_group": {
-    "type": "identifier"
+  "contact_groups": {
+    "type": "identifiers"
   },
 
   "grant_type": {


### PR DESCRIPTION
This commit renames the `contact_group` field in the `contact` schema to `contact_groups` and the type to `identifiers` to reflect the fact that there can be more than one contact group. The value of the field is an array of slugs.

Trello: https://trello.com/c/wD10DEXt/260-migrate-the-hmrc-contacts-page-to-a-finder