### PR TITLE
Use minimum should match for weighting in a/b tests

### DIFF
--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -52,9 +52,13 @@ module QueryComponents
       {
         bool: {
           must: must_conditions,
-          should: should_conditions
+          should: should_conditions,
         }
       }
+    end
+
+    def b_variant?
+      @search_params.ab_tests[:search_match_length] == 'B'
     end
 
     def payload_for_quoted_phrase
@@ -66,12 +70,14 @@ module QueryComponents
       if @search_params.enable_id_codes?
         [all_searchable_text_query]
       else
-        [query_string_query]
+        b_variant? ? [] : [query_string_query]
       end
     end
 
     def should_conditions
-      exact_field_boosts + [exact_match_boost, shingle_token_filter_boost]
+      fields = exact_field_boosts + [exact_match_boost, shingle_token_filter_boost]
+      fields = (fields + [query_string_query]) if b_variant?
+      fields
     end
 
     def all_searchable_text_query

--- a/test/support/test_helpers.rb
+++ b/test/support/test_helpers.rb
@@ -17,6 +17,7 @@ module TestHelpers
       return_fields: nil,
       facets: nil,
       debug: {},
+      ab_tests: {},
     }.merge(options))
   end
 

--- a/test/unit/search/query_components/core_query_test.rb
+++ b/test/unit/search/query_components/core_query_test.rb
@@ -19,4 +19,28 @@ class CoreQueryTest < ShouldaUnitTestCase
       refute_match(/query_with_old_synonyms/, query.to_s)
     end
   end
+
+  context "when ab testing minimum should match" do
+    should "use the default value when no variant is passed in" do
+      builder = QueryComponents::CoreQuery.new(search_query_params)
+
+      query = builder.payload
+      assert_match(/"2<2 3<3 7<50%"/, query[:bool][:must].to_s)
+    end
+
+    should "use variant b when it is passed in" do
+      builder = QueryComponents::CoreQuery.new(search_query_params(ab_tests: { search_match_length: 'B' }))
+
+      query = builder.payload
+      refute_match(/"2<2 3<3 7<50%"/, query[:bool][:must].to_s)
+      assert_match(/"2<2 3<3 7<50%"/, query[:bool][:should].to_s)
+    end
+
+    should "use variant a when it is passed in" do
+      builder = QueryComponents::CoreQuery.new(search_query_params(ab_tests: { search_match_length: 'A' }))
+
+      query = builder.payload
+      assert_match(/"2<2 3<3 7<50%"/, query[:bool][:must].to_s)
+    end
+  end
 end


### PR DESCRIPTION
The first ab test that we are running is a change to the minimum should match query. For variant b queries, minimum should match is now added for weighting in the should query params.

https://trello.com/c/J2nUnoMm/99-decide-on-choice-of-change-for-a-b-test

Mobbed with @JonathanHallam and @suzannehamilton.