### PR TITLE
Add versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :test do
   gem "mocha", "~> 1.1.0"
   gem "webmock", "~> 1.24"
   gem "timecop", "~> 0.8.0"
-  gem 'govuk_schemas', '~> 2.1'
+  gem 'govuk_schemas', '~> 2.2.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     govuk_document_types (0.1.4)
     govuk_message_queue_consumer (3.0.2)
       bunny (~> 2.2.0)
-    govuk_schemas (2.1.1)
+    govuk_schemas (2.2.0)
       json-schema (~> 2.5.0)
     hashdiff (0.3.0)
     http-cookie (1.0.3)
@@ -203,7 +203,7 @@ DEPENDENCIES
   govuk-lint (~> 1.2.1)
   govuk_document_types (= 0.1.4)
   govuk_message_queue_consumer (~> 3.0.2)
-  govuk_schemas (~> 2.1)
+  govuk_schemas (~> 2.2.0)
   logging (~> 2.1.0)
   minitest (~> 5.6.0)
   mocha (~> 1.1.0)
@@ -232,4 +232,4 @@ DEPENDENCIES
   whenever (~> 0.9.4)
 
 BUNDLED WITH
-   1.15.0
+   1.15.3

--- a/lib/govuk_index/elasticsearch_presenter.rb
+++ b/lib/govuk_index/elasticsearch_presenter.rb
@@ -7,7 +7,9 @@ module GovukIndex
     def identifier
       {
         _type: payload["document_type"],
-        _id: payload["base_path"]
+        _id: payload["base_path"],
+        version: payload["payload_version"],
+        version_type: "external",
       }
     end
 
@@ -15,7 +17,7 @@ module GovukIndex
       {
         link: payload["base_path"],
         title: payload["title"],
-        is_withdrawn: withdrawn?
+        is_withdrawn: withdrawn?,
       }
     end
 

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -57,6 +57,10 @@ module GovukIndex
         Services.statsd_client.increment("govuk_index.elasticsearch.#{action_type}")
       elsif action_type == 'delete' && details['status'] == 404 # failed while attempting to delete missing record so just ignore it
         Services.statsd_client.increment('govuk_index.elasticsearch.already_deleted')
+      elsif details['status'] == 409
+        # A version conflict indicates that messages were processed out of
+        # order. This is not expected to happen often but is safe to ignore.
+        Services.statsd_client.increment('govuk_index.elasticsearch.version_conflict')
       else
         Services.statsd_client.increment("govuk_index.elasticsearch.#{action_type}_error")
         raise ElasticsearchError, action_type: action_type, details: details

--- a/test/integration/govuk_index/publishing_event_processor_test.rb
+++ b/test/integration/govuk_index/publishing_event_processor_test.rb
@@ -22,8 +22,9 @@ class GovukIndex::PublishingEventProcessorTest < IntegrationTest
   end
 
   def test_should_save_new_document_to_elasticsearch
-    schema = GovukSchemas::Schema.find(frontend_schema: "specialist_document")
-    random_example = GovukSchemas::RandomExample.new(schema: schema).payload
+    random_example = GovukSchemas::RandomExample
+      .for_schema(notification_schema: "specialist_document")
+      .merge_and_validate(payload_version: 123)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 

--- a/test/integration/govuk_index/unpublishing_message_processing_test.rb
+++ b/test/integration/govuk_index/unpublishing_message_processing_test.rb
@@ -2,9 +2,9 @@ require 'govuk_schemas'
 require 'integration_test_helper'
 require 'govuk_index/publishing_event_processor'
 
-class GovukIndex::UnpusblishingMessageProcessing < IntegrationTest
+class GovukIndex::UnpublishingMessageProcessing < IntegrationTest
   def test_unpublish_message_will_remove_record_from_elasticsearch
-    message = create_message(publisher_schema: 'unpublishing')
+    message = create_message('unpublishing', payload_version: 2)
     base_path = message.payload['base_path']
     type = message.payload['document_type']
 
