### PR TITLE
Add support for ab_test configuration to be passed in

### DIFF
--- a/docs/search-api.md
+++ b/docs/search-api.md
@@ -168,6 +168,15 @@ The parameters supported are:
    but it is good practice to set this to only the fields you actually want
    information on (doing this will normally increase performance).
 
+ - ab_tests: a/b test with selected variant type. This allows test to be configured
+   from upstream apps.
+
+   Each a/b test name should be followed by a ':' and then the variant type to
+   be used. If multiple a/b test setting are being passed in they should be
+   comma separated.
+
+   No validation is done to ensure the a/b test name provided is current implemented.
+
 ## Examples
 
 For example:
@@ -180,7 +189,8 @@ For example:
      filter_organisations[]=cabinet-office&
      filter_organisations[]=driver-vehicle-licensing-agency&
      filter_section[]=driving
-     facet_organisations=10
+     facet_organisations=10&
+     ab_test=test1:B,test2:A
 
 Returns something like:
 

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -39,6 +39,7 @@ private
       facets: facets,
       debug: debug_options,
       suggest: character_separated_param("suggest"),
+      ab_tests: ab_tests,
     }
 
     # Search can be run either with a text query or a base_path to find
@@ -345,5 +346,17 @@ private
     end
 
     options
+  end
+
+  def ab_tests
+    variants = character_separated_param("ab_tests")
+    variants = variants.map { |variant| variant.split(':', 2) }
+
+    variants.each_with_object({}) do |(variant_name, variant_code), variants_hash|
+      if variant_code.blank?
+        @errors << %{Invalid ab_tests, missing type "#{variant_name}"}
+      end
+      variants_hash[variant_name.to_sym] = variant_code
+    end
   end
 end

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -2,7 +2,7 @@ module Search
   # Value object that holds the parsed parameters for a search.
   class QueryParameters
     attr_accessor :query, :similar_to, :order, :start, :count, :return_fields,
-                  :facets, :filters, :debug, :suggest, :is_quoted_phrase
+                  :facets, :filters, :debug, :suggest, :is_quoted_phrase, :ab_tests
 
     # starts and ends with quotes with no quotes in between, with or without
     # leading or trailing whitespace

--- a/test/unit/parameter_parser/search_parameter_parser_test.rb
+++ b/test/unit/parameter_parser/search_parameter_parser_test.rb
@@ -15,6 +15,7 @@ class SearchParameterParserTest < ShouldaUnitTestCase
       facets: {},
       debug: {},
       suggest: [],
+      ab_tests: {},
     }.merge(params)
   end
 
@@ -808,5 +809,26 @@ class SearchParameterParserTest < ShouldaUnitTestCase
 
     assert p.valid?
     assert_equal expected_params({ debug: { disable_synonyms: true } }), p.parsed_params
+  end
+
+  should "understand the test_variant parameter" do
+    p = SearchParameterParser.new({ "ab_tests" => ["min_should_match_length:A"] }, @schema)
+
+    assert p.valid?
+    assert_equal expected_params({ ab_tests: { min_should_match_length: 'A' } }), p.parsed_params
+  end
+
+  should "understand multiple test_variant parameters" do
+    p = SearchParameterParser.new({ "ab_tests" => ["min_should_match_length:A,other_test_case:B"] }, @schema)
+
+    assert p.valid?
+    assert_equal expected_params({ ab_tests: { min_should_match_length: 'A', other_test_case: 'B' } }), p.parsed_params
+  end
+
+  should "complain about invalid test_variant where no variant_type is provided" do
+    p = SearchParameterParser.new({ "ab_tests" => ["min_should_match_length"] }, @schema)
+
+    assert !p.valid?
+    assert_equal("Invalid ab_tests, missing type \"min_should_match_length\"", p.error)
   end
 end


### PR DESCRIPTION
A/B test variants should be controlled by upstream apps to ensure
users receive a consistent experience for the life of the test. This
requires the test configuration to be passed in.

We are using a single field to receive the test configuration to avoid
adding a new fields for each test that we run.

https://trello.com/c/43eBQfwf/80-prepare-the-infrastructure-for-the-minimum-should-match-a-b-test