### PR TITLE
Upgrade govuk_document_types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ else
   gem "govuk_message_queue_consumer", "~> 3.0.2"
 end
 
-gem "govuk_document_types", "0.1.3"
+gem "govuk_document_types", "0.1.4"
 gem "govuk-lint", "~> 1.2.1"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_document_types (0.1.3)
+    govuk_document_types (0.1.4)
     govuk_message_queue_consumer (3.0.2)
       bunny (~> 2.2.0)
     hashdiff (0.3.0)
@@ -191,7 +191,7 @@ DEPENDENCIES
   elasticsearch (~> 1.0.15)
   gds-api-adapters (~> 37.5)
   govuk-lint (~> 1.2.1)
-  govuk_document_types (= 0.1.3)
+  govuk_document_types (= 0.1.4)
   govuk_message_queue_consumer (~> 3.0.2)
   logging (~> 2.1.0)
   minitest-colorize (~> 0.0.5)

--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -4,7 +4,9 @@
     "content_id",
     "content_store_document_type",
     "description",
+    "email_document_supertype",
     "format",
+    "government_document_supertype",
     "indexable_content",
     "navigation_document_supertype",
     "is_withdrawn",
@@ -25,7 +27,6 @@
     "taxons",
     "title",
     "topic_content_ids",
-    "whitehall_document_supertype",
     "updated_at"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -8,11 +8,15 @@
     "type": "identifier"
   },
 
-  "navigation_document_supertype": {
+  "email_document_supertype": {
     "type": "identifier"
   },
 
-  "whitehall_document_supertype": {
+  "government_document_supertype": {
+    "type": "identifier"
+  },
+
+  "navigation_document_supertype": {
     "type": "identifier"
   },
 

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -35,7 +35,9 @@ class BaseParameterParser
     detailed_format
     document_collections
     document_series
+    email_document_supertype
     format
+    government_document_supertype
     mainstream_browse_pages
     manual
     navigation_document_supertype
@@ -49,7 +51,6 @@ class BaseParameterParser
     search_format_types
     specialist_sectors
     taxons
-    whitehall_document_supertype
     world_locations
   ).freeze
 
@@ -62,7 +63,9 @@ class BaseParameterParser
   # restriction could be relaxed in future.
   ALLOWED_FACET_EXAMPLE_FIELDS = %w(
     content_store_document_type
+    email_document_supertype
     format
+    government_document_supertype
     mainstream_browse_pages
     manual
     navigation_document_supertype
@@ -70,7 +73,6 @@ class BaseParameterParser
     publishing_app
     rendering_app
     specialist_sectors
-    whitehall_document_supertype
   ).freeze
 
   # The keys by which facet values can be sorted (using the "order" option).

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -39,6 +39,8 @@ class ElasticsearchIndexingTest < IntegrationTest
       "link" => "/an-example-answer",
       "indexable_content" => "HERE IS SOME CONTENT",
       "navigation_document_supertype" => "guidance",
+      "email_document_supertype" => "other",
+      "government_document_supertype" => "other",
     })
   end
 


### PR DESCRIPTION
This add "email" and "government" supertypes which
are needed for the email migration from govuk_delivery
to email_alert_api.