### PR TITLE
Index parents of the taxon for each page

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -1,7 +1,6 @@
 {
   "fields": [
     "all_searchable_text",
-    "taxons",
     "content_id",
     "content_store_document_type",
     "description",
@@ -14,15 +13,17 @@
     "mainstream_browse_page_content_ids",
     "organisations",
     "organisation_content_ids",
+    "part_of_taxonomy",
     "policies",
     "popularity",
     "public_timestamp",
     "publishing_app",
     "rendering_app",
     "specialist_sectors",
-    "topic_content_ids",
     "spelling_text",
+    "taxons",
     "title",
+    "topic_content_ids",
     "updated_at"
   ]
 }

--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -13,7 +13,7 @@
     "mainstream_browse_page_content_ids",
     "organisations",
     "organisation_content_ids",
-    "part_of_taxonomy",
+    "part_of_taxonomy_tree",
     "policies",
     "popularity",
     "public_timestamp",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -85,6 +85,11 @@
     "type": "identifiers"
   },
 
+  "part_of_taxonomy": {
+    "description": "Any taxon tagged to the document and any of their ancestor taxons",
+    "type": "identifiers"
+  },
+
   "updated_at": {
     "type": "date"
   },

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -85,7 +85,7 @@
     "type": "identifiers"
   },
 
-  "part_of_taxonomy": {
+  "part_of_taxonomy_tree": {
     "description": "Any taxon tagged to the document and any of their ancestor taxons",
     "type": "identifiers"
   },

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -133,7 +133,7 @@ module Indexer
         'topic_content_ids' => content_ids_for(links, 'topics'),
         'mainstream_browse_page_content_ids' => content_ids_for(links, 'mainstream_browse_pages'),
         'organisation_content_ids' => content_ids_for(links, 'organisations'),
-        'part_of_taxonomy' => parts_of_taxonomy_for_all_taxons(links)
+        'part_of_taxonomy_tree' => parts_of_taxonomy_for_all_taxons(links)
       }
     end
 

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -132,8 +132,30 @@ module Indexer
       {
         'topic_content_ids' => content_ids_for(links, 'topics'),
         'mainstream_browse_page_content_ids' => content_ids_for(links, 'mainstream_browse_pages'),
-        'organisation_content_ids' => content_ids_for(links, 'organisations')
+        'organisation_content_ids' => content_ids_for(links, 'organisations'),
+        'part_of_taxonomy' => parts_of_taxonomy_for_all_taxons(links)
       }
+    end
+
+    def parts_of_taxonomy_for_all_taxons(links)
+      links.fetch("taxons", []).flat_map { |taxon_hash| parts_of_taxonomy(taxon_hash) }
+    end
+
+    def parts_of_taxonomy(taxon_hash)
+      parents = [taxon_hash["content_id"]]
+
+      direct_parents = taxon_hash.dig("links", "parent_taxons")
+      while direct_parents
+        # There should not be more than one parent for a taxon. If there is,
+        # make an arbitrary choice.
+        direct_parent = direct_parents.first
+
+        parents << direct_parent["content_id"]
+
+        direct_parents = direct_parent["links"]["parent_taxons"]
+      end
+
+      parents.reverse
     end
 
     def content_ids_for(links, link_type)

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -57,25 +57,6 @@ class ElasticsearchIndexingTest < IntegrationTest
     })
   end
 
-  def test_parts_of_taxonomy
-    post "/documents", {
-      "title" => "TITLE",
-      "format" => "organisation",
-      "slug" => "my-organisation",
-      "link" => "/an-example-organisation",
-      "part_of_taxonomy" => ["6b965b82-2e33-4587-a70c-60204cbb3e29", "4b965b82-2e33-4587-a70c-60204cbb3e29"],
-    }.to_json
-
-    assert_document_is_in_rummager({
-      "title" => "TITLE",
-      "format" => "organisation",
-      "slug" => "my-organisation",
-      "link" => "/an-example-organisation",
-      "organisations" => ["my-organisation"],
-      "part_of_taxonomy" => ["6b965b82-2e33-4587-a70c-60204cbb3e29", "4b965b82-2e33-4587-a70c-60204cbb3e29"],
-    })
-  end
-
   def test_start_and_end_dates
     post "/documents", {
       "title" => "TITLE",

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -57,6 +57,25 @@ class ElasticsearchIndexingTest < IntegrationTest
     })
   end
 
