### PR TITLE
Add assessment_date for Service Standard Report

### DIFF
--- a/config/schema/elasticsearch_types/service_standard_report.json
+++ b/config/schema/elasticsearch_types/service_standard_report.json
@@ -1,3 +1,5 @@
 {
-  "fields": []
+  "fields": [
+    "assessment_date"
+  ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -498,5 +498,10 @@
   "dfid_document_type": {
     "description": "The document type of the output (e.g. Book Chapter, Conference Paper)",
     "type": "searchable_identifier"
+  },
+
+  "assessment_date": {
+    "description": "The date when the assessment was held.",
+    "type": "date"
   }
 }


### PR DESCRIPTION
We are adding `assessment_date` so Specialist Frontend can present this value
on assessment report documents.

This is a follow up work on moving all the service assessments and self
certification documents away from GDS Data blog
(https://gdsdata.blog.gov.uk/all-service-assessments-and-self-certification/)
and move them to Specialist Publisher.

Trello:
https://trello.com/c/ADPnDXsE/385-add-assessment-date-to-service-standard-specialist-document

Paired with: @klssmith