### PR TITLE
Fix unpublishing

### DIFF
--- a/lib/govuk_index/client.rb
+++ b/lib/govuk_index/client.rb
@@ -1,0 +1,42 @@
+module GovukIndex
+  class Client
+    TIMEOUT_SECONDS = 5.0
+
+    class << self
+      delegate :get, :bulk, to: :instance
+
+      def instance
+        @instance || new
+      end
+    end
+
+    def get(params)
+      client.get(
+        params.merge(index: index_name)
+      )
+    end
+
+    def bulk(params)
+      client.bulk(
+        params.merge(index: index_name)
+      )
+    end
+
+  private
+
+    def client(options = {})
+      @_client ||= Services.elasticsearch(
+        hosts: search_config.base_uri,
+        timeout: options[:timeout] || TIMEOUT_SECONDS
+      )
+    end
+
+    def search_config
+      @_config ||= SearchConfig.instance
+    end
+
+    def index_name
+      @_index ||= search_config.govuk_index_name
+    end
+  end
+end

--- a/lib/govuk_index/document_type_inferer.rb
+++ b/lib/govuk_index/document_type_inferer.rb
@@ -1,0 +1,30 @@
+module GovukIndex
+  class DocumentTypeInferer
+    UNPUBLISHING_TYPES = %w(gone redirect substitute vanish).freeze
+
+    def initialize(payload)
+      @payload = payload
+    end
+
+    def type
+      if unpublishing_type?
+        raise NotFoundError if existing_document.nil?
+        existing_document['_type']
+      else
+        payload['document_type']
+      end
+    end
+
+    def unpublishing_type?
+      UNPUBLISHING_TYPES.include?(payload['document_type'])
+    end
+
+  private
+
+    attr_reader :payload
+
+    def existing_document
+      @_existing_document ||= Client.get(type: '_all', id: payload['base_path'])
+    end
+  end
+end

--- a/lib/govuk_index/elasticsearch_presenter.rb
+++ b/lib/govuk_index/elasticsearch_presenter.rb
@@ -1,13 +1,14 @@
 module GovukIndex
   class ElasticsearchPresenter
-    def initialize(payload)
+    def initialize(payload, type)
       @payload = payload
+      @type = type
     end
 
     def identifier
       {
-        _type: payload["document_type"],
-        _id: payload["base_path"],
+        _type: type,
+        _id: id,
         version: payload["payload_version"],
         version_type: "external",
       }
@@ -21,17 +22,21 @@ module GovukIndex
       }
     end
 
+    def id
+      payload["base_path"]
+    end
+
     def valid!
       return if payload["base_path"]
       raise(ValidationError, "base_path missing from payload")
     end
 
+  private
+
+    attr_reader :payload, :type
+
     def withdrawn?
       !payload["withdrawn_notice"].nil?
     end
-
-  private
-
-    attr_reader :payload
   end
 end

--- a/lib/govuk_index/elasticsearch_processor.rb
+++ b/lib/govuk_index/elasticsearch_processor.rb
@@ -1,7 +1,5 @@
 module GovukIndex
   class ElasticsearchProcessor
-    TIMEOUT_SECONDS = 5.0
-
     def initialize
       @actions = []
     end
@@ -17,27 +15,9 @@ module GovukIndex
 
     def commit
       return if @actions.empty?
-      client.bulk(
-        index: index_name,
+      GovukIndex::Client.bulk(
         body: @actions
       )
-    end
-
-  private
-
-    def client(options = {})
-      @_client ||= Services.elasticsearch(
-        hosts: search_config.base_uri,
-        timeout: options[:timeout] || TIMEOUT_SECONDS
-      )
-    end
-
-    def search_config
-      @_config ||= SearchConfig.instance
-    end
-
-    def index_name
-      @_index ||= search_config.govuk_index_name
     end
   end
 end

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -1,7 +1,8 @@
 module GovukIndex
-  class ValidationError < StandardError; end
   class ElasticsearchError < StandardError; end
   class MultipleMessagesInElasticsearchResponse < StandardError; end
+  class NotFoundError < StandardError; end
+  class ValidationError < StandardError; end
 
   class PublishingEventWorker < Indexer::BaseWorker
     notify_of_failures
@@ -19,6 +20,11 @@ module GovukIndex
           message_body: payload,
         }
       )
+    # Unpublishing messages for something that does not exist may have been
+    # processed out of order so we don't want to notify errbit but just allow
+    # the process to continue
+    rescue NotFoundError
+      Services.statsd_client.increment('govuk_index.not-found-error')
     # Rescuing exception to guarantee we capture all Sidekiq retries
     rescue Exception # rubocop:disable Lint/RescueException
       Services.statsd_client.increment('govuk_index.sidekiq-retry')
@@ -29,10 +35,12 @@ module GovukIndex
 
     def process_action(actions, routing_key, payload)
       Services.statsd_client.increment('govuk_index.sidekiq-consumed')
