### PR TITLE
Upgrade govuk_document_types gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ else
   gem "govuk_message_queue_consumer", "~> 3.0.2"
 end
 
-gem "govuk_document_types", "0.1.1"
+gem "govuk_document_types", "0.1.3"
 gem "govuk-lint", "~> 1.2.1"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_document_types (0.1.1)
+    govuk_document_types (0.1.3)
     govuk_message_queue_consumer (3.0.2)
       bunny (~> 2.2.0)
     hashdiff (0.3.0)
@@ -196,7 +196,7 @@ DEPENDENCIES
   elasticsearch (~> 1.0.15)
   gds-api-adapters (~> 37.5)
   govuk-lint (~> 1.2.1)
-  govuk_document_types (= 0.1.1)
+  govuk_document_types (= 0.1.3)
   govuk_message_queue_consumer (~> 3.0.2)
   logging (~> 2.1.0)
   minitest-colorize (~> 0.0.5)
@@ -226,4 +226,4 @@ DEPENDENCIES
   whenever (~> 0.9.4)
 
 BUNDLED WITH
-   1.11.2
+   1.14.5


### PR DESCRIPTION
Pick up the latest document supertypes: `notice` has been removed from the `guidance` supertype.

https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list