### PR TITLE
Parse publishing API json payload correctly

### DIFF
--- a/lib/govuk_index/publishing_event_processor.rb
+++ b/lib/govuk_index/publishing_event_processor.rb
@@ -2,7 +2,7 @@ module GovukIndex
   class PublishingEventProcessor
     def process(message)
       Services.statsd_client.increment('govuk_index.rabbit-mq-consumed')
-      PublishingEventWorker.perform_async(message.delivery_info[:routing_key], message.payload)
+      PublishingEventWorker.perform_async(message.delivery_info[:routing_key], JSON.parse(message.payload))
       message.ack
     end
   end

--- a/test/unit/govuk_index/elasticsearch_processor_test.rb
+++ b/test/unit/govuk_index/elasticsearch_processor_test.rb
@@ -20,4 +20,31 @@ class ElasticsearchProcessorTest < Minitest::Test
     actions.save(presenter)
     actions.commit
   end
+
+  def test_should_delete_valid_document
+    presenter = stub(:presenter)
+    presenter.stubs(:identifier).returns(
+      _type: "cheddar",
+      _id: "/cheese"
+    )
+    presenter.stubs(:document).returns(
+      link: "/cheese",
+      title: "We love cheese"
+    )
+
+    client = stub('client')
+    Services.stubs('elasticsearch').returns(client)
+    client.expects(:bulk).with(
+      index: SearchConfig.instance.govuk_index_name,
+      body: [
+        {
+          delete: presenter.identifier
+        }
+      ]
+    )
+
+    actions = GovukIndex::ElasticsearchProcessor.new
+    actions.delete(presenter)
+    actions.commit
+  end
 end


### PR DESCRIPTION
We were not parsing the publishing API payload before putting it onto the sidekiq queue. This resulted in the `payload_version` being read as a string instead of its actual value.

https://trello.com/c/LatZVRg8/213-make-versioning-work-for-all-publishing-events

Mobbed with @Rosa-Fox @MatMoore 