### PR TITLE
Remove inside-government-link duplicate remover rake task

### DIFF
--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -66,29 +66,4 @@ namespace :delete do
       end
     end
   end
-
-  desc "Delete duplicate inside-government-link results"
-  task :duplicate_inside_government_links do
-    require 'duplicate_links_finder'
-    require "indexer/workers/delete_worker"
-    elasticsearch_url = SearchConfig.new.elasticsearch['base_uri']
-
-    params = {
-      filter: {
-        term: {
-          format: "inside-government-link"
-        }
-      },
-      size: 10_000
-    }
-
-    duplicates = DuplicateLinksFinder.new(elasticsearch_url, CONTENT_SEARCH_INDICES)
-      .find_full_url_duplicates(params)
-
-    duplicates.each do |item|
-      puts "Deleting #{item['_source']['link']}"
-      index = SearchIndices::Index.strip_alias_from_index_name(item['_index'])
-      Indexer::DeleteWorker.perform_async(index, item['_type'], item['_id'])
-    end
-  end
 end


### PR DESCRIPTION
This has now been run in prod.

[Trello card](https://trello.com/c/BTGTcDMy/138-delete-leftover-inside-government-link-results-from-search-index)