### PR TITLE
Add duplicate deleter rake task

### DIFF
--- a/lib/duplicate_deleter.rb
+++ b/lib/duplicate_deleter.rb
@@ -32,43 +32,48 @@ class DuplicateDeleter
     )
   end
 
-  def call(content_ids)
-    content_ids.each do |content_id|
-      parser = SearchParameterParser.new({ "filter_content_id" => content_id }, schema)
+  def call(ids, id_type: 'content_id')
+    ids.each do |id|
+      parser = SearchParameterParser.new({ "filter_#{id_type}" => id, 'fields' => ['content_id'] }, schema)
       search_params = Search::QueryParameters.new(parser.parsed_params)
       results = searcher.run(search_params)
 
       if results[:results].count < 2
-        io.puts "Skipping #{content_id} as less than 2 results found"
+        io.puts "Skipping #{id_type} #{id} as less than 2 results found"
         next
       end
 
       types = results[:results].map { |a| a[:elasticsearch_type] }
       if types.uniq.count < 2
-        io.puts "Skipping #{content_id} not enough uniq types"
+        io.puts "Skipping #{id_type} #{id} not enough uniq types"
         next
       end
 
       if !types.include?(type_to_delete)
-        io.puts "Skipping #{content_id} as type to delete #{type_to_delete} not present in #{types.join(', ')}"
+        io.puts "Skipping #{id_type} #{id} as type to delete #{type_to_delete} not present in #{types.join(', ')}"
         next
       end
 
       ids = results[:results].map { |a| a[:_id] }
       if ids.uniq.count != 1
-        io.puts "Skipping #{content_id} as multiple _id's detected #{ids.uniq.join(', ')}"
+        io.puts "Skipping #{id_type} #{id} as multiple _id's detected #{ids.uniq.join(', ')}"
+        next
+      end
+
+      content_ids = results[:results].map { |a| a['content_id'] }
+      if content_ids.uniq.count != 1
+        io.puts "Skipping #{id_type} #{id} as multiple content_id's detected #{content_ids.uniq.join(', ')}"
         next
       end
 
       index_names = results[:results].map { |a| a[:index] }
       if index_names.uniq.count != 1
-        io.puts "Skipping #{content_id} as multiple indicies detected #{index_names.uniq.join(', ')}"
+        io.puts "Skipping #{id_type} #{id} as multiple indicies detected #{index_names.uniq.join(', ')}"
         next
       end
 
       Indexer::DeleteWorker.new.perform(index_names.first, type_to_delete, ids.first)
-      io.puts "Deleted duplicate for content_id #{content_id}"
+      io.puts "Deleted duplicate for #{id_type} #{id}"
     end
-
   end
 end

--- a/lib/duplicate_deleter.rb
+++ b/lib/duplicate_deleter.rb
@@ -1,0 +1,74 @@
+require_relative "../app"
+
+class DuplicateDeleter
+  attr_reader :type_to_delete, :io
+  def initialize(type_to_delete, io = STDOUT)
+    @type_to_delete = type_to_delete
+    @io = io
+  end
+
+  def search_config
+    Rummager.settings.search_config
+  end
+
+  def searcher
+    @searcher ||= begin
+      unified_index = search_config.search_server.index_for_search(
+        search_config.content_index_names
+      )
+
+      registries = Search::Registries.new(
+        search_config.search_server,
+        search_config
+      )
+      Search::Query.new(unified_index, registries)
+    end
+  end
+
+  def schema
+    @schema ||= CombinedIndexSchema.new(
+      search_config.content_index_names,
+      search_config.schema_config
+    )
+  end
+
+  def call(content_ids)
+    content_ids.each do |content_id|
+      parser = SearchParameterParser.new({ "filter_content_id" => content_id }, schema)
+      search_params = Search::QueryParameters.new(parser.parsed_params)
+      results = searcher.run(search_params)
+
+      if results[:results].count < 2
+        io.puts "Skipping #{content_id} as less than 2 results found"
+        next
+      end
+
+      types = results[:results].map { |a| a[:elasticsearch_type] }
+      if types.uniq.count < 2
+        io.puts "Skipping #{content_id} not enough uniq types"
+        next
+      end
+
+      if !types.include?(type_to_delete)
+        io.puts "Skipping #{content_id} as type to delete #{type_to_delete} not present in #{types.join(', ')}"
+        next
+      end
+
+      ids = results[:results].map { |a| a[:_id] }
+      if ids.uniq.count != 1
+        io.puts "Skipping #{content_id} as multiple _id's detected #{ids.uniq.join(', ')}"
+        next
+      end
+
+      index_names = results[:results].map { |a| a[:index] }
+      if index_names.uniq.count != 1
+        io.puts "Skipping #{content_id} as multiple indicies detected #{index_names.uniq.join(', ')}"
+        next
+      end
+
+      Indexer::DeleteWorker.new.perform(index_names.first, type_to_delete, ids.first)
+      io.puts "Deleted duplicate for content_id #{content_id}"
+    end
+
+  end
+end

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -4,8 +4,11 @@ namespace :delete do
     require 'duplicate_deleter'
 
     type_to_delete = ENV.fetch("TYPE_TO_DELETE")
