### PR TITLE
Promote minimum should match to production

### DIFF
--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -57,10 +57,6 @@ module QueryComponents
       }
     end
 
-    def b_variant?
-      @search_params.ab_tests[:search_match_length] == 'B'
-    end
-
     def payload_for_quoted_phrase
       groups = [field_boosts_phrase]
       groups.map { |queries| dis_max_query(queries) }
@@ -70,14 +66,12 @@ module QueryComponents
       if @search_params.enable_id_codes?
         [all_searchable_text_query]
       else
-        b_variant? ? [] : [query_string_query]
+        []
       end
     end
 
     def should_conditions
-      fields = exact_field_boosts + [exact_match_boost, shingle_token_filter_boost]
-      fields = (fields + [query_string_query]) if b_variant?
-      fields
+      exact_field_boosts + [exact_match_boost, shingle_token_filter_boost, query_string_query]
     end
 
     def all_searchable_text_query

--- a/test/unit/search/query_components/core_query_test.rb
+++ b/test/unit/search/query_components/core_query_test.rb
@@ -20,27 +20,13 @@ class CoreQueryTest < ShouldaUnitTestCase
     end
   end
 
-  context "when ab testing minimum should match" do
-    should "use the default value when no variant is passed in" do
+  context "the search query" do
+    should "down-weight results which match fewer words in the search term" do
       builder = QueryComponents::CoreQuery.new(search_query_params)
-
-      query = builder.payload
-      assert_match(/"2<2 3<3 7<50%"/, query[:bool][:must].to_s)
-    end
-
-    should "use variant b when it is passed in" do
-      builder = QueryComponents::CoreQuery.new(search_query_params(ab_tests: { search_match_length: 'B' }))
 
       query = builder.payload
       refute_match(/"2<2 3<3 7<50%"/, query[:bool][:must].to_s)
       assert_match(/"2<2 3<3 7<50%"/, query[:bool][:should].to_s)
-    end
-
-    should "use variant a when it is passed in" do
-      builder = QueryComponents::CoreQuery.new(search_query_params(ab_tests: { search_match_length: 'A' }))
-
-      query = builder.payload
-      assert_match(/"2<2 3<3 7<50%"/, query[:bool][:must].to_s)
     end
   end
 end


### PR DESCRIPTION
The A/B test around making the minimum should match criteria part of the
`should` calculation instead of having it as a `must` criteria has provide to
give better results. This change makes the B criteria live for all users.

https://trello.com/c/YTXRJKUE/130-deploy-minimum-should-match-a-b-test