### PR TITLE
Add A/B test of format boosts

### DIFF
--- a/config/query/format_boosting.yml
+++ b/config/query/format_boosting.yml
@@ -42,7 +42,6 @@ format_boosts:
   aaib_report: 0.2
   dfid_research_output: 0.2
   hmrc_manual_section: 0.2
-  service_standard_report: 0.2
   # Inside Gov formats
   contact: 0.3
   document_collection: 1.3

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -26,9 +26,9 @@ module QueryComponents
       boosts = format_boosts + [time_boost, closed_org_boost, devolved_org_boost, historic_edition_boost]
 
       if @search_params.format_boosting_b_variant?
-        boosts + [guidance_boost]
+        boosts + [guidance_boost, service_standard_report_boost(0.05)]
       else
-        boosts
+        boosts + [service_standard_report_boost(0.2)]
       end
     end
 
@@ -55,11 +55,21 @@ module QueryComponents
 
     def format_boosts
       boosted_formats.map do |format, boost|
-        {
-          filter: { term: { format: format } },
-          boost_factor: boost
-        }
+        format_boost(format, boost)
       end
+    end
+
+    # TODO: This should be merged with the other format boosts after the format
+    # boosting A/B test is complete
+    def service_standard_report_boost(boost)
+      format_boost("service_standard_report", boost)
+    end
+
+    def format_boost(format, boost)
+      {
+        filter: { term: { format: format } },
+        boost_factor: boost
+      }
     end
 
     def guidance_boost

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -26,7 +26,7 @@ module QueryComponents
       boosts = format_boosts + [time_boost, closed_org_boost, devolved_org_boost, historic_edition_boost]
 
       if @search_params.format_boosting_b_variant?
-        boosts + [guidance_boost, service_standard_report_boost(0.05)]
+        boosts + [guidance_boost, foi_boost, service_standard_report_boost(0.05)]
       else
         boosts + [service_standard_report_boost(0.2)]
       end
@@ -76,6 +76,13 @@ module QueryComponents
       {
         filter: { term: { navigation_document_supertype: "guidance" } },
         boost_factor: 2.5
+      }
+    end
+
+    def foi_boost
+      {
+        filter: { term: { content_store_document_type: "foi_release" } },
+        boost_factor: 0.2
       }
     end
 

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -23,23 +23,33 @@ module QueryComponents
   private
 
     def boost_filters
-      format_boosts + [time_boost, closed_org_boost, devolved_org_boost, historic_edition_boost]
+      boosts = format_boosts + [time_boost, closed_org_boost, devolved_org_boost, historic_edition_boost]
+
+      if @search_params.format_boosting_b_variant?
+        boosts + [guidance_boost]
+      else
+        boosts
+      end
     end
 
     def boosted_formats
-      government_index_config = FORMAT_BOOST_CONFIG["government_index"]
-      government_index_boost = government_index_config["boost"]
-      government_formats = government_index_config["formats"]
-
       individual_format_boosts = FORMAT_BOOST_CONFIG["format_boosts"]
 
-      boosted_formats = (government_formats + individual_format_boosts.keys).uniq
+      if @search_params.format_boosting_b_variant?
+        individual_format_boosts
+      else
+        government_index_config = FORMAT_BOOST_CONFIG["government_index"]
+        government_index_boost = government_index_config["boost"]
+        government_formats = government_index_config["formats"]
 
-      boosted_formats.each_with_object({}) do |format_name, boosts|
-        format_index_boost = government_formats.include?(format_name) ? government_index_boost : DEFAULT_BOOST
-        individual_format_boost = individual_format_boosts.fetch(format_name, DEFAULT_BOOST)
+        boosted_formats = (government_formats + individual_format_boosts.keys).uniq
 
-        boosts[format_name] = format_index_boost * individual_format_boost
+        boosted_formats.each_with_object({}) do |format_name, boosts|
+          format_index_boost = government_formats.include?(format_name) ? government_index_boost : DEFAULT_BOOST
+          individual_format_boost = individual_format_boosts.fetch(format_name, DEFAULT_BOOST)
+
+          boosts[format_name] = format_index_boost * individual_format_boost
+        end
       end
     end
 
@@ -50,6 +60,13 @@ module QueryComponents
           boost_factor: boost
         }
       end
+    end
+
+    def guidance_boost
+      {
+        filter: { term: { navigation_document_supertype: "guidance" } },
+        boost_factor: 2.5
+      }
     end
 
     # An implementation of http://wiki.apache.org/solr/FunctionQuery#recip

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -9,7 +9,7 @@ module Search
     QUOTED_STRING_REGEX = /^\s*"[^"]+"\s*$/
 
     def initialize(params = {})
