### PR TITLE
Treat search input keywords as strings

### DIFF
--- a/lib/search/escaping.rb
+++ b/lib/search/escaping.rb
@@ -7,6 +7,8 @@ module Search
     LUCENE_BOOLEANS = /\b(AND|OR|NOT)\b/
 
     def escape(s)
+      s = s.to_s
+
       # 6 slashes =>
       #  ruby reads it as 3 backslashes =>
       #    the first 2 =>

--- a/test/integration/search/legacy_search_test.rb
+++ b/test/integration/search/legacy_search_test.rb
@@ -99,6 +99,13 @@ class ElasticsearchAdvancedSearchTest < IntegrationTest
     assert_result_links "/an-example-answer"
   end
 
+  def test_should_treat_keywords_as_string
+    get "/#{@index_name}/advanced_search.json?per_page=1&page=1&keywords[something]=1"
+    assert last_response.ok?
+    assert_result_total 2
+    assert_result_links "/an-example-answer"
+  end
+
   def test_should_search_by_nested_data
     get "/#{@index_name}/advanced_search.json?per_page=1&page=1&keywords=#{CGI.escape('Special thing')}"
 


### PR DESCRIPTION
This morning a bot visited the site using weirdly formatted query strings, presumably some automated SQLI attempt.

The request returned 500 because we expect `keywords` to be a string. This commit casts it to a string by default, so that it won't error and warn us via errbit.