### PR TITLE
[DO NOT MERGE] Add a debug option to use dfs_query_then_fetch option

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -193,9 +193,10 @@ module SearchIndices
       LegacySearch::AdvancedSearch.new(@mappings, @elasticsearch_types, @client, @index_name).result_set(params)
     end
 
-    def raw_search(payload, type = nil)
+    def raw_search(payload, type = nil, search_type: "query_then_fetch")
       logger.debug "Request payload: #{payload.to_json}"
-      @client.search(index: @index_name, type: type, body: payload)
+
+      @client.search(index: @index_name, type: type, body: payload, search_type: search_type)
     end
 
     # Convert a best bet query to a string formed by joining the normalised

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -338,6 +338,9 @@ private
         options[:include_withdrawn] = true
       when "use_id_codes"
         options[:use_id_codes] = true
+      when "dfs_query_then_fetch"
+        # DO NOT DEPLOY TO PRODUCTION
+        options[:dfs_query_then_fetch] = true
       when "show_query"
         options[:show_query] = true
       else

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -18,7 +18,9 @@ module Search
     def run(search_params)
       builder = QueryBuilder.new(search_params)
       payload = builder.payload
-      es_response = index.raw_search(payload)
+      search_type = search_params.debug[:dfs_query_then_fetch] ? "dfs_query_then_fetch" : "query_then_fetch"
+
+      es_response = index.raw_search(payload, search_type: search_type)
 
       example_fetcher = FacetExampleFetcher.new(index, es_response, search_params, builder)
       facet_examples = example_fetcher.fetch

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -30,7 +30,7 @@ module Search
         sort: sort,
         facets: facets,
         highlight: highlight,
-        explain: search_params.debug[:explain],
+        explain: search_params.debug[:explain]
       )
     end
 

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -88,7 +88,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_raw_search
-    stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/_search").with(
+    stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/_search?search_type=query_then_fetch").with(
       body: %r{"query":"keyword search"},
     ).to_return(
       body: '{"hits":{"hits":[]}}',
@@ -101,7 +101,7 @@ class ElasticsearchIndexTest < MiniTest::Unit::TestCase
   end
 
   def test_raw_search_with_type
-    stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/test-type/_search").with(
+    stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/test-type/_search?search_type=query_then_fetch").with(
       body: %r{"query":"keyword search"},
     ).to_return(
       body: '{"hits":{"hits":[]}}',
@@ -287,7 +287,7 @@ private
 
   def stub_popularity_index_requests(paths, popularity, total_pages = 10, total_requested = total_pages, paths_to_return = paths)
     # stub the request for total results
-    stub_request(:get, "http://example.com:9200/page-traffic_test/_search").
+    stub_request(:get, "http://example.com:9200/page-traffic_test/_search?search_type=query_then_fetch").
       with(body: { "query" => { "match_all" => {} }, "size" => 0 }.to_json).
       to_return(
         body: { "hits" => { "total" => total_pages } }.to_json,
@@ -321,7 +321,7 @@ private
       }
     }
 
-    stub_request(:get, "http://example.com:9200/page-traffic_test/_search").
+    stub_request(:get, "http://example.com:9200/page-traffic_test/_search?search_type=query_then_fetch").
       with(body: expected_query.to_json).
       to_return(
         body: response.to_json,

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -8,7 +8,7 @@ class QueryTest < ShouldaUnitTestCase
 
       search_payload = stub('payload')
       Search::QueryBuilder.any_instance.expects(:payload).returns(search_payload)
-      index.expects(:raw_search).with(search_payload).returns({})
+      index.expects(:raw_search).with(search_payload, search_type: "query_then_fetch").returns({})
 
       Search::FacetExampleFetcher.any_instance.expects(:fetch).returns(stub('fetch'))
       Search::ResultSetPresenter.any_instance.expects(:present).returns(stub('presenter'))


### PR DESCRIPTION
This is a temporary test and shouldn't be released to production.

We noticed several differences to search results for the same queries when
- changing the count parameter in https://infinite-escarpment-22010.herokuapp.com/result?search_term=water&count=10&which_test=search_match_length
- comparing results across environments

We think this is because local IDF can differ from global IDF in multi
node clusters. See
https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-is-broken.html

When we are evaluating changes to search, we don't want to falsely
attribute these differences to the things we changed.

We're going to see if using dfs_query_then_fetch gives us a more stable
comparison if so, this will give us more confidence in using the healthcheck.