### PR TITLE
Add "primary_publishing_organisation"

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -21,6 +21,7 @@
     "part_of_taxonomy_tree",
     "policies",
     "popularity",
+    "primary_publishing_organisation",
     "public_timestamp",
     "publishing_app",
     "rendering_app",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -56,6 +56,11 @@
     "type": "identifiers"
   },
 
+  "primary_publishing_organisation": {
+    "description": "The organisation that published this page. This field is copied from the publishing-api. It is only populated by Whitehall.",
+    "type": "identifiers"
+  },
+
   "specialist_sectors": {
     "description": "The navigation \"topics\" that the document is assigned to.  Nothing to do with \"policy areas\"",
     "type": "identifiers"

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -47,6 +47,7 @@
   },
 
   "organisations": {
+    "description": "The organisations related to this page. This field is copied from the publishing-api. Note that means different things for different formats.",
     "type": "identifiers"
   },
 

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -123,6 +123,10 @@ module Indexer
         content_item['base_path'].sub('/government/organisations/', '').sub('/courts-tribunals/', '')
       end
 
+      links_with_slugs["primary_publishing_organisation"] = links["primary_publishing_organisation"].to_a.map do |content_item|
+        content_item['base_path'].sub('/government/organisations/', '').sub('/courts-tribunals/', '')
+      end
+
       links_with_slugs["taxons"] = content_ids_for(links, 'taxons')
 
       links_with_slugs

--- a/test/integration/indexer/links_lookup_test.rb
+++ b/test/integration/indexer/links_lookup_test.rb
@@ -62,6 +62,12 @@ class TaglookupDuringIndexingTest < IntegrationTest
             "base_path" => "/courts-tribunals/my-court",
           }
         ],
+        primary_publishing_organisation: [
+          {
+            "content_id" => "ORG-1",
+            "base_path" => "/government/organisations/my-org/1",
+          },
+        ],
         taxons: [
           {
             "content_id" => "TAXON-1",
@@ -80,6 +86,7 @@ class TaglookupDuringIndexingTest < IntegrationTest
       "specialist_sectors" => ["my-topic/a", "my-topic/b"],
       "mainstream_browse_pages" => ["my-browse/1"],
       "organisations" => ["my-org/1", "my-court"],
+      "primary_publishing_organisation" => ["my-org/1"],
       "part_of_taxonomy_tree" => ["TAXON-1"],
       "taxons" => ["TAXON-1"],
       "topic_content_ids" => ["TOPIC-CONTENT-ID-1", "TOPIC-CONTENT-ID-2"],


### PR DESCRIPTION
This field is populated in Whitehall (https://github.com/alphagov/whitehall/pull/3259) and represents the org that published the page. It will be used in the auditing of content.

https://trello.com/c/86sDRf3t