### PR TITLE
Fix requires for health check

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -11,6 +11,7 @@ LIBRARY_PATH = PROJECT_ROOT + "lib/"
 end
 
 DEFAULT_JSON_URL = "https://www.gov.uk/api/search.json".freeze
+require 'logging'
 require 'health_check/logging_config'
 require "rummager"
 


### PR DESCRIPTION
This could also be fixed by change the order of requires to:

```
require "rummager"
require 'health_check/logging_config'
```

However this would result in the following warning:

```
warning: already initialized constant Logging::MAX_LEVEL_LENGTH
```

due to how logging is initialized.