### PR TITLE
Remove _type and _id from the document hash

### DIFF
--- a/lib/indexer/bulk_payload_generator.rb
+++ b/lib/indexer/bulk_payload_generator.rb
@@ -70,7 +70,6 @@ module Indexer
       popularities = lookup_popularities(links.compact)
       actions.flat_map { |command_hash, doc_hash|
         if command_hash.keys == ["index"]
-          doc_hash["_type"] = command_hash["index"]["_type"]
           [
             command_hash,
             index_doc(doc_hash, popularities),

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -18,6 +18,11 @@ module Indexer
       end
 
       doc_hash = prepare_if_best_bet(doc_hash)
+
+      # These fields should be part of the action hash, not the document hash.
+      doc_hash.delete('_type')
+      doc_hash.delete('_id')
+
       doc_hash
     end
 

--- a/test/integration/duplicate_deleter_test.rb
+++ b/test/integration/duplicate_deleter_test.rb
@@ -5,9 +5,11 @@ class DuplicateDeleterTest < IntegrationTest
   def test_can_not_delete_when_only_a_single_document
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "edition",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "edition",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
@@ -19,15 +21,20 @@ class DuplicateDeleterTest < IntegrationTest
   def test_can_delete_duplicate_documents_on_different_types
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "edition",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "edition",
     )
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "cma_case",
+
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "cma_case",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
@@ -40,15 +47,19 @@ class DuplicateDeleterTest < IntegrationTest
   def test_cant_delete_a_type_that_doesnt_exist
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "edition",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "edition",
     )
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "cma_case",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "cma_case",
     )
 
     DuplicateDeleter.new('ab_case', io, search_config: stubbed_search_config).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
@@ -61,15 +72,19 @@ class DuplicateDeleterTest < IntegrationTest
   def test_cant_delete_duplicate_content_ids_when_id_doesnt_match
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/not-an-example-page",
-      "_type" => "edition",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/not-an-example-page",
+      },
+      type: "edition",
     )
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "cma_case",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "cma_case",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
@@ -82,17 +97,21 @@ class DuplicateDeleterTest < IntegrationTest
   def test_can_delete_duplicate_content_ids_when_contact_id_is_wrong
     commit_document(
       "mainstream_test",
-      "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
-      "link" => "/contact-page",
-      "_type" => "contact",
-      "_id" => "contact-page",
+      {
+        "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
+        "link" => "/contact-page",
+        "_id" => "contact-page",
+      },
+      type: "contact",
     )
     commit_document(
       "mainstream_test",
-      "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
-      "link" => "/contact-page",
-      "_type" => "edition",
-      "_id" => "/contact-page",
+      {
+        "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
+        "link" => "/contact-page",
+        "_id" => "/contact-page",
+      },
+      type: "edition",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["e3eaa461-3a85-4881-b412-9c58e7ea4ebd"])
@@ -105,15 +124,19 @@ class DuplicateDeleterTest < IntegrationTest
   def test_can_delete_duplicate_documents_on_different_types_using_link
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "edition",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "edition",
     )
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "cma_case",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "cma_case",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["/an-example-page"], id_type: "link")
@@ -126,15 +149,19 @@ class DuplicateDeleterTest < IntegrationTest
   def test_cant_delete_duplicate_documents_using_link_with_different_content_ids
     commit_document(
       "mainstream_test",
-      "content_id" => "aaaaaaaa-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "edition",
+      {
+        "content_id" => "aaaaaaaa-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "edition",
     )
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "cma_case",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "cma_case",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["/an-example-page"], id_type: "link")
@@ -147,14 +174,16 @@ class DuplicateDeleterTest < IntegrationTest
   def test_can_delete_duplicate_documents_if_bad_item_has_nil_content_id
     commit_document(
       "mainstream_test",
-      "link" => "/an-example-page",
-      "_type" => "edition",
+      { "link" => "/an-example-page" },
+      type: "edition",
     )
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "cma_case",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "cma_case",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["/an-example-page"], id_type: "link")
@@ -167,14 +196,16 @@ class DuplicateDeleterTest < IntegrationTest
   def test_cant_delete_duplicate_documents_if_good_item_has_nil_content_id
     commit_document(
       "mainstream_test",
-      "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
-      "link" => "/an-example-page",
-      "_type" => "edition",
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => "/an-example-page",
+      },
+      type: "edition",
     )
     commit_document(
       "mainstream_test",
-      "link" => "/an-example-page",
-      "_type" => "cma_case",
+      { "link" => "/an-example-page" },
+      type: "cma_case",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["/an-example-page"], id_type: "link")
@@ -187,13 +218,13 @@ class DuplicateDeleterTest < IntegrationTest
   def test_can_delete_duplicate_documents_on_different_types_using_link_when_both_content_ids_are_missing
     commit_document(
       "mainstream_test",
-      "link" => "/an-example-page",
-      "_type" => "edition",
+      { "link" => "/an-example-page" },
+      type: "edition",
     )
     commit_document(
       "mainstream_test",
-      "link" => "/an-example-page",
-      "_type" => "cma_case",
+      { "link" => "/an-example-page" },
+      type: "cma_case",
     )
 
     DuplicateDeleter.new('edition', io, search_config: stubbed_search_config).call(["/an-example-page"], id_type: "link")

