### PR TITLE
Add and use the govuk_taxonomy_helpers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "airbrake", "~> 4.3.6"
 gem 'appsignal', '~> 2.0'
 gem "unf", "~> 0.1.4"
 gem "elasticsearch", "~> 1.0.15"
+gem "govuk_taxonomy_helpers", "~> 0.1.0"
 
 if ENV["MESSAGE_QUEUE_CONSUMER_DEV"]
   gem "govuk_message_queue_consumer", path: "../govuk_message_queue_consumer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     govuk_document_types (0.1.1)
     govuk_message_queue_consumer (3.0.2)
       bunny (~> 2.2.0)
+    govuk_taxonomy_helpers (0.1.0)
     hashdiff (0.3.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -198,6 +199,7 @@ DEPENDENCIES
   govuk-lint (~> 1.2.1)
   govuk_document_types (= 0.1.1)
   govuk_message_queue_consumer (~> 3.0.2)
+  govuk_taxonomy_helpers (~> 0.1.0)
   logging (~> 2.1.0)
   minitest-colorize (~> 0.0.5)
   mocha (~> 1.1.0)
@@ -226,4 +228,4 @@ DEPENDENCIES
   whenever (~> 0.9.4)
 
 BUNDLED WITH
-   1.11.2
+   1.14.5

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -1,4 +1,5 @@
 require 'services'
+require 'govuk_taxonomy_helpers'
 
 # LinksLookup finds the tags (links) from the publishing-api and merges them into
 # the document. If there aren't any links, the payload will be returned unchanged.
@@ -23,12 +24,19 @@ module Indexer
       content_id = find_content_id(doc_hash)
       return doc_hash unless content_id
 
-      # Bail out if the base_path doesn't exist in publishing-api
-      links = find_links(content_id)
-      return doc_hash unless links
+      content_item = {
+        "content_id" => content_id,
+        "base_path" => doc_hash["link"],
+        "title" => doc_hash["title"],
+        "details" => {},
+      }
 
-      doc_hash = doc_hash.merge(taggings_with_slugs(links))
-      doc_hash.merge(taggings_with_content_ids(links))
+      # Bail out if the base_path doesn't exist in publishing-api
+      expanded_links_response = find_links(content_id)
+      return doc_hash unless expanded_links_response
+
+      doc_hash = doc_hash.merge(taggings_with_slugs(expanded_links_response))
+      doc_hash.merge(taggings_with_content_ids(expanded_links_response, content_item))
     end
 
   private
@@ -74,7 +82,7 @@ module Indexer
     def find_links(content_id)
       begin
         GdsApi.with_retries(maximum_number_of_attempts: 5) do
-          Services.publishing_api.get_expanded_links(content_id)['expanded_links']
+          Services.publishing_api.get_expanded_links(content_id)
         end
       rescue GdsApi::TimedOutException => e
         @logger.error("Timeout fetching expanded links for #{content_id}")
@@ -107,7 +115,8 @@ module Indexer
     # organisations by "slug", a concept that exists in Publisher and Whitehall.
     # It does not exist in the publishing-api, so we need to infer the slug
     # from the base path.
-    def taggings_with_slugs(links)
+    def taggings_with_slugs(expanded_links_response)
+      links = expanded_links_response['expanded_links']
       links_with_slugs = {}
 
       # We still call topics "specialist sectors" in rummager.
@@ -128,34 +137,23 @@ module Indexer
       links_with_slugs
     end
 
-    def taggings_with_content_ids(links)
+    def taggings_with_content_ids(expanded_links_response, content_item)
+      links = expanded_links_response['expanded_links']
+
       {
         'topic_content_ids' => content_ids_for(links, 'topics'),
         'mainstream_browse_page_content_ids' => content_ids_for(links, 'mainstream_browse_pages'),
         'organisation_content_ids' => content_ids_for(links, 'organisations'),
-        'part_of_taxonomy_tree' => parts_of_taxonomy_for_all_taxons(links)
+        'part_of_taxonomy_tree' => parts_of_taxonomy(expanded_links_response, content_item)
       }
     end
 
-    def parts_of_taxonomy_for_all_taxons(links)
-      links.fetch("taxons", []).flat_map { |taxon_hash| parts_of_taxonomy(taxon_hash) }
-    end
-
-    def parts_of_taxonomy(taxon_hash)
-      parents = [taxon_hash["content_id"]]
-
-      direct_parents = taxon_hash.dig("links", "parent_taxons")
-      while direct_parents
-        # There should not be more than one parent for a taxon. If there is,
-        # make an arbitrary choice.
-        direct_parent = direct_parents.first
-
-        parents << direct_parent["content_id"]
-
-        direct_parents = direct_parent["links"]["parent_taxons"]
-      end
-
-      parents.reverse
+    def parts_of_taxonomy(expanded_links, content_item)
+      linked_content_item = GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api(
+        content_item: content_item,
+        expanded_links: expanded_links
+      )
+      linked_content_item.taxons_with_ancestors.map(&:content_id)
     end
 
     def content_ids_for(links, link_type)

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -65,7 +65,12 @@ class TaglookupDuringIndexingTest < IntegrationTest
         taxons: [
           {
             "content_id" => "TAXON-1",
-            "base_path" => "/alpha-taxonomy/my-taxon-1"
+            "base_path" => "/alpha-taxonomy/my-taxon-1",
+            "title" => "Taxon 1",
+            "details" => {
+              "internal_name" => "Taxon 1"
+            },
+            "links" => {}
           }
         ],
       }
@@ -120,6 +125,9 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "content_id" => grandparent_1_content_id,
       "base_path" => "/grandparent-1",
       "title" => "Grandparent 1",
+      "details" => {
+        "internal_name" => "Grandparent 1",
+      },
       "links" => {}
     }
 
@@ -128,6 +136,9 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "content_id" => parent_1_content_id,
       "base_path" => "/parent-1",
       "title" => "Parent 1",
+      "details" => {
+        "internal_name" => "Parent 1",
+      },
       "links" => {
         "parent_taxons" => [grandparent_1]
       }
@@ -138,6 +149,9 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "content_id" => taxon_1_content_id,
       "base_path" => "/this-is-a-taxon",
       "title" => "Taxon 1",
+      "details" => {
+        "internal_name" => "Taxon 1",
+      },
       "links" => {
         "parent_taxons" => [parent_1]
       }
@@ -148,6 +162,9 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "content_id" => grandparent_2_content_id,
       "base_path" => "/grandparent-2",
       "title" => "Grandparent 2",
+      "details" => {
+        "internal_name" => "Grandparent 2",
+      },
       "links" => {}
     }
 
@@ -156,6 +173,9 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "content_id" => parent_2_content_id,
       "base_path" => "/parent-2",
       "title" => "Parent 2",
+      "details" => {
+        "internal_name" => "Parent 2",
+      },
       "links" => {
         "parent_taxons" => [grandparent_2]
       }
@@ -166,6 +186,9 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "content_id" => taxon_2_content_id,
       "base_path" => "/this-is-also-a-taxon",
       "title" => "Taxon 2",
+      "details" => {
+        "internal_name" => "Taxon 2",
+      },
       "links" => {
         "parent_taxons" => [parent_2]
       }


### PR DESCRIPTION
Added the govuk_taxonomy_helpers gem. We were then able to replace some
existing methods with a method from the gem.

Trello card: https://trello.com/c/PBIEgMMB/520-rummager-cleanup-use-new-taxonomy-gem

Paired with @MatMoore 