### PR TITLE
Rescue the correct error from links lookup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "elasticsearch", "~> 1.0.15"
 if ENV["MESSAGE_QUEUE_CONSUMER_DEV"]
   gem "govuk_message_queue_consumer", path: "../govuk_message_queue_consumer"
 else
-  gem "govuk_message_queue_consumer", "~> 3.0.1"
+  gem "govuk_message_queue_consumer", "~> 3.0.2"
 end
 
 gem "govuk_document_types", "0.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     airbrake (4.3.8)
       builder
       multi_json
-    amq-protocol (2.0.1)
+    amq-protocol (2.1.0)
     appsignal (2.0.5)
       rack
       thread_safe
@@ -51,7 +51,7 @@ GEM
       rubocop (~> 0.39.0)
       scss_lint
     govuk_document_types (0.1.1)
-    govuk_message_queue_consumer (3.0.1)
+    govuk_message_queue_consumer (3.0.2)
       bunny (~> 2.2.0)
     hashdiff (0.3.0)
     http-cookie (1.0.3)
@@ -197,7 +197,7 @@ DEPENDENCIES
   gds-api-adapters (~> 37.5)
   govuk-lint (~> 1.2.1)
   govuk_document_types (= 0.1.1)
-  govuk_message_queue_consumer (~> 3.0.1)
+  govuk_message_queue_consumer (~> 3.0.2)
   logging (~> 2.1.0)
   minitest-colorize (~> 0.0.5)
   mocha (~> 1.1.0)

--- a/app.rb
+++ b/app.rb
@@ -5,7 +5,6 @@ require "appsignal/integrations/sinatra"
 require "json"
 require "csv"
 require "redis"
-require "govuk_document_types"
 
 %w[ . lib ].each do |path|
   $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -1,3 +1,5 @@
+require "govuk_document_types"
+
 module Indexer
   class DocumentPreparer
     def initialize(client, index_name)
@@ -35,9 +37,10 @@ module Indexer
 
     def prepare_tags_field(doc_hash)
       Indexer::LinksLookup.prepare_tags(doc_hash)
-    rescue GdsApi::TimedOutException => e
+    rescue Indexer::PublishingApiError => e
       if ENV['LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE'] == '1'
         puts "Unable to lookup links for link: #{doc_hash['link']}"
+        doc_hash
       else
         raise e
       end


### PR DESCRIPTION
Since 114f78dcbf23ca3f3ab019b6ca4baefdb90cf2f7 we've been raising a different
exception class. Even before that, we were returning nil from the method after
handling the error, so I don't think this has ever worked.

This means that the overnight job to reindex search was aborting early if
publishing api times out, which is happening a lot at the moment.
We don't care if we can't fetch the links while reindexing - we can fall back
to whats already there.

Also, even if the links lookup worked, the document type group method would
have failed, since we only require it when running as a sinatra app.

The job has been failing since Jan 28, but we didn't notice this because of a
separate issue with our jenkins job:
https://github.com/alphagov/search-analytics/pull/11