### PR TITLE
Copy document type from canonical place when reindexing

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -176,6 +176,7 @@ class Rummager < Sinatra::Application
   post "/?:index?/documents" do
     request.body.rewind
     documents = [JSON.parse(request.body.read)].flatten.map { |hash|
+      hash["_type"] ||= "edition"
       current_index.document_from_hash(hash)
     }
 

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -11,11 +11,16 @@ class Document
   end
 
   def self.from_hash(hash, elasticsearch_types, es_score = nil)
-    type = hash["_type"] || "edition"
+    type = hash["_type"]
+    if type.nil?
+      raise "Missing elasticsearch type"
+    end
+
     doc_type = elasticsearch_types[type]
     if doc_type.nil?
       raise "Unexpected elasticsearch type '#{type}'. Document types must be configured"
     end
+
     self.new(doc_type.fields, hash, es_score)
   end
 
@@ -68,7 +73,7 @@ class Document
           doc[key] = value
         end
       end
-      doc["_type"] = @type || "edition"
+      doc["_type"] = @type
       doc["_id"] = @id if @id
     end
   end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -135,8 +135,7 @@ module SearchIndices
 
     def get_document_by_id(document_id)
       begin
-        response = @client.get(index: @index_name, type: "_all", id: document_id)
-        response
+        @client.get(index: @index_name, type: "_all", id: document_id)
       rescue Elasticsearch::Transport::Transport::Errors::NotFound
         nil
       end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -152,7 +152,7 @@ module SearchIndices
       search_body = { query: { match_all: {} } }
       batch_size = self.class.scroll_batch_size
       LegacyClient::ScrollEnumerator.new(client: client, index_names: @index_name, search_body: search_body, batch_size: batch_size) do |hit|
-        document_from_hash(hit["_source"].merge("_id" => hit["_id"]))
+        document_from_hash(hit["_source"].merge("_id" => hit["_id"], "_type" => hit["_type"]))
       end
     end
 

--- a/lib/search/result_set.rb
+++ b/lib/search/result_set.rb
@@ -1,4 +1,5 @@
 module Search
+  # This is only used by Advanced Search
   class ResultSet
     attr_reader :total, :results
 
@@ -18,7 +19,10 @@ module Search
     end
 
     def self.document_from_hit(hit, elasticsearch_types)
-      Document.from_hash(hit["_source"], elasticsearch_types, hit["_score"])
+      Document.from_hash(
+        hit["_source"].merge("_type" => hit["_type"], "_id" => hit["_id"]),
+        elasticsearch_types,
+        hit["_score"])
     end
   end
 end

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -24,6 +24,7 @@ class ElasticsearchIndexingTest < IntegrationTest
     )
 
     post "/documents", {
+      "_type" => "manual",
       "content_id" => "6b965b82-2e33-4587-a70c-60204cbb3e29",
       "title" => "TITLE",
       "format" => "answer",
@@ -35,6 +36,7 @@ class ElasticsearchIndexingTest < IntegrationTest
     }.to_json
 
     assert_document_is_in_rummager({
+      "_type" => "manual",
       "content_id" => "6b965b82-2e33-4587-a70c-60204cbb3e29",
       "title" => "TITLE",
       "format" => "answer",
@@ -45,6 +47,24 @@ class ElasticsearchIndexingTest < IntegrationTest
       "government_document_supertype" => "other",
       "licence_identifier" => "1201-5-1",
       "licence_short_description" => "A short description of a licence",
+    })
+  end
+
+  def test_document_type_defaults_to_edition
+    publishing_api_has_expanded_links(
+      content_id: "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
+      expanded_links: {},
+    )
+
+    post "/documents", {
+      "content_id" => "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
+      "link" => "/an-example-answer",
+    }.to_json
+
+    assert_document_is_in_rummager({
+      "_type" => "edition",
+      "content_id" => "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
+      "link" => "/an-example-answer",
     })
   end
 

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -7,7 +7,8 @@ class IntegrationTest < MiniTest::Unit::TestCase
     "title" => "TITLE1",
     "description" => "DESCRIPTION",
     "format" => "local_transaction",
