### PR TITLE
Allow searching by elasticsearch_type

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -24,6 +24,7 @@ class BaseParameterParser
   FILTER_NAME_MAPPING = {
     # TODO: clients should not use `document_type` to search for documents.
     "document_type" => "_type",
+    "elasticsearch_type" => "_type",
   }.freeze
 
   # The fields listed here are the only ones which can be used to calculated

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -163,11 +163,10 @@ private
   end
 
   def allowed_filter_fields
-    # TODO: Clients should not use this `document_type`
-
-    # document_type is a special case, because it's an alias for the internal
+    # `document_type` & `elasticsearch_type` are aliases for the internal
     # "_type" field.
-    ["document_type"] + @schema.allowed_filter_fields
+    # TODO: Clients should not use this `document_type`.
+    %w[document_type elasticsearch_type] + @schema.allowed_filter_fields
   end
 
   def allowed_return_fields

--- a/lib/search/presenters/result_presenter.rb
+++ b/lib/search/presenters/result_presenter.rb
@@ -92,7 +92,10 @@ module Search
         result[:_explanation] = raw_result["_explanation"]
       end
 
-      # TODO: clients should not use this.
+      result[:elasticsearch_type] = raw_result["_type"]
+
+      # TODO: clients should not use this. It's probably only used in the
+      # search results in the `frontend` application.
       result[:document_type] = raw_result["_type"]
 
       result

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -219,7 +219,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
     end
 
     should 'return only basic metadata of fields' do
-      expected_keys = [:index, :es_score, :_id, :document_type]
+      expected_keys = [:index, :es_score, :_id, :elasticsearch_type, :document_type]
 
       assert_equal expected_keys, @output[:results].first.keys
     end


### PR DESCRIPTION
This allows people to use `elasticsearch_type` instead of `document_type`. This will allow us to eventually replace the latter with the `document_type` from the content-store, making types consistent across GOV.UK.

https://trello.com/c/C8A9bnuO/344-work-on-making-the-document-type-concept-clearer