### PR TITLE
Map content store document_types to elasticsearch document_types

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -1,0 +1,8 @@
+answer: edition
+guide: edition
+help_page: edition
+licence: edition
+local_transaction: edition
+place: edition
+simple_smart_answer: edition
+transaction: edition

--- a/lib/govuk_index/document_type_inferer.rb
+++ b/lib/govuk_index/document_type_inferer.rb
@@ -11,7 +11,8 @@ module GovukIndex
         raise NotFoundError if existing_document.nil?
         existing_document['_type']
       else
-        payload['document_type']
+        raise UnknownDocumentTypeError if elasticsearch_document_type.nil?
+        elasticsearch_document_type
       end
     end
 
@@ -23,8 +24,18 @@ module GovukIndex
 
     attr_reader :payload
 
+    def mapped_document_types
+      @_document_types ||= begin
+        YAML.load_file(File.join(__dir__, '../../config/govuk_index/mapped_document_types.yaml'))
+      end
+    end
+
     def existing_document
       @_existing_document ||= Client.get(type: '_all', id: payload['base_path'])
+    end
+
+    def elasticsearch_document_type
+      @_elasticsearch_document_type ||= mapped_document_types[payload['document_type']]
     end
   end
 end

--- a/lib/govuk_index/elasticsearch_presenter.rb
+++ b/lib/govuk_index/elasticsearch_presenter.rb
@@ -19,6 +19,7 @@ module GovukIndex
         link: payload["base_path"],
         title: payload["title"],
         is_withdrawn: withdrawn?,
+        content_store_document_type: payload["document_type"],
       }
     end
 

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -25,8 +25,10 @@ module GovukIndex
     # processed out of order so we don't want to notify errbit but just allow
     # the process to continue
     rescue NotFoundError
+      logger.info("#{payload['base_path']} could not be found.")
       Services.statsd_client.increment('govuk_index.not-found-error')
     rescue UnknownDocumentTypeError
+      logger.info("#{payload['document_type']} document type is not known.")
       Services.statsd_client.increment('govuk_index.unknown-document-type')
     # Rescuing exception to guarantee we capture all Sidekiq retries
     rescue Exception # rubocop:disable Lint/RescueException

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -2,6 +2,7 @@ module GovukIndex
   class ElasticsearchError < StandardError; end
   class MultipleMessagesInElasticsearchResponse < StandardError; end
   class NotFoundError < StandardError; end
+  class UnknownDocumentTypeError < StandardError; end
   class ValidationError < StandardError; end
 
   class PublishingEventWorker < Indexer::BaseWorker
@@ -25,6 +26,8 @@ module GovukIndex
     # the process to continue
     rescue NotFoundError
       Services.statsd_client.increment('govuk_index.not-found-error')
+    rescue UnknownDocumentTypeError
+      Services.statsd_client.increment('govuk_index.unknown-document-type')
     # Rescuing exception to guarantee we capture all Sidekiq retries
     rescue Exception # rubocop:disable Lint/RescueException
       Services.statsd_client.increment('govuk_index.sidekiq-retry')

--- a/test/integration/govuk_index/publishing_event_processor_test.rb
+++ b/test/integration/govuk_index/publishing_event_processor_test.rb
@@ -19,8 +19,8 @@ class GovukIndex::PublishingEventProcessorTest < IntegrationTest
 
   def test_should_save_new_document_to_elasticsearch
     random_example = GovukSchemas::RandomExample
-      .for_schema(notification_schema: "specialist_document")
-      .merge_and_validate(payload_version: 123)
+      .for_schema(notification_schema: "help_page")
+      .merge_and_validate({ document_type: "help_page", payload_version: 123 })
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 
@@ -28,7 +28,7 @@ class GovukIndex::PublishingEventProcessorTest < IntegrationTest
 
     assert_equal random_example["base_path"], document["_source"]["link"]
     assert_equal random_example["base_path"], document["_id"]
-    assert_equal random_example["document_type"], document["_type"]
+    assert_equal "edition", document["_type"]
 
     assert_equal 0, @queue.message_count
     assert_equal 1, @channel.acknowledged_state[:acked].count
@@ -37,7 +37,7 @@ class GovukIndex::PublishingEventProcessorTest < IntegrationTest
   def test_should_discard_message_when_invalid
     invalid_payload = {
       "title" => "Pitts S-2B, G-SKYD, 21 June 1996",
-      "document_type" => "aaib_report"
+      "document_type" => "help_page"
     }
 
     Airbrake.expects(:notify_or_ignore)

--- a/test/integration/govuk_index/unpublishing_message_processing_test.rb
+++ b/test/integration/govuk_index/unpublishing_message_processing_test.rb
@@ -39,7 +39,7 @@ class GovukIndex::UnpublishingMessageProcessing < IntegrationTest
       }
     )
     base_path = message.payload['base_path']
-    type = message.payload['document_type']
+    type = 'edition'
 
     commit_document('govuk_test', { 'link' => base_path }, id: base_path, type: type)
 

--- a/test/integration/govuk_index/versioning_test.rb
+++ b/test/integration/govuk_index/versioning_test.rb
@@ -110,7 +110,7 @@ class GovukIndex::VersioningTest < IntegrationTest
     assert_equal 2, document["_version"]
   end
 
-  def generate_random_example(schema: "specialist_document", payload: {}, excluded_fields: [])
+  def generate_random_example(schema: "help_page", payload: {}, excluded_fields: [])
     # just in case RandomExample does not generate a type field
     payload[:document_type] = schema
     GovukSchemas::RandomExample

