### PR TITLE
Start adding document types to index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ else
   gem "govuk_message_queue_consumer", "~> 3.0.1"
 end
 
+gem "govuk_document_types", "0.1.1"
 gem "govuk-lint", "~> 1.2.1"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
+    govuk_document_types (0.1.1)
     govuk_message_queue_consumer (3.0.1)
       bunny (~> 2.2.0)
     hashdiff (0.3.0)
@@ -195,6 +196,7 @@ DEPENDENCIES
   elasticsearch (~> 1.0.15)
   gds-api-adapters (~> 37.5)
   govuk-lint (~> 1.2.1)
+  govuk_document_types (= 0.1.1)
   govuk_message_queue_consumer (~> 3.0.1)
   logging (~> 2.1.0)
   minitest-colorize (~> 0.0.5)

--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,7 @@ require "appsignal/integrations/sinatra"
 require "json"
 require "csv"
 require "redis"
+require "govuk_document_types"
 
 %w[ . lib ].each do |path|
   $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)

--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -6,6 +6,7 @@
     "description",
     "format",
     "indexable_content",
+    "navigation_document_supertype",
     "is_withdrawn",
     "latest_change_note",
     "link",
@@ -24,6 +25,7 @@
     "taxons",
     "title",
     "topic_content_ids",
+    "whitehall_document_supertype",
     "updated_at"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -8,6 +8,14 @@
     "type": "identifier"
   },
 
+  "navigation_document_supertype": {
+    "type": "identifier"
+  },
+
+  "whitehall_document_supertype": {
+    "type": "identifier"
+  },
+
   "content_id": {
     "description": "The content_id of the item. This will not be present for all items, as most application do not send it.",
     "type": "identifier"

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -13,6 +13,7 @@ module Indexer
         doc_hash = prepare_missing_fields_hack(doc_hash)
         doc_hash = prepare_tags_field(doc_hash)
         doc_hash = add_self_to_organisations_links(doc_hash)
+        doc_hash = prepare_document_supertypes(doc_hash)
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
@@ -125,6 +126,12 @@ module Indexer
       end
 
       doc_hash
+    end
+
+    def prepare_document_supertypes(doc_hash)
+      doc_hash.merge(
+        GovukDocumentTypes.supertypes(document_type: doc_hash["content_store_document_type"])
+      )
     end
   end
 end

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -38,6 +38,7 @@ class BaseParameterParser
     format
     mainstream_browse_pages
     manual
+    navigation_document_supertype
     organisation_type
     organisations
     people
@@ -48,6 +49,7 @@ class BaseParameterParser
     search_format_types
     specialist_sectors
     taxons
+    whitehall_document_supertype
     world_locations
   ).freeze
 
@@ -63,10 +65,12 @@ class BaseParameterParser
     format
     mainstream_browse_pages
     manual
+    navigation_document_supertype
     organisations
     publishing_app
     rendering_app
     specialist_sectors
+    whitehall_document_supertype
   ).freeze
 
   # The keys by which facet values can be sorted (using the "order" option).

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -27,6 +27,7 @@ class ElasticsearchIndexingTest < IntegrationTest
       "content_id" => "6b965b82-2e33-4587-a70c-60204cbb3e29",
       "title" => "TITLE",
       "format" => "answer",
+      "content_store_document_type" => "answer",
       "link" => "/an-example-answer",
       "indexable_content" => "HERE IS SOME CONTENT",
     }.to_json
@@ -37,6 +38,7 @@ class ElasticsearchIndexingTest < IntegrationTest
       "format" => "answer",
       "link" => "/an-example-answer",
       "indexable_content" => "HERE IS SOME CONTENT",
+      "navigation_document_supertype" => "guidance",
     })
   end
 

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -87,28 +87,6 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_should_bulk_update_documents_with_raw_command_stream
-    stub_tagging_lookup
-    stub_traffic_index
-    stub_popularity_index_requests(["/foo/bar"], 1.0)
-
-    # Note that this comes with a trailing newline, which elasticsearch needs
-    payload = <<-eos
-{"index":{"_type":"edition","_id":"/foo/bar"}}
-{"_type":"edition","link":"/foo/bar","title":"TITLE ONE","popularity":0.09090909090909091,"format":"edition"}
-    eos
-    request = stub_request(:post, "http://example.com:9200/mainstream_test/_bulk").with(
-      body: payload,
-    ).to_return(
-      body: '{"items":[]}',
-      headers: { 'Content-Type' => 'application/json' }
-    )
-
-    @index.bulk_index(payload)
-
-    assert_requested(request)
-  end
-
   def test_raw_search
     stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/_search").with(
       body: %r{"query":"keyword search"},

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -54,56 +54,6 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
     assert @index.exists?
   end
 
