### PR TITLE
Add a dummy param for cache busting

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -28,6 +28,9 @@ private
     # up the hash of parsed params.
     @used_params = []
 
+    # Dummy field that can be used to bypass caching when testing/debugging
+    @used_params << "c"
+
     @parsed_params = {
       start: single_integer_param("start", 0),
       count: capped_count,

--- a/test/unit/parameter_parser/search_parameter_parser_test.rb
+++ b/test/unit/parameter_parser/search_parameter_parser_test.rb
@@ -83,6 +83,13 @@ class SearchParameterParserTest < ShouldaUnitTestCase
     assert_equal(expected_params({}), p.parsed_params)
   end
 
+  should "allow the c parameter to be anything" do
+    p = SearchParameterParser.new({ "c" => ["1234567890"] }, @schema)
+
+    assert p.valid?
+    assert_equal(expected_params({}), p.parsed_params)
+  end
+
   should "complain about multiple unknown parameters" do
     p = SearchParameterParser.new({ "p" => ["extra"], "boo" => ["goose"] }, @schema)
 


### PR DESCRIPTION
When testing the API it's sometimes useful to bypass the caching layer.