### PR TITLE
Make answer format fully migrated

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -1,7 +1,7 @@
 migrated:
+- answer
 - help_page
 indexable:
-- answer
 - guide
 - licence
 - local_transaction

--- a/test/integration/indexer/migration_test.rb
+++ b/test/integration/indexer/migration_test.rb
@@ -33,12 +33,12 @@ class ElasticsearchMigrationTest < IntegrationTest
     [
       {
         "title" => "Important government directive",
-        "format" => "answer",
+        "format" => "transaction",
         "link" => "/important",
       },
       {
         "title" => "Direct contact with aliens",
-        "format" => "answer",
+        "format" => "transaction",
         "link" => "/aliens",
       }
     ]
@@ -85,7 +85,7 @@ class ElasticsearchMigrationTest < IntegrationTest
       {
         "_type" => "edition",
         "title" => "Document #{n}",
-        "format" => "answer",
+        "format" => "transaction",
         "link" => "/doc-#{n}",
       }
     end


### PR DESCRIPTION
We want to make sure that we can fully migrate all the mainstream formats over to use the new `govuk` index. Start with the answer format before doing the rest in bulk.

https://trello.com/c/XTRquJcn/286-make-answer-format-fully-migrated