### PR TITLE
Don't ignore link field when comparing Elasticsearch dumps

### DIFF
--- a/bin/compare_es_dumps
+++ b/bin/compare_es_dumps
@@ -12,7 +12,7 @@ old_file = ARGV[0]
 new_file = ARGV[1]
 # Source fields to ignore when comparing old and new objects for equality.
 # These are ones which we know have changed for most documents.
-FIELDS_TO_IGNORE = ["_id", "_type", "popularity", "primary_publishing_organisation"]
+FIELDS_TO_IGNORE = ["_id", "_type", "popularity"]
 
 def read_object_file(filename)
   documents = {}


### PR DESCRIPTION
Stop ignoring the `primary_publishing_organisation` field when comparing items in two ES dumps. This field was previously ignored because it had just been added, and so it would have overwhelmed the output of the `compare_es_dumps` script because its value would have changed for every item in search.

https://trello.com/b/T9cPzxHP/gov.uk-search-(doing)