### PR TITLE
Add licence-specific fields to Rummager

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -11,6 +11,8 @@
     "navigation_document_supertype",
     "is_withdrawn",
     "latest_change_note",
+    "licence_identifier",
+    "licence_short_description",
     "link",
     "mainstream_browse_pages",
     "mainstream_browse_page_content_ids",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -549,5 +549,14 @@
   "types_of_support": {
     "description": "The types of support provided by a business finance support scheme",
     "type": "searchable_identifiers"
+  },
+
+  "licence_identifier": {
+    "description": "The licence ID associated with a content item of type licence",
+    "type": "identifier"
+  },
+
+  "licence_short_description": {
+    "type": "searchable_text"
   }
 }

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -30,6 +30,8 @@ class ElasticsearchIndexingTest < IntegrationTest
       "content_store_document_type" => "answer",
       "link" => "/an-example-answer",
       "indexable_content" => "HERE IS SOME CONTENT",
+      "licence_identifier" => "1201-5-1",
+      "licence_short_description" => "A short description of a licence",
     }.to_json
 
     assert_document_is_in_rummager({
@@ -41,6 +43,8 @@ class ElasticsearchIndexingTest < IntegrationTest
       "navigation_document_supertype" => "guidance",
       "email_document_supertype" => "other",
       "government_document_supertype" => "other",
+      "licence_identifier" => "1201-5-1",
+      "licence_short_description" => "A short description of a licence",
     })
   end
 


### PR DESCRIPTION
These include:
- `licence_identifier`, which is the GDS_ID of a licence;
- `licence_short_description`, which is a short text description of a
  licence.

These fields will be used by `publisher` to send data to Rummager and
subsequently by `licence-finder` to use in the frontend.

We are replacing calls to the Content API with calls to Content Store and Rummager. In this case, we are particularly interested in removing [licences_for_ids](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/content_api.rb#L90-L93), which is basically a search query.

Trello: https://trello.com/c/vlqSHmTZ/76-make-licence-finder-use-something-else-to-fetch-licenses