### PR TITLE
Remove search format boosting a/b test code

### DIFF
--- a/config/query/format_boosting.yml
+++ b/config/query/format_boosting.yml
@@ -1,37 +1,3 @@
-government_index:
-  boost: 0.4
-  # Search formats used in the government index. These are defined by the
-  # publishing apps which push pages to the search API, and are different to the
-  # `format` field used in the content store.
-  #
-  # Any new formats used in search should be added to this list. Once all pages
-  # in search have a document_type, the document supertype should be used for
-  # boosting instead of formats, which will remove the need for this list.
-  formats:
-    - case_study
-    - consultation
-    - corporate_information_page
-    - document_collection
-    - edition
-    - fatality_notice
-    - finder
-    - inside-government-link
-    - minister
-    - news_article
-    - operational_field
-    - organisation
-    - person
-    - policy_group
-    - publication
-    - speech
-    - statistical_data_set
-    - statistics_announcement
-    - take_part
-    - topic
-    - topical_event
-    - world_location
-    - world_location_news_article
-    - worldwide_organisation
 format_boosts:
   # Mainstream formats
   service_manual_guide: 0.3
@@ -42,6 +8,7 @@ format_boosts:
   aaib_report: 0.2
   dfid_research_output: 0.2
   hmrc_manual_section: 0.2
+  service_standard_report: 0.05
   # Inside Gov formats
   contact: 0.3
   document_collection: 1.3

--- a/docs/search-api.md
+++ b/docs/search-api.md
@@ -188,7 +188,7 @@ For example:
      order=-public_timestamp&
      filter_organisations[]=cabinet-office&
      filter_organisations[]=driver-vehicle-licensing-agency&
-     filter_section[]=driving
+     filter_section[]=driving&
      facet_organisations=10&
      ab_tests=test1:B,test2:A
 

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -23,53 +23,23 @@ module QueryComponents
   private
 
     def boost_filters
-      boosts = format_boosts + [time_boost, closed_org_boost, devolved_org_boost, historic_edition_boost]
-
-      if @search_params.format_boosting_b_variant?
-        boosts + [guidance_boost, foi_boost, service_standard_report_boost(0.05)]
-      else
-        boosts + [service_standard_report_boost(0.2)]
-      end
-    end
-
-    def boosted_formats
-      individual_format_boosts = FORMAT_BOOST_CONFIG["format_boosts"]
-
-      if @search_params.format_boosting_b_variant?
-        individual_format_boosts
-      else
-        government_index_config = FORMAT_BOOST_CONFIG["government_index"]
-        government_index_boost = government_index_config["boost"]
-        government_formats = government_index_config["formats"]
-
-        boosted_formats = (government_formats + individual_format_boosts.keys).uniq
-
-        boosted_formats.each_with_object({}) do |format_name, boosts|
-          format_index_boost = government_formats.include?(format_name) ? government_index_boost : DEFAULT_BOOST
-          individual_format_boost = individual_format_boosts.fetch(format_name, DEFAULT_BOOST)
-
-          boosts[format_name] = format_index_boost * individual_format_boost
-        end
-      end
+      format_boosts + [
+        time_boost,
+        closed_org_boost,
+        devolved_org_boost,
+        historic_edition_boost,
+        guidance_boost,
+        foi_boost,
+      ]
     end
 
     def format_boosts
-      boosted_formats.map do |format, boost|
-        format_boost(format, boost)
+      FORMAT_BOOST_CONFIG["format_boosts"].map do |format, boost|
+        {
+          filter: { term: { format: format } },
+          boost_factor: boost
+        }
       end
-    end
-
-    # TODO: This should be merged with the other format boosts after the format
-    # boosting A/B test is complete
-    def service_standard_report_boost(boost)
-      format_boost("service_standard_report", boost)
-    end
-
-    def format_boost(format, boost)
-      {
-        filter: { term: { format: format } },
-        boost_factor: boost
-      }
     end
 
     def guidance_boost

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -52,10 +52,6 @@ module Search
       query && suggest.include?('spelling')
     end
 
-    def format_boosting_b_variant?
-      ab_tests[:format_boosting] == 'B'
-    end
-
   private
 
     def determine_if_quoted_phrase

--- a/test/unit/search/query_components/booster_test.rb
+++ b/test/unit/search/query_components/booster_test.rb
@@ -58,99 +58,43 @@ class BoosterTest < ShouldaUnitTestCase
     end
   end
 
