### PR TITLE
Return 400 response when invalid ElasticSearch query

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -90,6 +90,10 @@ class Rummager < Sinatra::Application
     halt(500, env['sinatra.error'].message)
   end
 
+  error Search::Query::Error do
+    halt(400, env['sinatra.error'].message)
+  end
+
   # Return results for the GOV.UK site search
   #
   # For details, see docs/search-api.md

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -699,6 +699,21 @@ class SearchTest < IntegrationTest
     assert_equal 1, parsed_response.fetch("total")
   end
 
+  def test_return_400_response_for_integers_out_of_range
+    get '/search.json?count=50&start=7599999900'
+
+    assert last_response.bad_request?
+    assert_equal('Integer value of 7599999900 exceeds maximum allowed', last_response.body)
+  end
+
+  def test_return_400_response_for_query_term_length_too_long
+    terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
+    get "/search.json?q=#{terms}"
+
+    assert last_response.bad_request?
+    assert_equal('Query must be less than 1024 words', last_response.body)
+  end
+
 private
 
   def first_result


### PR DESCRIPTION
We are catching error responses from elasticsearch instead of validating the
value before they are passed in. This has the advantage of catching all errors
for the types we are interested in and ensuring we don't block requests which
would be valid.

https://trello.com/c/C6WRzJGx/139-early-validation-of-rummager-fields