-    content_ids = ENV.fetch('CONTENT_IDS').split(',').map(&:strip)
+    content_ids = ENV.fetch('CONTENT_IDS', '').split(',').map(&:strip).compact
+    links = ENV.fetch('LINKS', '').split(',').map(&:strip).compact
 
-    DuplicateDeleter.new(type_to_delete).call(content_ids)
+    deleter = DuplicateDeleter.new(type_to_delete)
+    deleter.call(content_ids) if content_ids.any?
+    deleter.call(links, id_type: 'link') if links.any?
   end
 end

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,0 +1,11 @@
+namespace :delete do
+  desc "Delete duplicates from index"
+  task :duplicates do
+    require 'duplicate_deleter'
+
+    type_to_delete = ENV.fetch("TYPE_TO_DELETE")
+    content_ids = ENV.fetch('CONTENT_IDS').split(',').map(&:strip)
+
+    DuplicateDeleter.new(type_to_delete).call(content_ids)
+  end
+end

--- a/test/integration/duplicate_deleter_test.rb
+++ b/test/integration/duplicate_deleter_test.rb
@@ -1,0 +1,105 @@
+require "integration_test_helper"
+require 'duplicate_deleter'
+
+class DuplicateDeleterTest < IntegrationTest
+  def test_can_not_delete_when_only_a_single_document
+    commit_document(
+      "mainstream_test",
+      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+      "link" => "/an-example-page",
+      "_type" => "edition",
+    )
+
+    DuplicateDeleter.new('edition', io).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
+
+    assert_message(msg: "as less than 2 results found")
+    assert_document_present_in_rummager(link: "/an-example-page", type: "edition")
+  end
+
+  def test_can_delete_duplicate_documents_on_different_types
+    commit_document(
+      "mainstream_test",
+      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+      "link" => "/an-example-page",
+      "_type" => "edition",
+    )
+    commit_document(
+      "mainstream_test",
+      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+      "link" => "/an-example-page",
+      "_type" => "cma_case",
+    )
+
+    DuplicateDeleter.new('edition', io).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
+
+    assert_message(msg: "Deleted duplicate for content_id")
+    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
+    assert_document_missing_in_rummager(link: "/an-example-page", type: "edition")
+  end
+
+  def test_cant_delete_a_type_that_dosent_exist
+    commit_document(
+      "mainstream_test",
+      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+      "link" => "/an-example-page",
+      "_type" => "edition",
+    )
+    commit_document(
+      "mainstream_test",
+      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+      "link" => "/an-example-page",
+      "_type" => "cma_case",
+    )
+
+    DuplicateDeleter.new('ab_case', io).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
+
+    assert_message(msg: "as type to delete ab_case not present in")
+    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
+    assert_document_present_in_rummager(link: "/an-example-page", type: "edition")
+  end
+
+  def test_cant_delete_duplicate_content_ids_when_id_doesnt_match
+    commit_document(
+      "mainstream_test",
+      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+      "link" => "/not-an-example-page",
+      "_type" => "edition",
+    )
+    commit_document(
+      "mainstream_test",
+      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+      "link" => "/an-example-page",
+      "_type" => "cma_case",
+    )
+
+    DuplicateDeleter.new('edition', io).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
+
+    assert_message(msg: "as multiple _id's detected")
+    assert_document_present_in_rummager(link: "/not-an-example-page", type: "edition")
+    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
+  end
+
+  private
+
+  def assert_document_present_in_rummager(link:, type:, index: "mainstream_test")
+    doc = fetch_document_from_rummager(link: link, type: type, index: index)
+    assert doc
+  end
+
+  def assert_document_missing_in_rummager(link:, type:)
+    assert_raises Elasticsearch::Transport::Transport::Errors::NotFound do
+      fetch_document_from_rummager(link: link, type: type)
+    end
+  end
+
+
+  def assert_message(msg:)
+    io.rewind
+    log = io.read
+    assert log.include?(msg), "#{msg} not in #{log}"
+  end
+
+  def io
+    @io ||= StringIO.new
+  end
+end

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -136,10 +136,10 @@ private
     end
   end
 
-  def fetch_document_from_rummager(link:)
+  def fetch_document_from_rummager(link:, index: 'mainstream_test', type: '_all')
     response = client.get(
-      index: 'mainstream_test',
-      type: '_all',
+      index: index,
+      type: type,
       id: link
     )
     response['_source']


### PR DESCRIPTION
We can have duplicates when the type is different, but the content_id
and _id (link) are the same.

Paired with: @MatMoore 

https://trello.com/c/npsstuyq/103-elasticsearch-document-type-is-wrong-for-specialist-documents