### PR TITLE
Add help_page fields to govuk index

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -56,10 +56,10 @@ module GovukIndex
       presenter.valid!
 
       if document_type_inferer.unpublishing_type?
-        logger.info("#{routing_key} -> DELETE #{presenter.id} #{document_type_inferer.type}")
+        logger.info("#{routing_key} -> DELETE #{presenter.base_path} #{document_type_inferer.type}")
         actions.delete(presenter)
       else
-        logger.info("#{routing_key} -> INDEX #{presenter.id} #{document_type_inferer.type}")
+        logger.info("#{routing_key} -> INDEX #{presenter.base_path} #{document_type_inferer.type}")
         actions.save(presenter)
       end
     end


### PR DESCRIPTION
This adds the fields for help pages that are currently populated by the publishing api.

With this particular format the following fields are not populated and will be added as we move other mainstream formats:  

- all_searchable_text
- email_document_supertype
- government_document_supertype
- navigation_document_supertype
- latest_change_note
- licence_identifier
- licence_short_description
- mainstream_browse_pages
- mainstream_browse_page_content_ids 
- part_of_taxonomy_tree 
- policies 
- primary_publishing_organisation 
- specialist_sectors (aka topics) 
- spelling_text 
- taxons 
- topic_content_ids 
- updated_at 
- user_journey_document_supertype


https://trello.com/c/t0TCT7DX/231-implement-the-helppages-format