### PR TITLE
Reduce sidekiq concurrency on dev environments

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,7 @@
 ---
-:concurrency:  16
+:concurrency: 5
+production:
+  :concurrency:  16
 :require: ./app.rb
 :logfile: ./log/sidekiq.log
 :queues:


### PR DESCRIPTION
In production-like environments we want to use 16 concurrency for sidekiq, but
in non production environments this can swamp the other processes.  Almost all
the workers communicate with the publishing-api, and on the dev VM this only
has a connection pool size of 5 (see:
https://github.com/alphagov/publishing-api/blob/1bd0c84fdc02eb60fb7a7204bf59dc4db644f080/config/database.yml#L4)
and the sidekiq concurrency settings documentation
(see: https://github.com/mperham/sidekiq/wiki/Advanced-Options#concurrency)
suggests having parity between the pool size in your activerecord connection
and your sidekiq concurrency.  The assumption in the docs is that your sidekiq
workers are running against the same db as the app they live in, but I think it
makes sense to consider the impact of the concurrency on external systems.

By having the concurrency higher than the poolsize of the publishing-api db we
see lots of Connection Timeout errors on the dev VM.  Setting either the pool
size or the concurrency so they are both the same fixes this, but setting the
concurrency lower seems like a less controversial choice than setting the db
pool size higher which may have other consequences for the resources of the
machines.