### PR TITLE
Make hidden_indexable_content field searchable

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -483,6 +483,9 @@
   "tribunal_decision_reference_number": {
     "type": "identifier"
   },
+  "hidden_indexable_content": {
+    "type": "searchable_text"
+  },
   "dfid_authors": {
     "description": "A set of author names, which aren't selected from a predefined list and don't repeat",
     "type": "searchable_identifiers"


### PR DESCRIPTION
Each MOJ finder has a field called "hidden_indexable_content" which is
used by HMCTS staff to manually copy/paste PDF text into the document,
purely for search purposes.

Previously content in the hidden_indexable_content field was
searchable, but this seems to have stopped working. Strangely I see there has
never been a hidden_indexable_content field in the rummager
field_definitions schema.

I have limited knowledge of specialist-publisher and rummager, so it may be that further amends are required to allow the field to be searchable.