### PR TITLE
Use services publishing-api for missing meta data fetcher

### DIFF
--- a/lib/missing_metadata/runner.rb
+++ b/lib/missing_metadata/runner.rb
@@ -10,7 +10,7 @@ module MissingMetadata
     def initialize(missing_field_name, search_config: SearchConfig.new, logger: STDOUT)
       @missing_field_name = missing_field_name
       @search_config = search_config
-      publishing_api = GdsApi::PublishingApiV2.new(Plek.new.find("publishing-api"))
+      publishing_api = Services.publishing_api
       @fetcher = MissingMetadata::Fetcher.new(publishing_api)
       @logger = logger
     end


### PR DESCRIPTION
We were missing the bearer token previously.