### PR TITLE
Add Appsignal configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "plek", "~> 1.12"
 gem "gds-api-adapters", "~> 37.5"
 gem "rack-logstasher", "~> 0.0.3"
 gem "airbrake", "~> 4.3.6"
+gem 'appsignal', '~> 2.0'
 gem "unf", "~> 0.1.4"
 gem "elasticsearch", "~> 1.0.15"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,9 @@ GEM
       builder
       multi_json
     amq-protocol (2.0.1)
+    appsignal (2.0.5)
+      rack
+      thread_safe
     ast (2.3.0)
     builder (3.2.2)
     bunny (2.2.2)
@@ -164,6 +167,7 @@ GEM
     statsd-ruby (1.3.0)
     test-unit-minitest (0.9.1)
       minitest (~> 4.7)
+    thread_safe (0.3.5)
     tilt (2.0.5)
     timecop (0.8.1)
     unf (0.1.4)
@@ -186,6 +190,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (= 3.2.22.2)
   airbrake (~> 4.3.6)
+  appsignal (~> 2.0)
   ci_reporter (~> 1.7.1)
   elasticsearch (~> 1.0.15)
   gds-api-adapters (~> 37.5)

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,10 @@
+default: &defaults
+  push_api_key: "<%= ENV['APPSIGNAL_API_KEY'] %>"
+  name: "Rummager"
+  active: <%= ENV['APPSIGNAL_API_KEY'] ? true : false %>
+
+development:
+  <<: *defaults
+
+production:
+  <<: *defaults


### PR DESCRIPTION
This adds Appsignal to the app. We're evaluating to see if it is a good
replacement for Errbit, while also adding performance tracking.

It's only activated if APPSIGNAL_API_KEY is set, which is currently only in
integration (alphagov/govuk-puppet#5376
https://github.gds/gds/deployment/pull/1215).

https://trello.com/c/J3kDeZD7

cc/ @tijmenb 