### PR TITLE
Allow duplicate deleter to handle contacts with different IDs

### DIFF
--- a/lib/duplicate_deleter.rb
+++ b/lib/duplicate_deleter.rb
@@ -55,7 +55,7 @@ class DuplicateDeleter
       end
 
       ids = results[:results].map { |a| a[:_id] }
-      if ids.uniq.count != 1
+      if ids.uniq.count != 1 && !results_contain_duplicate_contacts(results[:results], type_to_delete)
         io.puts "Skipping #{id_type} #{id} as multiple _id's detected #{ids.uniq.join(', ')}"
         next
       end
@@ -80,5 +80,17 @@ class DuplicateDeleter
       Indexer::DeleteWorker.new.perform(index_names.first, type_to_delete, ids.first)
       io.puts "Deleted duplicate for #{id_type} #{id}"
     end
+  end
+
+private
+
+  def results_contain_duplicate_contacts(results, type_to_delete)
+    contact_results = results.select { |a| a[:elasticsearch_type] == "contact" }
+
+    # The _id field for most content is the same as the link (including the leading `/`), but contacts have an _id
+    # without a leading slash. It's possible for duplicate contacts to be created *with* a leading slash, so the
+    # _id's do not match exactly.
+    contact_results.size == 1 &&
+      results.any? { |a| a[:elasticsearch_type] == type_to_delete && a[:_id] == "/" + contact_results.first[:_id] }
   end
 end

--- a/test/integration/duplicate_deleter_test.rb
+++ b/test/integration/duplicate_deleter_test.rb
@@ -37,7 +37,7 @@ class DuplicateDeleterTest < IntegrationTest
     assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
