### PR TITLE
Fix rummager clean task

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -5,9 +5,6 @@ require 'rummager'
 require 'routes/content'
 
 class Rummager < Sinatra::Application
-  # this is needed to support the migration to ES 2.4
-  ELASTICSEARCH_VERSION = '1.7'.freeze
-
   # - Stop double slashes in URLs (even escaped ones) being flattened to single ones
   #
   # - Explicitly allow requests that are referred from other domains so we can link

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -1,6 +1,9 @@
 require 'rummager'
 
 namespace :rummager do
+  # this is needed to support the migration to ES 2.4
+  ELASTICSEARCH_VERSION = '1.7'.freeze
+
   desc "Lists current Rummager indices, pass [all] to show inactive indices"
   task :list_indices, :all do |_, args|
     show_all = args[:all] || false
@@ -90,7 +93,7 @@ You should run this task if the index schema has changed.
     # if we didn't check this we could potentially attempt to delete one of the new indices as we are importing
     # data into it.
     version = ENV.fetch('RUMMAGER_VERSION', '1.7')
-    if version == Rummager::ELASTICSEARCH_VERSION
+    if version == ELASTICSEARCH_VERSION
       index_names.each do |index_name|
         search_server.index_group(index_name).clean
       end


### PR DESCRIPTION
Move the index version definition to a location that is loaded inside the rake
task.