### PR TITLE
Add 'elasticsearch' Jenkins tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node {
+node('elasticsearch') {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
   govuk.buildProject()
 }


### PR DESCRIPTION
This is required so that we can support elasticsearch 2.4 builds for
our upgrade branch without causing other branches to fail (as they
still require elasticsearch 1.7)

https://trello.com/c/7UxzIqNo/205-update-es-version-for-ci