### PR TITLE
Remove duplicate inside-government-link from search results

### DIFF
--- a/lib/duplicate_links_finder.rb
+++ b/lib/duplicate_links_finder.rb
@@ -2,13 +2,11 @@ require_relative "../app"
 
 class DuplicateLinksFinder
   def initialize(elasticsearch_url, indices)
-    @elasticsearch_url = elasticsearch_url
+    @client = Elasticsearch::Client.new(host: elasticsearch_url)
     @indices = indices
   end
 
-  def find
-    client = Elasticsearch::Client.new(host: elasticsearch_url)
-
+  def find_exact_duplicates
     body = {
       "query": {
         "match_all": {}
@@ -31,7 +29,44 @@ class DuplicateLinksFinder
     results["aggregations"]["duplicates"]["buckets"].map { |duplicate| duplicate["key"] }
   end
 
+  # Find items whose link is a full URL which duplicate items whose links are just the path
+  # e.g. `https://www.gov.uk/ministers` and `/ministers`
+  def find_full_url_duplicates(query)
+    results = client.search(index: indices, body: query)
+
+    results['hits']['hits'].select do |item|
+      link = item['_source']['link']
+      if link.start_with?('https://www.gov.uk')
+        result = find_path_duplicate(link)
+
+        if result['hits']['hits'].empty?
+          puts "Skipping #{link} as it has no duplicates"
+          false
+        else
+          puts "Including #{link} for deletion"
+          true
+        end
+      else
+        puts "Skipping #{item['link']} as it does not start with https://www.gov.uk"
+        false
+      end
+    end
+  end
+
 private
 
-  attr_reader :elasticsearch_url, :indices
+  attr_reader :client, :indices
+
+  def find_path_duplicate(link)
+    client.search(
+      index: indices,
+      body: {
+        filter: {
+          term: {
+            link: link.gsub('https://www.gov.uk', '')
+          }
+        }
+      }
+    )
+  end
 end


### PR DESCRIPTION
This removes any duplicate results for the `inside-government-link` format. These now exist as `government edition`.

The rake task will be removed once it has been run in production.

[Trello card](https://trello.com/c/BTGTcDMy/138-delete-leftover-inside-government-link-results-from-search-index)

Paired with @suzannehamilton 