### PR TITLE
Allow sorting by popularity

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -14,6 +14,7 @@ class BaseParameterParser
     tribunal_decision_decision_date
     start_date
     assessment_date
+    popularity
   ).freeze
 
   SORT_MAPPINGS = {


### PR DESCRIPTION
As part of the work for surfacing "high volume tasks" to users on the new Education navigation, we need to fetch the most "popular" pages under a given taxon. This can be achieved with a Rummager query, if we allow sorting by the `popularity` field (which is calculated as the inverse of "rank", which itself is calculated by the Google Analytics [import script](https://github.com/alphagov/search-analytics/blob/master/analytics_fetcher/fetch.py#L64-L65)).

### Trello

https://trello.com/c/6iMEuGfC/140-epic-prepare-for-second-lab-testing-session