--- a/test/unit/govuk_index/document_type_inferer_test.rb
+++ b/test/unit/govuk_index/document_type_inferer_test.rb
@@ -4,12 +4,12 @@ class GovukIndex::DocumentTypeInfererTest < Minitest::Test
   def test_infer_payload_document_type
     payload = {
       "base_path" => "/cheese",
-      "document_type" => "cheddar"
+      "document_type" => "help_page"
     }
 
     document_type_inferer = GovukIndex::DocumentTypeInferer.new(payload)
 
-    assert_equal payload["document_type"], document_type_inferer.type
+    assert_equal "edition", document_type_inferer.type
   end
 
   def test_should_raise_not_found_error

--- a/test/unit/govuk_index/document_type_inferer_test.rb
+++ b/test/unit/govuk_index/document_type_inferer_test.rb
@@ -22,6 +22,16 @@ class GovukIndex::DocumentTypeInfererTest < Minitest::Test
     end
   end
 
+  def test_should_raise_unknown_document_type_error
+    payload = { "document_type" => "unknown" }
+
+    GovukIndex::DocumentTypeInferer.any_instance.stubs(:elasticsearch_document_type).returns(nil)
+
+    assert_raises(GovukIndex::UnknownDocumentTypeError) do
+      GovukIndex::DocumentTypeInferer.new(payload).type
+    end
+  end
+
   def test_infer_existing_document_type
     payload = {
       "base_path" => "/cheese",

--- a/test/unit/govuk_index/elasticsearch_presenter_test.rb
+++ b/test/unit/govuk_index/elasticsearch_presenter_test.rb
@@ -23,6 +23,7 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
       link: "/some/path",
       title: "A plane has had an issue",
       is_withdrawn: false,
+      content_store_document_type: "aaib_report"
     }
 
     assert_equal expected_identifier, presenter.identifier
@@ -75,6 +76,7 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
       link: "/some/path",
       title: "A plane has had an issue",
       is_withdrawn: true,
+      content_store_document_type: "aaib_report"
     }
 
     assert_equal expected_identifier, presenter.identifier

--- a/test/unit/govuk_index/elasticsearch_processor_test.rb
+++ b/test/unit/govuk_index/elasticsearch_processor_test.rb
@@ -4,7 +4,7 @@ class ElasticsearchProcessorTest < Minitest::Test
   def test_should_save_valid_document
     presenter = stub(:presenter)
     presenter.stubs(:identifier).returns(
-      _type: "cheddar",
+      _type: "help_page",
       _id: "/cheese"
     )
     presenter.stubs(:document).returns(
@@ -18,6 +18,33 @@ class ElasticsearchProcessorTest < Minitest::Test
 
     actions = GovukIndex::ElasticsearchProcessor.new
     actions.save(presenter)
+    actions.commit
+  end
+
+  def test_should_delete_valid_document
+    presenter = stub(:presenter)
+    presenter.stubs(:identifier).returns(
+      _type: "help_page",
+      _id: "/cheese"
+    )
+    presenter.stubs(:document).returns(
+      link: "/cheese",
+      title: "We love cheese"
+    )
+
+    client = stub('client')
+    Services.stubs('elasticsearch').returns(client)
+    client.expects(:bulk).with(
+      index: SearchConfig.instance.govuk_index_name,
+      body: [
+        {
+          delete: presenter.identifier
+        }
+      ]
+    )
+
+    actions = GovukIndex::ElasticsearchProcessor.new
+    actions.delete(presenter)
     actions.commit
   end
 end

--- a/test/unit/govuk_index/publishing_event_processor_test.rb
+++ b/test/unit/govuk_index/publishing_event_processor_test.rb
@@ -5,7 +5,7 @@ class PublishingEventProcessorTest < Minitest::Test
     message = OpenStruct.new(
       payload: {
         "base_path" => "/cheese",
-        "document_type" => "cheddar",
+        "document_type" => "help_page",
         "title" => "We love cheese"
       },
       delivery_info: {

--- a/test/unit/govuk_index/publishing_event_worker_test.rb
+++ b/test/unit/govuk_index/publishing_event_worker_test.rb
@@ -4,7 +4,7 @@ class PublishingEventWorkerTest < Minitest::Test
   def test_save_valid_message
     payload = {
       "base_path" => "/cheese",
-      "document_type" => "cheddar",
+      "document_type" => "help_page",
       "title" => "We love cheese"
     }
 
@@ -39,7 +39,7 @@ class PublishingEventWorkerTest < Minitest::Test
   def test_should_not_delete_withdrawn
     payload = {
       "base_path" => "/cheese",
-      "document_type" => "cheddar",
+      "document_type" => "help_page",
       "title" => "We love cheese",
       "withdrawn_notice" => {
         "explanation" => "<div class=\"govspeak\"><p>test 2</p>\n</div>",
@@ -122,13 +122,13 @@ class PublishingEventWorkerTest < Minitest::Test
 
   def test_notify_when_validation_error
     invalid_payload = {
-      "document_type" => "cheddar",
+      "document_type" => "help_page",
       "title" => "We love cheese"
     }
 
     Airbrake.expects(:notify_or_ignore).with(
       instance_of(GovukIndex::ValidationError),
-      parameters: { message_body: { 'document_type' => 'cheddar', 'title' => 'We love cheese' } }
+      parameters: { message_body: { 'document_type' => 'help_page', 'title' => 'We love cheese' } }
     )
 
     GovukIndex::PublishingEventWorker.new.perform('routing.key', invalid_payload)


### PR DESCRIPTION
- Previously sent content_store document_types. We need to send the
correct elasticsearch types.
- Currently we only care about the `edition` type as we are adding the
`mainstream` formats. This will expand to encompass all elasticsearch
document_types as we proceed to add each format.

https://trello.com/c/LatZVRg8/213-make-versioning-work-for-all-publishing-events

Mobbed with @MatMoore & @Rosa-Fox 