### PR TITLE
Add format weighting to sitemap

### DIFF
--- a/lib/sitemap/format_boost_calculator.rb
+++ b/lib/sitemap/format_boost_calculator.rb
@@ -1,0 +1,19 @@
+class FormatBoostCalculator
+  def initialize
+    format_boost_config = YAML.load_file('config/query/format_boosting.yml')
+    @format_boosts = format_boost_config["format_boosts"]
+  end
+
+  def boost(format)
+    page_boost = @format_boosts[format] || 1
+
+    # Normalise format boost to always give a value between 0 and 1
+    page_boost.to_f / max_boost
+  end
+
+private
+
+  def max_boost
+    @_max_boost ||= @format_boosts.values.max
+  end
+end

--- a/lib/sitemap/format_boost_calculator.rb
+++ b/lib/sitemap/format_boost_calculator.rb
@@ -8,7 +8,7 @@ class FormatBoostCalculator
     page_boost = @format_boosts[format] || 1
 
     # Normalise format boost to always give a value between 0 and 1
-    page_boost.to_f / max_boost
+    (page_boost.to_f / max_boost).round(2)
   end
 
 private

--- a/lib/sitemap/sitemap.rb
+++ b/lib/sitemap/sitemap.rb
@@ -5,6 +5,7 @@ require_relative "sitemap_cleanup"
 require_relative "sitemap_generator"
 require_relative "sitemap_presenter"
 require_relative "sitemap_writer"
+require_relative "format_boost_calculator"
 
 class Sitemap
   def initialize(directory, timestamp = Time.now.utc)

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -13,11 +13,11 @@ class SitemapGenerator
   def get_all_documents
     Enumerator.new do |yielder|
       # Hard-code the site root, as it isn't listed in any search index
-      yielder << homepage_document
+      yielder << homepage
 
       @sitemap_indices.each do |index|
         index.all_documents(exclude_formats: EXCLUDED_FORMATS).each do |document|
-          yielder << document
+          yielder << SitemapPresenter.new(document)
         end
       end
     end
@@ -34,12 +34,10 @@ class SitemapGenerator
     builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
         chunk.each do |document|
-          sitemap_presenter = SitemapPresenter.new(document)
-
           xml.url {
-            xml.loc sitemap_presenter.url
-            xml.lastmod sitemap_presenter.last_updated if sitemap_presenter.last_updated
-            xml.priority sitemap_presenter.priority
+            xml.loc document.url
+            xml.lastmod document.last_updated if document.last_updated
+            xml.priority document.priority
           }
         end
       end
@@ -50,9 +48,9 @@ class SitemapGenerator
 
 private
 
-  StaticDocument = Struct.new(:link, :public_timestamp, :is_withdrawn)
+  StaticDocumentPresenter = Struct.new(:url, :last_updated, :priority)
 
-  def homepage_document
-    StaticDocument.new("/", nil, false)
+  def homepage
+    StaticDocumentPresenter.new("/", nil, 1)
   end
 end

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -11,13 +11,15 @@ class SitemapGenerator
   end
 
   def get_all_documents
+    format_boost_calculator = FormatBoostCalculator.new
+
     Enumerator.new do |yielder|
       # Hard-code the site root, as it isn't listed in any search index
       yielder << homepage
 
       @sitemap_indices.each do |index|
         index.all_documents(exclude_formats: EXCLUDED_FORMATS).each do |document|
-          yielder << SitemapPresenter.new(document)
+          yielder << SitemapPresenter.new(document, format_boost_calculator)
         end
       end
     end

--- a/lib/sitemap/sitemap_presenter.rb
+++ b/lib/sitemap/sitemap_presenter.rb
@@ -1,6 +1,7 @@
 class SitemapPresenter
-  def initialize(document)
+  def initialize(document, format_boost_calculator)
     @document = document
+    @format_boost_calculator = format_boost_calculator
     @logger = Logging.logger[self]
   end
 
@@ -25,14 +26,18 @@ class SitemapPresenter
   end
 
   def priority
