### PR TITLE
Add more metadata for business finance support scheme

### DIFF
--- a/config/schema/elasticsearch_types/business_finance_support_scheme.json
+++ b/config/schema/elasticsearch_types/business_finance_support_scheme.json
@@ -1,6 +1,7 @@
 {
   "fields": [
     "additional_information",
+    "business_sizes",
     "continuation_link",
     "eligibility",
     "evaluation",
@@ -8,6 +9,9 @@
     "max_value",
     "min_value",
     "organiser",
+    "sectors",
+    "stages",
+    "support_types",
     "will_continue_on"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -515,6 +515,11 @@
     "type": "searchable_text"
   },
 
+  "business_sizes": {
+    "description": "The sizes of business served by a business finance support scheme",
+    "type": "searchable_identifier"
+  },
+
   "continuation_link": {
     "description": "Link to more information about a business finance support scheme",
     "type": "identifier"
@@ -547,6 +552,21 @@
 
   "organiser": {
     "description": "The name of the organiser of a business finance support scheme",
+    "type": "searchable_identifier"
+  },
+
+  "sectors": {
+    "description": "The sectors served by a business finance support scheme",
+    "type": "searchable_identifier"
+  },
+
+  "stages": {
+    "description": "The stages of business served by a business finance support scheme",
+    "type": "searchable_identifier"
+  },
+
+  "support_types": {
+    "description": "The types of support provided by a business finance support scheme",
     "type": "searchable_identifier"
   },
 


### PR DESCRIPTION
This commit adds more metadata fields to the new “business finance support scheme” elasticsearch type to rummager for content items migrated from business-support-finder.

Trello: https://trello.com/c/UHsavPI5/485-create-a-new-specialist-document-type-for-business-support-scheme