### PR TITLE
Fix integration tests

### DIFF
--- a/test/integration/indexer/index_group_test.rb
+++ b/test/integration/indexer/index_group_test.rb
@@ -11,8 +11,11 @@ class ElasticsearchIndexGroupTest < IntegrationTest
   end
 
   def teardown
-    # Making sure we keep the index after the tests run
-    @index_group.create_index
+    # Recreate index deleted by tests.
+    # Other integration tests rely on all the test indexes being present.
+    # Also ensures there are no missing aliases in the test indexes.
+    index = @index_group.create_index
+    @index_group.switch_to(index)
   end
 
   def test_should_create_index

--- a/test/integration/indexer/migration_test.rb
+++ b/test/integration/indexer/migration_test.rb
@@ -26,6 +26,11 @@ class ElasticsearchMigrationTest < IntegrationTest
     Indexer::Comparer.stubs(:new).returns(comparer)
   end
 
+  def teardown
+    super
+    search_server.index_group("mainstream_test").clean
+  end
+
   def sample_document_attributes
     [
       {


### PR DESCRIPTION
- Tests have been intermittently failing recently.
- This PR fixes some of those failures.
- We don't fully understand why this has only just become a problem or why we are only seeing this on CI and not in development. 
- We are continuing to look into this to fix the remaining failures.
- See commit messages for further explanation.
- See #746 for more context on why the integration tests set up and delete indexes before and after the whole test suite rather than for each individual test.

Paired with @suzannehamilton 

