### PR TITLE
Increase the ElasticSearch request timeout for index creation

### DIFF
--- a/lib/index_group.rb
+++ b/lib/index_group.rb
@@ -15,6 +15,9 @@ module SearchIndices
     def initialize(base_uri, name, schema, search_config)
       @base_uri = base_uri
       @client = Services::elasticsearch(hosts: base_uri)
+      # Index creation can take longer than other requests, so create a separate
+      # client with a longer timeout
+      @index_creation_client = Services::elasticsearch(hosts: base_uri, timeout: 10)
       @name = name
       @schema = schema
       @search_config = search_config
@@ -32,7 +35,7 @@ module SearchIndices
         "settings" => settings,
         "mappings" => mappings,
       }
-      @client.indices.create(
+      @index_creation_client.indices.create(
         index: index_name,
         body: index_payload
       )

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -21,6 +21,13 @@ module Services
   # Build a client to connect to one or more elasticsearch nodes.
   # hosts should be a comma separated string. Valid formats
   # are documented at http://www.rubydoc.info/gems/elasticsearch-transport#Setting_Hosts
+  #
+  # Be careful when setting a short timeout value. You may see confusing HTTP
+  # 4XX responses rather than timeout errors because the Elasticsearch client
+  # uses Faraday which uses Net::HTTP, and Net::HTTP retries idempotent requests
+  # which time out (including PUT and DELETE requests). So the first, slow,
+  # request succeeds (but times out) and the second retry request returns an
+  # error because the operation has already been run.
   def self.elasticsearch(hosts: ENV['ELASTICSEARCH_HOSTS'] || 'http://localhost:9200', timeout: 5)
     Elasticsearch::Client.new(
       hosts: hosts,

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -75,7 +75,9 @@ class IntegrationTest < Minitest::Test
   end
 
   def client
-    @client ||= Services::elasticsearch(hosts: 'http://localhost:9200')
+    # Set a fairly long timeout to avoid timeouts on index creation on the CI
+    # servers
+    @client ||= Services::elasticsearch(hosts: 'http://localhost:9200', timeout: 10)
   end
 
   def parsed_response


### PR DESCRIPTION
This fixes the intermittently failing integration tests. These were failing because index creation sometimes takes 6 or 7 seconds, but the request timeout was set to 5 seconds for all requests other than bulk reloading.

Confusingly, the error seen in the integration tests was not a timeout, but an error like this:

```
Elasticsearch::Transport::Transport::Errors::BadRequest: [400]
{"error":"IndexAlreadyExistsException[[mainstream_test-2017-07-31t09:41:05z-e5229cbf-6da5-4eb2-af27-7f9ad623ef53]
already exists]","status":400}
```

This is because the elasticsearch-transport library uses Faraday, which uses Net::HTTP under the hood. Net::HTTP automatically retries any idempotent requests which time out, including the PUT request to create an index. This request _is_ idempotent, but the second request returns a 400 because the index has already been created.

https://trello.com/c/vbOLcr7b/208-fix-intermittent-indexalreadyexistsexception-error-in-tests