### PR TITLE
Add minimum should match ab test query

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -100,7 +100,7 @@ private
       base_url: URI.parse(opts["json"]),
       authentication: opts[:auth],
       rate_limit_token: opts[:rate_limit_token],
-    )
+   )
   end
 
   def open_file(filename)

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -37,6 +37,7 @@ module QueryComponents
     # N clauses then M clauses should match. So, 2<2 means when there are
     # MORE than 2 clauses then 2 should match.
     MINIMUM_SHOULD_MATCH = "2<2 3<3 7<50%".freeze
+    MINIMUM_SHOULD_MATCH_VARIANT_B = "2<2".freeze
 
     def payload
       if @search_params.quoted_search_phrase?
@@ -92,10 +93,18 @@ module QueryComponents
           _all: {
             query: escape(search_term),
             analyzer: query_analyzer,
-            minimum_should_match: MINIMUM_SHOULD_MATCH,
+            minimum_should_match: minimum_should_match,
           }
         }
       }
+    end
+
+    def minimum_should_match
+      if @search_params.ab_tests[:search_match_length] == 'B'
+        MINIMUM_SHOULD_MATCH_VARIANT_B
+      else
+        MINIMUM_SHOULD_MATCH
+      end
     end
 
     def exact_field_boosts

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -37,7 +37,7 @@ module QueryComponents
     # N clauses then M clauses should match. So, 2<2 means when there are
     # MORE than 2 clauses then 2 should match.
     MINIMUM_SHOULD_MATCH = "2<2 3<3 7<50%".freeze
-    MINIMUM_SHOULD_MATCH_VARIANT_B = "2<2".freeze
+    MINIMUM_SHOULD_MATCH_VARIANT_B = "2<2 3<3 7<50%".freeze
 
     def payload
       if @search_params.quoted_search_phrase?
@@ -52,8 +52,8 @@ module QueryComponents
     def payload_for_unquoted_phrase
       {
         bool: {
-          must: must_conditions,
-          should: should_conditions
+          # must: must_conditions,
+          should: should_conditions + must_conditions,
         }
       }
     end

--- a/test/support/test_helpers.rb
+++ b/test/support/test_helpers.rb
@@ -17,6 +17,7 @@ module TestHelpers
       return_fields: nil,
       facets: nil,
       debug: {},
+      ab_tests: {},
     }.merge(options))
   end
 

--- a/test/unit/search/query_components/core_query_test.rb
+++ b/test/unit/search/query_components/core_query_test.rb
@@ -19,4 +19,30 @@ class CoreQueryTest < ShouldaUnitTestCase
       refute_match(/query_with_old_synonyms/, query.to_s)
     end
   end
+
+  context "when ab testing minimum should match" do
+    should "use the default value when no variant is passed in" do
+      builder = QueryComponents::CoreQuery.new(search_query_params)
+
+      query = builder.payload
+
+      assert_match(/"2<2 3<3 7<50%"/, query.to_s)
+    end
+
+    should "use variant b when it is passed in" do
+      builder = QueryComponents::CoreQuery.new(search_query_params(ab_tests: { search_match_length: 'B' }))
+
+      query = builder.payload
+
+      assert_match(/"2<2"/, query.to_s)
+    end
+
+    should "use variant a when it is passed in" do
+      builder = QueryComponents::CoreQuery.new(search_query_params(ab_tests: { search_match_length: 'A' }))
+
+      query = builder.payload
+
+      assert_match(/"2<2 3<3 7<50%"/, query.to_s)
+    end
+  end
 end


### PR DESCRIPTION
The first ab test that we are running is a change to the minimum should match query. For variant b queries, minimum should match is `2<2` instead of `2<2 3<3 7<50%`.

https://trello.com/c/J2nUnoMm/99-decide-on-choice-of-change-for-a-b-test