### PR TITLE
Add statsd logging for monitoring queue consumption

### DIFF
--- a/lib/govuk_index/publishing_event_processor.rb
+++ b/lib/govuk_index/publishing_event_processor.rb
@@ -3,6 +3,7 @@ require 'govuk_index/publishing_event_worker'
 module GovukIndex
   class PublishingEventProcessor
     def process(message)
+      Services.statsd_client.increment('govuk_index.rabbit-mq-consumed')
       PublishingEventWorker.perform_async(message.payload)
       message.ack
     end

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -9,11 +9,16 @@ module GovukIndex
     notify_of_failures
 
     def perform(payload)
+      Services.statsd_client.increment('govuk_index.sidekiq-consumed')
       presenter = ElasticsearchPresenter.new(payload)
       presenter.valid!
       ElasticsearchSaver.new.save(presenter)
     rescue ValidationError => e
       Airbrake.notify_or_ignore(e) # Rescuing as we don't want to retry
+    # Rescuing exception to guarantee we capture all Sidekiq retries
+    rescue Exception # rubocop:disable Lint/RescueException
+      Services.statsd_client.increment('govuk_index.sidekiq-retry')
+      raise
     end
   end
 end

--- a/lib/indexer/message_processor.rb
+++ b/lib/indexer/message_processor.rb
@@ -13,14 +13,10 @@ require_relative "change_notification_processor"
 # the links from the publishing-api.
 module Indexer
   class MessageProcessor
-    def initialize(statsd_client)
-      @statsd_client = statsd_client
-    end
-
     def process(message)
       with_logging(message) do
         indexing_status = Indexer::ChangeNotificationProcessor.trigger(message.payload)
-        @statsd_client.increment("message_queue.indexer.#{indexing_status}")
+        Services.statsd_client.increment("message_queue.indexer.#{indexing_status}")
         message.ack
       end
     rescue ProcessingError => e

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require "elasticsearch"
+require 'statsd'
 require 'gds_api/publishing_api_v2'
 
 module Services
@@ -27,6 +28,10 @@ module Services
       logger: Logging.logger[self],
       transport_options: { headers: { "Content-Type" => "application/json" } }
     )
+  end
+
+  def self.statsd_client
+    @statsd_client ||= Statsd.new.tap { |sd| sd.namespace = "govuk.app.rummager" }
   end
 end
 

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -7,21 +7,17 @@
 require 'airbrake'
 require 'govuk_message_queue_consumer'
 require 'indexer/message_processor'
-require 'statsd'
 require 'govuk_index/publishing_event_processor.rb'
 
 namespace :message_queue do
   desc "Index documents that are published to the publishing-api"
   task :listen_to_publishing_queue do
-    statsd_client = Statsd.new
-    statsd_client.namespace = "govuk.app.rummager"
-
     puts "Starting message queue consumer"
 
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "rummager_to_be_indexed",
-      processor: Indexer::MessageProcessor.new(statsd_client),
-      statsd_client: statsd_client,
+      processor: Indexer::MessageProcessor.new,
+      statsd_client: Services.statsd_client,
     ).run
   end
 

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -27,15 +27,12 @@ namespace :message_queue do
 
   desc "Gets data from RabbitMQ and insert into govuk index"
   task :insert_data_into_govuk do
-    statsd_client = Statsd.new
-    statsd_client.namespace = "govuk.app.rummager"
-
     puts "Starting message queue consumer"
 
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "rummager_govuk_index",
       processor: GovukIndex::PublishingEventProcessor.new,
-      statsd_client: statsd_client,
+      statsd_client: Services.statsd_client,
     ).run
   end
 end

--- a/test/unit/tasks/message_queue_test.rb
+++ b/test/unit/tasks/message_queue_test.rb
@@ -8,9 +8,9 @@ class MessageProcessorRakeTest < Minitest::Test
   context "when indexing published documents to publishing-api" do
     should "use GovukMessageQueueConsumer::Consumer" do
       statsd_client = Statsd.new
-      Statsd.expects(:new).returns(statsd_client)
+      Services.expects(:statsd_client).returns(statsd_client)
 
-      indexer = Indexer::MessageProcessor.new(statsd_client)
+      indexer = Indexer::MessageProcessor.new
       Indexer::MessageProcessor.expects(:new).returns(indexer)
 
       consumer = mock('consumer')


### PR DESCRIPTION
This counts the number of messages that have been consumed from Rabbit MQ, and Sidekiq. They will be displayed in Graphite in the dashboards "stats.govuk.app.rummager.govuk_index.rabbit-mq-consumed" and "stats.govuk.app.rummager.govuk_index.sidekiq-consumed".

paired with @binaryberry and @dwhenry 

https://trello.com/c/gN3eg1HS/191-monitor-indexing-progress