### PR TITLE
Take into account popularity when saving new messages

### DIFF
--- a/lib/govuk_index/elasticsearch_presenter.rb
+++ b/lib/govuk_index/elasticsearch_presenter.rb
@@ -20,6 +20,7 @@ module GovukIndex
         title: payload["title"],
         is_withdrawn: withdrawn?,
         content_store_document_type: payload["document_type"],
+        popularity: calculate_popularity(payload["base_path"]),
       }
     end
 
@@ -38,6 +39,11 @@ module GovukIndex
 
     def withdrawn?
       !payload["withdrawn_notice"].nil?
+    end
+
+    def calculate_popularity(base_path)
+      lookup = Indexer::PopularityLookup.new("govuk_index", SearchConfig.instance)
+      lookup.lookup_popularities([base_path])[base_path]
     end
   end
 end

--- a/test/integration/govuk_index/publishing_event_processor_test.rb
+++ b/test/integration/govuk_index/publishing_event_processor_test.rb
@@ -34,6 +34,32 @@ class GovukIndex::PublishingEventProcessorTest < IntegrationTest
     assert_equal 1, @channel.acknowledged_state[:acked].count
   end
 
+  def test_should_include_popularity_when_available
+    random_example = GovukSchemas::RandomExample
+      .for_schema(notification_schema: "help_page")
+      .merge_and_validate({ document_type: "help_page", payload_version: 123 })
+
+    # need to add additional page_traffic data in order to set maximum allowed ranking value
+    4.times.each do |i|
+      insert_document(
+        "page-traffic_test",
+        { rank_14: i },
+        id: "/path/#{i}",
+        type: "page-traffic"
+      )
+    end
+    insert_document("page-traffic_test", { rank_14: 5, path_components: [random_example["base_path"]] }, id: random_example["base_path"], type: "page-traffic")
+    commit_index("page-traffic_test")
+
+    popularity = 1.0 / (5 + SearchConfig.instance.popularity_rank_offset)
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
+
+    assert_equal popularity, document["_source"]["popularity"]
+  end
+
   def test_should_discard_message_when_invalid
     invalid_payload = {
       "title" => "Pitts S-2B, G-SKYD, 21 June 1996",


### PR DESCRIPTION
For each new publishing event, this looks up the popularity of the page using the existing code, and adds it to Elasticsearch.

paired with @dwhenry 

https://trello.com/c/KdBH7MuQ/238-when-indexing-content-use-the-traffic-index