### PR TITLE
Ensure Sidekiq workers write logs to Sidekiq log file

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -39,10 +39,6 @@ module GovukIndex
 
   private
 
-    def logger
-      @logger ||= Logging.logger[self]
-    end
-
     def process_action(actions, routing_key, payload)
       logger.debug("Processing #{routing_key}: #{payload}")
       Services.statsd_client.increment('govuk_index.sidekiq-consumed')

--- a/lib/indexer/workers/base_worker.rb
+++ b/lib/indexer/workers/base_worker.rb
@@ -8,19 +8,8 @@ module Indexer
     # Default options: can be overridden with `sidekiq_options` in subclasses
     sidekiq_options retry: 5, backtrace: 12
 
-    def logger
-      self.class.logger
-    end
-
-    # Logger is defined on the class for use in the `sidekiq_retries_exhausted`
-    # block, and as an instance method for use the rest of the time
-    def self.logger
-      Logging.logger[self]
-    end
-
     def self.notify_of_failures
       sidekiq_retries_exhausted do |msg|
-        logger.warn "Job '#{msg["jid"]}' failed"
         Airbrake.notify_or_ignore(Indexer::FailedJobException.new, parameters: msg)
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,7 @@ require "webmock/minitest"
 
 # Silence log output
 Logging.logger.root.appenders = nil
+Sidekiq::Logging.logger = nil
 
 # Prevent tests from messing with development/production data.
 only_test_databases = %r{http://localhost:9200/(_search/scroll|_aliases|[a-z_-]+(_|-)test.*)}


### PR DESCRIPTION
Delete the custom logger definitions from the Sidekiq workers, which means that logging falls back to the built-in Sidekig logging. This is configured to write to the file in <rummager_dir>/log/sidekiq.log.

Before, the `logger` instance was the standard Ruby logger, which was just configured to log to stdout. This meant the Sidekiq logs were not being persisted.

One logging line had to be deleted to get this to work: the `notify_of_failures` logging, which happens when Sidekiq retries have been exhausted. This is because it happens in a class method, which does not have access to the Sidekiq `logger` instance. But this event is already logged to Airbrake, so the deleted line was redundant anyway.

Also ensure that the log output is suppressed in tests.

https://trello.com/c/zAHyGMni/240-get-logging-to-work