### PR TITLE
Allow faceting for world locations, policy areas and taxons

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -35,8 +35,11 @@ class BaseParameterParser
     organisations
     people
     policies
+    policy_areas
     search_format_types
     specialist_sectors
+    taxons
+    world_locations
   ).freeze
 
   # The fields for which facet examples are allowed to be requested.


### PR DESCRIPTION
World locations and policy areas are used in the whitehall finders like https://www.gov.uk/government/announcements. We're building new finders for those, so to keep feature parity we need to be able to facet on those attributes.

The taxons facet we'd like to use to experiment in finders too.