### PR TITLE
Add business finance support scheme

### DIFF
--- a/config/schema/elasticsearch_types/business_finance_support_scheme.json
+++ b/config/schema/elasticsearch_types/business_finance_support_scheme.json
@@ -1,0 +1,13 @@
+{
+  "fields": [
+    "additional_information",
+    "continuation_link",
+    "eligibility",
+    "evaluation",
+    "max_employees",
+    "max_value",
+    "min_value",
+    "organiser",
+    "will_continue_on"
+  ]
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -508,5 +508,50 @@
   "content_store_document_type": {
     "description": "The document type as stored in the Content Store",
     "type": "identifier"
+  },
+
+  "additional_information": {
+    "description": "Additional information about a business finance support scheme",
+    "type": "searchable_text"
+  },
+
+  "continuation_link": {
+    "description": "Link to more information about a business finance support scheme",
+    "type": "identifier"
+  },
+
+  "eligibility": {
+    "description": "Eligibility information for a business finance support scheme",
+    "type": "searchable_text"
+  },
+
+  "evaluation": {
+    "description": "Evaluation criteria for a business finance support scheme",
+    "type": "searchable_text"
+  },
+
+  "max_employees": {
+    "description": "The maximum number of employees allowed to be eligible for a business finance support scheme",
+    "type": "identifier"
+  },
+
+  "max_value": {
+    "description": "The maximum amount of funding available for a business finance support scheme",
+    "type": "identifier"
+  },
+
+  "min_value": {
+    "description": "The minimum amount of funding available for a business finance support scheme",
+    "type": "identifier"
+  },
+
+  "organiser": {
+    "description": "The name of the organiser of a business finance support scheme",
+    "type": "searchable_identifier"
+  },
+
+  "will_continue_on": {
+    "description": "Human-readable name of the link to more information about a business finance support scheme",
+    "type": "identifier"
   }
 }

--- a/config/schema/indexes/mainstream.json
+++ b/config/schema/indexes/mainstream.json
@@ -2,6 +2,7 @@
   "elasticsearch_types": [
     "aaib_report",
     "asylum_support_decision",
+    "business_finance_support_scheme",
     "cma_case",
     "contact",
     "countryside_stewardship_grant",


### PR DESCRIPTION
This commit adds the new “business finance support scheme” elasticsearch type to rummager for content items migrated from `business-support-finder`.

Trello: https://trello.com/c/UHsavPI5/485-create-a-new-specialist-document-type-for-business-support-scheme