@@ -22,7 +22,8 @@ class GovukIndex::UnpusblishingMessageProcessing < IntegrationTest
 
   def test_unpublish_withdrawn_messages_will_set_is_withdrawn_flag
     message = create_message(
-      { publisher_schema: 'help_page' },
+      'help_page',
+      payload_version: 2,
       withdrawn_notice: {
         "explanation" => "<div class=\"govspeak\"><p>test 2</p>\n</div>",
         "withdrawn_at" => "2017-08-03T14:02:18Z"
@@ -42,7 +43,9 @@ class GovukIndex::UnpusblishingMessageProcessing < IntegrationTest
   end
 
   def create_message(schema_name, user_defined = {})
-    payload = GovukSchemas::RandomExample.for_schema(schema_name).merge_and_validate(user_defined)
+    payload = GovukSchemas::RandomExample
+      .for_schema(notification_schema: schema_name)
+      .merge_and_validate(user_defined)
     stubs(:message).tap do |message|
       message.stubs(:ack)
       message.stubs(:payload).returns(payload)

--- a/test/integration/govuk_index/versioning_test.rb
+++ b/test/integration/govuk_index/versioning_test.rb
@@ -1,0 +1,42 @@
+require 'govuk_schemas'
+require 'integration_test_helper'
+require 'bunny-mock'
+require 'govuk_index/publishing_event_processor'
+require 'govuk_message_queue_consumer'
+
+class GovukIndex::VersioningTest < IntegrationTest
+  def setup
+    super
+
+    bunny_mock = BunnyMock.new
+    @channel = bunny_mock.start.channel
+
+    consumer = GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "martha.test",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      rabbitmq_connection: bunny_mock
+    )
+
+    @queue = @channel.queue("martha.test")
+    consumer.run
+  end
+
+  def test_should_successfully_index_increasing_version_numbers
+    random_example = GovukSchemas::RandomExample.for_schema(
+      notification_schema: "specialist_document")
+
+    version1 = random_example.merge_and_validate(payload_version: 123)
+    base_path = version1["base_path"]
+
+    @queue.publish(version1.to_json, content_type: "application/json")
+    document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
+    assert_equal 123, document["_version"]
+
+    version2 = version1.merge(title: "new title", payload_version: 124)
+
+    @queue.publish(version2.to_json, content_type: "application/json")
+    document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
+    assert_equal 124, document["_version"]
+    assert_equal "new title", document["_source"]["title"]
+  end
+end

--- a/test/integration/govuk_index/versioning_test.rb
+++ b/test/integration/govuk_index/versioning_test.rb
@@ -1,59 +1,39 @@
 require 'govuk_schemas'
 require 'integration_test_helper'
-require 'bunny-mock'
 require 'govuk_index/publishing_event_processor'
-require 'govuk_message_queue_consumer'
 
 class GovukIndex::VersioningTest < IntegrationTest
   def setup
     super
-
-    bunny_mock = BunnyMock.new
-    @channel = bunny_mock.start.channel
-
-    consumer = GovukMessageQueueConsumer::Consumer.new(
-      queue_name: "martha.test",
-      processor: GovukIndex::PublishingEventProcessor.new,
-      rabbitmq_connection: bunny_mock
-    )
-
-    @queue = @channel.queue("martha.test")
-    consumer.run
+    @processor = GovukIndex::PublishingEventProcessor.new
   end
 
   def test_should_successfully_index_increasing_version_numbers
-    random_example = GovukSchemas::RandomExample.for_schema(
-      notification_schema: "specialist_document")
-
-    version1 = random_example.merge_and_validate(payload_version: 123)
+    version1 = generate_random_example(payload: { payload_version: 123 })
     base_path = version1["base_path"]
+    process_message(version1)
 
-    @queue.publish(version1.to_json, content_type: "application/json")
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
     assert_equal 123, document["_version"]
 
     version2 = version1.merge(title: "new title", payload_version: 124)
+    process_message(version2)
 
-    @queue.publish(version2.to_json, content_type: "application/json")
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
     assert_equal 124, document["_version"]
     assert_equal "new title", document["_source"]["title"]
   end
 
   def test_should_discard_message_with_same_version_as_existing_document
-    random_example = GovukSchemas::RandomExample.for_schema(
-      notification_schema: "specialist_document")
-
-    version1 = random_example.merge_and_validate(payload_version: 123)
+    version1 = generate_random_example(payload: { payload_version: 123 })
     base_path = version1["base_path"]
+    process_message(version1)
 
-    @queue.publish(version1.to_json, content_type: "application/json")
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
     assert_equal 123, document["_version"]
 
     version2 = version1.merge(title: "new title", payload_version: 123)
-
-    @queue.publish(version2.to_json, content_type: "application/json")
+    process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
     assert_equal 123, document["_version"]
@@ -61,22 +41,68 @@ class GovukIndex::VersioningTest < IntegrationTest
   end
 
   def test_should_discard_message_with_earlier_version_than_existing_document
-    random_example = GovukSchemas::RandomExample.for_schema(
-      notification_schema: "specialist_document")
-
-    version1 = random_example.merge_and_validate(payload_version: 123)
+    version1 = generate_random_example(payload: { payload_version: 123 })
     base_path = version1["base_path"]
+    process_message(version1)
 
-    @queue.publish(version1.to_json, content_type: "application/json")
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
     assert_equal 123, document["_version"]
 
     version2 = version1.merge(title: "new title", payload_version: 122)
-
-    @queue.publish(version2.to_json, content_type: "application/json")
+    process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
     assert_equal 123, document["_version"]
     assert_equal version1["title"], document["_source"]["title"]
+  end
+
+  def test_should_delete_and_recreate_document_when_unpublished_and_republished
+    version1 = generate_random_example(
+      payload: { payload_version: 1 },
+      excluded_fields: ["withdrawn_notice"]
+    )
+    base_path = version1["base_path"]
+    process_message(version1)
+
+    document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
+    assert_equal 1, document["_version"]
+
+    version2 = version1.merge(payload_version: 2)
+    process_message(version2, unpublishing: true)
+
+    assert_raises(Elasticsearch::Transport::Transport::Errors::NotFound) do
+      fetch_document_from_rummager(id: base_path, index: 'govuk_test')
+    end
+
+    version3 = version1.merge(payload_version: 3)
+    process_message(version3)
+
+    document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
+    assert_equal 3, document["_version"]
+  end
+
+  def test_should_discard_unpublishing_message_with_earlier_version
+    version1 = generate_random_example(payload: { payload_version: 2 })
+    base_path = version1["base_path"]
+    process_message(version1)
+
+    document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
+    assert_equal 2, document["_version"]
+
+    version2 = version1.merge(payload_version: 1)
+    process_message(version2, unpublishing: true)
+
+    document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
+    assert_equal 2, document["_version"]
+  end
+
+  def generate_random_example(payload: {}, excluded_fields: [])
+    GovukSchemas::RandomExample
+      .for_schema(notification_schema: "specialist_document")
+      .merge_and_validate(payload, excluded_fields)
+  end
+
+  def process_message(example_document, unpublishing: false)
+    @processor.process(stub_message_payload(example_document, unpublishing: unpublishing))
   end
 end

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -136,6 +136,15 @@ class IntegrationTest < Minitest::Test
     end
   end
 
+  def stub_message_payload(example_document, unpublishing: false)
+    routing_key = unpublishing ? 'test.unpublish' : 'test.a_routing_key'
+    stubs(:message).tap do |message|
+      message.stubs(:ack)
+      message.stubs(:payload).returns(example_document)
+      message.stubs(:delivery_info).returns(routing_key: routing_key)
+    end
+  end
+
 private
 
   def populate_content_indexes(params)

--- a/test/unit/govuk_index/elasticsearch_presenter_test.rb
+++ b/test/unit/govuk_index/elasticsearch_presenter_test.rb
@@ -6,14 +6,18 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
     payload = {
       "base_path" => "/some/path",
       "document_type" => "aaib_report",
-      "title" => "A plane has had an issue"
+      "title" => "A plane has had an issue",
+      "payload_version" => 1,
+      "version_type" => "external"
     }
 
     presenter = GovukIndex::ElasticsearchPresenter.new(payload)
 
     expected_identifier = {
       _type: "aaib_report",
-      _id: "/some/path"
+      _id: "/some/path",
+      version: 1,
+      version_type: "external"
     }
 
     expected_document = {
@@ -31,6 +35,8 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
       "base_path" => "/some/path",
       "document_type" => "aaib_report",
       "title" => "A plane has had an issue",
+      "payload_version" => 2,
+      "version_type" => "external",
       "withdrawn_notice" => {
         "explanation" => "<div class=\"govspeak\"><p>test 2</p>\n</div>",
         "withdrawn_at" => "2017-08-03T14:02:18Z"
@@ -41,7 +47,9 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
 
     expected_identifier = {
       _type: "aaib_report",
-      _id: "/some/path"
+      _id: "/some/path",
+      version: 2,
+      version_type: "external"
     }
 
     expected_document = {


### PR DESCRIPTION
**Add external versioning to documents in Elasticsearch:**
Use the `payload_version` field from the publishing API to add a document version. This will prevent old versions of documents overwriting new versions if the publishing events are processed out of
order.

**Handle messages published out of order:**
If messages from the publishing-api arrive out of order and cause a versioning error in Elasticsearch, discard the error and increment the statsd counter.

**Bump govuk_schemas gem to 2.2.0:**
This enables us to exclude fields when using the RandomExample generator in integration tests

**Fix intermitent failures of unpublishing tests**
RandomExampleGenerator was generating a `withdrawn_notice` field 50% of the time, even when we were trying to test unpublishing messages which were not withdrawn. We changed the tests to use `customise_and_merge` which now allows us to exclude the `withdrawn_notice`.

[Trello](https://trello.com/c/LatZVRg8/213-make-versioning-work-for-all-publishing-events)

Mobbed with @suzannehamilton, @dwhenry and @Rosa-Fox.

