### PR TITLE
Add index name as a field

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -549,5 +549,10 @@
   "types_of_support": {
     "description": "The types of support provided by a business finance support scheme",
     "type": "searchable_identifiers"
+  },
+
+  "index_name": {
+    "description": "Historical index name, used to allow government (whitehall) results to have a boost applied",
+    "type": "identifier"
   }
 }

--- a/lib/indexer/bulk_payload_generator.rb
+++ b/lib/indexer/bulk_payload_generator.rb
@@ -64,6 +64,7 @@ module Indexer
       payload.each_line.each_slice(2).map do |command, doc|
         command_hash = JSON.parse(command)
         doc_hash = JSON.parse(doc)
+        doc_hash['index_name'] = @index_name
         actions << [command_hash, doc_hash]
         links << doc_hash["link"]
       end


### PR DESCRIPTION
This has been added to perform two tasks:

* Allow the government index boost to be implemented the same as our other
boosts. It currently required a full copy of the query and uses
`no_match_query`.
* Merging data into a single index.

It should be noted that we are also looking to `rendering_app` and
`publishing_app` fields to the index, once this is done we can potentially
remove this field as it will be redundent.