### PR TITLE
Add more like this queries across indexes

### DIFF
--- a/lib/search/query_components/query.rb
+++ b/lib/search/query_components/query.rb
@@ -44,15 +44,18 @@ module QueryComponents
     end
 
     def more_like_this_query_hash
-      {
-        more_like_this: {
-          docs: [
-            {
-              _type: "edition",
-              _id: search_params.similar_to
-            }
-          ]
+      content_indices = Rummager.search_config.content_index_names
+
+      docs = content_indices.reduce([]) do |documents, index_name|
+        documents << {
+          _type: 'edition',
+          _id: search_params.similar_to,
+          _index: index_name
         }
+      end
+
+      {
+        more_like_this: { docs: docs }
       }
     end
   end

--- a/test/integration/search/more_like_this_test.rb
+++ b/test/integration/search/more_like_this_test.rb
@@ -14,26 +14,52 @@ class MoreLikeThisTest < IntegrationTest
     assert last_response.ok?
   end
 
-  def test_returns_similar_docs
-    # We need at least 5 documents in the index for "more like this"
-    # queries to work (default value of `min_doc_freq` in Elasticsearch)
-    populate_content_indexes(section_count: 15)
+  def test_returns_no_results_without_documents
+    get "/search?similar_to=/mainstream-1"
 
-    get "/search?similar_to=/mainstream-1&count=15&start=0"
+    assert result_links.empty?
+  end
+
+  def test_returns_results_from_mainstream_index
+    add_sample_documents('mainstream_test', 15)
+
+    get "/search?similar_to=/mainstream-1&count=20&start=0"
+
+    refute result_links.include? "/mainstream-1"
+    assert_equal(result_links.count, 14)
+  end
+
+  def test_returns_results_from_government_index
+    add_sample_documents('government_test', 15)
+
+    get "/search?similar_to=/government-1&count=20&start=0"
+
+    refute result_links.include? "/government-1"
+    assert_equal(result_links.count, 14)
+  end
+
+  def test_returns_similar_docs
+    add_sample_documents('mainstream_test', 15)
+    add_sample_documents('government_test', 15)
+
+    get "/search?similar_to=/mainstream-1&count=50&start=0"
 
     # All mainstream documents (excluding the one we're using for comparison)
-    # should be returned, but none of the government ones, since they're not
-    # "similar" enough
-    assert result_links.include? "/mainstream-2"
-    assert result_links.include? "/mainstream-3"
-    assert result_links.include? "/mainstream-4"
-    assert result_links.include? "/mainstream-5"
+    # should be returned. The government links should also be returned as they
+    # are similar enough (in this case, the test factories produce similar
+    # looking records).
     refute result_links.include? "/mainstream-1"
-    refute result_links.include? "/government-1"
-    refute result_links.include? "/government-2"
-    refute result_links.include? "/government-3"
-    refute result_links.include? "/government-4"
-    refute result_links.include? "/government-5"
+    assert_equal(result_links.count, 29)
+
+    mainstream_results = result_links.select do |result|
+      result.match(/mainstream-\d+/)
+    end
+    assert_equal(mainstream_results.count, 14)
+
+    government_results = result_links.select do |result|
+      result.match(/government-\d+/)
+    end
+    assert_equal(government_results.count, 15)
   end
 
 private


### PR DESCRIPTION
This commit allows for "more like this" queries across multiple indexes.

Before we were looking for mainstream content only. Although this worked for
quite a few documents, we also have documents in the government index too.

With this change, we make sure we don't miss documents.

Trello: https://trello.com/c/bbQErgLF/418-investigate-if-rummager-has-all-of-the-taxon-links-for-education-content

cc/ @tijmenb 

Useful links: 
- More like this: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html
- docs: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html