### PR TITLE
Add health-check summary based on word count of search terms

### DIFF
--- a/lib/health_check/search_checker.rb
+++ b/lib/health_check/search_checker.rb
@@ -12,6 +12,7 @@ module HealthCheck
       @search_client = search_client
       @overall_calculator = Calculator.new
       @tag_calculators = {}
+      @word_count_calculators = {}
       @file_output = produce_report ? SearchCheckReport.new : File.open(File::NULL, 'w')
     end
 
@@ -29,6 +30,10 @@ module HealthCheck
           tag_calculators[tag] ||= Calculator.new
           tag_calculators[tag].add(check_result)
         end
+
+        word_count = check.search_term.split.size
+        word_count_calculators[word_count] ||= Calculator.new
+        word_count_calculators[word_count].add(check_result)
       end
     end
 
@@ -37,11 +42,15 @@ module HealthCheck
         tag_calculator.summarise("#{tag} score")
       end
 
+      word_count_calculators.sort.each do |word_count, calculator|
+        calculator.summarise("score for #{word_count}-word queries")
+      end
+
       overall_calculator.summarise
     end
 
   private
-    attr_reader :overall_calculator, :tag_calculators
+    attr_reader :overall_calculator, :tag_calculators, :word_count_calculators
 
     def checks
       CheckFileParser.new(@test_data_file).checks.sort { |a, b| b.weight <=> a.weight }


### PR DESCRIPTION
Summarise the search health-check by grouping terms by word count. This will help us assess how changes to the search API affect search queries of different lengths.

https://trello.com/c/gbhkiTCS/100-segment-healthcheck-output-by-word-count