### PR TITLE
Allow sitemap format boosts to override internal search boosts

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -1,31 +1,38 @@
-format:
-  # Mainstream formats
-  service_manual_guide: 0.3
-  service_manual_topic: 0.3
-  smart-answer: 1.5
-  transaction: 1.5
-  # Should appear below mainstream content
-  aaib_report: 0.2
-  dfid_research_output: 0.2
-  hmrc_manual_section: 0.2
-  service_standard_report: 0.05
-  # Inside Gov formats
-  contact: 0.3
-  document_collection: 1.3
-  document_series: 1.3
-  minister: 1.7
-  operational_field: 1.5
-  organisation: 2.5
-  topic: 1.5
-  topical_event: 1.5
-  # Hide mainstream browse pages
-  mainstream_browse_page: 0
-content_store_document_type:
-  foi_release: 0.2
-navigation_document_supertype:
-  guidance: 2.5
-organisation_state:
-  closed: 0.2
-  devolved: 0.3
-is_historic:
-  true: 0.5
+base:
+  format:
+    # Mainstream formats
+    service_manual_guide: 0.3
+    service_manual_topic: 0.3
+    smart-answer: 1.5
+    transaction: 1.5
+    # Should appear below mainstream content
+    aaib_report: 0.2
+    dfid_research_output: 0.2
+    hmrc_manual_section: 0.2
+    service_standard_report: 0.05
+    # Inside Gov formats
+    contact: 0.3
+    document_collection: 1.3
+    document_series: 1.3
+    minister: 1.7
+    operational_field: 1.5
+    organisation: 2.5
+    topic: 1.5
+    topical_event: 1.5
+    # Hide mainstream browse pages
+    mainstream_browse_page: 0
+  content_store_document_type:
+    foi_release: 0.2
+  navigation_document_supertype:
+    guidance: 2.5
+  organisation_state:
+    closed: 0.2
+    devolved: 0.3
+  is_historic:
+    true: 0.5
+# Overrides to apply to the sitemap priorities in external search
+external_search:
+  format:
+    mainstream_browse_page: 2
+    policy: 1.5
+    topic: 2

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -2,7 +2,7 @@ require "yaml"
 
 module QueryComponents
   class Booster < BaseComponent
-    BOOST_CONFIG = YAML.load_file('config/query/boosting.yml')
+    BOOST_CONFIG = YAML.load_file('config/query/boosting.yml')["base"]
     DEFAULT_BOOST = 1
 
     def wrap(core_query)

--- a/lib/sitemap/property_boost_calculator.rb
+++ b/lib/sitemap/property_boost_calculator.rb
@@ -1,6 +1,8 @@
 class PropertyBoostCalculator
   def initialize
-    @boost_config = YAML.load_file('config/query/boosting.yml')
+    config = YAML.load_file('config/query/boosting.yml')
+    external_search_overrides = config.fetch("external_search", {})
+    @boost_config = config["base"].merge(external_search_overrides)
   end
 
   def boost(document)

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -53,6 +53,6 @@ private
   StaticDocumentPresenter = Struct.new(:url, :last_updated, :priority)
 
   def homepage
-    StaticDocumentPresenter.new("/", nil, 1)
+    StaticDocumentPresenter.new(Plek.current.website_root + "/", nil, 1)
   end
 end

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -53,6 +53,6 @@ private
   StaticDocumentPresenter = Struct.new(:url, :last_updated, :priority)
 
   def homepage
-    StaticDocumentPresenter.new(Plek.current.website_root + "/", nil, 1)
+    StaticDocumentPresenter.new(Plek.current.website_root + "/", nil, 0.5)
   end
 end

--- a/test/integration/sitemap/sitemap_test.rb
+++ b/test/integration/sitemap/sitemap_test.rb
@@ -79,7 +79,7 @@ class SitemapTest < IntegrationTest
       .select { |item| item.css("loc").text == "http://www.dev.gov.uk/" }
 
     assert_equal 1, pages.count
-    assert_equal "1", pages[0].css("priority").text
+    assert_equal "0.5", pages[0].css("priority").text
   end
 
   def test_should_not_include_recommended_links

--- a/test/integration/sitemap/sitemap_test.rb
+++ b/test/integration/sitemap/sitemap_test.rb
@@ -70,6 +70,18 @@ class SitemapTest < IntegrationTest
     assert_equal 3, sitemap_xml.length
   end
 
+  def test_should_include_homepage
+    generator = SitemapGenerator.new(search_server.content_indices)
+    sitemap_xml = generator.sitemaps
+
+    pages = Nokogiri::XML(sitemap_xml[0])
+      .css("url")
+      .select { |item| item.css("loc").text == "http://www.dev.gov.uk/" }
+
+    assert_equal 1, pages.count
+    assert_equal "1", pages[0].css("priority").text
+  end
+
   def test_should_not_include_recommended_links
     generator = SitemapGenerator.new(search_server.content_indices)
     sitemap_xml = generator.sitemaps

--- a/test/unit/sitemap/property_boost_calculator_test.rb
+++ b/test/unit/sitemap/property_boost_calculator_test.rb
@@ -115,8 +115,37 @@ class PropertyBoostCalculatorTest < Minitest::Test
     assert_equal 0.07, calculator.boost(document)
   end
 
+  def test_external_search_overrides_are_applied
+    config = {
+      "base" => {
+        "format" => {
+          "service_manual_guide" => 1,
+        }
+      },
+      "external_search" => {
+        "format" => {
+          "service_manual_guide" => 2
+        }
+      },
+    }
+    stub_full_config(config)
+
+    calculator = PropertyBoostCalculator.new
+
+    # 1 - 2^(-boost_override) = 1 - 2^(-2) = 0.75
+    expected_boost_override = 0.75
+    actual_boost = calculator.boost(build_document(format: "service_manual_guide"))
+    assert_equal expected_boost_override, actual_boost
+  end
+
   def stub_boost_config(boosts)
-    YAML.stubs(:load_file).returns(boosts)
+    stub_full_config({
+      "base" => boosts
+    })
+  end
+
+  def stub_full_config(config)
+    YAML.stubs(:load_file).returns(config)
   end
 
   def build_document(format: nil, document_type: nil)


### PR DESCRIPTION
Before, the weightings applied to documents in the sitemap were the same as those used to rank documents in internal search. The assumption was that search results that rank highly in internal search should also rank highly in external search because users are searching for the same content.

But this isn't always the case: navigation pages are inappropriate results in internal search because the user is already on the site, but may help to orient a user coming from external search. So a boost of 0 for mainstream browse pages should be increased in the external search ranking.

https://trello.com/c/8JQ38H0K/217-override-boost-for-navigation-pages