### PR TITLE
Remove the service manual index

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ rebuild the index nightly to incorporate the latest analytics.
 	[config/schema/elasticsearch_types](config/schema/elasticsearch_types)
 - **Index**: An [elasticsearch search
 	index](https://www.elastic.co/blog/what-is-an-elasticsearch-index). Rummager
-	maintains several separate indices (`mainstream`, `details`, `government`,
-	and `service-manual`), but searches return documents from all of them.
+	maintains several separate indices (`mainstream`, `details` and `government`),
+	but searches return documents from all of them.
 - **Index Group**: An alias in elasticsearch that points to one index at a
 	time. This allows us to rebuild indexes without downtime.
 

--- a/bin/stats
+++ b/bin/stats
@@ -29,7 +29,7 @@ def words_without_punctuation(copy)
   copy.split(/\s+/) # this will include lots of things not wordy, and include variations that have eg punctuation
 end
 
-# The indexes which make up GOV.UK. Excludes the Service Manual
+# The indexes which make up GOV.UK.
 index_names = %w(mainstream detailed government)
 search_server = SearchConfig.new.search_server
 indices = index_names.map { |name| search_server.index(name) }

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,5 +1,5 @@
 base_uri: "http://localhost:9200"
-content_index_names: ["mainstream", "detailed", "government", "service-manual"]
+content_index_names: ["mainstream", "detailed", "government"]
 auxiliary_index_names: ["page-traffic", "metasearch"]
 registry_index: "government"
 metasearch_index_name: "metasearch"

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -38,8 +38,8 @@ module SearchIndices
       @is_content_index = !(@search_config.auxiliary_index_names.include? base_index_name)
     end
 
-    # Translate index names like `mainstream-2015-05-06t09..` into its
-    # proper name, eg. "mainstream", "government" or "service-manual".
+    # Translate index names like `mainstream-2015-05-06t09..` into its proper
+    # name, eg. "mainstream" or "government".
     # The regex takes the string until the first digit. After that, strip any
     # trailing dash from the string.
     def self.strip_alias_from_index_name(aliased_index_name)

--- a/lib/search/query_components/query.rb
+++ b/lib/search/query_components/query.rb
@@ -4,7 +4,6 @@ require_relative "text_query"
 module QueryComponents
   class Query < BaseComponent
     GOVERNMENT_BOOST_FACTOR = 0.4
-    SERVICE_MANUAL_BOOST_FACTOR = 0.1
 
     def payload
       QueryComponents::BestBets.new(search_params).wrap(query_hash)
@@ -22,18 +21,7 @@ module QueryComponents
               boost_factor: GOVERNMENT_BOOST_FACTOR
             }
           },
-          no_match_query: {
-            indices: {
-              index: :"service-manual",
-              query: {
-                function_score: {
-                  query: base_query,
-                  boost_factor: SERVICE_MANUAL_BOOST_FACTOR
-                }
-              },
-              no_match_query: base_query
-            }
-          }
+          no_match_query: base_query
         }
       }
     end

--- a/lib/search/spell_check_fetcher.rb
+++ b/lib/search/spell_check_fetcher.rb
@@ -1,14 +1,13 @@
 require_relative 'query_components/suggest'
 require_relative 'suggestion_blacklist'
 
-# Elasticsearch tries to find spelling suggestions for words that don't occur
-# in our content, as they are probably mispelled. However, currently it is
+# Elasticsearch tries to find spelling suggestions for words that don't occur in
+# our content, as they are probably mispelled. However, currently it is
 # returning suggestions for words that do not occur in *every* index. Because
-# the `service-manual` index contains very few words, elasticsearch returns
-# too many spelling suggestions for common terms. For example, using the
-# suggester on all four indices will yield a suggestion for "PAYE", because
-# it's mentioned only in the `government` index, and not the `service-manual`
-# index.
+# some indexes contain very few words, Elasticsearch returns too many spelling
+# suggestions for common terms. For example, using the suggester on all indices
+# will yield a suggestion for "PAYE", because it's mentioned only in the
+# `government` index, and not in other indexes.
 #
 # This issue is mentioned in
 # https://github.com/elastic/elasticsearch/issues/7472.

--- a/test/unit/result_set_presenter_test.rb
+++ b/test/unit/result_set_presenter_test.rb
@@ -182,7 +182,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
 
     should "have short index names" do
       @output[:results].each do |result|
-        assert_contains %w[mainstream government service-manual], result[:index]
+        assert_contains %w[mainstream government], result[:index]
       end
     end
 
@@ -251,7 +251,7 @@ class ResultSetPresenterTest < ShouldaUnitTestCase
 
     should "have short index names" do
       @output[:results].each do |result|
-        assert_contains %w[mainstream government service-manual], result[:index]
+        assert_contains %w[mainstream government], result[:index]
       end
     end
 


### PR DESCRIPTION
The `service-manual` index contains only content from the old service manual which has now been entirely replaced.

Content from the new service manual is indexed in the `mainstream` index.

https://trello.com/c/w9RIW7qz/539-remove-content-from-the-old-manual-from-search-index