### PR TITLE
Replace government index boost with format boosts

### DIFF
--- a/config/query/format_boosting.yml
+++ b/config/query/format_boosting.yml
@@ -1,0 +1,22 @@
+format_boosts:
+  # Mainstream formats
+  service_manual_guide: 0.3
+  service_manual_topic: 0.3
+  smart-answer: 1.5
+  transaction: 1.5
+  # Should appear below mainstream content
+  aaib_report: 0.2
+  dfid_research_output: 0.2
+  hmrc_manual_section: 0.2
+  service_standard_report: 0.2
+  # Inside Gov formats
+  contact: 0.3
+  document_collection: 1.3
+  document_series: 1.3
+  minister: 1.7
+  operational_field: 1.5
+  organisation: 2.5
+  topic: 1.5
+  topical_event: 1.5
+  # Hide mainstream browse pages
+  mainstream_browse_page: 0

--- a/config/query/format_boosting.yml
+++ b/config/query/format_boosting.yml
@@ -1,3 +1,37 @@
+government_index:
+  boost: 0.4
+  # Search formats used in the government index. These are defined by the
+  # publishing apps which push pages to the search API, and are different to the
+  # `format` field used in the content store.
+  #
+  # Any new formats used in search should be added to this list. Once all pages
+  # in search have a document_type, the document supertype should be used for
+  # boosting instead of formats, which will remove the need for this list.
+  formats:
+    - case_study
+    - consultation
+    - corporate_information_page
+    - document_collection
+    - edition
+    - fatality_notice
+    - finder
+    - inside-government-link
+    - minister
+    - news_article
+    - operational_field
+    - organisation
+    - person
+    - policy_group
+    - publication
+    - speech
+    - statistical_data_set
+    - statistics_announcement
+    - take_part
+    - topic
+    - topical_event
+    - world_location
+    - world_location_news_article
+    - worldwide_organisation
 format_boosts:
   # Mainstream formats
   service_manual_guide: 0.3

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -4,13 +4,13 @@ module QueryComponents
       {
         function_score: {
           boost_mode: :multiply,
+          score_mode: :multiply,
           query: {
             bool: {
               should: [core_query]
             }
           },
           functions: boost_filters,
-          score_mode: "multiply",
         }
       }
     end

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -1,5 +1,9 @@
+require "yaml"
+
 module QueryComponents
   class Booster < BaseComponent
+    FORMAT_BOOST_CONFIG = YAML.load_file('config/query/format_boosting.yml')
+
     def wrap(core_query)
       {
         function_score: {
@@ -21,37 +25,8 @@ module QueryComponents
       format_boosts + [time_boost, closed_org_boost, devolved_org_boost, historic_edition_boost]
     end
 
-    def boosted_formats
-      {
-        # Mainstream formats
-        "service_manual_guide" => 0.3,
-        "service_manual_topic" => 0.3,
-        "smart-answer" => 1.5,
-        "transaction" => 1.5,
-
-        # Inside Gov formats
-        "topical_event" => 1.5,
-        "minister" => 1.7,
-        "organisation" => 2.5,
-        "topic" => 1.5,
-        "document_series" => 1.3,
-        "document_collection" => 1.3,
-        "operational_field" => 1.5,
-        "contact" => 0.3,
-
-        # Should appear below mainstream content
-        "aaib_report" => 0.2,
-        "dfid_research_output" => 0.2,
-        "hmrc_manual_section" => 0.2,
-        "service_standard_report" => 0.2,
-
-        # Hide mainstream browse pages for now.
-        "mainstream_browse_page" => 0,
-      }
-    end
-
     def format_boosts
-      boosted_formats.map do |format, boost|
+      FORMAT_BOOST_CONFIG["format_boosts"].map do |format, boost|
         {
           filter: { term: { format: format } },
           boost_factor: boost

--- a/lib/search/query_components/query.rb
+++ b/lib/search/query_components/query.rb
@@ -3,11 +3,9 @@ require_relative "text_query"
 
 module QueryComponents
   class Query < BaseComponent
-    GOVERNMENT_BOOST_FACTOR = 0.4
-
     def payload
       if search_params.similar_to.nil?
-        QueryComponents::BestBets.new(search_params).wrap(search_query_hash)
+        QueryComponents::BestBets.new(search_params).wrap(base_query)
       else
         more_like_this_query_hash
       end
@@ -26,21 +24,6 @@ module QueryComponents
 
       boosted_query = QueryComponents::Booster.new(search_params).wrap(core_query)
       QueryComponents::Popularity.new(search_params).wrap(boosted_query)
-    end
-
-    def search_query_hash
-      {
-        indices: {
-          index: :government,
-          query: {
-            function_score: {
-              query: base_query,
-              boost_factor: GOVERNMENT_BOOST_FACTOR
-            }
-          },
-          no_match_query: base_query
-        }
-      }
     end
 
     def more_like_this_query_hash

--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -7,7 +7,7 @@ class BoosterTest < ShouldaUnitTestCase
     result = builder.wrap({ some: 'query' })
 
     assert_equal :multiply, result[:function_score][:boost_mode]
-    assert_equal "multiply", result[:function_score][:score_mode]
+    assert_equal :multiply, result[:function_score][:score_mode]
   end
 
   should "boost results by format" do


### PR DESCRIPTION
- Simplify unit test of format boosting
- Tiny refactoring of format boost query
- Extract format boosts to config file to make the next change simpler
- **Main change**: Replace government index boost with format boosts:

Remove the search query boost based on index, and replace it with boosts to the individual search formats.

This produces a much simpler Elasticsearch query, because it no longer has to generate one weighted query for the `government` index and a separate unweighted query for everything else.

This should have almost no effect on search results. The only difference will be in the few formats which are shared between `government` and `mainstream`: `edition`, `finder` and `inside-government-link`. However, this just affects 23 mainstream documents and so the overall change will be very small. It didn't have any effect on the search healthcheck results when I tested it locally.

This should make it easier for us to make more changes to format weightings because they won't appear twice in the generated Elasticsearch query.

https://trello.com/c/FhscGKf2/127-refactor-code-where-weightings-are-applied