-    "link" => "/URL"
+    "link" => "/URL",
+    "_type" => "edition",
   }.freeze
 
   def initialize(args)

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -201,7 +201,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       headers: { 'Content-Type' => 'application/json' },
     )
     hits = (1..100).map { |i|
-      { "_source" => { "link" => "/foo-#{i}" } }
+      { "_source" => { "link" => "/foo-#{i}" }, "_type" => "edition" }
     }
     stub_request(:get, scroll_uri).with(
       body: "abcdefgh"
@@ -234,7 +234,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
       headers: { 'Content-Type' => 'application/json' },
     )
     hits = (1..3).map { |i|
-      { "_source" => { "link" => "/foo-#{i}" } }
+      { "_source" => { "link" => "/foo-#{i}" }, "_type" => "edition" }
     }
     total = hits.size
 

--- a/test/unit/legacy_search/elasticsearch_index_advanced_search_test.rb
+++ b/test/unit/legacy_search/elasticsearch_index_advanced_search_test.rb
@@ -184,16 +184,16 @@ class IndexerIndexAdvancedSearchTest < MiniTest::Unit::TestCase
   end
 
   def test_returns_the_hits_converted_into_documents
-    Document.expects(:from_hash).with({ "woo" => "hoo" }, anything, nil).returns :woo_hoo
     stub_request(:get, "http://example.com:9200/mainstream_test/_search")
       .to_return(
         status: 200,
-        body: "{\"hits\": {\"total\": 10, \"hits\": [{\"_source\": {\"woo\": \"hoo\"}}]}}",
+        body: "{\"hits\": {\"total\": 10, \"hits\": [{\"_source\": {\"indexable_content\": \"some_content\"}, \"_type\": \"contact\"}]}}",
         headers: { "Content-Type" => "application/json" }
       )
     result_set = @wrapper.advanced_search(default_params)
     assert_equal 10, result_set.total
-    assert_equal [:woo_hoo], result_set.results
+    assert_equal 1, result_set.results.size
+    assert_equal "some_content", result_set.results.first.get("indexable_content")
   end
 
   def default_params

--- a/test/unit/search/result_set_test.rb
+++ b/test/unit/search/result_set_test.rb
@@ -31,7 +31,9 @@ class ResultSetTest < ShouldaUnitTestCase
           "hits" => [
             {
               "_score" => 12,
-              "_source" => { "foo" => "bar" }
+              "_type" => "contact",
+              "_id" => "some_id",
+              "_source" => { "foo" => "bar" },
             }
           ]
         }
@@ -52,6 +54,14 @@ class ResultSetTest < ShouldaUnitTestCase
 
     should "pass the result score to Document.from_hash" do
       Document.expects(:from_hash).with(is_a(Hash), sample_elasticsearch_types, 12).returns(:doc)
+
+      result_set = Search::ResultSet.from_elasticsearch(sample_elasticsearch_types, @response)
+      assert_equal [:doc], result_set.results
+    end
+
+    should "populate the document id and type from the metafields" do
+      expected_hash = has_entries("_type" => "contact", "_id" => "some_id")
+      Document.expects(:from_hash).with(expected_hash, sample_elasticsearch_types, anything).returns(:doc)
 
       result_set = Search::ResultSet.from_elasticsearch(sample_elasticsearch_types, @response)
       assert_equal [:doc], result_set.results


### PR DESCRIPTION
- When fetching all documents, look up the document `_type` from the top-level `_type` field, not the copy in `_source`. This is a step towards deleting `_source._type` entirely, which we need to do before upgrading to Elasticsearch 2.
- Move default `_type` assignment to POST request. Add more validation of search content `_type`, and move the fallback to "edition" to the /documents POST endpoint, which is the only place which is permitted to create documents without supplying a specific type. This should help us avoid situations like the recent corrupted search data, in which the `_type` was not being specified properly and was falling back to "edition" even for specialist document types.

https://trello.com/c/npsstuyq/103-elasticsearch-document-type-is-wrong-for-specialist-documents

Paired with @MatMoore.

Marked as DO NOT MERGE while we add more integration tests.