### PR TITLE
Add mainstream transaction format to govuk index

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -64,7 +64,12 @@ module GovukIndex
     end
 
     def details
-      @_details ||= DetailsPresenter.new(payload["details"])
+      @_details ||=
+        DetailsPresenter.new(
+          details: payload["details"],
+          format: common_fields.format,
+          sanitiser: IndexableContentSanitiser.new
+        )
     end
 
     def expanded_links

--- a/test/unit/govuk_index/presenters/details_presenter_test.rb
+++ b/test/unit/govuk_index/presenters/details_presenter_test.rb
@@ -50,7 +50,9 @@ class GovukIndex::DetailsPresenterTest < Minitest::Test
       "will_continue_on" => "on and on",
     }
 
-    assert_equal "short description\n\noverview", details_presenter(details).indexable_content
+    presenter = details_presenter(details, "licence")
+
+    assert_equal "short description\n\noverview", presenter.indexable_content
   end
 
   def test_mapped_licence_fields
@@ -66,13 +68,31 @@ class GovukIndex::DetailsPresenterTest < Minitest::Test
       "will_continue_on" => "on and on",
     }
 
-    presenter = details_presenter(details)
+    presenter = details_presenter(details, "licence")
 
     assert_equal presenter.licence_identifier, details["licence_identifier"]
     assert_equal presenter.licence_short_description, details["licence_short_description"]
   end
 
-  def details_presenter(details)
-    GovukIndex::DetailsPresenter.new(details)
+  def test_transaction_indexable_content
+    details = {
+      "external_related_links" => [],
+      "introductory_paragraph" => [
+        { "content_type" => "text/govspeak", "content" => "**introductory paragraph**" },
+        { "content_type" => "text/html", "content" => "<strong>introductory paragraph</strong>" }
+      ],
+      "more_information" => "more information",
+      "start_button_text" => "Start now",
+    }
+
+    assert_equal "introductory paragraph\n\nmore information", details_presenter(details, "transaction").indexable_content
+  end
+
+  def details_presenter(details, format = "help_page")
+    GovukIndex::DetailsPresenter.new(
+      details: details,
+      format: format,
+      sanitiser: GovukIndex::IndexableContentSanitiser.new
+    )
   end
 end


### PR DESCRIPTION
his adds the necessary additional fields for the transaction format. The fields are also used by other formats in the publishing api payload but not necessarily required in elasticsearch so we need to specify certain fields by format

https://trello.com/c/k0gpEuQi/264-add-transactions