+  def test_parts_of_taxonomy
+    post "/documents", {
+      "title" => "TITLE",
+      "format" => "organisation",
+      "slug" => "my-organisation",
+      "link" => "/an-example-organisation",
+      "part_of_taxonomy" => ["6b965b82-2e33-4587-a70c-60204cbb3e29", "4b965b82-2e33-4587-a70c-60204cbb3e29"],
+    }.to_json
+
+    assert_document_is_in_rummager({
+      "title" => "TITLE",
+      "format" => "organisation",
+      "slug" => "my-organisation",
+      "link" => "/an-example-organisation",
+      "organisations" => ["my-organisation"],
+      "part_of_taxonomy" => ["6b965b82-2e33-4587-a70c-60204cbb3e29", "4b965b82-2e33-4587-a70c-60204cbb3e29"],
+    })
+  end
+
   def test_start_and_end_dates
     post "/documents", {
       "title" => "TITLE",

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -113,4 +113,86 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "topic_content_ids" => ["TOPIC-CONTENT-ID-1"],
     )
   end
+
+  def test_extracts_parts_of_taxonomy
+    grandparent_1_content_id = "22aadc14-9bca-40d9-abb4-4f21f9792a05"
+    grandparent_1 = {
+      "content_id" => grandparent_1_content_id,
+      "base_path" => "/grandparent-1",
+      "title" => "Grandparent 1",
+      "links" => {}
+    }
+
+    parent_1_content_id = "11aadc14-9bca-40d9-abb4-4f21f9792a05"
+    parent_1 = {
+      "content_id" => parent_1_content_id,
+      "base_path" => "/parent-1",
+      "title" => "Parent 1",
+      "links" => {
+        "parent_taxons" => [grandparent_1]
+      }
+    }
+
+    taxon_1_content_id = "00aadc14-9bca-40d9-abb4-4f21f9792a05"
+    taxon_1 = {
+      "content_id" => taxon_1_content_id,
+      "base_path" => "/this-is-a-taxon",
+      "title" => "Taxon 1",
+      "links" => {
+        "parent_taxons" => [parent_1]
+      }
+    }
+
+    grandparent_2_content_id = "03aadc14-9bca-40d9-abb4-4f21f9792a05"
+    grandparent_2 = {
+      "content_id" => grandparent_2_content_id,
+      "base_path" => "/grandparent-2",
+      "title" => "Grandparent 2",
+      "links" => {}
+    }
+
+    parent_2_content_id = "02aadc14-9bca-40d9-abb4-4f21f9792a05"
+    parent_2 = {
+      "content_id" => parent_2_content_id,
+      "base_path" => "/parent-2",
+      "title" => "Parent 2",
+      "links" => {
+        "parent_taxons" => [grandparent_2]
+      }
+    }
+
+    taxon_2_content_id = "01aadc14-9bca-40d9-abb4-4f21f9792a05"
+    taxon_2 = {
+      "content_id" => taxon_2_content_id,
+      "base_path" => "/this-is-also-a-taxon",
+      "title" => "Taxon 2",
+      "links" => {
+        "parent_taxons" => [parent_2]
+      }
+    }
+
+    publishing_api_has_lookups(
+      "/foo/bar" => "DOCUMENT-CONTENT-ID"
+    )
+
+    publishing_api_has_expanded_links(
+      content_id: "DOCUMENT-CONTENT-ID",
+      expanded_links: {
+        taxons: [taxon_1, taxon_2],
+      }
+    )
+
+    post "/documents", {
+      "link" => "/foo/bar",
+    }.to_json
+
+    assert_document_is_in_rummager(
+      "link" => "/foo/bar",
+      "part_of_taxonomy" => [
+        grandparent_1_content_id, parent_1_content_id, taxon_1_content_id,
+        grandparent_2_content_id, parent_2_content_id, taxon_2_content_id,
+      ],
+      "taxons" => [taxon_1_content_id, taxon_2_content_id],
+    )
+  end
 end

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -80,7 +80,7 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "specialist_sectors" => ["my-topic/a", "my-topic/b"],
       "mainstream_browse_pages" => ["my-browse/1"],
       "organisations" => ["my-org/1", "my-court"],
