### PR TITLE
Speed up integration tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,11 @@ require "config"
 Dir[File.join(PROJECT_ROOT, 'lib/tasks/**/*.rake')].each { |file| load file }
 
 desc "Run all the tests"
-task "test" => ["test:units", "test:integration"]
+task "test" => [
+  "test:units",
+  "test:integration",
+  'test:clean_test_indexes'
+]
 
 namespace "test" do
   desc "Run the unit tests"
@@ -28,6 +32,14 @@ namespace "test" do
     t.libs << "test"
     t.test_files = FileList["test/integration/**/*_test.rb"]
     t.verbose = true
+  end
+
+  desc 'Clean all test indexes'
+  task :clean_test_indexes do
+    require 'app'
+    require 'test/support/test_index_helpers'
+
+    TestIndexHelpers.clean_all
   end
 end
 

--- a/test/integration/app/content_endpoints_test.rb
+++ b/test/integration/app/content_endpoints_test.rb
@@ -1,15 +1,6 @@
 require "integration_test_helper"
 
 class ContentEndpointsTest < IntegrationTest
-  def setup
-    stub_elasticsearch_settings
-    create_test_indexes
-  end
-
-  def teardown
-    clean_test_indexes
-  end
-
   def test_content_document_not_found
     get "/content?link=/a-document/that-does-not-exist"
 

--- a/test/integration/indexer/amendment_test.rb
+++ b/test/integration/indexer/amendment_test.rb
@@ -3,13 +3,8 @@ require "app"
 
 class ElasticsearchAmendmentTest < IntegrationTest
   def setup
-    stub_elasticsearch_settings
-    create_test_indexes
+    super
     stub_tagging_lookup
-  end
-
-  def teardown
-    clean_test_indexes
   end
 
   def test_should_amend_a_document

--- a/test/integration/indexer/bulk_loader_test.rb
+++ b/test/integration/indexer/bulk_loader_test.rb
@@ -4,13 +4,8 @@ require "cgi"
 
 class BulkLoaderTest < IntegrationTest
   def setup
+    super
     stub_tagging_lookup
-    stub_elasticsearch_settings
-    create_test_indexes
-  end
-
-  def teardown
-    clean_test_indexes
   end
 
   def test_indexes_documents
@@ -69,7 +64,10 @@ class BulkLoaderTest < IntegrationTest
 private
 
   def bulk_load!(document)
-    bulk_loader = Indexer::BulkLoader.new(app.settings.search_config, DEFAULT_INDEX_NAME)
+    bulk_loader = Indexer::BulkLoader.new(
+      app.settings.search_config,
+      TestIndexHelpers::DEFAULT_INDEX_NAME
+    )
     bulk_loader.load_from(StringIO.new(index_payload(document)))
   end
 

--- a/test/integration/indexer/change_notification_processor_test.rb
+++ b/test/integration/indexer/change_notification_processor_test.rb
@@ -2,15 +2,6 @@ require "integration_test_helper"
 require "indexer/change_notification_processor"
 
 class ChangeNotificationProcessorTest < IntegrationTest
