### PR TITLE
Add facet values for business finance support schemes

### DIFF
--- a/config/schema/elasticsearch_types/business_finance_support_scheme.json
+++ b/config/schema/elasticsearch_types/business_finance_support_scheme.json
@@ -4,5 +4,135 @@
     "business_stages",
     "industries",
     "types_of_support"
-  ]
+  ],
+
+  "expanded_search_result_fields": {
+    "types_of_support": [
+      {
+        "label": "Finance",
+        "value": "finance"
+      },
+      {
+        "label": "Equity",
+        "value": "equity"
+      },
+      {
+        "label": "Grant",
+        "value": "grant"
+      },
+      {
+        "label": "Loan",
+        "value": "loan"
+      },
+      {
+        "label": "Expertise and advice",
+        "value": "expertise-and-advice"
+      },
+      {
+        "label": "Recognition awards",
+        "value": "recognition-award"
+      }
+    ],
+
+    "business_stages": [
+      {
+        "label": "Not yet trading",
+        "value": "not-yet-trading"
+      },
+      {
+        "label": "Start-ups (1-2 years trading)",
+        "value": "start-up"
+      },
+      {
+        "label": "Established",
+        "value": "established"
+      }
+    ],
+
+    "industries": [
+      {
+        "label": "Agriculture and food",
+        "value": "agriculture-and-food"
+      },
+      {
+        "label": "Business and finance",
+        "value": "business-and-finance"
+      },
+      {
+        "label": "Construction",
+        "value": "construction"
+      },
+      {
+        "label": "Education",
+        "value": "education"
+      },
+      {
+        "label": "Health",
+        "value": "health"
+      },
+      {
+        "label": "Hospitality and catering",
+        "value": "hospitality-and-catering"
+      },
+      {
+        "label": "IT, digital and creative",
+        "value": "information-technology-digital-and-creative"
+      },
+      {
+        "label": "Manufacturing",
+        "value": "manufacturing"
+      },
+      {
+        "label": "Mining",
+        "value": "mining"
+      },
+      {
+        "label": "Real estate and property",
+        "value": "real-estate-and-property"
+      },
+      {
+        "label": "Science and technology",
+        "value": "science-and-technology"
+      },
+      {
+        "label": "Service industries",
+        "value": "service-industries"
+      },
+      {
+        "label": "Transport and distribution",
+        "value": "transport-and-distribution"
+      },
+      {
+        "label": "Travel and leisure",
+        "value": "travel-and-leisure"
+      },
+      {
+        "label": "Utilities providers",
+        "value": "utilities-providers"
+      },
+      {
+        "label": "Wholesale and retail",
+        "value": "wholesale-and-retail"
+      }
+    ],
+
+    "business_sizes": [
+      {
+        "label": "0 to 9 employees",
+        "value": "under-10"
+      },
+      {
+        "label": "10 to 249 employees",
+        "value": "between-10-and-249"
+      },
+      {
+        "label": "250 to 500 employees",
+        "value": "between-250-and-500"
+      },
+      {
+        "label": "More than 500 employees",
+        "value": "over-500"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This commit adds the facet values for business finance support schemes to enable the finder to display user-friendly values rather than slugs.

Trello: https://trello.com/c/UHsavPI5/1102-create-a-new-specialist-document-type-for-business-support-scheme