### PR TITLE
Use consitent sitemap names

### DIFF
--- a/lib/sitemap/sitemap_writer.rb
+++ b/lib/sitemap/sitemap_writer.rb
@@ -9,11 +9,11 @@ class SitemapWriter
     sitemap_generator = SitemapGenerator.new(content_indices)
     # write our sitemap files and return an array of filenames
     sitemap_generator.sitemaps.map do |sitemap_xml|
-      filename = next_filename
+      filename, link_filename = next_filename
       File.open(File.join(@directory, filename), "w") do |file|
         file.write(sitemap_xml)
       end
-      filename
+      [filename, link_filename]
     end
   end
 
@@ -21,6 +21,9 @@ private
 
   def next_filename
     @sitemap_file_count += 1
-    "sitemap_#{@sitemap_file_count}_#{@timestamp.strftime('%FT%H')}.xml"
+    [
+      "sitemap_#{@sitemap_file_count}_#{@timestamp.strftime('%FT%H')}.xml",
+      "sitemap_#{@sitemap_file_count}.xml",
+    ]
   end
 end

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -10,11 +10,6 @@ namespace :sitemap do
     sitemap = Sitemap.new(output_directory)
     sitemap_index_path = sitemap.generate(search_server.content_indices)
 
-    sitemap_link_path = File.join(output_directory, "sitemap.xml")
-
-    `ln -sf #{sitemap_index_path} #{sitemap_link_path}`
-    fail("Symlinking failed") unless $?.success?
-
     sitemap.cleanup
   end
 end

--- a/test/integration/sitemap/sitemap_generator_test.rb
+++ b/test/integration/sitemap/sitemap_generator_test.rb
@@ -1,0 +1,132 @@
+require 'integration_test_helper'
+
+class SitemapGeneratorTest < IntegrationTest
+  SAMPLE_DATA = [
+    {
+      "title" => "Cheese in my face",
+      "description" => "Hummus weevils",
+      "format" => "answer",
+      "link" => "/an-example-answer",
+      "indexable_content" => "I like my badger: he is tasty and delicious",
+      "public_timestamp" => "2017-07-01T12:41:34+00:00"
+    },
+    {
+      "title" => "Cheese on Ruby's face",
+      "description" => "Ruby weevils",
+      "format" => "answer",
+      "link" => "/an-example-answer-rubylol",
+      "indexable_content" => "I like my rubby badger: he is tasty and delicious"
+    },
+    {
+      "title" => "Cheese on Python's face",
+      "description" => "Python weevils",
+      "format" => "answer",
+      "link" => "/an-example-answer-pythonwin",
+      "indexable_content" => "I like my badger: he is pythonic and delicious"
+    },
+    {
+      "title" => "Cheese in my ears",
+      "description" => "Wordpress weevils",
+      "format" => "answer",
+      "link" => "/an-example-answer-stuff",
+      "indexable_content" => "I like my wordpress: says Joshua who is win"
+    },
+    {
+      "title" => "Useful government information",
+      "description" => "Government, government, government. Developers.",
+      "format" => "answer",
+      "link" => "/another-example-answer",
+      "indexable_content" => "Tax, benefits, roads and stuff"
+    },
+    {
+      "title" => "External government information",
+      "description" => "Government, government, government. Developers.",
+      "format" => "recommended-link",
+      "link" => "http://www.example.com/external-example-answer",
+      "indexable_content" => "Tax, benefits, roads and stuff"
+    },
+    {
+      "title" => "Some content from Inside Gov",
+      "description" => "We list some inside gov results in the mainstream index.",
+      "format" => "inside-government-link",
+      "link" => "https://www.gov.uk/government/some-content",
+    }
+  ].freeze
+
+  def setup
+    super
+    add_sample_documents
+  end
+
+  def test_should_generate_multiple_sitemaps
+    SitemapGenerator.stubs(:sitemap_limit).returns(2)
+    generator = SitemapGenerator.new(search_server.content_indices)
+
+    sitemap_xml = generator.sitemaps
+
+    assert_equal 3, sitemap_xml.length
+  end
+
+  def test_should_include_homepage
+    generator = SitemapGenerator.new(search_server.content_indices)
+    sitemap_xml = generator.sitemaps
+
+    pages = Nokogiri::XML(sitemap_xml[0])
+      .css("url")
+      .select { |item| item.css("loc").text == "http://www.dev.gov.uk/" }
+
+    assert_equal 1, pages.count
+    assert_equal "0.5", pages[0].css("priority").text
+  end
+
+  def test_should_not_include_recommended_links
+    generator = SitemapGenerator.new(search_server.content_indices)
+    sitemap_xml = generator.sitemaps
+
+    assert_equal 1, sitemap_xml.length
+
+    refute_includes sitemap_xml[0], "/external-example-answer"
+  end
+
+  def test_should_not_include_inside_government_links
+    generator = SitemapGenerator.new(search_server.content_indices)
+
+    sitemap_xml = generator.sitemaps
+
+    assert_equal 1, sitemap_xml.length
+    refute_includes sitemap_xml[0], "/government/some-content"
+  end
+
+  def test_links_should_include_timestamps
+    generator = SitemapGenerator.new(search_server.content_indices)
+
+    sitemap_xml = generator.sitemaps
+
+    pages = Nokogiri::XML(sitemap_xml[0])
+      .css("url")
+      .select { |item| item.css("loc").text == "http://www.dev.gov.uk/an-example-answer" }
+
+    assert_equal 1, pages.count
+    assert_equal "2017-07-01T12:41:34+00:00", pages[0].css("lastmod").text
+  end
+
+  def test_links_should_include_priorities
+    generator = SitemapGenerator.new(search_server.content_indices)
+
+    sitemap_xml = generator.sitemaps
+
+    priorities = Nokogiri::XML(sitemap_xml[0])
+      .css("url > priority")
+
+    assert_equal 6, priorities.count
+  end
+
+private
+
+  def add_sample_documents
+    SAMPLE_DATA.each do |sample_document|
+      insert_document("mainstream_test", sample_document)
+    end
+    commit_index
+  end
+end


### PR DESCRIPTION
We believe this will allow search engines to better parse the sitemap

https://trello.com/c/bsvYLOaf/265-see-if-renaming-the-sitemap-affects-how-google-indexes-it