### PR TITLE
Fix the list of facets to check

### DIFF
--- a/lib/tasks/report_inconsistent_facet_values.rake
+++ b/lib/tasks/report_inconsistent_facet_values.rake
@@ -1,14 +1,22 @@
 require "gds_api/rummager"
-require "json"
-require_relative "../parameter_parser/base_parameter_parser"
 
 class DataInconsistencyError < StandardError
 end
 
 desc "Check for and report any non-expanded facet values"
 task :report_inconsistent_facet_values do
-  # List of facets to check
-  facets = BaseParameterParser::ALLOWED_FACET_FIELDS
+  # List of expandable facets
+  # Same as in `lib/search/presenters/entity_expander.rb` minus
+  # the content_id mappings which are not valid facet fields.
+  facets = %w(
+    document_series
+    document_collections
+    organisations
+    policy_areas
+    world_locations
+    specialist_sectors
+    people
+  )
 
   rummager = GdsApi::Rummager.new(Plek.new.find("rummager"))
   facet_values_to_report = {}


### PR DESCRIPTION
This commit changes the list of facets to check so that non-expandable facets are not checked. These currently add a lot of noise and make it difficult to work out what needs to be fixed.

Trello: https://trello.com/c/d3MUlWBS/350-fix-inconsistent-data-in-rummager-elasticsearch