### PR TITLE
Require ERB library

### DIFF
--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -2,6 +2,7 @@ require "yaml"
 require "search_server"
 require "schema/schema_config"
 require "plek"
+require "erb"
 
 class SearchConfig
   %w[


### PR DESCRIPTION
This was added recently in 2a519249ed907547a3a0641b2624c0678de4afa5.

The class doesn't seem to be required anywhere else when running `bin/bulk_load`.
I'm not sure why this hasn't caused problems before now.

https://ruby-doc.org/stdlib-2.3.0/libdoc/erb/rdoc/ERB.html