### PR TITLE
Return an error for facet parameters with empty values

### DIFF
--- a/lib/parameter_parser/facet_parameter_parser.rb
+++ b/lib/parameter_parser/facet_parameter_parser.rb
@@ -17,6 +17,9 @@ private
   end
 
   def process(value)
+    # Prevent exceptions later on by turning a nil value into an empty string
+    value = "" if value.nil?
+
     options = value.split(",")
 
     @errors = []


### PR DESCRIPTION
If a user requests a facet parameter with an empty value (for example /search.json?facet_policies) then rummager currently throws an exception when attempting to split the nil value.

This commit adds a check to change the nil value to an empty string, allowing the rest of the function to complete and display an error message.

Trello: https://trello.com/c/6LLgmAFM/470-return-4xx-from-rummager-when-making-a-facet-request-request-without-value