### PR TITLE
Add Jenkinsfile for Rummager

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,101 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'rummager'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '50')
+      ),
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    [$class: 'ThrottleJobProperty',
+      categories: [],
+      limitOneJobWithMatchingParams: true,
+      maxConcurrentPerNode: 1,
+      maxConcurrentTotal: 0,
+      paramsToUseForLimit: 'Rummager',
+      throttleEnabled: true,
+      throttleOption: 'category'],
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: DEFAULT_SCHEMA_BRANCH,
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
+  ])
+
+  try {
+    govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
+    ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+
+    stage("Checkout") {
+      checkout scm
+    }
+
+    stage("git merge") {
+      govuk.mergeMasterBranch()
+    }
+
+    stage("bundle install") {
+      govuk.bundleApp()
+    }
+
+    stage("rubylinter") {
+      govuk.rubyLinter('app test lib')
+    }
+
+    stage("Run tests") {
+      govuk.setEnvar('USE_SIMPLECOV', 'true')
+      govuk.setEnvar('RACK_ENV', 'test')
+      govuk.runRakeTask('ci:setup:minitest test --trace')
+    }
+
+    if (env.BRANCH_NAME == 'master') {
+      stage("Push release tag") {
+        govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+      }
+
+      stage("Deploy to Integration") {
+        govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+      }
+
+      stage("Publish JUnit test result report") {
+        junit 'test/reports/*.xml'
+      }
+
+      stage("Publish Rcov report") {
+        step([
+          $class: 'RcovPublisher',
+          reportDir: "coverage/rcov",
+          targets: [
+            [metric: "CODE_COVERAGE", healthy: 80, unhealthy: 0, unstable: 0]
+          ]
+        ])
+      }
+    }
+
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+
+}


### PR DESCRIPTION
This adds the Jenkinsfile to Rummager to allow builds on the Jenkins pipeline.

This has now been successfully tested, although build times are slower than the current CI environment at ~13 minutes rather than ~5 minutes. 

The release tag pushing is still disabled in the PR, but if we decide to migrate then the steps should be:

1) Push new commit enabling tag pushes
2) Update build number on new CI to reflect the build number on the current CI environment
3) Update the webhook 
4) Merge the PR