### PR TITLE
Include asylum support decision missing fields

### DIFF
--- a/config/schema/elasticsearch_types/asylum_support_decision.json
+++ b/config/schema/elasticsearch_types/asylum_support_decision.json
@@ -1,5 +1,6 @@
 {
   "fields": [
+    "tribunal_decision_categories",
     "tribunal_decision_category",
     "tribunal_decision_category_name",
     "tribunal_decision_decision_date",
@@ -8,6 +9,7 @@
     "tribunal_decision_landmark",
     "tribunal_decision_landmark_name",
     "tribunal_decision_reference_number",
+    "tribunal_decision_sub_categories",
     "tribunal_decision_sub_category",
     "tribunal_decision_sub_category_name"
   ]


### PR DESCRIPTION
The categories and sub-categories facets aren't working on [the asylum support
tribunal decision finder][1].  We've noticed that the [relevant][2] [fields][3] are
missing from the schema, so we're adding them.

They are already defined in the [field definitions][4] [json file][5]

[Trello card][6]

[1]: https://www.gov.uk/asylum-support-tribunal-decisions
[2]: https://github.com/alphagov/govuk-content-schemas/blob/7e1ae8de58d91d574735c37b19f31b804aaf44cc/formats/specialist_document/frontend/examples/asylum-support-decision.json#L20
[3]: https://github.com/alphagov/govuk-content-schemas/blob/7e1ae8de58d91d574735c37b19f31b804aaf44cc/formats/specialist_document/frontend/examples/asylum-support-decision.json#L24
[4]: https://github.com/alphagov/rummager/blob/af5eaa7313c309d10cb5572248c48972b0295a20/config/schema/field_definitions.json#L443
[5]: https://github.com/alphagov/rummager/blob/af5eaa7313c309d10cb5572248c48972b0295a20/config/schema/field_definitions.json#L476
[6]: https://trello.com/c/0utlcZfC/645-fix-asylum-support-tribunal-decision-finder