### PR TITLE
Revert "Do not insert reserved words in Elasticsearch document"

### DIFF
--- a/lib/indexer/bulk_payload_generator.rb
+++ b/lib/indexer/bulk_payload_generator.rb
@@ -78,7 +78,7 @@ module Indexer
         else
           [
             command_hash,
-            doc_hash.tap { |h| h.delete('_type'); h.delete('_id') },
+            doc_hash,
           ]
         end
       }

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -18,8 +18,6 @@ module Indexer
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
-      doc_hash.delete('_type')
-      doc_hash.delete('_id')
       doc_hash
     end
 


### PR DESCRIPTION
Reverts alphagov/rummager#777.

It looks like documents sent from specialist-publisher are incorrectly indexed as `edition` types, which prevents them from showing up in the finder.
