### PR TITLE
Add page timestamps to sitemap

### DIFF
--- a/bin/stats
+++ b/bin/stats
@@ -14,7 +14,7 @@ EXCLUDED_FORMATS = ["recommended-link", "inside-government-link"].freeze
 def all_documents(indices)
   Enumerator.new do |yielder|
     indices.each do |index|
-      index.all_documents.each do |document|
+      index.all_documents(exclude_formats: EXCLUDED_FORMATS).each do |document|
         yielder << document
       end
     end
@@ -38,8 +38,6 @@ document_count = 0
 word_count = 0
 all_words = Set.new
 all_documents(indices).each do |document|
-  next if EXCLUDED_FORMATS.include?(document.format)
-
   document_count += 1
   if document.indexable_content
     words = words_without_punctuation(document.indexable_content)

--- a/lib/indexer/bulk_loader.rb
+++ b/lib/indexer/bulk_loader.rb
@@ -25,7 +25,7 @@ module Indexer
       build_and_switch_index do |queue|
         current_index = index_group.current_real
         if current_index
-          current_index.all_documents(timeout_options).each_slice(@document_batch_size) do |documents|
+          current_index.all_documents(client_options: timeout_options).each_slice(@document_batch_size) do |documents|
             queue.push(documents.map(&:elasticsearch_export))
           end
         end
@@ -45,7 +45,7 @@ module Indexer
 
       @logger.info "Populating new #{@index_name} index..."
       populate_index(new_index) do |queue|
-        old_index.all_documents(timeout_options).each_slice(@document_batch_size) do |documents|
+        old_index.all_documents(client_options: timeout_options).each_slice(@document_batch_size) do |documents|
           queue.push(documents.map(&:elasticsearch_export))
         end
       end

--- a/test/integration/sitemap/sitemap_test.rb
+++ b/test/integration/sitemap/sitemap_test.rb
@@ -10,7 +10,8 @@ class SitemapTest < IntegrationTest
       "description" => "Hummus weevils",
       "format" => "answer",
       "link" => "/an-example-answer",
