### PR TITLE
Ignore very old publishing dates in sitemap

### DIFF
--- a/lib/sitemap/sitemap_presenter.rb
+++ b/lib/sitemap/sitemap_presenter.rb
@@ -1,4 +1,6 @@
 class SitemapPresenter
+  GOVUK_LAUNCH_DATE = DateTime.new(2012, 10, 17).freeze
+
   def initialize(document, property_boost_calculator)
     @document = document
     @property_boost_calculator = property_boost_calculator
@@ -17,7 +19,11 @@ class SitemapPresenter
     return nil unless document.public_timestamp
 
     # Attempt to parse timestamp to validate it
-    DateTime.iso8601(document.public_timestamp)
+    parsed_date = DateTime.iso8601(document.public_timestamp)
+
+    # Limit timestamps for old documents to GOV.UK was launch date
+    return GOVUK_LAUNCH_DATE.iso8601 if parsed_date < GOVUK_LAUNCH_DATE
+
     document.public_timestamp
   rescue ArgumentError
     @logger.warn("Invalid timestamp '#{document.public_timestamp}' for page '#{document.link}'")

--- a/test/unit/sitemap/sitemap_presenter_test.rb
+++ b/test/unit/sitemap/sitemap_presenter_test.rb
@@ -45,6 +45,15 @@ class SitemapPresenterTest < Minitest::Test
     assert_equal "2017-07-12", presenter.last_updated
   end
 
+  def test_last_updated_is_limited_to_recent_date
+    document = build_document(
+      url: "/some/path",
+      timestamp: "1995-06-01"
+    )
+    presenter = SitemapPresenter.new(document, @boost_calculator)
+    assert_equal "2012-10-17T00:00:00+00:00", presenter.last_updated
+  end
+
   def test_last_updated_is_omitted_if_timestamp_is_missing
     document = build_document(
       url: "/some/path",


### PR DESCRIPTION
Some documents have been backdated with very old `public_timestamp` dates, e.g.
https://www.gov.uk/government/publications/ukho-1914-archives-catalogue

The Google Search Console (understandably) raises an error when these dates are used as the `lastmod` date in the sitemap.

Ideally we would use a date which corresponds to the last time the document was updated on GOV.UK, but we do not have that information in the search index at the moment.

As a workaround, limit the `lastmod` date to recent dates, and use the launch of GOV.UK as a cut-off point because documents could not have been on the site before this date. This affects around 76,000 documents.

https://trello.com/c/O2FcYxgQ/241-fix-old-dates-in-sitemap