--- a/test/integration/duplicate_deleter_test.rb
+++ b/test/integration/duplicate_deleter_test.rb
@@ -100,8 +100,8 @@ class DuplicateDeleterTest < IntegrationTest
       {
         "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
         "link" => "/contact-page",
-        "_id" => "contact-page",
       },
+      id: "contact-page",
       type: "contact",
     )
     commit_document(
@@ -109,8 +109,8 @@ class DuplicateDeleterTest < IntegrationTest
       {
         "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
         "link" => "/contact-page",
-        "_id" => "/contact-page",
       },
+      id: "/contact-page",
       type: "edition",
     )
 

--- a/test/integration/indexer/amendment_test.rb
+++ b/test/integration/indexer/amendment_test.rb
@@ -23,10 +23,9 @@ class ElasticsearchAmendmentTest < IntegrationTest
 
   def test_should_amend_a_document_from_non_edition_docs
     commit_document("mainstream_test", {
-      "_type" => "aaib_report",
       "title" => "The old title",
       "link" => "/an-example-answer",
-    })
+    }, type: "aaib_report")
 
     post "/documents/%2Fan-example-answer", "title=A+new+title"
 

--- a/test/integration/indexer/amendment_test.rb
+++ b/test/integration/indexer/amendment_test.rb
@@ -32,7 +32,6 @@ class ElasticsearchAmendmentTest < IntegrationTest
     assert_document_is_in_rummager({
       "title" => "A new title",
       "link" => "/an-example-answer",
-      "_type" => "aaib_report",
     }, type: "aaib_report")
   end
 

--- a/test/integration/indexer/amendment_test.rb
+++ b/test/integration/indexer/amendment_test.rb
@@ -18,7 +18,7 @@ class ElasticsearchAmendmentTest < IntegrationTest
     assert_document_is_in_rummager({
       "title" => "A new title",
       "link" => "/an-example-answer",
-    })
+    }, type: "edition")
   end
 
   def test_should_amend_a_document_from_non_edition_docs
@@ -32,21 +32,8 @@ class ElasticsearchAmendmentTest < IntegrationTest
     assert_document_is_in_rummager({
       "title" => "A new title",
       "link" => "/an-example-answer",
-    })
-  end
-
-  def test_should_preserve_meta_fields
-    commit_document("mainstream_test", {
-      "title" => "The old title",
-      "link" => "/an-example-answer",
+      "_type" => "aaib_report",
     }, type: "aaib_report")
-
-    post "/documents/%2Fan-example-answer", "title=A+new+title"
-
-    retrieved = fetch_raw_document_from_rummager(id: "/an-example-answer")
-
-    assert_equal "aaib_report", retrieved["_type"]
-    assert_equal "aaib_report", retrieved["_source"]["_type"]
   end
 
   def test_should_amend_a_document_queued

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -36,7 +36,6 @@ class ElasticsearchIndexingTest < IntegrationTest
     }.to_json
 
     assert_document_is_in_rummager({
-      "_type" => "manual",
       "content_id" => "6b965b82-2e33-4587-a70c-60204cbb3e29",
       "title" => "TITLE",
       "format" => "answer",
@@ -62,7 +61,6 @@ class ElasticsearchIndexingTest < IntegrationTest
     }.to_json
 
     assert_document_is_in_rummager({
-      "_type" => "edition",
       "content_id" => "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
       "link" => "/an-example-answer",
     }, type: "edition")

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -47,7 +47,7 @@ class ElasticsearchIndexingTest < IntegrationTest
       "government_document_supertype" => "other",
       "licence_identifier" => "1201-5-1",
       "licence_short_description" => "A short description of a licence",
-    })
+    }, type: "manual")
   end
 
   def test_document_type_defaults_to_edition
@@ -65,7 +65,7 @@ class ElasticsearchIndexingTest < IntegrationTest
       "_type" => "edition",
       "content_id" => "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
       "link" => "/an-example-answer",
-    })
+    }, type: "edition")
   end
 
   def test_tagging_organisations_to_self

--- a/test/integration/missing_metadata_test.rb
+++ b/test/integration/missing_metadata_test.rb
@@ -7,7 +7,6 @@ class MissingMetadataTest < IntegrationTest
     commit_document(
       'mainstream_test',
       'link' => '/path/to_page',
-      '_type' => 'edition',
     )
 
     runner = MissingMetadata::Runner.new('content_id', search_config: stubbed_search_config, logger: io)