-      "indexable_content" => "I like my badger: he is tasty and delicious"
+      "indexable_content" => "I like my badger: he is tasty and delicious",
+      "public_timestamp" => "2017-07-01T12:41:34+00:00"
     },
     {
       "title" => "Cheese on Ruby's face",
@@ -85,6 +86,19 @@ class SitemapTest < IntegrationTest
 
     assert_equal 1, sitemap_xml.length
     refute_includes sitemap_xml[0], "/government/some-content"
+  end
+
+  def test_links_should_include_timestamps
+    generator = SitemapGenerator.new(search_server.content_indices)
+
+    sitemap_xml = generator.sitemaps
+
+    pages = Nokogiri::XML(sitemap_xml[0])
+      .css("url")
+      .select { |item| item.css("loc").text == "http://www.dev.gov.uk/an-example-answer" }
+
+    assert_equal 1, pages.count
+    assert_equal "2017-07-01T12:41:34+00:00", pages[0].css("lastmod").text
   end
 
 private

--- a/test/unit/elasticsearch_index_test.rb
+++ b/test/unit/elasticsearch_index_test.rb
@@ -183,7 +183,7 @@ class ElasticsearchIndexTest < Minitest::Test
     # Test that we can count the documents without retrieving them all
     search_pattern = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=50"
     stub_request(:get, search_pattern).with(
-      body: { query: { match_all: {} } }.to_json
+      body: { query: expected_all_documents_query }.to_json
     ).to_return(
       body: { _scroll_id: "abcdefgh", hits: { total: 100 } }.to_json,
       headers: { 'Content-Type' => 'application/json' },
@@ -195,7 +195,7 @@ class ElasticsearchIndexTest < Minitest::Test
     search_uri = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=50"
 
     stub_request(:get, search_uri).with(
-      body: { query: { match_all: {} } }.to_json
+      body: { query: expected_all_documents_query }.to_json
     ).to_return(
       body: { _scroll_id: "abcdefgh", hits: { total: 100, hits: [] } }.to_json,
       headers: { 'Content-Type' => 'application/json' },
@@ -227,7 +227,7 @@ class ElasticsearchIndexTest < Minitest::Test
     SearchIndices::Index.stubs(:scroll_batch_size).returns(2)
 
     stub_request(:get, search_uri).with(
-      body: { query: { match_all: {} } }.to_json
+      body: { query: expected_all_documents_query }.to_json
     ).to_return(
       body: { _scroll_id: "abcdefgh", hits: { total: 3, hits: [] } }.to_json,
 
@@ -336,5 +336,17 @@ private
     traffic_index = SearchIndices::Index.new(base_uri, "page-traffic_test", "page-traffic_test", page_traffic_mappings, search_config)
     Indexer::PopularityLookup.any_instance.stubs(:traffic_index).returns(traffic_index)
     traffic_index.stubs(:real_name).returns("page-traffic_test")
+  end
+
+  def expected_all_documents_query
+    {
+      "bool" => {
+        "must_not" => {
+          "terms" => {
+            "format" => []
+          }
+        }
+      }
+    }
   end
 end

--- a/test/unit/sitemap/sitemap_generator_test.rb
+++ b/test/unit/sitemap/sitemap_generator_test.rb
@@ -5,11 +5,25 @@ class SitemapGeneratorTest < Minitest::Test
   def test_should_generate_sitemap
     sitemap = SitemapGenerator.new('')
 
-    sitemap_xml = sitemap.generate_xml(['https://www.gov.uk/page', '/another-page', 'yet-another-page'])
+    sitemap_xml = sitemap.generate_xml([
+      document_with_url('https://www.gov.uk/page'),
+      document_with_url('/another-page'),
+      document_with_url('yet-another-page'),
+    ])
+
     doc = Nokogiri::XML(sitemap_xml)
     urls = doc.css('url > loc').map(&:inner_html)
     assert_equal urls[0], 'https://www.gov.uk/page'
     assert_equal urls[1], 'http://www.dev.gov.uk/another-page'
     assert_equal urls[2], 'http://www.dev.gov.uk/yet-another-page'
+  end
+
+  def document_with_url(url)
+    attributes = {
+      "link" => url,
+      "_type" => "some_type",
+    }
+
+    Document.new(sample_field_definitions, attributes)
   end
 end

--- a/test/unit/sitemap/sitemap_generator_test.rb
+++ b/test/unit/sitemap/sitemap_generator_test.rb
@@ -6,9 +6,9 @@ class SitemapGeneratorTest < Minitest::Test
     sitemap = SitemapGenerator.new('')
 
     sitemap_xml = sitemap.generate_xml([
-      document_with_url('https://www.gov.uk/page'),
-      document_with_url('/another-page'),
-      document_with_url('yet-another-page'),
+      build_document('https://www.gov.uk/page'),
+      build_document('/another-page'),
+      build_document('yet-another-page'),
     ])
 
     doc = Nokogiri::XML(sitemap_xml)
@@ -18,12 +18,61 @@ class SitemapGeneratorTest < Minitest::Test
     assert_equal urls[2], 'http://www.dev.gov.uk/yet-another-page'
   end
 
-  def document_with_url(url)
+  def test_links_should_include_timestamps
+    sitemap = SitemapGenerator.new('')
+
+    sitemap_xml = sitemap.generate_xml([
+      build_document('/page-with-datetime', "2014-01-28T14:41:50+00:00"),
+      build_document('/page-with-date', "2017-07-12"),
+    ])
+
+    pages = Nokogiri::XML(sitemap_xml).css("url")
+
+    assert_equal "2014-01-28T14:41:50+00:00", pages[0].css("lastmod").text
+    assert_equal "2017-07-12", pages[1].css("lastmod").text
+  end
+
+  def test_missing_timestamps_are_ignored
+    sitemap = SitemapGenerator.new('')
+
+    sitemap_xml = sitemap.generate_xml([
+      build_document('/page-without-date'),
+    ])
+
+    pages = Nokogiri::XML(sitemap_xml).css("url")
+
+    assert_page_has_no_lastmod(pages[0])
+  end
+
+  def test_invalid_timestamps_are_ignored
+    sitemap = SitemapGenerator.new('')
+
+    sitemap_xml = sitemap.generate_xml([
+      build_document('/page-1', ""),
+      build_document('/page-2', "not-a-date"),
+      build_document('/page-3', "01-01-2017"),
+    ])
+
+    pages = Nokogiri::XML(sitemap_xml).css("url")
+
+    assert_page_has_no_lastmod(pages[0])
+    assert_page_has_no_lastmod(pages[1])
+    assert_page_has_no_lastmod(pages[2])
+  end
+
+  def build_document(url, timestamp = nil)
     attributes = {
       "link" => url,
       "_type" => "some_type",
     }
+    attributes["public_timestamp"] = timestamp if timestamp
 
     Document.new(sample_field_definitions, attributes)
+  end
+
+  def assert_page_has_no_lastmod(page)
+    last_modified = page.css("lastmod").text
+    assert last_modified.empty?,
+      "Page in sitemap has unexpected 'lastmod' date: '#{last_modified}'"
   end
 end


### PR DESCRIPTION
- Refactor method which fetches all documents. This gives the sitemap generator access to more fields, such as the last modified date (which is used in the next commit) and the format (which will be used to modify page priority in a later PR).
- Add a `lastmod` field to entries in the sitemap, based on the `public_timestamp` field in Elasticsearch. This will help search engines rank GOV.UK pages against each other by boosting more recent content. This should help users to find more recent, relevant pages when searching in an external search engine.

https://trello.com/c/DJx7rxiy/190-add-timestamps-to-sitemap