### PR TITLE
We don't want to report errors for know ES validation issues

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -33,5 +33,11 @@ configure do
   # don't send this dummy exception.
   Airbrake.configuration.ignore << "Indexer::PublishingApiError"
 
+  # We catch this error and return a 400 response, however as a result of enabling
+  # `raise_error` in the sinatra config this still tries to report to airbrake which
+  # we don't want. This is a short term fix until we have a chance to make the config
+  # more standard (disabling `raise_error` which is the default for production)
+  Airbrake.configuration.ignore << "Search::Query::Error"
+
   use Airbrake::Sinatra
 end


### PR DESCRIPTION
We enable 'raise_error` in production which is non-standard.
The result of this is that we respond with a 400 but still
send an error report. Bu ignoring the custom error class
we can disable this functionality until we have time to
investigate disabling `raise_error`

https://trello.com/c/C6WRzJGx/139-early-validation-of-rummager-fields