### PR TITLE
Add rake task to find and delete all duplicate content

### DIFF
--- a/lib/duplicate_deleter.rb
+++ b/lib/duplicate_deleter.rb
@@ -68,7 +68,7 @@ class DuplicateDeleter
 
       index_names = results[:results].map { |a| a[:index] }
       if index_names.uniq.count != 1
-        io.puts "Skipping #{id_type} #{id} as multiple indicies detected #{index_names.uniq.join(', ')}"
+        io.puts "Skipping #{id_type} #{id} as multiple indices detected #{index_names.uniq.join(', ')}"
         next
       end
 

--- a/lib/duplicate_links_finder.rb
+++ b/lib/duplicate_links_finder.rb
@@ -1,0 +1,37 @@
+require_relative "../app"
+
+class DuplicateLinksFinder
+  def initialize(elasticsearch_url, indices)
+    @elasticsearch_url = elasticsearch_url
+    @indices = indices
+  end
+
+  def find
+    client = Elasticsearch::Client.new(host: elasticsearch_url)
+
+    body = {
+      "query": {
+        "match_all": {}
+      },
+      "aggs": {
+        "duplicates": {
+          "terms": {
+            "field": "link",
+            "order": {
+              "_count": "desc"
+            },
+            "size": 100000,
+            "min_doc_count": 2
+          }
+        }
+      }
+    }
+
+    results = client.search(index: indices, body: body)
+    results["aggregations"]["duplicates"]["buckets"].map { |duplicate| duplicate["key"] }
+  end
+
+private
+
+  attr_reader :elasticsearch_url, :indices
+end

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,5 +1,12 @@
 namespace :delete do
-  desc "Delete duplicates from index"
+  CONTENT_SEARCH_INDICES = %w(mainstream detailed government).freeze
+
+  desc "
+  Delete duplicates with the content IDs and/or links provided
+  Usage
+  TYPE_TO_DELETE=edition CONTENT_IDS=id1,id2 rake delete:duplicates
+  TYPE_TO_DELETE=edition LINKS=/path/one,/path/two rake delete:duplicates
+  "
   task :duplicates do
     require 'duplicate_deleter'
 
@@ -10,5 +17,26 @@ namespace :delete do
     deleter = DuplicateDeleter.new(type_to_delete)
     deleter.call(content_ids) if content_ids.any?
     deleter.call(links, id_type: 'link') if links.any?
+  end
+
+  desc "
+  Find all duplicates and delete them
+  Usage
+  TYPE_TO_DELETE=edition rake delete:all_duplicates
+  "
+  task :all_duplicates do
+    require 'duplicate_deleter'
+    require 'duplicate_links_finder'
+
+    type_to_delete = ENV.fetch("TYPE_TO_DELETE")
+
+    elasticsearch_config = YAML.load("../../elasticsearch.yml")
+
+    links = DuplicateLinksFinder.new(elasticsearch_config["base_uri"], CONTENT_SEARCH_INDICES).find
+
+    puts "Found #{links.size} duplicate links to delete"
+
+    deleter = DuplicateDeleter.new(type_to_delete)
+    deleter.call(links, id_type: 'link')
   end
 end


### PR DESCRIPTION
The existing `delete:duplicates` task requires a list of content IDs or paths when deleting duplicate entries. This is quite unwieldy when deleting large numbers of entries, such as the ones caused by the recent rummager `_type` bug.

To speed up the duplicate cleanup process, this new rake task finds the duplicate content before deleting it.

https://trello.com/c/npsstuyq/103-elasticsearch-document-type-is-wrong-for-specialist-documents