### PR TITLE
Don't allow extremely high value for `page`

### DIFF
--- a/lib/legacy_search/advanced_search.rb
+++ b/lib/legacy_search/advanced_search.rb
@@ -24,6 +24,10 @@ module LegacySearch
       per_page  = params.delete("per_page").to_i
       page      = params.delete("page").to_i
 
+      if page > 500_000
+        raise LegacySearch::InvalidQuery, "The maximum for `page` parameter is 500000."
+      end
+
       query_builder = AdvancedSearchQueryBuilder.new(keywords, params, order, @mappings)
 
       unless query_builder.valid?

--- a/test/integration/search/legacy_search_test.rb
+++ b/test/integration/search/legacy_search_test.rb
@@ -195,4 +195,10 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
     assert_result_total 5
     assert_result_links "/yet-another-example-answer", "/another-example-answer", "/pork-pies", "/an-example-answer"
   end
+
+  def test_does_not_allow_page_to_be_super_high
+    get "/#{@index_name}/advanced_search.json?per_page=4&page=500001&order[updated_at]=desc"
+
+    assert_equal 422, last_response.status
+  end
 end


### PR DESCRIPTION
We're currently seeing requests coming in via Whitehall with an absurdly high `page` value:

https://www.gov.uk/government/publications?publication_filter_option=consultations%2Fsurvey.php&page=6082121121121212.1

It results in queries to rummager like this:

https://rummager.publishing.service.gov.uk/government/advanced_search?page=6082121121121212.1&per_page=40

Which in turn generates an elasticsearch query with a `from` value of `243284844844848440`. This hits some kind of java integer JSON parse limit, causing elasticsearch errors.

We have only 300.000 documents in the index, so there's absolutely no reason to request a quintillion. 500.000 will be a good limit for the coming years.

Errbit:

https://errbit.publishing.service.gov.uk/apps/539849ba0da115be230008b7/problems/58418b3a6578637afdc00100

Kibana:

https://kibana.publishing.service.gov.uk/kibana#dashboard/temp/AVjAJrpo77njsOZtnkGH

This will probably cause a new kind of error on Whitehall.

cc @carvil 