### PR TITLE
Create new govuk index

### DIFF
--- a/config/schema/indexes/govuk.json
+++ b/config/schema/indexes/govuk.json
@@ -1,0 +1,31 @@
+{
+  "elasticsearch_types": [
+    "aaib_report",
+    "asylum_support_decision",
+    "business_finance_support_scheme",
+    "cma_case",
+    "contact",
+    "countryside_stewardship_grant",
+    "drug_safety_update",
+    "dfid_research_output",
+    "edition",
+    "employment_appeal_tribunal_decision",
+    "employment_tribunal_decision",
+    "european_structural_investment_fund",
+    "hmrc_manual",
+    "hmrc_manual_section",
+    "international_development_fund",
+    "maib_report",
+    "manual",
+    "manual_section",
+    "medical_safety_alert",
+    "policy",
+    "raib_report",
+    "service_manual_guide",
+    "service_manual_topic",
+    "service_standard_report",
+    "tax_tribunal_decision",
+    "utaac_decision",
+    "vehicle_recalls_and_faults_alert"
+  ]
+}

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -22,6 +22,13 @@ namespace :rummager do
     end
   end
 
+  desc "Create a brand new index and assign an alias if no alias currently exists"
+  task :create_index, :index_name do |_, args|
+    index_group = search_config.search_server.index_group(args[:index_name])
+    index = index_group.create_index
+    index_group.switch_to(index) unless index_group.current_real
+  end
+
   desc "Migrates an index group to a new index.
 
 Seamlessly creates a new index in the same index_group using the latest


### PR DESCRIPTION
- Also add a rake task to allow this to be done in prod.

We need to create a new index in order to replace the existing
mainstream, government and detailed indices. All queries will therefore
be done against a single index. This is the first step in the migration
process.

Mobbed with @dwhenry and @brenetic

https://trello.com/c/2U7jTkC3/158-create-new-elasticsearch-index