### PR TITLE
Add content_store_document_type field to schema

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -3,6 +3,7 @@
     "all_searchable_text",
     "taxons",
     "content_id",
+    "content_store_document_type",
     "description",
     "format",
     "indexable_content",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -503,5 +503,10 @@
   "assessment_date": {
     "description": "The date when the assessment was held.",
     "type": "date"
+  },
+
+  "content_store_document_type": {
+    "description": "The document type as stored in the Content Store",
+    "type": "identifier"
   }
 }


### PR DESCRIPTION
Add a `content_store_document_type` field to the search schema. This is to allow us to populate at least Guidance material with the corresponding Content Store Document Type in the appropriate publishing applications.

Trello: https://trello.com/c/M1cXENeB/341-add-content-store-document-type-to-all-guidance-content-in-rummager