### PR TITLE
Down-weight withdrawn pages in the sitemap

### DIFF
--- a/lib/sitemap/sitemap.rb
+++ b/lib/sitemap/sitemap.rb
@@ -3,6 +3,7 @@ require "plek"
 
 require_relative "sitemap_cleanup"
 require_relative "sitemap_generator"
+require_relative "sitemap_presenter"
 require_relative "sitemap_writer"
 
 class Sitemap

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -43,6 +43,7 @@ class SitemapGenerator
           xml.url {
             xml.loc url
             xml.lastmod timestamp if timestamp
+            xml.priority priority(document)
           }
         end
       end
@@ -69,9 +70,13 @@ private
     nil
   end
 
-  StaticDocument = Struct.new(:link, :public_timestamp)
+  StaticDocument = Struct.new(:link, :public_timestamp, :is_withdrawn)
 
   def homepage_document
-    StaticDocument.new("/", nil)
+    StaticDocument.new("/", nil, false)
+  end
+
+  def priority(document)
+    document.is_withdrawn ? 0.25 : 1
   end
 end

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -4,7 +4,6 @@ class SitemapGenerator
   def initialize(sitemap_indices)
     @sitemap_indices = sitemap_indices
     @all_documents = get_all_documents
-    @logger = Logging.logger[self]
   end
 
   def self.sitemap_limit
@@ -35,15 +34,12 @@ class SitemapGenerator
     builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
         chunk.each do |document|
-          url = document.link
-          url = URI.join(base_url, url) unless url.start_with?("http")
-
-          timestamp = validated_timestamp(document.public_timestamp)
+          sitemap_presenter = SitemapPresenter.new(document)
 
           xml.url {
-            xml.loc url
-            xml.lastmod timestamp if timestamp
-            xml.priority priority(document)
+            xml.loc sitemap_presenter.url
+            xml.lastmod sitemap_presenter.last_updated if sitemap_presenter.last_updated
+            xml.priority sitemap_presenter.priority
           }
         end
       end
@@ -54,29 +50,9 @@ class SitemapGenerator
 
 private
 
-  def base_url
-    Plek.current.website_root
-  end
-
-  def validated_timestamp(timestamp)
-    return nil unless timestamp
-
-    # Attempt to parse timestamp to validate it
-    DateTime.iso8601(timestamp)
-    timestamp
-  rescue ArgumentError
-    @logger.warn("Invalid timestamp #{timestamp}")
-    # Ignore invalid or missing timestamps
-    nil
-  end
-
   StaticDocument = Struct.new(:link, :public_timestamp, :is_withdrawn)
 
   def homepage_document
     StaticDocument.new("/", nil, false)
-  end
-
-  def priority(document)
-    document.is_withdrawn ? 0.25 : 1
   end
 end

--- a/lib/sitemap/sitemap_presenter.rb
+++ b/lib/sitemap/sitemap_presenter.rb
@@ -1,0 +1,38 @@
+class SitemapPresenter
+  def initialize(document)
+    @document = document
+    @logger = Logging.logger[self]
+  end
+
+  def url
+    if document.link.start_with?("http")
+      document.link
+    else
+      URI.join(base_url, document.link)
+    end
+  end
+
+  def last_updated
+    return nil unless document.public_timestamp
+
+    # Attempt to parse timestamp to validate it
+    DateTime.iso8601(document.public_timestamp)
+    document.public_timestamp
+  rescue ArgumentError
+    @logger.warn("Invalid timestamp '#{document.public_timestamp}' for page '#{document.link}'")
+    # Ignore invalid or missing timestamps
+    nil
+  end
+
+  def priority
+    document.is_withdrawn ? 0.25 : 1
+  end
+
+private
+
+  attr_reader :document
+
+  def base_url
+    Plek.current.website_root
+  end
+end

--- a/test/integration/sitemap/sitemap_test.rb
+++ b/test/integration/sitemap/sitemap_test.rb
@@ -101,6 +101,17 @@ class SitemapTest < IntegrationTest
     assert_equal "2017-07-01T12:41:34+00:00", pages[0].css("lastmod").text
   end
 
+  def test_links_should_include_priorities
+    generator = SitemapGenerator.new(search_server.content_indices)
+
+    sitemap_xml = generator.sitemaps
+
+    priorities = Nokogiri::XML(sitemap_xml[0])
+      .css("url > priority")
+
+    assert_equal 6, priorities.count
+  end
+
 private
 
   def add_sample_documents


### PR DESCRIPTION
Set a priority for each page in the sitemap:
- For regular, non-withdrawn pages, set the priority to 1
- For all withdrawn pages, set the priority to 0.25

The priority is a value from 0 to 1 which influences the relative ranking of pages in search engines.

The values of 1 and 0.25 are fairly arbitrary because we have not been able to find advice on how to pick relative priorities. The aim is to push relevant non-withdrawn content above withdrawn content so that users are not confused by old guidance or publications, but still keep the withdrawn content findable in external search if it really is the most relevant information.

Probably easiest to review each commit separately, because the second one is just refactoring.

https://trello.com/c/iR68Sm6R/192-downweight-withdrawn-content-in-the-sitemap

Marked as DO NOT MERGE until all the sitemap changes are ready to be deployed.