-  def setup
-    stub_elasticsearch_settings
-    create_test_indexes
-  end
-
-  def teardown
-    clean_test_indexes
-  end
-
   def test_triggering_a_reindex
     publishing_api_has_lookups(
       "/foo" => "DOCUMENT-CONTENT-ID"

--- a/test/integration/indexer/closing_test.rb
+++ b/test/integration/indexer/closing_test.rb
@@ -2,21 +2,20 @@ require "integration_test_helper"
 
 class ElasticsearchClosingTest < IntegrationTest
   def setup
+    super
     stub_tagging_lookup
-    stub_elasticsearch_settings
-    create_test_index
-  end
-
-  def teardown
-    clean_test_indexes
   end
 
   def test_should_fail_to_insert_or_get_when_index_closed
-    index = search_server.index_group(DEFAULT_INDEX_NAME).current
+    index = search_server.index_group(TestIndexHelpers::DEFAULT_INDEX_NAME).current
     index.close
 
     assert_raises Indexer::BulkIndexFailure do
       index.add([sample_document])
     end
+
+    # Re-opening the index again, as they are not recreated on each test run
+    # anymore.
+    client.indices.open(index: TestIndexHelpers::DEFAULT_INDEX_NAME)
   end
 end

--- a/test/integration/indexer/deletion_test.rb
+++ b/test/integration/indexer/deletion_test.rb
@@ -2,15 +2,6 @@ require "integration_test_helper"
 require "app"
 
 class ElasticsearchDeletionTest < IntegrationTest
-  def setup
-    stub_elasticsearch_settings
-    create_test_indexes
-  end
-
-  def teardown
-    clean_test_indexes
-  end
-
   def test_removes_a_document_from_the_index
     commit_document("mainstream_test", {
       "link" => "/an-example-page"

--- a/test/integration/indexer/index_group_test.rb
+++ b/test/integration/indexer/index_group_test.rb
@@ -3,14 +3,15 @@ require "integration_test_helper"
 class ElasticsearchIndexGroupTest < IntegrationTest
   def setup
     @group_name = "mainstream_test"
-    stub_elasticsearch_settings
-    try_remove_test_index
+    TestIndexHelpers.stub_elasticsearch_settings
+    TestIndexHelpers.clean_index_group(@group_name)
 
     @index_group = search_server.index_group(@group_name)
   end
 
   def teardown
-    clean_index_group @group_name
+    # Making sure we keep the index after the tests run
+    @index_group.create_index
   end
 
   def test_should_create_index

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -12,16 +12,12 @@ class ElasticsearchIndexingTest < IntegrationTest
   }.freeze
 
   def setup
-    stub_elasticsearch_settings
-    create_test_indexes
-  end
+    super
 
-  def teardown
-    clean_test_indexes
+    stub_tagging_lookup
   end
 
   def test_adding_a_document_to_the_search_index
-    stub_tagging_lookup
     publishing_api_has_expanded_links(
       content_id: "6b965b82-2e33-4587-a70c-60204cbb3e29",
       expanded_links: {},
@@ -45,8 +41,6 @@ class ElasticsearchIndexingTest < IntegrationTest
   end
 
   def test_tagging_organisations_to_self
-    stub_tagging_lookup
-
     post "/documents", {
       "title" => "TITLE",
       "format" => "organisation",
@@ -64,7 +58,6 @@ class ElasticsearchIndexingTest < IntegrationTest
   end
 
   def test_start_and_end_dates
-    stub_tagging_lookup
     post "/documents", {
       "title" => "TITLE",
       "format" => "topical_event",
@@ -85,8 +78,6 @@ class ElasticsearchIndexingTest < IntegrationTest
   end
 
   def test_adding_a_document_to_the_search_index_with_organisation_self_tagging
-    stub_tagging_lookup
-
     post "/documents", {
       'title' => 'HMRC',
       'link' => '/government/organisations/hmrc',
@@ -102,8 +93,6 @@ class ElasticsearchIndexingTest < IntegrationTest
   end
 
   def test_adding_a_document_to_the_search_index_with_queue
-    stub_tagging_lookup
-
     post "/documents", SAMPLE_DOCUMENT.to_json
 
     assert_equal 202, last_response.status

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -4,16 +4,6 @@ require "gds_api/test_helpers/publishing_api_v2"
 class TaglookupDuringIndexingTest < IntegrationTest
   include GdsApi::TestHelpers::PublishingApiV2
 
-  def setup
-    stub_elasticsearch_settings
-    create_test_indexes
-    reset_content_indexes
-  end
-
-  def teardown
-    clean_test_indexes
-  end
-
   def test_indexes_document_without_publishing_api_content_unchanged
     publishing_api_has_lookups({})
 

--- a/test/integration/indexer/locking_test.rb
+++ b/test/integration/indexer/locking_test.rb
@@ -2,45 +2,54 @@ require "integration_test_helper"
 
 class ElasticsearchLockingTest < IntegrationTest
   def setup
-    stub_elasticsearch_settings
-    try_remove_test_index
-    create_test_indexes
-  end
-
-  def teardown
-    clean_test_indexes
+    super
+    stub_tagging_lookup
   end
 
   def test_should_fail_to_insert_when_index_locked
-    index = search_server.index_group(DEFAULT_INDEX_NAME).current
-    index.lock
-    assert_raises SearchIndices::IndexLocked do
-      index.add([sample_document])
+    index = search_server.index_group(TestIndexHelpers::DEFAULT_INDEX_NAME).current
+    with_lock(index) do
+      assert_raises SearchIndices::IndexLocked do
+        index.add([sample_document])
+      end
     end
   end
 
   def test_should_fail_to_amend_when_index_locked
-    index = search_server.index_group(DEFAULT_INDEX_NAME).current
+    index = search_server.index_group(TestIndexHelpers::DEFAULT_INDEX_NAME).current
     index.add([sample_document])
-    index.lock
-    assert_raises SearchIndices::IndexLocked do
-      index.amend(sample_document.link, "title" => "New title")
+
+    with_lock(index) do
+      assert_raises SearchIndices::IndexLocked do
+        index.amend(sample_document.link, "title" => "New title")
+      end
     end
   end
 
   def test_should_fail_to_delete_when_index_locked
-    index = search_server.index_group(DEFAULT_INDEX_NAME).current
+    index = search_server.index_group(TestIndexHelpers::DEFAULT_INDEX_NAME).current
     index.add([sample_document])
-    index.lock
-    assert_raises SearchIndices::IndexLocked do
-      index.delete("edition", sample_document.link)
+
+    with_lock(index) do
+      assert_raises SearchIndices::IndexLocked do
+        index.delete("edition", sample_document.link)
+      end
     end
   end
 
   def test_should_unlock_index
-    index = search_server.index_group(DEFAULT_INDEX_NAME).current
-    index.lock
-    index.unlock
+    index = search_server.index_group(TestIndexHelpers::DEFAULT_INDEX_NAME).current
+    with_lock(index) do
+      # Nothing to do here
+    end
     index.add([sample_document])
+  end
+
+private
+
+  def with_lock(index)
+    index.lock
+    yield
+    index.unlock
   end
 end

--- a/test/integration/indexer/migration_test.rb
+++ b/test/integration/indexer/migration_test.rb
@@ -4,7 +4,8 @@ require "indexer/bulk_loader"
 
 class ElasticsearchMigrationTest < IntegrationTest
   def setup
-    stub_elasticsearch_settings
+    stub_tagging_lookup
+    TestIndexHelpers.stub_elasticsearch_settings
     try_remove_test_index
 
     schema = app.settings.search_config.schema_config
@@ -13,13 +14,9 @@ class ElasticsearchMigrationTest < IntegrationTest
     @stemmer = settings["analysis"]["filter"]["stemmer_override"]
     @stemmer["rules"] = ["fish => fish"]
 
-    create_test_indexes
+    TestIndexHelpers.create_all
     add_documents(sample_document_attributes)
     commit_index
-  end
-
-  def teardown
-    clean_test_indexes
   end
 
   def sample_document_attributes

--- a/test/integration/schema/stemming_test.rb
+++ b/test/integration/schema/stemming_test.rb
@@ -60,8 +60,6 @@ private
   # Verifies that certain input will be tokenised as expected by the specified
   # analyzer.
   def assert_tokenisation(analyzer, assertions)
-    refresh_test_index
-
     assertions.each do |query, expected_output|
       tokens = fetch_tokens_for_analyzer(query, analyzer)
       assert_equal expected_output, tokens
@@ -69,18 +67,8 @@ private
   end
 
   def fetch_tokens_for_analyzer(query, analyzer)
-    result = client.indices.analyze(index: 'government-test', analyzer: analyzer.to_s, body: query)
+    result = client.indices.analyze(index: 'government_test', analyzer: analyzer.to_s, body: query)
     mappings = result['tokens']
     mappings.map { |mapping| mapping['token'] }
-  end
-
-  def refresh_test_index
-    index_name = 'government-test'
-    try_remove_test_index(index_name)
-    create_test_index(index_name)
-  end
-
-  def client
-    @client ||= Services::elasticsearch(hosts: 'http://localhost:9200')
   end
 end

--- a/test/integration/search/best_bets_test.rb
+++ b/test/integration/search/best_bets_test.rb
@@ -1,16 +1,6 @@
 require "integration_test_helper"
 
 class BestBetsTest < IntegrationTest
-  def setup
-    stub_elasticsearch_settings
-    reset_content_indexes
-    create_meta_indexes
-  end
-
-  def teardown
-    clean_meta_indexes
-  end
-
   def test_exact_best_bet
     commit_document("mainstream_test",
       link: '/an-organic-result',

--- a/test/integration/search/booster_test.rb
+++ b/test/integration/search/booster_test.rb
@@ -1,16 +1,6 @@
 require "integration_test_helper"
 
 class BoosterTest < IntegrationTest
-  def setup
-    stub_elasticsearch_settings
-    reset_content_indexes
-    create_meta_indexes
-  end
-
-  def teardown
-    clean_meta_indexes
-  end
-
   def test_service_manual_formats_are_weighted_down
     commit_document("mainstream_test",
       title: "Agile is good",

--- a/test/integration/search/expands_values_from_schema_test.rb
+++ b/test/integration/search/expands_values_from_schema_test.rb
@@ -1,15 +1,6 @@
 require "integration_test_helper"
 
 class ExpandsValuesFromSchemaTest < IntegrationTest
-  def setup
-    stub_elasticsearch_settings
-    reset_content_indexes
-  end
-
-  def teardown
-    clean_test_indexes
-  end
-
   def test_extra_fields_decorated_by_schema
     commit_document("mainstream_test", {
       "link" => "/cma-cases/sample-cma-case",

--- a/test/integration/search/legacy_search_test.rb
+++ b/test/integration/search/legacy_search_test.rb
@@ -3,18 +3,11 @@ require "app"
 
 class ElasticsearchAdvancedSearchTest < IntegrationTest
   def setup
+    super
     @index_name = "mainstream_test"
 
-    stub_elasticsearch_settings
-    try_remove_test_index
-
-    create_test_indexes
     add_sample_documents
     commit_index
-  end
-
-  def teardown
-    clean_test_indexes
   end
 
   def sample_document_attributes

--- a/test/integration/search/quoted_and_unquoted_searches_test.rb
+++ b/test/integration/search/quoted_and_unquoted_searches_test.rb
@@ -6,15 +6,8 @@ class QuotedAndUnquotedSearchTest < IntegrationTest
     # prevent caching issues we manually clear them here to make a "new" app.
     Rummager.class_variable_set(:'@@registries', nil)
 
-    stub_elasticsearch_settings
-    create_meta_indexes
-    reset_content_indexes
+    super
   end
-
-  def teardown
-    clean_meta_indexes
-  end
-
 
   # NEW WEIGHTING TESTS
   #

--- a/test/integration/search/results_with_highlighting_test.rb
+++ b/test/integration/search/results_with_highlighting_test.rb
@@ -1,16 +1,6 @@
 require "integration_test_helper"
 
 class ResultsWithHighlightingTest < IntegrationTest
-  def setup
-    stub_elasticsearch_settings
-    create_meta_indexes
-    reset_content_indexes
-  end
-
-  def teardown
-    clean_meta_indexes
-  end
-
   def test_returns_highlighted_title
     commit_document("mainstream_test",
       title: "I am the result",

--- a/test/integration/sitemap/sitemap_test.rb
+++ b/test/integration/sitemap/sitemap_test.rb
@@ -56,13 +56,8 @@ class SitemapTest < IntegrationTest
   ].freeze
 
   def setup
-    stub_elasticsearch_settings
-    reset_content_indexes
+    super
     add_sample_documents
-  end
-
-  def teardown
-    clean_test_indexes
   end
 
   def test_should_generate_multiple_sitemaps

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -3,4 +3,7 @@ require "app"
 require "search_server"
 require "sidekiq/testing/inline" # Make all queued jobs run immediately
 require "support/integration_test"
+require 'support/test_index_helpers'
 require "pry-byebug"
+
+TestIndexHelpers.setup_test_indexes

--- a/test/support/test_index_helpers.rb
+++ b/test/support/test_index_helpers.rb
@@ -1,0 +1,73 @@
+class TestIndexHelpers
+  AUXILIARY_INDEX_NAMES = ["page-traffic_test", "metasearch_test"].freeze
+  INDEX_NAMES = %w(mainstream_test government_test).freeze
+  DEFAULT_INDEX_NAME = INDEX_NAMES.first
+  ALL_TEST_INDEXES = (AUXILIARY_INDEX_NAMES + INDEX_NAMES).freeze
+
+  def self.setup_test_indexes
+    puts 'Setting up test indexes...'
+
+    stub_elasticsearch_settings
+    clean_all
+    create_all
+
+    puts 'Done.'
+  end
+
+  def self.check_index_name!(index_name)
+    unless /^[a-z_-]+(_|-)test($|-)/ =~ index_name
+      raise "#{index_name} is not a valid test index name"
+    end
+  end
+
+  def self.clean_all
+    ALL_TEST_INDEXES.each do |index_name|
+      clean_index_group(index_name)
+    end
+  end
+
+  def self.clean_index_group(index_name)
+    check_index_name!(index_name)
+
+    search_server = Rummager.settings.search_config.search_server
+    index_group = search_server.index_group(index_name)
+
+    # Delete any indices left over
+    index_group.clean
+
+    # Clean up the test index too
+    if index_group.current.exists?
+      index_group.send(:delete, index_group.current.real_name)
+    end
+  end
+
+  def self.create_all
+    ALL_TEST_INDEXES.each do |index|
+      create_test_index(index)
+    end
+  end
+
+  def self.create_test_index(group_name = DEFAULT_INDEX_NAME)
+    search_server = Rummager.settings.search_config.search_server
+    index_group = search_server.index_group(group_name)
+    index = index_group.create_index
+    index_group.switch_to(index)
+  end
+
+  def self.stub_elasticsearch_settings
+    ALL_TEST_INDEXES.each do |index_name|
+      check_index_name!(index_name)
+    end
+
+    Rummager.settings.search_config.stubs(:elasticsearch).returns({
+      "base_uri" => "http://localhost:9200",
+      "content_index_names" => INDEX_NAMES,
+      "auxiliary_index_names" => AUXILIARY_INDEX_NAMES,
+      "metasearch_index_name" => "metasearch_test",
+      "registry_index" => "government_test",
+      "spelling_index_names" => INDEX_NAMES,
+      "popularity_rank_offset" => 10,
+    })
+    Rummager.settings.stubs(:default_index_name).returns(DEFAULT_INDEX_NAME)
+  end
+end


### PR DESCRIPTION
This commit speeds up the entire test suite from:

```
Finished tests in 457.060166s, 0.3063 tests/s, 0.6564 assertions/s.
140 tests, 300 assertions, 0 failures, 0 errors, 0 skips
```

To:

```
Finished tests in 48.789358s, 2.8695 tests/s, 6.1489 assertions/s.
140 tests, 300 assertions, 0 failures, 0 errors, 0 skips
```

It does so by changing the approach we have been using so far.
Previously, we were deleting and creating the test indexes before every
test. Even though this provides a clean environment for each test to
run, it is also quite expensive in terms of time spent.

The approach I'm proposing only creates the test indexes once, on
startup, and makes sure all data on those indexes is deleted on every
test run (on teardown more specifically).  This also provides a clean
environment for each of the tests to run, since most tests don't deal
specifically with functionality that creates and deletes indexes.

It also makes sure we clean up test indexes after the entire test suite
runs. This isn't strictly necessary, because the test suite cleans them
up on startup, but a good thing to do to avoid leaving unwanted indexes
around.

Finally, this commit also moves test indexes' actions to a helper class.
This means we will be able to use it in other contexts without having to
require the test stack.

**NOTE**

There are exceptions, unfortunately. A few test cases still delete and
create certain indexes because that's exactly what they are testing. I
didn't remove this logic, meaning some tests will still be quite slow.