### PR TITLE
Add start and end dates to edition schema

### DIFF
--- a/config/schema/document_types/edition.json
+++ b/config/schema/document_types/edition.json
@@ -6,6 +6,7 @@
     "display_type",
     "document_collections",
     "document_series",
+    "end_date",
     "government_name",
     "has_act_paper",
     "has_command_paper",
@@ -28,6 +29,7 @@
     "search_format_types",
     "slug",
     "specialist_sectors",
+    "start_date",
     "statistics_announcement_state",
     "world_locations"
   ]

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -93,6 +93,16 @@
     "type": "date"
   },
 
+  "start_date": {
+    "type": "date",
+    "description": "Start date for topical content."
+  },
+
+  "end_date": {
+    "type": "date",
+    "description": "End date for topical content. Assume null means in the past for topical event pages."
+  },
+
   "latest_change_note": {
     "type": "unsearchable_text"
   },

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -63,6 +63,27 @@ class ElasticsearchIndexingTest < IntegrationTest
     })
   end
 
+  def test_start_and_end_dates
+    stub_tagging_lookup
+    post "/documents", {
+      "title" => "TITLE",
+      "format" => "topical_event",
+      "slug" => "/government/topical-events/foo",
+      "link" => "/government/topical-events/foo",
+      "start_date" => "2016-01-01T00:00:00Z",
+      "end_date" => "2017-01-01T00:00:00Z"
+    }.to_json
+
+    assert_document_is_in_rummager({
+      "title" => "TITLE",
+      "format" => "topical_event",
+      "slug" => "/government/topical-events/foo",
+      "link" => "/government/topical-events/foo",
+      "start_date" => "2016-01-01T00:00:00Z",
+      "end_date" => "2017-01-01T00:00:00Z"
+    })
+  end
+
   def test_adding_a_document_to_the_search_index_with_organisation_self_tagging
     stub_tagging_lookup
 


### PR DESCRIPTION
These are used for topical events to capture their topicalness.

Currently we store this in the placeholder content schema, but not rummager
https://github.com/alphagov/govuk-content-schemas/blob/0bda3ae3e0be97cba8849eb700dfd34d9c4c3d05/dist/formats/placeholder/frontend/schema.json

This will allow us to replace /government/topical-events with a finder
of topical events, and /government/topics with a finder of policy areas,
so we have one less thing being rendered from whitehall data using a custom
template.

Currently whitehall shows any with an end date in the future: https://github.com/alphagov/whitehall/blob/master/app/models/topical_event.rb#L38

Trello: https://trello.com/c/oVfSAO9W/311-migrate-policy-areas-index-to-a-finder