### PR TITLE
Allow topical events to be sorted by start_date

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -12,6 +12,7 @@ class BaseParameterParser
     closing_date
     title
     tribunal_decision_decision_date
+    start_date
   ).freeze
 
   SORT_MAPPINGS = {


### PR DESCRIPTION
The topics (policy areas and topical events) index page in whitehall
is being migrated to two finders.

To implement the topical events finder we need to sort by start date.

https://trello.com/c/oVfSAO9W/311-migrate-policy-areas-index-to-a-finder