### PR TITLE
Ensure the metafields are preserved when amending a document

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -136,7 +136,7 @@ module SearchIndices
     def get_document_by_id(document_id)
       begin
         response = @client.get(index: @index_name, type: "_all", id: document_id)
-        document_from_hash(response["_source"])
+        response
       rescue Elasticsearch::Transport::Transport::Errors::NotFound
         nil
       end

--- a/lib/indexer/amender.rb
+++ b/lib/indexer/amender.rb
@@ -11,9 +11,16 @@ module Indexer
         raise ArgumentError, "Cannot change the `link` attribute of a document."
       end
 
-      document = index.get_document_by_id(document_id)
+      raw_document = index.get_document_by_id(document_id)
+      return unless raw_document
 
-      return unless document
+      document_source = raw_document["_source"]
+      # For backwards-compatibility, ensure that the source _type and _id are
+      # the same as the main Elasticsearch _type and _id
+      document_source["_type"] = raw_document["_type"]
+      document_source["_id"] = raw_document["_id"]
+
+      document = index.document_from_hash(document_source)
 
       updates.each do |key, value|
         if document.has_field?(key)

--- a/test/integration/indexer/amendment_test.rb
+++ b/test/integration/indexer/amendment_test.rb
@@ -36,6 +36,20 @@ class ElasticsearchAmendmentTest < IntegrationTest
     })
   end
 
+  def test_should_preserve_meta_fields
+    commit_document("mainstream_test", {
+      "title" => "The old title",
+      "link" => "/an-example-answer",
+    }, type: "aaib_report")
+
+    post "/documents/%2Fan-example-answer", "title=A+new+title"
+
+    retrieved = fetch_raw_document_from_rummager(link: "/an-example-answer")
+
+    assert_equal "aaib_report", retrieved["_type"]
+    assert_equal "aaib_report", retrieved["_source"]["_type"]
+  end
+
   def test_should_amend_a_document_queued
     commit_document("mainstream_test", {
       "title" => "The old title",

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -36,9 +36,9 @@ class IntegrationTest < MiniTest::Unit::TestCase
     Document.from_hash(SAMPLE_DOCUMENT_ATTRIBUTES, sample_elasticsearch_types)
   end
 
-  def insert_document(index_name, attributes)
+  def insert_document(index_name, attributes, type: "edition")
     attributes.stringify_keys!
-    type = attributes["_type"] || "edition"
+    type = attributes["_type"] || type
     client.create(
       index: index_name,
       type: type,
@@ -58,8 +58,8 @@ class IntegrationTest < MiniTest::Unit::TestCase
     )
   end
 
-  def commit_document(index_name, attributes)
-    insert_document(index_name, attributes)
+  def commit_document(index_name, attributes, type: "edition")
+    insert_document(index_name, attributes, type: type)
     commit_index(index_name)
   end
 
@@ -134,6 +134,14 @@ private
     TestIndexHelpers::INDEX_NAMES.each do |index_name|
       add_sample_documents(index_name, params[:section_count])
     end
+  end
+
+  def fetch_raw_document_from_rummager(link:, index: 'mainstream_test', type: '_all')
+    client.get(
+      index: index,
+      type: type,
+      id: link
+    )
   end
 
   def fetch_document_from_rummager(link:, index: 'mainstream_test', type: '_all')


### PR DESCRIPTION
When amending a document, which happens when the publishing API sends an update, copy the `_type` and `_id` fields directly to the new Elasticsearch item. Currently, they are copied from the nested `_source` data, which has caused problems when the main `_type` and the `_source` `_type` are out of sync.

This will help prevent some of the bad data that has been appearing in search results over the past week: search results with the wrong `_type` value and duplicate results with the same URL but different `_type`s.

https://trello.com/c/npsstuyq/103-elasticsearch-document-type-is-wrong-for-specialist-documents

Paired with @MatMoore 