### PR TITLE
Add rate limit token to health check requests

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -39,6 +39,7 @@ class HealthCheckCLI
       on 'h', 'help', "Show this message"
       on 'limit=', "Limit to the first n tests", as: Integer
       on 'a', 'auth=', "Basic auth credentials (of the form 'user:pass'", as: HealthCheck::BasicAuthCredentials
+      on 'rate_limit_token=', "Token to bypass rate limiting"
       on 'j', 'json=', "Connect to a Rummager search endpoint at the the given url (default) (eg. #{DEFAULT_JSON_URL})", default: DEFAULT_JSON_URL
       on 'v', 'verbose', "Show verbose logging output"
       on 'type=', "Which tests to run. 'suggestions' or 'results' (default)"
@@ -99,7 +100,8 @@ private
   def search_client
     HealthCheck::JsonSearchClient.new(
       base_url: URI.parse(opts["json"]),
-      authentication: opts[:auth]
+      authentication: opts[:auth],
+      rate_limit_token: opts[:rate_limit_token],
     )
   end
 

--- a/lib/health_check/json_search_client.rb
+++ b/lib/health_check/json_search_client.rb
@@ -8,6 +8,7 @@ module HealthCheck
     def initialize(options = {})
       @base_url       = options[:base_url] || URI.parse("https://www.gov.uk/api/search.json")
       @authentication = options[:authentication] || nil
+      @rate_limit_token = options[:rate_limit_token] || nil
     end
 
     def search(term, params = {})
@@ -25,6 +26,8 @@ module HealthCheck
 
       request = Net::HTTP::Get.new(url)
       request.basic_auth(*@authentication) if @authentication
+      request["Rate-Limit-Token"] = @rate_limit_token if @rate_limit_token
+
       response = http_client.request(request)
       case response
       when Net::HTTPSuccess # 2xx

--- a/test/unit/health_check/json_search_client_test.rb
+++ b/test/unit/health_check/json_search_client_test.rb
@@ -21,9 +21,9 @@ B)
       }
     end
 
-    def stub_search(search_term)
+    def stub_search(search_term, custom_headers = {})
       stub_request(:get, "http://www.gov.uk/api/search.json?q=#{CGI.escape(search_term)}").
-        with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }).
+        with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' }.merge(custom_headers)).
         to_return(status: 200, body: search_response_body.to_json)
     end
 
@@ -31,7 +31,19 @@ B)
       stub_search("cheese")
       expected = { results: ["/a", "/b"], suggested_queries: %w[A B] }
       base_url = URI.parse("http://www.gov.uk/api/search.json")
+
       assert_equal expected, JsonSearchClient.new(base_url: base_url).search("cheese")
+    end
+
+    should "call the search API with a rate limit token if provided" do
+      stub_search("cheese", "Rate-Limit-Token" => "some_token")
+
+      expected = { results: ["/a", "/b"], suggested_queries: %w[A B] }
+      base_url = URI.parse("http://www.gov.uk/api/search.json")
+
+      response = JsonSearchClient.new(base_url: base_url, rate_limit_token: "some_token").search("cheese")
+
+      assert_equal expected, response
     end
   end
 end


### PR DESCRIPTION
Add an optional `--rate_limit_token` parameter to the health check. Clients can pass a valid token to bypass search API rate limiting.

This will allow Jenkins to bypass rate limiting to fix the 429 Too Many Requests responses which we see when running the health check on Jenkins.

https://trello.com/c/TXeHcOnY/53-revive-the-search-healthcheck