-    document.is_withdrawn ? 0.25 : 1
+    withdrawn_status_boost * format_boost_calculator.boost(document.format)
   end
 
 private
 
-  attr_reader :document
+  attr_reader :document, :format_boost_calculator
 
   def base_url
     Plek.current.website_root
+  end
+
+  def withdrawn_status_boost
+    document.is_withdrawn ? 0.25 : 1
   end
 end

--- a/lib/sitemap/sitemap_presenter.rb
+++ b/lib/sitemap/sitemap_presenter.rb
@@ -8,7 +8,7 @@ class SitemapPresenter
     if document.link.start_with?("http")
       document.link
     else
-      URI.join(base_url, document.link)
+      URI.join(base_url, document.link).to_s
     end
   end
 

--- a/test/unit/sitemap/format_boost_calculator_test.rb
+++ b/test/unit/sitemap/format_boost_calculator_test.rb
@@ -33,4 +33,19 @@ class FormatBoostCalculatorTest < Minitest::Test
 
     assert_equal 0.25, calculator.boost("other_format")
   end
+
+  def test_boosts_are_rounded
+    boosts = {
+      "format_boosts" => {
+        "top_format" => 3,
+        "other_format" => 2,
+      },
+    }
+
+    YAML.stubs(:load_file).returns(boosts)
+
+    calculator = FormatBoostCalculator.new
+
+    assert_equal 0.67, calculator.boost("other_format")
+  end
 end

--- a/test/unit/sitemap/format_boost_calculator_test.rb
+++ b/test/unit/sitemap/format_boost_calculator_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "sitemap/sitemap"
+
+class FormatBoostCalculatorTest < Minitest::Test
+  def setup
+    @calculator = FormatBoostCalculator.new
+  end
+
+  def test_unconfigured_format_has_default_boost
+    expected_max_boost = 2.5
+    expected_default_boost = 1 / expected_max_boost
+
+    assert_equal expected_default_boost, @calculator.boost("some_other_format")
+  end
+
+  def test_formats_are_boosted_relative_to_default
+    assert_equal 1, @calculator.boost("organisation")
+    assert_equal 0.12, @calculator.boost("service_manual_guide")
+    assert_equal 0, @calculator.boost("mainstream_browse_page")
+  end
+
+  def test_boosts_are_not_rounded_by_integer_division
+    boosts = {
+      "format_boosts" => {
+        "top_format" => 4,
+        "other_format" => 1,
+      },
+    }
+
+    YAML.stubs(:load_file).returns(boosts)
+
+    calculator = FormatBoostCalculator.new
+
+    assert_equal 0.25, calculator.boost("other_format")
+  end
+end

--- a/test/unit/sitemap/sitemap_generator_test.rb
+++ b/test/unit/sitemap/sitemap_generator_test.rb
@@ -13,9 +13,9 @@ class SitemapGeneratorTest < Minitest::Test
 
     doc = Nokogiri::XML(sitemap_xml)
     urls = doc.css('url > loc').map(&:inner_html)
-    assert_equal urls[0], 'https://www.gov.uk/page'
-    assert_equal urls[1], 'http://www.dev.gov.uk/another-page'
-    assert_equal urls[2], 'http://www.dev.gov.uk/yet-another-page'
+    assert_equal "https://www.gov.uk/page", urls[0]
+    assert_equal "http://www.dev.gov.uk/another-page", urls[1]
+    assert_equal "http://www.dev.gov.uk/yet-another-page", urls[2]
   end
 
   def test_links_should_include_timestamps

--- a/test/unit/sitemap/sitemap_generator_test.rb
+++ b/test/unit/sitemap/sitemap_generator_test.rb
@@ -63,7 +63,10 @@ class SitemapGeneratorTest < Minitest::Test
     attributes["public_timestamp"] = timestamp if timestamp
     attributes["is_withdrawn"] = is_withdrawn if !is_withdrawn.nil?
 