@@ -21,7 +20,6 @@ class MissingMetadataTest < IntegrationTest
       'mainstream_test',
       'link' => '/path/to_page',
       'content_id' => '8aea1742-9cc6-4dfb-a63b-12c3e66a601f',
-      '_type' => 'edition',
     )
 
     runner = MissingMetadata::Runner.new('content_id', search_config: stubbed_search_config, logger: io)
@@ -35,7 +33,6 @@ class MissingMetadataTest < IntegrationTest
       'mainstream_test',
       'link' => '/path/to_page',
       'content_id' => '8aea1742-9cc6-4dfb-a63b-12c3e66a601f',
-      '_type' => 'edition',
     )
 
     runner = MissingMetadata::Runner.new('content_store_document_type', search_config: stubbed_search_config, logger: io)
@@ -50,7 +47,6 @@ class MissingMetadataTest < IntegrationTest
       'link' => '/path/to_page',
       'content_id' => '8aea1742-9cc6-4dfb-a63b-12c3e66a601f',
       'content_store_document_type' => 'guide',
-      '_type' => 'edition',
     )
 
     runner = MissingMetadata::Runner.new('content_store_document_type', search_config: stubbed_search_config, logger: io)

--- a/test/integration/search/best_bets_test.rb
+++ b/test/integration/search/best_bets_test.rb
@@ -3,13 +3,13 @@ require "integration_test_helper"
 class BestBetsTest < IntegrationTest
   def test_exact_best_bet
     commit_document("mainstream_test",
-      link: '/an-organic-result',
-      indexable_content: 'I will turn up in searches for "a forced best bet"',
+      "link" => '/an-organic-result',
+      "indexable_content" => 'I will turn up in searches for "a forced best bet"',
     )
 
     commit_document("mainstream_test",
-      link: '/the-link-that-should-surface',
-      indexable_content: 'Empty.',
+      "link" => '/the-link-that-should-surface',
+      "indexable_content" => 'Empty.',
     )
 
     add_best_bet(
@@ -26,8 +26,8 @@ class BestBetsTest < IntegrationTest
 
   def test_exact_worst_bet
     commit_document("mainstream_test",
-      indexable_content: 'I should not be shown.',
-      link: '/we-never-show-this',
+      "indexable_content" => 'I should not be shown.',
+      "link" => '/we-never-show-this',
     )
 
     add_worst_bet(
@@ -44,7 +44,7 @@ class BestBetsTest < IntegrationTest
 
   def test_stemmed_best_bet
     commit_document("mainstream_test",
-      link: '/the-link-that-should-surface',
+      "link" => '/the-link-that-should-surface',
     )
 
     add_best_bet(
@@ -61,7 +61,7 @@ class BestBetsTest < IntegrationTest
 
   def test_stemmed_best_bet_variant
     commit_document("mainstream_test",
-      link: '/the-link-that-should-surface',
+      "link" => '/the-link-that-should-surface',
     )
 
     add_best_bet(
@@ -79,7 +79,7 @@ class BestBetsTest < IntegrationTest
 
   def test_stemmed_best_bet_words_not_in_phrase_order
     commit_document("mainstream_test",
-      link: '/only-shown-for-exact-matches',
+      "link" => '/only-shown-for-exact-matches',
     )
 
     add_best_bet(

--- a/test/integration/search/booster_test.rb
+++ b/test/integration/search/booster_test.rb
@@ -3,20 +3,20 @@ require "integration_test_helper"
 class BoosterTest < IntegrationTest
   def test_service_manual_formats_are_weighted_down
     commit_document("mainstream_test",
-      title: "Agile is good",
-      link: "/agile-is-good",
-      format: "service_manual_guide",
+      "title" => "Agile is good",
+      "link" => "/agile-is-good",
+      "format" => "service_manual_guide",
     )
 
     commit_document("mainstream_test",
-      title: "Being agile is good",
-      link: "/being-agile-is-good",
-      format: "service_manual_topic",
+      "title" => "Being agile is good",
+      "link" => "/being-agile-is-good",
+      "format" => "service_manual_topic",
     )
 
     commit_document("mainstream_test",
-      title: "Can we be agile?",
-      link: "/can-we-be-agile",
+      "title" => "Can we be agile?",
+      "link" => "/can-we-be-agile",
     )
 
     get "/search?q=agile"

--- a/test/integration/search/expands_values_from_schema_test.rb
+++ b/test/integration/search/expands_values_from_schema_test.rb
@@ -5,8 +5,7 @@ class ExpandsValuesFromSchemaTest < IntegrationTest
     commit_document("mainstream_test", {
       "link" => "/cma-cases/sample-cma-case",
       "case_type" => "mergers",
-      "_type" => "cma_case",
-    })
+    }, type: "cma_case")
 
     get "/search?filter_document_type=cma_case&fields=case_type,description,title"
     first_result = parsed_response["results"].first

--- a/test/integration/search/quoted_and_unquoted_searches_test.rb
+++ b/test/integration/search/quoted_and_unquoted_searches_test.rb
@@ -124,49 +124,49 @@ private
 
   def commit_london_transport_docs
     commit_document("mainstream_test",
-      title: "This is about London and its environs",
-      indexable_content: 'London is a world-class city with a modern transport infrastucture',
-      link: "/london-and-environs",
+      "title" => "This is about London and its environs",
+      "indexable_content" => 'London is a world-class city with a modern transport infrastucture',
+      "link" => "/london-and-environs",
       )
 
     commit_document("mainstream_test",
-      title: "This is about the transport in Britain",
-      indexable_content: 'Britain has a developed transport infrastructure, especially in London',
-      link: "/transport-in-britain",
+      "title" => "This is about the transport in Britain",
+      "indexable_content" => 'Britain has a developed transport infrastructure, especially in London',
+      "link" => "/transport-in-britain",
       )
 
     commit_document("mainstream_test",
-      title: "Transport for London formerly known as London Transport",
-      indexable_content: 'Transport for London used to be known as London Transport',
-      link: "/transport-for-london",
+      "title" => "Transport for London formerly known as London Transport",
+      "indexable_content" => 'Transport for London used to be known as London Transport',
+      "link" => "/transport-for-london",
       )
   end
 
   def commit_synonym_documents
     commit_document("mainstream_test",
-      title: "Driving abroad",
-      indexable_content: 'Driving abroad can be tricky.  For a start, they drive on the wrong side of the road',
-      link: "/driving-abroad",
+      "title" => "Driving abroad",
+      "indexable_content" => 'Driving abroad can be tricky.  For a start, they drive on the wrong side of the road',
+      "link" => "/driving-abroad",
       )
 
     commit_document("mainstream_test",
-      title: "Driving overseas",
-      indexable_content: 'Driving overseas can be tricky.  For a start, they drive on the wrong side of the road',
-      link: "/driving-overseas",
+      "title" => "Driving overseas",
+      "indexable_content" => 'Driving overseas can be tricky.  For a start, they drive on the wrong side of the road',
+      "link" => "/driving-overseas",
       )
   end
 
   def commit_stemming_documents
     commit_document("mainstream_test",
-      title: "Dog ownership",
-      indexable_content: 'Owning a dog is a lifelong commitment',
-      link: "/dog-ownership",
+      "title" => "Dog ownership",
+      "indexable_content" => 'Owning a dog is a lifelong commitment',
+      "link" => "/dog-ownership",
       )
 
     commit_document("mainstream_test",
-      title: "Problem Dogs",
-      indexable_content: 'Dogs which attack people can be put down and the owner prosecuted',
-      link: "/problem_dogs",
+      "title" => "Problem Dogs",
+      "indexable_content" => 'Dogs which attack people can be put down and the owner prosecuted',
+      "link" => "/problem_dogs",
       )
   end
 end

--- a/test/integration/search/results_with_highlighting_test.rb
+++ b/test/integration/search/results_with_highlighting_test.rb
@@ -3,8 +3,8 @@ require "integration_test_helper"
 class ResultsWithHighlightingTest < IntegrationTest
   def test_returns_highlighted_title
     commit_document("mainstream_test",
-      title: "I am the result",
-      link: "/some-nice-link",
+      "title" => "I am the result",
+      "link" => "/some-nice-link",
     )
 
     get "/search?q=result&fields[]=title_with_highlighting"
@@ -16,9 +16,9 @@ class ResultsWithHighlightingTest < IntegrationTest
 
   def test_returns_highlighted_title_fallback
     commit_document("mainstream_test",
-      title: "Thing without",
-      description: "I am the result",
-      link: "/some-nice-link",
+      "title" => "Thing without",
+      "description" => "I am the result",
+      "link" => "/some-nice-link",
     )
 
     get "/search?q=result&fields[]=title_with_highlighting"
@@ -30,8 +30,8 @@ class ResultsWithHighlightingTest < IntegrationTest
 
   def test_returns_highlighted_description
     commit_document("mainstream_test",
-      link: "/some-nice-link",
-      description: "This is a test search result of many results."
+      "link" => "/some-nice-link",
+      "description" => "This is a test search result of many results."
     )
 
     get "/search?q=result&fields[]=description_with_highlighting"
@@ -43,9 +43,9 @@ class ResultsWithHighlightingTest < IntegrationTest
 
   def test_returns_documents_html_escaped
     commit_document("mainstream_test",
-      title: "Escape & highlight my title",
-      link: "/some-nice-link",
-      description: "Escape & highlight the description as well."
+      "title" => "Escape & highlight my title",
+      "link" => "/some-nice-link",
+      "description" => "Escape & highlight the description as well."
     )
 
     get "/search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
@@ -58,8 +58,8 @@ class ResultsWithHighlightingTest < IntegrationTest
 
   def test_returns_truncated_correctly_where_result_at_start_of_description
     commit_document("mainstream_test",
-      link: "/some-nice-link",
-      description: "word " + ("something " * 200)
+      "link" => "/some-nice-link",
+      "description" => "word " + ("something " * 200)
     )
 
     get "/search?q=word&fields[]=description_with_highlighting"
@@ -71,8 +71,8 @@ class ResultsWithHighlightingTest < IntegrationTest
 
   def test_returns_truncated_correctly_where_result_at_end_of_description
     commit_document("mainstream_test",
-      link: "/some-nice-link",
-      description: ("something " * 200) + " word"
+      "link" => "/some-nice-link",
+      "description" => ("something " * 200) + " word"
     )
 
     get "/search?q=word&fields[]=description_with_highlighting"
@@ -84,8 +84,8 @@ class ResultsWithHighlightingTest < IntegrationTest
 
   def test_returns_truncated_correctly_where_result_in_middle_of_description
     commit_document("mainstream_test",
-      link: "/some-nice-link",
-      description: ("something " * 200) + " word " + ("something " * 200)
+      "link" => "/some-nice-link",
+      "description" => ("something " * 200) + " word " + ("something " * 200)
     )
 
     get "/search?q=word&fields[]=description_with_highlighting"

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -13,9 +13,9 @@ class SearchTest < IntegrationTest
 
     commit_document(
       "mainstream_test",
-      title: "Get P45, P60 and other forms for your employees",
-      description: "Get PAYE forms from HMRC including P45, P60, starter checklist (which replaced the P46), P11D(b)",
-      link: "/get-paye-forms-p45-p60"
+      "title" => "Get P45, P60 and other forms for your employees",
+      "description" => "Get PAYE forms from HMRC including P45, P60, starter checklist (which replaced the P46), P11D(b)",
+      "link" => "/get-paye-forms-p45-p60"
 
     )
 
@@ -30,9 +30,9 @@ class SearchTest < IntegrationTest
 
   def test_spell_checking_with_typo
     commit_document("mainstream_test",
-      title: "I am the result",
-      description: "This is a test search result",
-      link: "/some-nice-link"
+      "title" => "I am the result",
+      "description" => "This is a test search result",
+      "link" => "/some-nice-link"
     )
 
     get "/search?q=serch&suggest=spelling"
@@ -42,9 +42,9 @@ class SearchTest < IntegrationTest
 
   def test_spell_checking_with_blacklisted_typo
     commit_document("mainstream_test",
-      title: "Brexitt",
-      description: "Brexitt",
-      link: "/brexitt")
+      "title" => "Brexitt",
+      "description" => "Brexitt",
+      "link" => "/brexitt")
 
     get "/search?q=brexit&suggest=spelling"
 
@@ -409,16 +409,16 @@ class SearchTest < IntegrationTest
 
   def test_expandinging_of_organisations
     commit_document("mainstream_test",
-      title: 'Advice on Treatment of Dragons',
-      link: '/dragon-guide',
-      organisations: ['/ministry-of-magic']
+      "title" => 'Advice on Treatment of Dragons',
+      "link" => '/dragon-guide',
+      "organisations" => ['/ministry-of-magic']
     )
 
     commit_document("government_test",
-      slug: '/ministry-of-magic',
-      title: 'Ministry of Magic',
-      link: '/ministry-of-magic-site',
-      format: 'organisation'
+      "slug" => '/ministry-of-magic',
+      "title" => 'Ministry of Magic',
+      "link" => '/ministry-of-magic-site',
+      "format" => 'organisation'
     )
 
     get "/search.json?q=dragons"
@@ -432,18 +432,18 @@ class SearchTest < IntegrationTest
   def test_expandinging_of_organisations_via_content_id
     commit_document(
       "mainstream_test",
-      title: 'Advice on Treatment of Dragons',
-      link: '/dragon-guide',
-      organisation_content_ids: ['organisation-content-id']
+      "title" => 'Advice on Treatment of Dragons',
+      "link" => '/dragon-guide',
+      "organisation_content_ids" => ['organisation-content-id']
     )
 
     commit_document(
       "government_test",
-      content_id: 'organisation-content-id',
-      slug: '/ministry-of-magic',
-      title: 'Ministry of Magic',
-      link: '/ministry-of-magic-site',
-      format: 'organisation'
+      "content_id" => 'organisation-content-id',
+      "slug" => '/ministry-of-magic',
+      "title" => 'Ministry of Magic',
+      "link" => '/ministry-of-magic-site',
+      "format" => 'organisation'
     )
 
     get "/search.json?q=dragons"
@@ -471,18 +471,18 @@ class SearchTest < IntegrationTest
   def test_search_for_expanded_organisations_works
     commit_document(
       "mainstream_test",
-      title: 'Advice on Treatment of Dragons',
-      link: '/dragon-guide',
-      organisation_content_ids: ['organisation-content-id']
+      "title" => 'Advice on Treatment of Dragons',
+      "link" => '/dragon-guide',
+      "organisation_content_ids" => ['organisation-content-id']
     )
 
     commit_document(
       "government_test",
-      content_id: 'organisation-content-id',
-      slug: '/ministry-of-magic',
-      title: 'Ministry of Magic',
-      link: '/ministry-of-magic-site',
-      format: 'organisation'
+      "content_id" => 'organisation-content-id',
+      "slug" => '/ministry-of-magic',
+      "title" => 'Ministry of Magic',
+      "link" => '/ministry-of-magic-site',
+      "format" => 'organisation'
     )
 
     get "/search.json?q=dragons&fields[]=expanded_organisations"
@@ -493,18 +493,18 @@ class SearchTest < IntegrationTest
   def test_filter_by_organisation_content_ids_works
     commit_document(
       "mainstream_test",
-      title: 'Advice on Treatment of Dragons',
-      link: '/dragon-guide',
-      organisation_content_ids: ['organisation-content-id']
+      "title" => 'Advice on Treatment of Dragons',
+      "link" => '/dragon-guide',
+      "organisation_content_ids" => ['organisation-content-id']
     )
 
     commit_document(
       "government_test",
-      content_id: 'organisation-content-id',
-      slug: '/ministry-of-magic',
-      title: 'Ministry of Magic',
-      link: '/ministry-of-magic-site',
-      format: 'organisation'
+      "content_id" => 'organisation-content-id',
+      "slug" => '/ministry-of-magic',
+      "title" => 'Ministry of Magic',
+      "link" => '/ministry-of-magic-site',
+      "format" => 'organisation'
     )
 
     get "/search.json?filter_organisation_content_ids[]=organisation-content-id"
@@ -514,18 +514,18 @@ class SearchTest < IntegrationTest
 
   def test_expandinging_of_topics
     commit_document("mainstream_test",
-      title: 'Advice on Treatment of Dragons',
-      link: '/dragon-guide',
-      topic_content_ids: ['topic-content-id']
+      "title" => 'Advice on Treatment of Dragons',
+      "link" => '/dragon-guide',
+      "topic_content_ids" => ['topic-content-id']
     )
 
     commit_document("government_test",
-      content_id: 'topic-content-id',
-      slug: 'topic-magic',
-      title: 'Magic topic',
-      link: '/magic-topic-site',
+      "content_id" => 'topic-content-id',
+      "slug" => 'topic-magic',
+      "title" => 'Magic topic',
+      "link" => '/magic-topic-site',
       # TODO: we should rename this format to `topic` and update all apps
-      format: 'specialist_sector'
+      "format" => 'specialist_sector'
     )
 
     get "/search.json?q=dragons"
@@ -549,18 +549,18 @@ class SearchTest < IntegrationTest
 
   def test_filter_by_topic_content_ids_works
     commit_document("mainstream_test",
-      title: 'Advice on Treatment of Dragons',
-      link: '/dragon-guide',
-      topic_content_ids: ['topic-content-id']
+      "title" => 'Advice on Treatment of Dragons',
+      "link" => '/dragon-guide',
+      "topic_content_ids" => ['topic-content-id']
     )
 
     commit_document("government_test",
-      content_id: 'topic-content-id',
-      slug: 'topic-magic',
-      title: 'Magic topic',
-      link: '/magic-topic-site',
+      "content_id" => 'topic-content-id',
+      "slug" => 'topic-magic',
+      "title" => 'Magic topic',
+      "link" => '/magic-topic-site',
       # TODO: we should rename this format to `topic` and update all apps
-      format: 'specialist_sector'
+      "format" => 'specialist_sector'
     )
     get "/search.json?filter_topic_content_ids[]=topic-content-id"
 
@@ -577,10 +577,10 @@ class SearchTest < IntegrationTest
 
   def test_withdrawn_content
     commit_document("mainstream_test",
-      title: "I am the result",
-      description: "This is a test search result",
-      link: "/some-nice-link",
-      is_withdrawn: true
+      "title" => "I am the result",
+      "description" => "This is a test search result",
+      "link" => "/some-nice-link",
+      "is_withdrawn" => true
     )
 
     get "/search?q=test"
@@ -589,10 +589,10 @@ class SearchTest < IntegrationTest
 
   def test_withdrawn_content_with_flag
     commit_document("mainstream_test",
-      title: "I am the result",
-      description: "This is a test search result",
-      link: "/some-nice-link",
-      is_withdrawn: true
+      "title" => "I am the result",
+      "description" => "This is a test search result",
+      "link" => "/some-nice-link",
+      "is_withdrawn" => true
     )
 
     get "/search?q=test&debug=include_withdrawn&fields[]=is_withdrawn"
@@ -602,11 +602,11 @@ class SearchTest < IntegrationTest
 
   def test_withdrawn_content_with_flag_with_aggregations
     commit_document("mainstream_test",
-      title: "I am the result",
-      organisation: "Test Org",
-      description: "This is a test search result",
-      link: "/some-nice-link",
-      is_withdrawn: true
+      "title" => "I am the result",
+      "organisation" => "Test Org",
+      "description" => "This is a test search result",
+      "link" => "/some-nice-link",
+      "is_withdrawn" => true
     )
 
     get "/search?q=test&debug=include_withdrawn&aggregate_mainstream_browse_pages=2"
@@ -645,10 +645,10 @@ class SearchTest < IntegrationTest
 
   def test_taxonomy_can_be_returned
     commit_document("mainstream_test",
-      title: "I am the result",
-      description: "This is a test search result",
-      link: "/some-nice-link",
-      taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
+      "title" => "I am the result",
+      "description" => "This is a test search result",
+      "link" => "/some-nice-link",
+      "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
     )
 
     get "/search?q=test&fields[]=taxons"
@@ -660,10 +660,10 @@ class SearchTest < IntegrationTest
 
   def test_taxonomy_can_be_filtered
     commit_document("mainstream_test",
-      title: "I am the result",
-      description: "This is a test search result",
-      link: "/some-nice-link",
-      taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
+      "title" => "I am the result",
+      "description" => "This is a test search result",
+      "link" => "/some-nice-link",
+      "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
     )
 
     get "/search?filter_taxons=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
@@ -681,11 +681,11 @@ class SearchTest < IntegrationTest
 
   def test_taxonomy_can_be_filtered_by_part
     commit_document("mainstream_test",
-      title: "I am the result",
-      description: "This is a test search result",
-      link: "/some-nice-link",
-      taxons: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"],
-      part_of_taxonomy_tree: %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
+      "title" => "I am the result",
+      "description" => "This is a test search result",
+      "link" => "/some-nice-link",
+      "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"],
+      "part_of_taxonomy_tree" => %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
     )
 
     get "/search?filter_part_of_taxonomy_tree=eb2093ef-778c-4105-9f33-9aa03d14bc5c"

--- a/test/integration/search/search_test.rb
+++ b/test/integration/search/search_test.rb
@@ -307,7 +307,7 @@ class SearchTest < IntegrationTest
   end
 
   def test_can_scope_by_elasticsearch_type
-    commit_document("mainstream_test", cma_case_attributes)
+    commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
 
     get "/search?filter_document_type=cma_case"
 
@@ -315,7 +315,7 @@ class SearchTest < IntegrationTest
     assert_equal 1, parsed_response.fetch("total")
     assert_equal(
       hash_including(
-        "document_type" => cma_case_attributes.fetch("_type"),
+        "document_type" => "cma_case",
         "title" => cma_case_attributes.fetch("title"),
         "link" => cma_case_attributes.fetch("link"),
       ),
@@ -324,7 +324,7 @@ class SearchTest < IntegrationTest
   end
 
   def test_can_filter_between_dates
-    commit_document("mainstream_test", cma_case_attributes)
+    commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
 
     get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
 
@@ -340,7 +340,7 @@ class SearchTest < IntegrationTest
   end
 
   def test_can_filter_between_dates_with_reversed_parameter_order
-    commit_document("mainstream_test", cma_case_attributes)
+    commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
 
     get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
 
@@ -356,7 +356,7 @@ class SearchTest < IntegrationTest
   end
 
   def test_can_filter_from_date
-    commit_document("mainstream_test", cma_case_attributes)
+    commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
 
     get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
 
@@ -372,7 +372,7 @@ class SearchTest < IntegrationTest
   end
 
   def test_can_filter_to_date
-    commit_document("mainstream_test", cma_case_attributes)
+    commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
 
     get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
 
@@ -620,7 +620,7 @@ class SearchTest < IntegrationTest
   end
 
   def test_dfid_can_search_by_every_aggregate
-    commit_document("mainstream_test", dfid_research_output_attributes)
+    commit_document("mainstream_test", dfid_research_output_attributes, type: "dfid_research_output")
 
     aggregate_queries = %w(
       filter_dfid_review_status[]=peer_reviewed
@@ -634,7 +634,7 @@ class SearchTest < IntegrationTest
       assert_equal 1, parsed_response.fetch("total"), "Failure to search by #{filter_query}"
       assert_equal(
         hash_including(
-          "document_type" => dfid_research_output_attributes.fetch("_type"),
+          "document_type" => "dfid_research_output",
           "title" => dfid_research_output_attributes.fetch("title"),
           "link" => dfid_research_output_attributes.fetch("link"),
         ),
@@ -737,7 +737,6 @@ private
       "title" => "Somewhat Unique CMA Case",
       "link" => "/cma-cases/somewhat-unique-cma-case",
       "indexable_content" => "Mergers of cheeses and faces",
-      "_type" => "cma_case",
       "specialist_sectors" => ["farming"],
       "opened_date" => "2014-04-01",
     }
@@ -748,7 +747,6 @@ private
       "title" => "Somewhat Unique DFID Research Output",
       "link" => "/dfid-research-outputs/somewhat-unique-dfid-research-output",
       "indexable_content" => "Use of calcrete in gender roles in Tanzania",
-      "_type" => "dfid_research_output",
       "country" => %w(TZ AL),
       "dfid_review_status" => "peer_reviewed",
       "first_published_at" => "2014-04-02",

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -41,9 +41,7 @@ class IntegrationTest < MiniTest::Unit::TestCase
     Document.from_hash(SAMPLE_DOCUMENT_ATTRIBUTES, sample_elasticsearch_types)
   end
 
-  def insert_document(index_name, attributes, type: "edition")
-    attributes.stringify_keys!
-    id = attributes["_id"] || attributes['link']
+  def insert_document(index_name, attributes, id: attributes["link"], type: "edition")
     client.create(
       index: index_name,
       type: type,
@@ -63,8 +61,8 @@ class IntegrationTest < MiniTest::Unit::TestCase
     )
   end
 
-  def commit_document(index_name, attributes, type: "edition")
-    insert_document(index_name, attributes, type: type)
+  def commit_document(index_name, attributes, id: attributes["link"], type: "edition")
+    insert_document(index_name, attributes, id: id, type: type)
     commit_index(index_name)
   end
 

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -43,7 +43,6 @@ class IntegrationTest < MiniTest::Unit::TestCase
 
   def insert_document(index_name, attributes, type: "edition")
     attributes.stringify_keys!
-    type = attributes["_type"] || type
     id = attributes["_id"] || attributes['link']
     client.create(
       index: index_name,

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -84,12 +84,15 @@ class IntegrationTest < MiniTest::Unit::TestCase
     JSON.parse(last_response.body)
   end
 
-  def assert_document_is_in_rummager(document)
+  def assert_document_is_in_rummager(document, type: "edition")
     retrieved = fetch_document_from_rummager(id: document['link'])
 
+    assert_equal type, retrieved["_type"]
+
+    retrieved_source = retrieved["_source"]
     document.each do |key, value|
-      assert_equal value, retrieved[key],
-        "Field #{key} should be '#{value}' but was '#{retrieved[key]}'"
+      assert_equal value, retrieved_source[key],
+        "Field #{key} should be '#{value}' but was '#{retrieved_source[key]}'"
     end
   end
 
@@ -141,21 +144,12 @@ private
     end
   end
 
-  def fetch_raw_document_from_rummager(id:, index: 'mainstream_test', type: '_all')
+  def fetch_document_from_rummager(id:, index: 'mainstream_test', type: '_all')
     client.get(
       index: index,
       type: type,
       id: id
     )
-  end
-
-  def fetch_document_from_rummager(id:, index: 'mainstream_test', type: '_all')
-    response = client.get(
-      index: index,
-      type: type,
-      id: id
-    )
-    response['_source']
   end
 
   def stubbed_search_config


### PR DESCRIPTION
This is a blocker to upgrading Elasticsearch. When the Elasticsearch migration plugin is run, all the indexes return an error like this:

> Reserved field names ([info](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking_20_mapping_changes.html#migration-meta-fields))
The `_uid`, `_id`, `_type`, `_source`, `_all`, `_parent`, `_field_names`, `_routing`, `_index`, `_size`, `_timestamp`, and `_ttl` field names are reserved and can no longer be used in the document `_source`., in type: `edition`.

We tried removing these fields in https://github.com/alphagov/rummager/pull/777, and it didn't work out so well, but it's now safe to remove from the document hash, because we've changed the codebase to reference the top level
"_type" and "_id" from elasticsearch responses. :crossed_fingers: 

See
- https://github.com/alphagov/rummager/pull/791
- https://github.com/alphagov/rummager/pull/792

Trello: https://trello.com/c/2aAKWCwE/149-remove-reserved-id-and-type-fields-from-source-again