-  def test_cant_delete_a_type_that_dosent_exist
+  def test_cant_delete_a_type_that_doesnt_exist
     commit_document(
       "mainstream_test",
       "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
@@ -83,23 +83,23 @@ class DuplicateDeleterTest < IntegrationTest
     commit_document(
       "mainstream_test",
       "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
-      "link" => "/some-contact-page",
+      "link" => "/contact-page",
       "_type" => "edition",
-      "_id" => "/some-contact-page",
+      "_id" => "/contact-page",
     )
     commit_document(
       "mainstream_test",
       "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
-      "link" => "/some-contact-page",
+      "link" => "/contact-page",
       "_type" => "contact",
-      "_id" => "some-contact-page",
+      "_id" => "contact-page",
     )
 
     DuplicateDeleter.new('edition', io).call(["e3eaa461-3a85-4881-b412-9c58e7ea4ebd"])
 
     assert_message(msg: "Deleted duplicate for content_id")
-    assert_document_present_in_rummager(id: "some-contact-page", type: "contact")
-    assert_document_missing_in_rummager(id: "/some-contact-page", type: "edition")
+    assert_document_present_in_rummager(id: "contact-page", type: "contact")
+    assert_document_missing_in_rummager(id: "/contact-page", type: "edition")
   end
 
   def test_can_delete_duplicate_documents_on_different_types_using_link

--- a/test/integration/duplicate_deleter_test.rb
+++ b/test/integration/duplicate_deleter_test.rb
@@ -13,7 +13,7 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('edition', io).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
 
     assert_message(msg: "as less than 2 results found")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   def test_can_delete_duplicate_documents_on_different_types
@@ -33,8 +33,8 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('edition', io).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
 
     assert_message(msg: "Deleted duplicate for content_id")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
-    assert_document_missing_in_rummager(link: "/an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   def test_cant_delete_a_type_that_dosent_exist
@@ -54,8 +54,8 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('ab_case', io).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
 
     assert_message(msg: "as type to delete ab_case not present in")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   def test_cant_delete_duplicate_content_ids_when_id_doesnt_match
@@ -75,8 +75,8 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('edition', io).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
 
     assert_message(msg: "as multiple _id's detected")
-    assert_document_present_in_rummager(link: "/not-an-example-page", type: "edition")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
+    assert_document_present_in_rummager(id: "/not-an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
   end
 
   def test_can_delete_duplicate_documents_on_different_types_using_link
@@ -96,8 +96,8 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('edition', io).call(["/an-example-page"], id_type: "link")
 
     assert_message(msg: "Deleted duplicate for link")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
-    assert_document_missing_in_rummager(link: "/an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   def test_cant_delete_duplicate_documents_using_link_with_different_content_ids
@@ -117,8 +117,8 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('edition', io).call(["/an-example-page"], id_type: "link")
 
     assert_message(msg: "as multiple non-null content_id's detected")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   def test_can_delete_duplicate_documents_if_bad_item_has_nil_content_id
@@ -137,8 +137,8 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('edition', io).call(["/an-example-page"], id_type: "link")
 
     assert_message(msg: "Deleted duplicate for link")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
-    assert_document_missing_in_rummager(link: "/an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   def test_cant_delete_duplicate_documents_if_good_item_has_nil_content_id
@@ -157,8 +157,8 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('edition', io).call(["/an-example-page"], id_type: "link")
 
     assert_message(msg: "indexed with a valid '_type' but a missing content ID")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   def test_can_delete_duplicate_documents_on_different_types_using_link_when_both_content_ids_are_missing
@@ -176,20 +176,20 @@ class DuplicateDeleterTest < IntegrationTest
     DuplicateDeleter.new('edition', io).call(["/an-example-page"], id_type: "link")
 
     assert_message(msg: "Deleted duplicate for link")
-    assert_document_present_in_rummager(link: "/an-example-page", type: "cma_case")
-    assert_document_missing_in_rummager(link: "/an-example-page", type: "edition")
+    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
 private
 
-  def assert_document_present_in_rummager(link:, type:, index: "mainstream_test")
-    doc = fetch_document_from_rummager(link: link, type: type, index: index)
+  def assert_document_present_in_rummager(id:, type:, index: "mainstream_test")
+    doc = fetch_document_from_rummager(id: id, type: type, index: index)
     assert doc
   end
 
-  def assert_document_missing_in_rummager(link:, type:)
+  def assert_document_missing_in_rummager(id:, type:)
     assert_raises Elasticsearch::Transport::Transport::Errors::NotFound do
-      fetch_document_from_rummager(link: link, type: type)
+      fetch_document_from_rummager(id: id, type: type)
     end
   end
 

--- a/test/integration/duplicate_deleter_test.rb
+++ b/test/integration/duplicate_deleter_test.rb
@@ -79,6 +79,29 @@ class DuplicateDeleterTest < IntegrationTest
     assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
   end
 
+  def test_can_delete_duplicate_content_ids_when_contact_id_is_wrong
+    commit_document(
+      "mainstream_test",
+      "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
+      "link" => "/some-contact-page",
+      "_type" => "edition",
+      "_id" => "/some-contact-page",
+    )
+    commit_document(
+      "mainstream_test",
+      "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
+      "link" => "/some-contact-page",
+      "_type" => "contact",
+      "_id" => "some-contact-page",
+    )
+
+    DuplicateDeleter.new('edition', io).call(["e3eaa461-3a85-4881-b412-9c58e7ea4ebd"])
+
+    assert_message(msg: "Deleted duplicate for content_id")
+    assert_document_present_in_rummager(id: "some-contact-page", type: "contact")
+    assert_document_missing_in_rummager(id: "/some-contact-page", type: "edition")
+  end
+
   def test_can_delete_duplicate_documents_on_different_types_using_link
     commit_document(
       "mainstream_test",

--- a/test/integration/indexer/amendment_test.rb
+++ b/test/integration/indexer/amendment_test.rb
@@ -44,7 +44,7 @@ class ElasticsearchAmendmentTest < IntegrationTest
 
     post "/documents/%2Fan-example-answer", "title=A+new+title"
 
-    retrieved = fetch_raw_document_from_rummager(link: "/an-example-answer")
+    retrieved = fetch_raw_document_from_rummager(id: "/an-example-answer")
 
     assert_equal "aaib_report", retrieved["_type"]
     assert_equal "aaib_report", retrieved["_source"]["_type"]

--- a/test/integration/indexer/deletion_test.rb
+++ b/test/integration/indexer/deletion_test.rb
@@ -9,7 +9,7 @@ class ElasticsearchDeletionTest < IntegrationTest
 
     delete "/documents/%2Fan-example-page"
 
-    assert_document_missing_in_rummager(link: "/an-example-page")
+    assert_document_missing_in_rummager(id: "/an-example-page")
   end
 
   def test_removes_a_document_from_the_index_queued
@@ -29,7 +29,7 @@ class ElasticsearchDeletionTest < IntegrationTest
 
     delete "/documents/edition/http:%2F%2Fexample.com%2F"
 
-    assert_document_missing_in_rummager(link: "http://example.com/")
+    assert_document_missing_in_rummager(id: "http://example.com/")
   end
 
   def test_should_delete_a_best_bet_by_type_and_id
@@ -54,9 +54,9 @@ class ElasticsearchDeletionTest < IntegrationTest
 
 private
 
-  def assert_document_missing_in_rummager(link:)
+  def assert_document_missing_in_rummager(id:)
     assert_raises Elasticsearch::Transport::Transport::Errors::NotFound do
-      fetch_document_from_rummager(link: link)
+      fetch_document_from_rummager(id: id)
     end
   end
 end

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -80,7 +80,7 @@ class IntegrationTest < MiniTest::Unit::TestCase
   end
 
   def assert_document_is_in_rummager(document)
-    retrieved = fetch_document_from_rummager(link: document['link'])
+    retrieved = fetch_document_from_rummager(id: document['link'])
 
     document.each do |key, value|
       assert_equal value, retrieved[key],
@@ -136,19 +136,19 @@ private
     end
   end
 
-  def fetch_raw_document_from_rummager(link:, index: 'mainstream_test', type: '_all')
+  def fetch_raw_document_from_rummager(id:, index: 'mainstream_test', type: '_all')
     client.get(
       index: index,
       type: type,
-      id: link
+      id: id
     )
   end
 
-  def fetch_document_from_rummager(link:, index: 'mainstream_test', type: '_all')
+  def fetch_document_from_rummager(id:, index: 'mainstream_test', type: '_all')
     response = client.get(
       index: index,
       type: type,
-      id: link
+      id: id
     )
     response['_source']
   end

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -39,10 +39,11 @@ class IntegrationTest < MiniTest::Unit::TestCase
   def insert_document(index_name, attributes, type: "edition")
     attributes.stringify_keys!
     type = attributes["_type"] || type
+    id = attributes["_id"] || attributes['link']
     client.create(
       index: index_name,
       type: type,
-      id: attributes['link'],
+      id: id,
       body: attributes
     )
   end


### PR DESCRIPTION
Main change:

The duplicate deleter was skipping over duplicate HMRC contacts because their `_id` fields were different, even though their content IDs and links were the same. This is because the `edition` duplicates were created with the wrong `_id`: contact IDs do not have a leading `/`.

Add this special case to the duplicate deleter so that it deletes the `edition` version if it also has the wrong `_id`.

Related changes:
- Give integration test helper parameter a more accurate name
- Fix typo in existing test name

This is part of the overall data cleanup arising from the Rummager `_type` bug.

https://trello.com/c/npsstuyq/103-elasticsearch-document-type-is-wrong-for-specialist-documents