### PR TITLE
Replace usages of MiniTest::Unit::TestCase with Minitest::Test

### DIFF
--- a/test/unit/govuk_index/elasticsearch_presenter_test.rb
+++ b/test/unit/govuk_index/elasticsearch_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "govuk_index/elasticsearch_presenter"
 
-class GovukIndex::ElasticsearchPresenterTest < MiniTest::Unit::TestCase
+class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
   def test_converts_message_payload_to_elasticsearch_format
     payload = {
       "base_path" => "/some/path",

--- a/test/unit/govuk_index/elasticsearch_saver_test.rb
+++ b/test/unit/govuk_index/elasticsearch_saver_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require 'govuk_index/elasticsearch_saver'
 require 'support/test_index_helpers'
 
-class ElasticsearchSaverTest < MiniTest::Unit::TestCase
+class ElasticsearchSaverTest < Minitest::Test
   def test_should_save_valid_document
     # TestIndexHelpers.setup_test_indexes
 

--- a/test/unit/govuk_index/publishing_event_processor_test.rb
+++ b/test/unit/govuk_index/publishing_event_processor_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require 'govuk_index/publishing_event_processor'
 require 'govuk_index/publishing_event_worker'
 
-class PublishingEventProcessorTest < MiniTest::Unit::TestCase
+class PublishingEventProcessorTest < Minitest::Test
   def test_should_process_and_acknowledge_a_message
     message = OpenStruct.new(
       payload: {

--- a/test/unit/govuk_index/publishing_event_worker_test.rb
+++ b/test/unit/govuk_index/publishing_event_worker_test.rb
@@ -3,7 +3,7 @@ require 'support/test_index_helpers'
 require 'govuk_index/elasticsearch_presenter'
 require 'govuk_index/publishing_event_worker'
 
-class PublishingEventWorkerTest < MiniTest::Unit::TestCase
+class PublishingEventWorkerTest < Minitest::Test
   def test_should_save_valid_message
     payload = {
       "base_path" => "/cheese",


### PR DESCRIPTION
The former is deprecated in the version of MiniTest that we are using (5.6), and was causing warnings when running the unit tests.