-      params = { facets: [], filters: {}, debug: {}, return_fields: [] }.merge(params)
+      params = { facets: [], filters: {}, debug: {}, return_fields: [], ab_tests: {} }.merge(params)
       params.each do |k, v|
         public_send("#{k}=", v)
       end
@@ -50,6 +50,10 @@ module Search
 
     def suggest_spelling?
       query && suggest.include?('spelling')
+    end
+
+    def format_boosting_b_variant?
+      ab_tests[:format_boosting] == 'B'
     end
 
   private

--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -87,6 +87,14 @@ class BoosterTest < ShouldaUnitTestCase
 
         assert_no_boost_for_field(result, :navigation_document_supertype, "guidance")
       end
+
+      should "downweight service assessments by small amount" do
+        params = search_query_params(ab_tests: { format_boosting: "A" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "service_standard_report", 0.2)
+      end
     end
 
     context "in the B variant" do
@@ -116,6 +124,14 @@ class BoosterTest < ShouldaUnitTestCase
         result = builder.wrap({ some: 'query' })
 
         assert_boost_for_field(result, :navigation_document_supertype, "guidance", 2.5)
+      end
+
+      should "downweight service assessments by large amount" do
+        params = search_query_params(ab_tests: { format_boosting: "B" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "service_standard_report", 0.05)
       end
     end
   end

--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -19,24 +19,6 @@ class BoosterTest < ShouldaUnitTestCase
     assert_format_boost(result, "smart-answer", 1.5)
   end
 
-  should "boost government index results" do
-    builder = QueryComponents::Booster.new(search_query_params)
-    result = builder.wrap({ some: 'query' })
-
-    assert_format_boost(result, "case_study", 0.4)
-    assert_format_boost(result, "take_part", 0.4)
-    assert_format_boost(result, "worldwide_organisation", 0.4)
-  end
-
-  should "combine government index and individual format weightings" do
-    builder = QueryComponents::Booster.new(search_query_params)
-    result = builder.wrap({ some: 'query' })
-
-    assert_format_boost(result, "minister", 0.68)
-    assert_format_boost(result, "organisation", 1.0)
-    assert_format_boost(result, "topic", 0.6)
-  end
-
   should "not apply a boost to unspecified formats" do
     builder = QueryComponents::Booster.new(search_query_params)
     result = builder.wrap({ some: 'query' })
@@ -57,9 +39,7 @@ class BoosterTest < ShouldaUnitTestCase
     builder = QueryComponents::Booster.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    historic_boost = result[:function_score][:functions].detect { |f| f[:filter][:term][:is_historic] }
-    refute_nil historic_boost, "Could not find boost for 'is_historic'"
-    assert_equal 0.5, historic_boost[:boost_factor]
+    assert_boost_for_field(result, :is_historic, true, 0.5)
   end
 
   should "boost announcements by date" do
@@ -78,20 +58,88 @@ class BoosterTest < ShouldaUnitTestCase
     end
   end
 
+  context "when A/B testing format boosting" do
+    context "in the A variant" do
+      should "boost government index results" do
+        params = search_query_params(ab_tests: { format_boosting: "A" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "case_study", 0.4)
+        assert_format_boost(result, "take_part", 0.4)
+        assert_format_boost(result, "worldwide_organisation", 0.4)
+      end
+
+      should "combine government index and individual format weightings" do
+        params = search_query_params(ab_tests: { format_boosting: "A" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "minister", 0.68)
+        assert_format_boost(result, "organisation", 1.0)
+        assert_format_boost(result, "topic", 0.6)
+      end
+
+      should "not boost guidance content" do
+        params = search_query_params(ab_tests: { format_boosting: "A" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_no_boost_for_field(result, :navigation_document_supertype, "guidance")
+      end
+    end
+
+    context "in the B variant" do
+      should "not boost government index results" do
+        params = search_query_params(ab_tests: { format_boosting: "B" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_no_format_boost(result, "case_study")
+        assert_no_format_boost(result, "take_part")
+        assert_no_format_boost(result, "worldwide_organisation")
+      end
+
+      should "apply only individual format weightings for government formats" do
+        params = search_query_params(ab_tests: { format_boosting: "B" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_format_boost(result, "minister", 1.7)
+        assert_format_boost(result, "organisation", 2.5)
+        assert_format_boost(result, "topic", 1.5)
+      end
+
+      should "boost guidance content" do
+        params = search_query_params(ab_tests: { format_boosting: "B" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_boost_for_field(result, :navigation_document_supertype, "guidance", 2.5)
+      end
+    end
+  end
+
   def assert_format_boost(result, content_format, expected_boost_factor)
-    format_boost = result[:function_score][:functions].detect { |f| f[:filter][:term][:format] == content_format }
-    refute_nil format_boost, "Could not find boost for format '#{content_format}'"
-    assert_in_delta expected_boost_factor, format_boost[:boost_factor], 0.001
+    assert_boost_for_field(result, :format, content_format, expected_boost_factor)
   end
 
   def assert_no_format_boost(result, content_format)
-    format_boosts = result[:function_score][:functions].select { |f| f[:filter][:term][:format] == content_format }
-    assert_empty format_boosts, "Found unexpected boost for format #{content_format}"
+    assert_no_boost_for_field(result, :format, content_format)
   end
 
   def assert_organisation_state_boost(result, state, expected_boost_factor)
-    state_boost = result[:function_score][:functions].detect { |f| f[:filter][:term][:organisation_state] == state }
-    refute_nil state_boost, "Could not find boost for organisation state '#{state}'"
-    assert_equal expected_boost_factor, state_boost[:boost_factor]
+    assert_boost_for_field(result, :organisation_state, state, expected_boost_factor)
+  end
+
+  def assert_boost_for_field(result, field, value, expected_boost_factor)
+    boost = result[:function_score][:functions].detect { |f| f[:filter][:term][field] == value }
+    refute_nil boost, "Could not find boost for '#{field}': '#{value}'"
+    assert_in_delta expected_boost_factor, boost[:boost_factor], 0.001
+  end
+
+  def assert_no_boost_for_field(result, field, value)
+    format_boost = result[:function_score][:functions].select { |f| f[:filter][:term][field] == value }
+    assert_empty format_boost, "Found unexpected boost for '#{field}' #{value}"
   end
 end

--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -95,6 +95,14 @@ class BoosterTest < ShouldaUnitTestCase
 
         assert_format_boost(result, "service_standard_report", 0.2)
       end
+
+      should "not downweight FOI requests" do
+        params = search_query_params(ab_tests: { format_boosting: "A" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_no_boost_for_field(result, :content_store_document_type, "foi_release")
+      end
     end
 
     context "in the B variant" do
@@ -132,6 +140,15 @@ class BoosterTest < ShouldaUnitTestCase
         result = builder.wrap({ some: 'query' })
 
         assert_format_boost(result, "service_standard_report", 0.05)
+      end
+
+
+      should "downweight FOI requests" do
+        params = search_query_params(ab_tests: { format_boosting: "B" })
+        builder = QueryComponents::Booster.new(params)
+        result = builder.wrap({ some: 'query' })
+
+        assert_boost_for_field(result, :content_store_document_type, "foi_release", 0.2)
       end
     end
   end

--- a/test/unit/search/query_parameter_test.rb
+++ b/test/unit/search/query_parameter_test.rb
@@ -76,4 +76,26 @@ class QueryParameterTest < ShouldaUnitTestCase
       assert_equal %{  \t"Enclosing quotes but with "embedded" quotes"  }, params.query
     end
   end
+
+  context "format_boosting_b_variant?" do
+    should "return false if no variant is specified" do
+      params = Search::QueryParameters.new
+      refute params.format_boosting_b_variant?
+    end
+
+    should "return false if unknown variant is specified" do
+      params = Search::QueryParameters.new(ab_tests: { format_boosting: "some_other_variant" })
+      refute params.format_boosting_b_variant?
+    end
+
+    should "return false if A variant is specified" do
+      params = Search::QueryParameters.new(ab_tests: { format_boosting: "A" })
+      refute params.format_boosting_b_variant?
+    end
+
+    should "return true if B variant is specified" do
+      params = Search::QueryParameters.new(ab_tests: { format_boosting: "B" })
+      assert params.format_boosting_b_variant?
+    end
+  end
 end


### PR DESCRIPTION
In the B variant, remove the down-weighting of content with formats used in the government index. Replace it with an up-weighting of guidance content.

The government index down-weighting was originally added when there was a clear split between specialist content int the government index and mainstream content in the mainstream index. This distinction is no longer as clear because new specialist content has been added to the mainstream index.

The B variant uses the `navigation_document_supertype` field to boost guidance content. This should push truly mainstream content (as opposed to content in the `mainstream` index) higher in search results, helping mainstream users find content faster.

A boost of 2.5 was chosen because it is the inverse of the 0.4 boost that is applied to government index formats in the A variant.

https://trello.com/c/TjolBPDX/126-have-new-format-weightings-ready-to-use