### PR TITLE
Allow indexing of `organisation_type`

### DIFF
--- a/config/schema/document_types/edition.json
+++ b/config/schema/document_types/edition.json
@@ -18,6 +18,7 @@
     "metadata",
     "operational_field",
     "organisation_state",
+    "organisation_type",
     "organisations",
     "people",
     "policies",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -162,6 +162,7 @@
   },
 
   "organisation_type": {
+    "description": "The organisation type identifier, like 'ministerial_department' or 'public_corporation'. Only applies to organisations. Expected value is the `organisation_type_key` from Whitehall, enumerated in https://github.com/alphagov/whitehall/blob/master/app/models/organisation_type.rb.",
     "type": "identifier"
   },
 


### PR DESCRIPTION
This field type already exists in the field definitions, but was never used in a schema. I suspect this was forgotten when first implementing the schemas. We'll be sending this from Whitehall soon to allow us to build a organisation finder with this type as a facet.

Trello: https://trello.com/c/FRYiVa3U