-      presenter = ElasticsearchPresenter.new(payload)
+
+      document_type_inferer = DocumentTypeInferer.new(payload)
+      presenter = ElasticsearchPresenter.new(payload, document_type_inferer.type)
       presenter.valid!
 
-      if routing_key =~ /\.unpublish$/ && !presenter.withdrawn?
+      if document_type_inferer.unpublishing_type?
         actions.delete(presenter)
       else
         actions.save(presenter)

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -53,6 +53,8 @@ require 'indexer/workers/amend_worker'
 require 'indexer/workers/bulk_index_worker'
 require 'indexer/workers/delete_worker'
 
+require 'govuk_index/client'
+require "govuk_index/document_type_inferer"
 require 'govuk_index/elasticsearch_presenter'
 require 'govuk_index/elasticsearch_processor'
 require 'govuk_index/publishing_event_processor'

--- a/test/integration/govuk_index/unpublishing_message_processing_test.rb
+++ b/test/integration/govuk_index/unpublishing_message_processing_test.rb
@@ -2,45 +2,57 @@ require 'integration_test_helper'
 
 class GovukIndex::UnpublishingMessageProcessing < IntegrationTest
   def test_unpublish_message_will_remove_record_from_elasticsearch
-    message = unpublishing_event_message('unpublishing', { payload_version: 2 }, ['withdrawn_notice'])
+    message = unpublishing_event_message(
+      "gone",
+      user_defined: {
+        payload_version: 2,
+        base_path: "/carrots",
+        document_type: "gone"
+      },
+      excluded_fields: ['withdrawn_notice']
+    )
     base_path = message.payload['base_path']
-    type = message.payload['document_type']
 
-    commit_document('govuk_test', { 'link' => base_path }, type: type)
+    commit_document('govuk_test', { 'link' => base_path }, id: base_path, type: 'answer')
+    assert_document_is_in_rummager({ 'link' => base_path }, index: 'govuk_test', type: 'answer')
 
-    assert_document_is_in_rummager({ 'link' => base_path }, index: 'govuk_test', type: type)
     processor = GovukIndex::PublishingEventProcessor.new
-    processor.process(message)
 
+    processor.process(message)
     commit_index('govuk_test')
+
     assert_raises(Elasticsearch::Transport::Transport::Errors::NotFound) do
-      fetch_document_from_rummager(id: base_path, index: 'govuk_test', type: type)
+      fetch_document_from_rummager(id: base_path, index: 'govuk_test', type: 'answer')
     end
   end
 
   def test_unpublish_withdrawn_messages_will_set_is_withdrawn_flag
     message = unpublishing_event_message(
-      'help_page',
-      payload_version: 2,
-      withdrawn_notice: {
-        "explanation" => "<div class=\"govspeak\"><p>test 2</p>\n</div>",
-        "withdrawn_at" => "2017-08-03T14:02:18Z"
+      "help_page",
+      user_defined: {
+        payload_version: 2,
+        document_type: "help_page",
+        withdrawn_notice: {
+          "explanation" => "<div class=\"govspeak\"><p>test 2</p>\n</div>",
+          "withdrawn_at" => "2017-08-03T14:02:18Z"
+        }
       }
     )
     base_path = message.payload['base_path']
     type = message.payload['document_type']
 
-    commit_document('govuk_test', { 'link' => base_path }, type: type)
+    commit_document('govuk_test', { 'link' => base_path }, id: base_path, type: type)
 
     assert_document_is_in_rummager({ 'link' => base_path, 'is_withdrawn' => nil }, index: 'govuk_test', type: type)
     processor = GovukIndex::PublishingEventProcessor.new
-    processor.process(message)
 
+    processor.process(message)
     commit_index('govuk_test')
+
     assert_document_is_in_rummager({ 'link' => base_path, 'is_withdrawn' => true }, index: 'govuk_test', type: type)
   end
 
-  def unpublishing_event_message(schema_name, user_defined = {}, excluded_fields = [])
+  def unpublishing_event_message(schema_name, user_defined: {}, excluded_fields: [])
     payload = GovukSchemas::RandomExample
       .for_schema(notification_schema: schema_name)
       .customise_and_validate(user_defined, excluded_fields)

--- a/test/unit/govuk_index/document_type_inferer_test.rb
+++ b/test/unit/govuk_index/document_type_inferer_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class GovukIndex::DocumentTypeInfererTest < Minitest::Test
+  def test_infer_payload_document_type
+    payload = {
+      "base_path" => "/cheese",
+      "document_type" => "cheddar"
+    }
+
+    document_type_inferer = GovukIndex::DocumentTypeInferer.new(payload)
+
+    assert_equal payload["document_type"], document_type_inferer.type
+  end
+
+  def test_should_raise_not_found_error
+    payload = { "document_type" => "gone" }
+
+    GovukIndex::DocumentTypeInferer.any_instance.stubs(:existing_document).returns(nil)
+
+    assert_raises(GovukIndex::NotFoundError) do
+      GovukIndex::DocumentTypeInferer.new(payload).type
+    end
+  end
+
+  def test_infer_existing_document_type
+    payload = {
+      "base_path" => "/cheese",
+      "document_type" => "redirect"
+    }
+
+    existing_document = {
+      "_type" => "cheddar",
+      "_id" => "/cheese"
+    }
+
+    GovukIndex::DocumentTypeInferer.any_instance.stubs(:existing_document).returns(existing_document)
+
+    document_type_inferer = GovukIndex::DocumentTypeInferer.new(payload)
+
+    assert_equal existing_document["_type"], document_type_inferer.type
+  end
+end

--- a/test/unit/govuk_index/elasticsearch_presenter_test.rb
+++ b/test/unit/govuk_index/elasticsearch_presenter_test.rb
@@ -10,7 +10,7 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
       "version_type" => "external"
     }
 