-  def test_add_sends_updates_to_the_bulk_index_endpoint
-    stub_tagging_lookup
-    stub_traffic_index
-    stub_popularity_index_requests(["/foo/bar"], 1.0)
-
-    document = stub(
-      "document",
-      elasticsearch_export: {
-        "_type" => "edition",
-        "link" => "/foo/bar",
-        "title" => "TITLE ONE",
-    })
-
-    payload = [
-      {
-        "_type" => "edition",
-        "link" => "/foo/bar",
-        "title" => "TITLE ONE",
-        "popularity" => 0.09090909090909091,
-        "format" => "edition"
-      }
-    ]
-
-    expected_body = [
-      {
-        "index" => {
-          "_type" => "edition",
-          "_id" => "/foo/bar"
-        }
-      },
-    ] + payload
-
-    response = <<-eos
-{"took":5,"items":[
-  { "index": { "_index":"mainstream_test", "_type":"edition", "_id":"/foo/bar", "ok":true } }
-]}
-    eos
-
-    request = stub_request(:post, "http://example.com:9200/mainstream_test/_bulk").with(
-      body: expected_body.map(&:to_json).join("\n") + "\n",
-    ).to_return(
-      body: response,
-      headers: { 'Content-Type' => 'application/json' },
-    )
-
-    @index.add([document])
-
-    assert_requested(request)
-  end
-
   def test_should_raise_error_for_failures_in_bulk_update
     stub_tagging_lookup
     stub_traffic_index
@@ -154,41 +104,6 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       headers: { 'Content-Type' => 'application/json' }
     )
 
-    @index.bulk_index(payload)
-
-    assert_requested(request)
-  end
-
-  def test_should_bulk_index_documents
-    stub_tagging_lookup
-    stub_traffic_index
-    stub_popularity_index_requests(["/foo/bar"], 1.0)
-
-    payload = [
-      {
-        "_type" => "edition",
-        "link" => "/foo/bar",
-        "title" => "TITLE ONE",
-        "popularity" => 0.09090909090909091,
-        "format" => "edition"
-      }
-    ]
-
-    expected_body = [
-      {
-        "index" => {
-          "_type" => "edition",
-          "_id" => "/foo/bar"
-        }
-      },
-    ] + payload
-
-    request = stub_request(:post, "http://example.com:9200/mainstream_test/_bulk").with(
-      body: expected_body.map(&:to_json).join("\n") + "\n",
-    ).to_return(
-      body: '{"items":[]}',
-      headers: { 'Content-Type' => 'application/json' },
-    )
     @index.bulk_index(payload)
 
     assert_requested(request)

--- a/test/unit/indexer/document_preparer_test.rb
+++ b/test/unit/indexer/document_preparer_test.rb
@@ -55,5 +55,22 @@ describe Indexer::DocumentPreparer do
       assert updated_doc_hash["publishing_app"]
       assert updated_doc_hash["rendering_app"]
     end
+
+    it "adds document type groupings" do
+      stub_tagging_lookup
+
+      doc_hash = {
+        "link" => "/some-link",
+        "content_store_document_type" => "detailed_guide",
+      }
+
+      updated_doc_hash = Indexer::DocumentPreparer.new("fake_client", "fake_index").prepared(
+        doc_hash,
+        {},
+        true
+      )
+
+      assert_equal "guidance", updated_doc_hash["navigation_document_supertype"]
+    end
   end
 end


### PR DESCRIPTION
The "document supertype" is a grouping for document types. It will allow us to segment pages by more types, like "Publication" or "Announcement" (used in Whitehall).

With this we'll be able to search like this:

```
https://www.gov.uk/api/search.json?filter_navigation_document_supertype=guidance
https://www.gov.uk/api/search.json?filter_whitehall_document_supertype=publication
```

See https://github.com/alphagov/govuk_document_types/pull/1.

https://trello.com/c/07lAcDtC