### PR TITLE
Add user_journey_document_supertype

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -30,6 +30,7 @@
     "taxons",
     "title",
     "topic_content_ids",
-    "updated_at"
+    "updated_at",
+    "user_journey_document_supertype"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -20,6 +20,10 @@
     "type": "identifier"
   },
 
+  "user_journey_document_supertype": {
+    "type": "identifier"
+  },
+
   "content_id": {
     "description": "The content_id of the item. This will not be present for all items, as most application do not send it.",
     "type": "identifier"

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -64,6 +64,7 @@ class BaseParameterParser
     search_format_types
     specialist_sectors
     taxons
+    user_journey_document_supertype
     world_locations
   ).freeze
 

--- a/test/integration/indexer/indexing_test.rb
+++ b/test/integration/indexer/indexing_test.rb
@@ -43,6 +43,7 @@ class ElasticsearchIndexingTest < IntegrationTest
       "indexable_content" => "HERE IS SOME CONTENT",
       "navigation_document_supertype" => "guidance",
       "email_document_supertype" => "other",
+      "user_journey_document_supertype" => "thing",
       "government_document_supertype" => "other",
       "licence_identifier" => "1201-5-1",
       "licence_short_description" => "A short description of a licence",


### PR DESCRIPTION
This is the only supertype that is not indexed in search. We use it to differentiate between content that is the destination (the thing) and the part of the journey (the finding). In the short term I need this field to filter the results to get all documents that should be tagged. In the long term we might use it to create a finder (in which you would only expect "things").