### PR TITLE
Use sinatra integration for Appsignal

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,7 @@
 require "sinatra"
+set :root, File.dirname(__FILE__)
+
+require "appsignal/integrations/sinatra"
 require "json"
 require "csv"
 require "redis"


### PR DESCRIPTION
Outside Rails, we need to require the correct integration script. We
also need to make the `root` available in order for appsignal to pickup
the correct configuration file.

This is a follow up task from https://github.com/alphagov/rummager/pull/735

Trello: https://trello.com/c/J3kDeZD7

cc/ @tijmenb 