### PR TITLE
Ensure duplicate deleter uses the correct ID for contacts

### DIFF
--- a/lib/duplicate_deleter.rb
+++ b/lib/duplicate_deleter.rb
@@ -77,8 +77,15 @@ class DuplicateDeleter
         next
       end
 
-      Indexer::DeleteWorker.new.perform(index_names.first, type_to_delete, ids.first)
-      io.puts "Deleted duplicate for #{id_type} #{id}"
+      item_to_delete = results[:results].detect { |a| a[:elasticsearch_type] == type_to_delete }
+      if item_to_delete
+        Indexer::DeleteWorker.new.perform(index_names.first, type_to_delete, item_to_delete[:_id])
+        io.puts "Deleted duplicate for #{id_type} #{id}"
+      else
+        puts "Skipping #{id_type} #{id} as no duplicate with #{type_to_delete} can be found. This should " +
+          "not happen, and might indicate a bug in the duplicate deleter, or a race condition, where some " +
+          "other process has already deleted this item."
+      end
     end
   end
 

--- a/test/integration/duplicate_deleter_test.rb
+++ b/test/integration/duplicate_deleter_test.rb
@@ -84,15 +84,15 @@ class DuplicateDeleterTest < IntegrationTest
       "mainstream_test",
       "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
       "link" => "/contact-page",
-      "_type" => "edition",
-      "_id" => "/contact-page",
+      "_type" => "contact",
+      "_id" => "contact-page",
     )
     commit_document(
       "mainstream_test",
       "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
       "link" => "/contact-page",
-      "_type" => "contact",
-      "_id" => "contact-page",
+      "_type" => "edition",
+      "_id" => "/contact-page",
     )
 
     DuplicateDeleter.new('edition', io).call(["e3eaa461-3a85-4881-b412-9c58e7ea4ebd"])


### PR DESCRIPTION
The duplicate deleter assumed that duplicated content always had the same `_id` field. This isn't true for HMRC contacts, where the link was the same but the `_id` of the bad version had a leading `/`. This meant that the duplicate deleter sometimes tried to delete non-existent items with the correct `_type` but the wrong `_id`.

Fix this by looking up the correct `_id` to delete rather than picking one of the duplicate `_id`s arbitrarily.

https://trello.com/c/npsstuyq/103-elasticsearch-document-type-is-wrong-for-specialist-documents