-      "part_of_taxonomy" => ["TAXON-1"],
+      "part_of_taxonomy_tree" => ["TAXON-1"],
       "taxons" => ["TAXON-1"],
       "topic_content_ids" => ["TOPIC-CONTENT-ID-1", "TOPIC-CONTENT-ID-2"],
       "mainstream_browse_page_content_ids" => ["BROWSE-1"],
@@ -188,7 +188,7 @@ class TaglookupDuringIndexingTest < IntegrationTest
 
     assert_document_is_in_rummager(
       "link" => "/foo/bar",
-      "part_of_taxonomy" => [
+      "part_of_taxonomy_tree" => [
         grandparent_1_content_id, parent_1_content_id, taxon_1_content_id,
         grandparent_2_content_id, parent_2_content_id, taxon_2_content_id,
       ],

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -80,6 +80,7 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "specialist_sectors" => ["my-topic/a", "my-topic/b"],
       "mainstream_browse_pages" => ["my-browse/1"],
       "organisations" => ["my-org/1", "my-court"],
+      "part_of_taxonomy" => ["TAXON-1"],
       "taxons" => ["TAXON-1"],
       "topic_content_ids" => ["TOPIC-CONTENT-ID-1", "TOPIC-CONTENT-ID-2"],
       "mainstream_browse_page_content_ids" => ["BROWSE-1"],

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -642,15 +642,15 @@ class SearchTest < IntegrationTest
       description: "This is a test search result",
       link: "/some-nice-link",
       taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"],
-      part_of_taxonomy: %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
+      part_of_taxonomy_tree: %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
     )
 
-    get "/search?filter_part_of_taxonomy=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
+    get "/search?filter_part_of_taxonomy_tree=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
 
     assert last_response.ok?
     assert_equal 1, parsed_response.fetch("total")
 
-    get "/search?filter_part_of_taxonomy=aa2093ef-778c-4105-9f33-9aa03d14bc5c"
+    get "/search?filter_part_of_taxonomy_tree=aa2093ef-778c-4105-9f33-9aa03d14bc5c"
 
     assert last_response.ok?
     assert_equal 1, parsed_response.fetch("total")

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -636,6 +636,26 @@ class SearchTest < IntegrationTest
     )
   end
 
+  def test_taxonomy_can_be_filtered_by_part
+    commit_document("mainstream_test",
+      title: "I am the result",
+      description: "This is a test search result",
+      link: "/some-nice-link",
+      taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"],
+      part_of_taxonomy: %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
+    )
+
+    get "/search?filter_part_of_taxonomy=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
+
+    assert last_response.ok?
+    assert_equal 1, parsed_response.fetch("total")
+
+    get "/search?filter_part_of_taxonomy=aa2093ef-778c-4105-9f33-9aa03d14bc5c"
+
+    assert last_response.ok?
+    assert_equal 1, parsed_response.fetch("total")
+  end
+
 private
 
   def first_result


### PR DESCRIPTION
Content tools would like to be able to fetch all content related to education.
We added a filter, part_of_taxonomy, that returns everything that is tagged
to the given taxon and any of that taxon's children.

Trello card: https://trello.com/c/dIMlC5JH/481-index-parents-of-the-taxon-for-each-page

Paired with @MatMoore 