-    SitemapPresenter.new(Document.new(sample_field_definitions, attributes))
+    SitemapPresenter.new(
+      Document.new(sample_field_definitions, attributes),
+      FormatBoostCalculator.new
+    )
   end
 
   def assert_page_has_no_lastmod(page)

--- a/test/unit/sitemap/sitemap_generator_test.rb
+++ b/test/unit/sitemap/sitemap_generator_test.rb
@@ -22,14 +22,12 @@ class SitemapGeneratorTest < Minitest::Test
     sitemap = SitemapGenerator.new('')
 
     sitemap_xml = sitemap.generate_xml([
-      build_document('/page-with-datetime', timestamp: "2014-01-28T14:41:50+00:00"),
-      build_document('/page-with-date', timestamp: "2017-07-12"),
+      build_document('/some-page', timestamp: "2014-01-28T14:41:50+00:00"),
     ])
 
     pages = Nokogiri::XML(sitemap_xml).css("url")
 
     assert_equal "2014-01-28T14:41:50+00:00", pages[0].css("lastmod").text
-    assert_equal "2017-07-12", pages[1].css("lastmod").text
   end
 
   def test_missing_timestamps_are_ignored
@@ -44,56 +42,17 @@ class SitemapGeneratorTest < Minitest::Test
     assert_page_has_no_lastmod(pages[0])
   end
 
-  def test_invalid_timestamps_are_ignored
+  def test_page_priority_is_document_priority
     sitemap = SitemapGenerator.new('')
 
-    sitemap_xml = sitemap.generate_xml([
-      build_document('/page-1', timestamp: ""),
-      build_document('/page-2', timestamp: "not-a-date"),
-      build_document('/page-3', timestamp: "01-01-2017"),
-    ])
+    document = build_document('/some-path')
+    document.stubs(:priority).returns(0.48)
+
+    sitemap_xml = sitemap.generate_xml([document])
 
     pages = Nokogiri::XML(sitemap_xml).css("url")
 
-    assert_page_has_no_lastmod(pages[0])
-    assert_page_has_no_lastmod(pages[1])
-    assert_page_has_no_lastmod(pages[2])
-  end
-
-  def test_default_page_priority_is_maximum_value
-    sitemap = SitemapGenerator.new('')
-
-    sitemap_xml = sitemap.generate_xml([
-      build_document('/some-path', is_withdrawn: false),
-    ])
-
-    pages = Nokogiri::XML(sitemap_xml).css("url")
-
-    assert_equal("1", pages[0].css("priority").text)
-  end
-
-  def test_withdrawn_pages_have_lower_priority
-    sitemap = SitemapGenerator.new('')
-
-    sitemap_xml = sitemap.generate_xml([
-      build_document('/some-path', is_withdrawn: true),
-    ])
-
-    pages = Nokogiri::XML(sitemap_xml).css("url")
-
-    assert_equal("0.25", pages[0].css("priority").text)
-  end
-
-  def test_pages_with_no_withdrawn_flag_have_maximum_priority
-    sitemap = SitemapGenerator.new('')
-
-    sitemap_xml = sitemap.generate_xml([
-      build_document('/some-path', is_withdrawn: nil),
-    ])
-
-    pages = Nokogiri::XML(sitemap_xml).css("url")
-
-    assert_equal("1", pages[0].css("priority").text)
+    assert_equal("0.48", pages[0].css("priority").text)
   end
 
   def build_document(url, timestamp: nil, is_withdrawn: nil)
@@ -104,7 +63,7 @@ class SitemapGeneratorTest < Minitest::Test
     attributes["public_timestamp"] = timestamp if timestamp
     attributes["is_withdrawn"] = is_withdrawn if !is_withdrawn.nil?
 
-    Document.new(sample_field_definitions, attributes)
+    SitemapPresenter.new(Document.new(sample_field_definitions, attributes))
   end
 
   def assert_page_has_no_lastmod(page)

