### PR TITLE
Do not insert reserved words in Elasticsearch document

### DIFF
--- a/lib/indexer/bulk_payload_generator.rb
+++ b/lib/indexer/bulk_payload_generator.rb
@@ -78,7 +78,7 @@ module Indexer
         else
           [
             command_hash,
-            doc_hash,
+            doc_hash.tap { |h| h.delete('_type'); h.delete('_id') },
           ]
         end
       }

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -18,6 +18,8 @@ module Indexer
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
+      doc_hash.delete('_type')
+      doc_hash.delete('_id')
       doc_hash
     end
 


### PR DESCRIPTION
The _type and _id fields are already included in the command hash so including
them in the document hash is redundant and appears to be causing the _type
field to be indexed (and added to the `_mapping` hash which is seen as a
blocker to upgrading elasticsearch.

# Warning

This change could have unforeseen consequences on the search index and needs to be tested on integration before being merged.

https://trello.com/c/mkn7SAn0/84-fix-reserved-field-name-errors-in-elasticsearch-2-x-upgrade