### PR TITLE
Delete stale comment

### DIFF
--- a/lib/scroll_enumerator.rb
+++ b/lib/scroll_enumerator.rb
@@ -2,10 +2,6 @@ class ScrollEnumerator < Enumerator
   # How long to hold a scroll cursor open between requests
   # We want to keep this low (eg, 1 minute), because scroll contexts can be
   # quite expensive.
-  # However, the scroll timeout in old releases of elasticsearch is based on
-  # the time since the scan operation started, not the time since the last
-  # activity happened in the scan, so until we upgrade to elasticsearch
-  # 0.90.12+, we should set this high.
   SCROLL_TIMEOUT_MINUTES = 1
 
   # The number of documents to retrieve at once.


### PR DESCRIPTION
The scroll timeout was dropped from 60 minutes to 1 minute in PR #811, so this comment is no longer necessary.