### PR TITLE
Allow multiple values for business finance support scheme facets

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -529,21 +529,21 @@
 
   "business_sizes": {
     "description": "The sizes of business served by a business finance support scheme",
-    "type": "searchable_identifier"
+    "type": "searchable_identifiers"
   },
 
   "business_stages": {
     "description": "The stages of business served by a business finance support scheme",
-    "type": "searchable_identifier"
+    "type": "searchable_identifiers"
   },
 
   "industries": {
     "description": "The industries served by a business finance support scheme",
-    "type": "searchable_identifier"
+    "type": "searchable_identifiers"
   },
 
   "types_of_support": {
     "description": "The types of support provided by a business finance support scheme",
-    "type": "searchable_identifier"
+    "type": "searchable_identifiers"
   }
 }


### PR DESCRIPTION
This commit allow business finance support schemes to have multiple values for each facet.

Trello: https://trello.com/c/UHsavPI5/1102-create-a-new-specialist-document-type-for-business-support-scheme

Deployment checklist:

- [x] Deploy rummager
- [x] Run the rake task `republish:document_type["business_finance_support_scheme"]` in specialist-publisher