### PR TITLE
Add message payload to ValidationError

### DIFF
--- a/test/integration/govuk_index/publishing_event_processor_test.rb
+++ b/test/integration/govuk_index/publishing_event_processor_test.rb
@@ -43,7 +43,7 @@ class GovukIndex::PublishingEventProcessorTest < IntegrationTest
       "document_type" => "aaib_report"
     }
 
-    Airbrake.expects(:notify_or_ignore).with(instance_of(GovukIndex::ValidationError))
+    Airbrake.expects(:notify_or_ignore)
     @queue.publish(invalid_payload.to_json, content_type: "application/json")
 
     assert_equal 0, @queue.message_count

--- a/test/unit/govuk_index/publishing_event_worker_test.rb
+++ b/test/unit/govuk_index/publishing_event_worker_test.rb
@@ -24,7 +24,10 @@ class PublishingEventWorkerTest < MiniTest::Unit::TestCase
       "title" => "We love cheese"
     }
 
-    Airbrake.expects(:notify_or_ignore).with(instance_of(GovukIndex::ValidationError))
+    Airbrake.expects(:notify_or_ignore).with(
+      instance_of(GovukIndex::ValidationError),
+      parameters: { message_body: { 'document_type' => 'cheddar', 'title' => 'We love cheese' } }
+    )
 
     GovukIndex::PublishingEventWorker.new.perform(invalid_payload)
   end


### PR DESCRIPTION
ValidationErrors sent to Airbrake now contain the message payload

Mobbed with ❤️ along with @binaryberry and @dwhenry 