### PR TITLE
Delete unnecessary Jenkins build parameters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
 REPOSITORY = 'rummager'
-DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
@@ -20,29 +19,9 @@ node {
       paramsToUseForLimit: 'Rummager',
       throttleEnabled: true,
       throttleOption: 'category'],
-    [$class: 'ParametersDefinitionProperty',
-      parameterDefinitions: [
-        [$class: 'BooleanParameterDefinition',
-          name: 'IS_SCHEMA_TEST',
-          defaultValue: false,
-          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
-        [$class: 'StringParameterDefinition',
-          name: 'SCHEMA_BRANCH',
-          defaultValue: DEFAULT_SCHEMA_BRANCH,
-          description: 'The branch of govuk-content-schemas to test against']]
-    ],
   ])
 
   try {
-    govuk.initializeParameters([
-      'IS_SCHEMA_TEST': 'false',
-      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
-    ])
-
-    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
-      return
-    }
-
     stage("Checkout") {
       checkout scm
     }


### PR DESCRIPTION
The build parameters are only necessary if a project depends directly on the govuk-content-schemas repo. Rummager's build does not clone that repo, so it's safe to delete these parameters.