--- a/test/unit/sitemap/sitemap_presenter_test.rb
+++ b/test/unit/sitemap/sitemap_presenter_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+require "sitemap/sitemap"
+
+class SitemapPresenterTest < Minitest::Test
+  def setup
+    Plek.any_instance.stubs(:website_root).returns("https://website_root")
+  end
+
+  def test_url_is_document_link_if_link_is_http_url
+    document = build_document(url: "http://some.url")
+    presenter = SitemapPresenter.new(document)
+    assert_equal "http://some.url", presenter.url
+  end
+
+  def test_url_is_document_link_if_link_is_https_url
+    document = build_document(url: "https://some.url")
+    presenter = SitemapPresenter.new(document)
+    assert_equal "https://some.url", presenter.url
+  end
+
+  def test_url_appends_host_name_if_link_is_a_path
+    document = build_document(url: "/some/path")
+    presenter = SitemapPresenter.new(document)
+    assert_equal "https://website_root/some/path", presenter.url
+  end
+
+  def test_last_updated_is_timestamp_if_timestamp_is_date_time
+    document = build_document(
+      url: "/some/path",
+      timestamp: "2014-01-28T14:41:50+00:00"
+    )
+    presenter = SitemapPresenter.new(document)
+    assert_equal "2014-01-28T14:41:50+00:00", presenter.last_updated
+  end
+
+  def test_last_updated_is_timestamp_if_timestamp_is_date
+    document = build_document(
+      url: "/some/path",
+      timestamp: "2017-07-12"
+    )
+    presenter = SitemapPresenter.new(document)
+    assert_equal "2017-07-12", presenter.last_updated
+  end
+
+  def test_last_updated_is_omitted_if_timestamp_is_missing
+    document = build_document(
+      url: "/some/path",
+      timestamp: nil
+    )
+    presenter = SitemapPresenter.new(document)
+    assert_nil presenter.last_updated
+  end
+
+  def test_last_updated_is_omitted_if_timestamp_is_invalid
+    document = build_document(
+      url: "/some/path",
+      timestamp: "not-a-date"
+    )
+    presenter = SitemapPresenter.new(document)
+    assert_nil presenter.last_updated
+  end
+
+  def test_last_updated_is_omitted_if_timestamp_is_in_invalid_format
+    document = build_document(
+      url: "/some/path",
+      timestamp: "01-01-2017"
+    )
+    presenter = SitemapPresenter.new(document)
+    assert_nil presenter.last_updated
+  end
+
+  def test_default_page_priority_is_maximum_value
+    document = build_document(
+      url: "/some/path",
+      is_withdrawn: false
+    )
+    presenter = SitemapPresenter.new(document)
+    assert_equal 1, presenter.priority
+  end
+
+  def test_withdrawn_page_has_lower_priority
+    document = build_document(
+      url: "/some/path",
+      is_withdrawn: true
+    )
+    presenter = SitemapPresenter.new(document)
+    assert_equal 0.25, presenter.priority
+  end
+
+  def test_page_with_no_withdrawn_flag_has_maximum_priority
+    document = build_document(
+      url: "/some/path"
+    )
+    presenter = SitemapPresenter.new(document)
+    assert_equal 1, presenter.priority
+  end
+
+  def build_document(url:, timestamp: nil, is_withdrawn: nil)
+    attributes = {
+      "link" => url,
+      "_type" => "some_type",
+    }
+    attributes["public_timestamp"] = timestamp if timestamp
+    attributes["is_withdrawn"] = is_withdrawn if !is_withdrawn.nil?
+
+    Document.new(sample_field_definitions, attributes)
+  end
+end


### PR DESCRIPTION
Probably easiest to review commit-by-commit:

- Small fix of assertion parameters in existing test
- Split unit tests for the sitemap generator and sitemap presenter to make the next change easier
- Set sitemap priorities based on format

  Take the format boosting configured for internal search and apply it to sitemap priorities for external search.

  Search engines use these values to rank GOV.UK pages against each other, so this should help increase the position of more generally relevant pages in external search results.

I'll raise a separate PR for boosting pages based on document supertype, which will boost all guidance content. It would be good to get some feedback on this approach first, though.

https://trello.com/c/wTcs0JaG/194-add-format-weightings-to-sitemap