### PR TITLE
Add assessment_date to the allowed sort fields

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -13,6 +13,7 @@ class BaseParameterParser
     title
     tribunal_decision_decision_date
     start_date
+    assessment_date
   ).freeze
 
   SORT_MAPPINGS = {


### PR DESCRIPTION
- This is to allow service standard reports to be sorted by assessment
date.

Trello:
https://trello.com/c/ADPnDXsE/385-add-assessment-date-to-service-standard-specialist-document