### PR TITLE
Fix the ./console command

### DIFF
--- a/console
+++ b/console
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-bundle exec irb -I . -I lib -r app.rb
+bundle exec irb -I . -I lib -r rummager


### PR DESCRIPTION
It looks like lib/app.rb was replaced with lib/rummager.rb