### PR TITLE
Fix applied aggregate query filter

### DIFF
--- a/lib/search/query_components/aggregates.rb
+++ b/lib/search/query_components/aggregates.rb
@@ -46,18 +46,22 @@ module QueryComponents
       # after applying all filters - ie, just on the documents which will be
       # included in the result set.
       if options[:scope] == :exclude_field_filter
-        aggregates_filter = filters_hash([field_name])
+        applied_query_filters = filters_hash([field_name])
       elsif options[:scope] == :all_filters
-        aggregates_filter = filters_hash([])
+        applied_query_filters = filters_hash([])
       end
 
-      if aggregates_filter && aggregates_filter.count > 0
-        {
-          filter: aggregates_filter,
-          aggs: { 'filtered_aggregations' => query }
-        }
+      {
+        filter: applied_filter(applied_query_filters),
+        aggs: { 'filtered_aggregations' => query }
+      }
+    end
+
+    def applied_filter(applied_query_filters)
+      if applied_query_filters && applied_query_filters.count > 0
+        applied_query_filters
       else
-        query
+        { match_all: {} }
       end
     end
 

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -596,6 +596,19 @@ class SearchTest < IntegrationTest
     assert_equal true, parsed_response.dig("results", 0, "is_withdrawn")
   end
 
+  def test_withdrawn_content_with_flag_with_aggregations
+    commit_document("mainstream_test",
+      title: "I am the result",
+      organisation: "Test Org",
+      description: "This is a test search result",
+      link: "/some-nice-link",
+      is_withdrawn: true
+    )
+
+    get "/search?q=test&debug=include_withdrawn&aggregate_mainstream_browse_pages=2"
+    assert_equal 1, parsed_response.fetch("total")
+  end
+
   def test_show_the_query
     get "/search?q=test&debug=show_query"
 

--- a/test/unit/search/query_components/aggregates_test.rb
+++ b/test/unit/search/query_components/aggregates_test.rb
@@ -21,14 +21,24 @@ class AggregatesTest < ShouldaUnitTestCase
       assert_equal(
         {
           "organisations" => {
-            terms: {
-              field: "organisations",
-              order: { _count: "desc" },
-              size: 100000,
-            },
+            filter: { match_all: {} },
+            aggs: {
+              "filtered_aggregations" => {
+                terms: {
+                  field: "organisations",
+                  order: { _count: "desc" },
+                  size: 100000,
+                }
+              }
+            }
           },
           "organisations_with_missing_value" => {
-            missing: { field: "organisations" }
+            filter: { match_all: {} },
+            aggs: {
+              "filtered_aggregations" => {
+                missing: { field: "organisations" }
+              }
+            }
           },
         },
         result
@@ -50,14 +60,24 @@ class AggregatesTest < ShouldaUnitTestCase
       assert_equal(
         {
           "organisations" => {
-            terms: {
-              field: "organisations",
-              order: { _count: "desc" },
-              size: 100000,
-            },
+            filter: { match_all: {} },
+            aggs: {
+              "filtered_aggregations" => {
+                terms: {
+                  field: "organisations",
+                  order: { _count: "desc" },
+                  size: 100000,
+                }
+              }
+            }
           },
           "organisations_with_missing_value" => {
-            missing: { field: "organisations" }
+            filter: { match_all: {} },
+            aggs: {
+              "filtered_aggregations" => {
+                missing: { field: "organisations" }
+              }
+            }
           },
         },
         @builder.payload)


### PR DESCRIPTION
When there are no filters to be applied from a query we need to filter on `match_all`.

[Trello card](https://trello.com/c/lsUYGUtp/93-change-facets-to-aggregates)