### PR TITLE
Logging is a good thing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,9 @@ namespace "test" do
 
   desc 'Clean all test indexes'
   task :clean_test_indexes do
+    # Silence log output
+    Logging.logger.root.appenders = nil
+
     require 'test/support/test_index_helpers'
 
     TestIndexHelpers.clean_all

--- a/config.ru
+++ b/config.ru
@@ -15,7 +15,7 @@ in_development = ENV['RACK_ENV'] == 'development'
 log_path = ENV.fetch("LOG_PATH", in_development ? nil : "log/production.log")
 
 if in_development
-  set :logging, $DEBUG ? Logger::DEBUG : Logger::INFO
+  set :logging, Logger::DEBUG
 end
 
 if log_path

--- a/config/logging_setup.rb
+++ b/config/logging_setup.rb
@@ -3,5 +3,5 @@ Logging.logger.root.add_appenders Logging.appenders.stdout
 if ENV['DEBUG'] || $DEBUG
   Logging.logger.root.level = :debug
 else
-  Logging.logger.root.level = :warn
+  Logging.logger.root.level = :info
 end

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -10,8 +10,6 @@ require 'rummager'
 namespace :message_queue do
   desc "Index documents that are published to the publishing-api"
   task :listen_to_publishing_queue do
-    puts "Starting message queue consumer"
-
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "rummager_to_be_indexed",
       processor: Indexer::MessageProcessor.new,
@@ -21,8 +19,6 @@ namespace :message_queue do
 
   desc "Gets data from RabbitMQ and insert into govuk index"
   task :insert_data_into_govuk do
-    puts "Starting message queue consumer"
-
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "rummager_govuk_index",
       processor: GovukIndex::PublishingEventProcessor.new,

--- a/test/support/test_index_helpers.rb
+++ b/test/support/test_index_helpers.rb
@@ -22,6 +22,7 @@ class TestIndexHelpers
   end
 
   def self.clean_all
+    puts 'Cleaning up test indexes...'
     ALL_TEST_INDEXES.each do |index_name|
       clean_index_group(index_name)
     end


### PR DESCRIPTION
The logging we have is actually useful but it's suppressed most of the time.

No data that gets sent to rummager is sensitive, so there is no need for logs to be much less detailed on production.

This PR changes the following:
- Log at INFO level in integration/staging/production instead of WARN
- Log at DEBUG level in development instead of INFO (we can change this if it's annoying)
- Remove unwanted output from tests.
- Add logging for the new index so we can see what the event processor is doing.