-  context "when A/B testing format boosting" do
-    context "in the A variant" do
-      should "boost government index results" do
-        params = search_query_params(ab_tests: { format_boosting: "A" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
+  should "not boost government index results" do
+    builder = QueryComponents::Booster.new(search_query_params)
+    result = builder.wrap({ some: 'query' })
 
-        assert_format_boost(result, "case_study", 0.4)
-        assert_format_boost(result, "take_part", 0.4)
-        assert_format_boost(result, "worldwide_organisation", 0.4)
-      end
+    assert_no_format_boost(result, "case_study")
+    assert_no_format_boost(result, "take_part")
+    assert_no_format_boost(result, "worldwide_organisation")
+  end
 
-      should "combine government index and individual format weightings" do
-        params = search_query_params(ab_tests: { format_boosting: "A" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
+  should "apply only individual format weightings for government formats" do
+    builder = QueryComponents::Booster.new(search_query_params)
+    result = builder.wrap({ some: 'query' })
 
-        assert_format_boost(result, "minister", 0.68)
-        assert_format_boost(result, "organisation", 1.0)
-        assert_format_boost(result, "topic", 0.6)
-      end
+    assert_format_boost(result, "minister", 1.7)
+    assert_format_boost(result, "organisation", 2.5)
+    assert_format_boost(result, "topic", 1.5)
+  end
 
-      should "not boost guidance content" do
-        params = search_query_params(ab_tests: { format_boosting: "A" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
+  should "boost guidance content" do
+    builder = QueryComponents::Booster.new(search_query_params)
+    result = builder.wrap({ some: 'query' })
 
-        assert_no_boost_for_field(result, :navigation_document_supertype, "guidance")
-      end
+    assert_boost_for_field(result, :navigation_document_supertype, "guidance", 2.5)
+  end
 
-      should "downweight service assessments by small amount" do
-        params = search_query_params(ab_tests: { format_boosting: "A" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
+  should "downweight service assessments by large amount" do
+    builder = QueryComponents::Booster.new(search_query_params)
+    result = builder.wrap({ some: 'query' })
 
-        assert_format_boost(result, "service_standard_report", 0.2)
-      end
+    assert_format_boost(result, "service_standard_report", 0.05)
+  end
 
-      should "not downweight FOI requests" do
-        params = search_query_params(ab_tests: { format_boosting: "A" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
+  should "downweight FOI requests" do
+    builder = QueryComponents::Booster.new(search_query_params)
+    result = builder.wrap({ some: 'query' })
 
-        assert_no_boost_for_field(result, :content_store_document_type, "foi_release")
-      end
-    end
-
-    context "in the B variant" do
-      should "not boost government index results" do
-        params = search_query_params(ab_tests: { format_boosting: "B" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
-
-        assert_no_format_boost(result, "case_study")
-        assert_no_format_boost(result, "take_part")
-        assert_no_format_boost(result, "worldwide_organisation")
-      end
-
-      should "apply only individual format weightings for government formats" do
-        params = search_query_params(ab_tests: { format_boosting: "B" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
-
-        assert_format_boost(result, "minister", 1.7)
-        assert_format_boost(result, "organisation", 2.5)
-        assert_format_boost(result, "topic", 1.5)
-      end
-
-      should "boost guidance content" do
-        params = search_query_params(ab_tests: { format_boosting: "B" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
-
-        assert_boost_for_field(result, :navigation_document_supertype, "guidance", 2.5)
-      end
-
-      should "downweight service assessments by large amount" do
-        params = search_query_params(ab_tests: { format_boosting: "B" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
-
-        assert_format_boost(result, "service_standard_report", 0.05)
-      end
-
-
-      should "downweight FOI requests" do
-        params = search_query_params(ab_tests: { format_boosting: "B" })
-        builder = QueryComponents::Booster.new(params)
-        result = builder.wrap({ some: 'query' })
-
-        assert_boost_for_field(result, :content_store_document_type, "foi_release", 0.2)
-      end
-    end
+    assert_boost_for_field(result, :content_store_document_type, "foi_release", 0.2)
   end
 
   def assert_format_boost(result, content_format, expected_boost_factor)

--- a/test/unit/search/query_parameter_test.rb
+++ b/test/unit/search/query_parameter_test.rb
@@ -76,26 +76,4 @@ class QueryParameterTest < ShouldaUnitTestCase
       assert_equal %{  \t"Enclosing quotes but with "embedded" quotes"  }, params.query
     end
   end
-
-  context "format_boosting_b_variant?" do
-    should "return false if no variant is specified" do
-      params = Search::QueryParameters.new
-      refute params.format_boosting_b_variant?
-    end
-
-    should "return false if unknown variant is specified" do
-      params = Search::QueryParameters.new(ab_tests: { format_boosting: "some_other_variant" })
-      refute params.format_boosting_b_variant?
-    end
-
-    should "return false if A variant is specified" do
-      params = Search::QueryParameters.new(ab_tests: { format_boosting: "A" })
-      refute params.format_boosting_b_variant?
-    end
-
-    should "return true if B variant is specified" do
-      params = Search::QueryParameters.new(ab_tests: { format_boosting: "B" })
-      assert params.format_boosting_b_variant?
-    end
-  end
 end


### PR DESCRIPTION
The test has reached statistical significance, so it can be removed. The version that is being kept was the b variant which boosts guidance content rather than non government index content and reduces the boost for service standard report.

Also fix missing ampersand in README docs.

[Trello card](https://trello.com/c/Z5KURpnB/147-deploy-format-boosting-%F0%9F%9A%80)

paired with @brenetic 