### PR TITLE
Disable minitest-pride in Jenkins build

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,8 @@ $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 require 'app'
 
 require "minitest/autorun"
-require "minitest/pride"
+# Add colourful test output. This works in development but not in CI.
+require "minitest/pride" unless ENV["JENKINS_URL"]
 
 require "bundler/setup"
 require "rack/test"


### PR DESCRIPTION
Minitest Pride gives colourful test output, but this leads to noisy control characters in the Jenkins test output because Jenkins has a monochrome output.