### PR TITLE
Catch publishing-api exceptions

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -27,5 +27,11 @@ configure do
   # parameters for debugging. Ignore it here so that we don't send them twice.
   Airbrake.configuration.ignore << "Indexer::BulkIndexFailure"
 
+  # We manually send `GdsApi` exceptions to Airbrake with normalised
+  # messages for publishing-api errors, and then raise an Indexer::PublishingApiError
+  # exception to ensure the execution flow stops. Ignore it here so that we
+  # don't send this dummy exception.
+  Airbrake.configuration.ignore << "Indexer::PublishingApiError"
+
   use Airbrake::Sinatra
 end

--- a/test/unit/indexer/links_lookup_test.rb
+++ b/test/unit/indexer/links_lookup_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "indexer/links_lookup"
 require "gds_api/test_helpers/publishing_api_v2"
 
-class LinkslookupTest < MiniTest::Unit::TestCase
+class LinksLookupTest < MiniTest::Unit::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
   def test_retry_links_on_timeout
@@ -11,7 +11,7 @@ class LinkslookupTest < MiniTest::Unit::TestCase
     expanded_links_url = endpoint + "/expanded-links/" + content_id
     stub_request(:get, expanded_links_url).to_timeout
 
-    assert_raises(GdsApi::TimedOutException) do
+    assert_raises(Indexer::PublishingApiError) do
       Indexer::LinksLookup.prepare_tags({
         "content_id" => content_id,
         "link" => "/my-base-path",


### PR DESCRIPTION
This commit adds `rescue` blocks to catch timeout and HTTP exceptions raised by gds-api-adapters when communicating with the publishing-api.

Catching these exceptions allows us to log them and send them manually to Airbrake with custom messages such that errors are grouped in a sane manner.

This will prevent Airbrake seeing each message as a separate error to be reported.

Trello: https://trello.com/c/Ku9HEzFc/467-rummager-should-bundle-errors-to-avoid-spamming-from-errbit