### PR TITLE
[REVIEW ONLY] Add A/B test of format boosts

### DIFF
--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -19,24 +19,6 @@ class BoosterTest < ShouldaUnitTestCase
     assert_format_boost(result, "smart-answer", 1.5)
   end
 
-  should "boost government index results" do
-    builder = QueryComponents::Booster.new(search_query_params)
-    result = builder.wrap({ some: 'query' })
-
-    assert_format_boost(result, "case_study", 0.4)
-    assert_format_boost(result, "take_part", 0.4)
-    assert_format_boost(result, "worldwide_organisation", 0.4)
-  end
-
-  should "combine government index and individual format weightings" do
-    builder = QueryComponents::Booster.new(search_query_params)
-    result = builder.wrap({ some: 'query' })
-
-    assert_format_boost(result, "minister", 0.68)
-    assert_format_boost(result, "organisation", 1.0)
-    assert_format_boost(result, "topic", 0.6)
-  end
-
   should "not apply a boost to unspecified formats" do
     builder = QueryComponents::Booster.new(search_query_params)
     result = builder.wrap({ some: 'query' })
@@ -57,9 +39,7 @@ class BoosterTest < ShouldaUnitTestCase
     builder = QueryComponents::Booster.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    historic_boost = result[:function_score][:functions].detect { |f| f[:filter][:term][:is_historic] }
-    refute_nil historic_boost, "Could not find boost for 'is_historic'"
-    assert_equal 0.5, historic_boost[:boost_factor]
+    assert_boost_for_field(result, :is_historic, true, 0.5)
   end
 
   should "boost announcements by date" do
@@ -78,20 +58,113 @@ class BoosterTest < ShouldaUnitTestCase
     end
   end
 
+  context "when A/B testing format boosting" do
+    context "when no variant is specified" do
+      should "boost government index results" do
+        builder = QueryComponents::Booster.new(search_query_params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "case_study", 0.4)
+        assert_format_boost(result, "take_part", 0.4)
+        assert_format_boost(result, "worldwide_organisation", 0.4)
+      end
+
+      should "combine government index and individual format weightings" do
+        builder = QueryComponents::Booster.new(search_query_params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "minister", 0.68)
+        assert_format_boost(result, "organisation", 1.0)
+        assert_format_boost(result, "topic", 0.6)
+      end
+
+      should "not boost guidance content" do
+        builder = QueryComponents::Booster.new(search_query_params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_no_boost_for_field(result, :navigation_document_supertype, "guidance")
+      end
+    end
+
+    context "in the A variant" do
+      should "boost government index results" do
+        builder = QueryComponents::Booster.new(search_query_params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "case_study", 0.4)
+        assert_format_boost(result, "take_part", 0.4)
+        assert_format_boost(result, "worldwide_organisation", 0.4)
+      end
+
+      should "combine government index and individual format weightings" do
+        builder = QueryComponents::Booster.new(search_query_params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "minister", 0.68)
+        assert_format_boost(result, "organisation", 1.0)
+        assert_format_boost(result, "topic", 0.6)
+      end
+
+      should "not boost guidance content" do
+        params = search_query_params(ab_tests: { format_boosting: "A" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_no_boost_for_field(result, :navigation_document_supertype, "guidance")
+      end
+    end
+
+    context "in the B variant" do
+      should "not boost government index results" do
+        params = search_query_params(ab_tests: { format_boosting: "B" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_no_format_boost(result, "case_study")
+        assert_no_format_boost(result, "take_part")
+        assert_no_format_boost(result, "worldwide_organisation")
+      end
+
+      should "apply only individual format weightings for government formats" do
+        params = search_query_params(ab_tests: { format_boosting: "B" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "minister", 1.7)
+        assert_format_boost(result, "organisation", 2.5)
+        assert_format_boost(result, "topic", 1.5)
+      end
+
+      should "boost guidance content" do
+        params = search_query_params(ab_tests: { format_boosting: "B" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_boost_for_field(result, :navigation_document_supertype, "guidance", 2.5)
+      end
+    end
+  end
+
   def assert_format_boost(result, content_format, expected_boost_factor)
-    format_boost = result[:function_score][:functions].detect { |f| f[:filter][:term][:format] == content_format }
-    refute_nil format_boost, "Could not find boost for format '#{content_format}'"
-    assert_in_delta expected_boost_factor, format_boost[:boost_factor], 0.001
+    assert_boost_for_field(result, :format, content_format, expected_boost_factor)
   end
 
   def assert_no_format_boost(result, content_format)
-    format_boosts = result[:function_score][:functions].select { |f| f[:filter][:term][:format] == content_format }
-    assert_empty format_boosts, "Found unexpected boost for format #{content_format}"
+    assert_no_boost_for_field(result, :format, content_format)
   end
 
   def assert_organisation_state_boost(result, state, expected_boost_factor)
-    state_boost = result[:function_score][:functions].detect { |f| f[:filter][:term][:organisation_state] == state }
-    refute_nil state_boost, "Could not find boost for organisation state '#{state}'"
-    assert_equal expected_boost_factor, state_boost[:boost_factor]
+    assert_boost_for_field(result, :organisation_state, state, expected_boost_factor)
+  end
+
+  def assert_boost_for_field(result, field, value, expected_boost_factor)
+    boost = result[:function_score][:functions].detect { |f| f[:filter][:term][field] == value }
+    refute_nil boost, "Could not find boost for '#{field}': '#{value}'"
+    assert_in_delta expected_boost_factor, boost[:boost_factor], 0.001
+  end
+
+  def assert_no_boost_for_field(result, field, value)
+    format_boost = result[:function_score][:functions].select { |f| f[:filter][:term][field] == value }
+    assert_empty format_boost, "Found unexpected boost for '#{field}' #{value}"
   end
 end


### PR DESCRIPTION
In the B variant, remove the down-weighting of content with formats used in the government index. Replace it with an up-weighting of guidance content.

The government index down-weighting was originally added when there was a clear split between specialist content int the government index and mainstream content in the mainstream index. This distinction is no longer as clear because new specialist content has been added to the mainstream index.

The B variant uses the `navigation_document_supertype` field to boost guidance content. This should push truly mainstream content (as opposed to content in the `mainstream` index) higher in search results, helping mainstream users find content faster.

A boost of 2.5 was chosen because it is the inverse of the 0.4 boost that is applied to government index formats in the A variant.

https://trello.com/c/TjolBPDX/126-have-new-format-weightings-ready-to-use

Marked as REVIEW ONLY until we've run this against the healthcheck and updated the base branch to master.