### PR TITLE
[WIP] Proof of concept for reindexing from a separate queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 worker: bundle exec sidekiq -C ./config/sidekiq.yml
 publishing-queue-listener: bundle exec rake message_queue:listen_to_publishing_queue
 govuk-index-queue-listener: bundle exec rake message_queue:insert_data_into_govuk
+govuk-index-queue-reindex-listener: bundle exec rake message_queue:listen_to_reindexing_messages

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -30,12 +30,14 @@ require 'yaml'
 initializers_path = File.expand_path("../config/initializers/*.rb", __dir__)
 Dir[initializers_path].each { |f| require f }
 
+require 'govuk_message_queue_consumer'
 require 'analytics_data'
 require File.expand_path('../config/logging_setup', __dir__)
 require 'document'
 require 'duplicate_deleter'
 require 'duplicate_links_finder'
 require 'govuk_document_types'
+require 'bulk_consumer'
 
 require 'indexer'
 require 'indexer/amender'
@@ -61,7 +63,6 @@ require 'govuk_index/elasticsearch_processor'
 require 'govuk_index/indexable_content_sanitiser'
 require 'govuk_index/publishing_event_processor'
 require 'govuk_index/publishing_event_worker'
-require 'govuk_message_queue_consumer'
 require 'health_check/basic_auth_credentials'
 require 'health_check/calculator'
 require 'health_check/calculator'

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -25,4 +25,13 @@ namespace :message_queue do
       statsd_client: Services.statsd_client,
     ).run
   end
+
+  desc "Subscribe to reindexed messages"
+  task :listen_to_reindexing_messages do
+    GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "rummager_govuk_index_reindexing",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      statsd_client: Services.statsd_client,
+    ).run
+  end
 end


### PR DESCRIPTION
At the moment, this reuses the existing sidekiq queue to process the messages.
I think we should add another sidekiq queue as well so that we can priorise
normal indexing messages, but for the moment I just want to make sure that
reindexing does not affect other parts of the system if the consumer isn't
working properly.

- If no consumers are running RabbitMQ should drop the messages (auto delete)
- If RabbitMQ falls over, the queues can be lost and the consumers can just die (transient)
- We are expecting a high throughput so the assumptions the message queue makes about prefetching are wrong. I've picked a fairly arbitrary number (10) instead.

Trello: https://trello.com/c/k2L67c4a/272-cleanup-puppet-module-for-declaring-message-queue-consumers