### PR TITLE
Only clean the index is the RUMMAGER_VERSION matches

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,6 +28,9 @@ require "indexer/comparer"
 require "govuk_index/publishing_event_processor"
 
 class Rummager < Sinatra::Application
+  # this is needed to support the migration to ES 2.4
+  ELASTICSEARCH_VERSION = '1.7'
+
   # - Stop double slashes in URLs (even escaped ones) being flattened to single ones
   #
   # - Explicitly allow requests that are referred from other domains so we can link

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -89,8 +89,14 @@ You should run this task if the index schema has changed.
 
   desc "Cleans out old indices"
   task :clean do
-    index_names.each do |index_name|
-      search_server.index_group(index_name).clean
+    # as we only want to clean the indices for the versions that matches from the overnight copy task
+    # if we didn't check this we could potentially attempt to delete one of the new indices as we are importing
+    # data into it.
+    version = ENV.fetch('RUMMAGER_VERSION', '1.7')
+    if version == Rummager::ELASTICSEARCH_VERSION
+      index_names.each do |index_name|
+        search_server.index_group(index_name).clean
+      end
     end
   end
 


### PR DESCRIPTION
We only want to clean the indices for the versions that 
matches from the overnight copy task

If we didn't check this we could potentially attempt to 
delete one of the new indices as we are importing data 
into it.

https://trello.com/c/3vligOJD/219-resolve-the-write-index-lock-for-mainstream-copied-to-integration