### PR TITLE
Update bunny-mock gem to 1.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "govuk_document_types", "0.1.4"
 gem "govuk-lint", "~> 1.2.1"
 
 group :test do
-  gem "bunny-mock", git: "https://github.com/alphagov/bunny-mock.git", branch: "add-tracking-for-channel-reject-method"
+  gem 'bunny-mock', '~> 1.7'
   gem "test-unit", "~> 3.0"
   gem "minitest", "~> 5.6.0"
   gem "shoulda-context", "~> 1.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/bunny-mock.git
-  revision: f5ffb9d1a7794064dcc4a170292baf92cf89e93e
-  branch: add-tracking-for-channel-reject-method
-  specs:
-    bunny-mock (1.6.0)
-      bunny (>= 1.7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -22,6 +14,8 @@ GEM
     builder (3.2.2)
     bunny (2.2.2)
       amq-protocol (>= 2.0.1)
+    bunny-mock (1.7.0)
+      bunny (>= 1.7)
     byebug (9.0.5)
     chronic (0.10.2)
     ci_reporter (1.7.3)
@@ -196,7 +190,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (= 3.2.22.2)
   airbrake (~> 4.3.6)
-  bunny-mock!
+  bunny-mock (~> 1.7)
   ci_reporter (~> 1.7.1)
   elasticsearch (~> 1.0.15)
   gds-api-adapters (~> 41.2)


### PR DESCRIPTION
The change we implemented in https://github.com/arempe93/bunny-mock/pull/32 has been released!

https://trello.com/c/taEdIx5E/163-external-enable-testing-of-queues-in-rummager