-    presenter = GovukIndex::ElasticsearchPresenter.new(payload)
+    presenter = GovukIndex::ElasticsearchPresenter.new(payload, "aaib_report")
 
     expected_identifier = {
       _type: "aaib_report",
@@ -29,6 +29,26 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
     assert_equal expected_document, presenter.document
   end
 
+  def test_converts_gone_message_payload_to_elasticsearch_format
+    payload = {
+      "base_path" => "/some/path",
+      "document_type" => "gone",
+      "payload_version" => 1,
+      "version_type" => "external"
+    }
+
+    presenter = GovukIndex::ElasticsearchPresenter.new(payload, "aaib_report")
+
+    expected_identifier = {
+      _type: "aaib_report",
+      _id: "/some/path",
+      version: 1,
+      version_type: "external"
+    }
+
+    assert_equal expected_identifier, presenter.identifier
+  end
+
   def test_withdrawn_when_withdrawn_notice_present
     payload = {
       "base_path" => "/some/path",
@@ -42,7 +62,7 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
       }
     }
 
-    presenter = GovukIndex::ElasticsearchPresenter.new(payload)
+    presenter = GovukIndex::ElasticsearchPresenter.new(payload, "aaib_report")
 
     expected_identifier = {
       _type: "aaib_report",

--- a/test/unit/govuk_index/publishing_event_worker_test.rb
+++ b/test/unit/govuk_index/publishing_event_worker_test.rb
@@ -21,9 +21,10 @@ class PublishingEventWorkerTest < Minitest::Test
   def test_delete_record_when_unpublishing_message_received
     payload = {
       "base_path" => "/cheese",
-      "document_type" => "cheddar",
+      "document_type" => "redirect",
       "title" => "We love cheese"
     }
+    stub_document_type_inferer
 
     actions = stub('actions')
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
@@ -60,9 +61,10 @@ class PublishingEventWorkerTest < Minitest::Test
   def test_raise_error_when_elasticsearch_update_error
     payload = {
       "base_path" => "/cheese",
-      "document_type" => "cheddar",
+      "document_type" => "gone",
       "title" => "We love cheese"
     }
+    stub_document_type_inferer
 
     actions = stub('actions')
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
@@ -81,9 +83,10 @@ class PublishingEventWorkerTest < Minitest::Test
   def test_does_not_raise_error_when_document_not_found_while_attempting_to_delete
     payload = {
       "base_path" => "/cheese",
-      "document_type" => "cheddar",
+      "document_type" => "substitute",
       "title" => "We love cheese"
     }
+    stub_document_type_inferer
 
     actions = stub('actions')
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
@@ -98,9 +101,10 @@ class PublishingEventWorkerTest < Minitest::Test
   def test_raise_error_if_elasticsearch_returns_multiple_responses
     payload = {
       "base_path" => "/cheese",
-      "document_type" => "cheddar",
+      "document_type" => "vanish",
       "title" => "We love cheese"
     }
+    stub_document_type_inferer
 
     actions = stub('actions')
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
@@ -128,5 +132,10 @@ class PublishingEventWorkerTest < Minitest::Test
     )
 
     GovukIndex::PublishingEventWorker.new.perform('routing.key', invalid_payload)
+  end
+
+  def stub_document_type_inferer
+    GovukIndex::DocumentTypeInferer.any_instance.stubs(:unpublishing_type).returns(true)
+    GovukIndex::DocumentTypeInferer.any_instance.stubs(:type).returns('real_document_type')
   end
 end


### PR DESCRIPTION
The `document_type` in the payload from the publishing api differs depending on the unpublishing
type.

- `gone` => `gone`
- `redirect` => `redirect`
- `substitute` => `substitute`
- `vanish` => `vanish`
- `withdrawn` => keeps the `document_type` of the document being withdrawn

Mobbed with @binaryberry @suzannehamilton @dwhenry @MatMoore @Rosa-Fox 

https://trello.com/c/LatZVRg8/213-make-versioning-work-for-all-publishing-events