### PR TITLE
Remove the format check when unpublishing

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -49,14 +49,12 @@ module GovukIndex
       )
       presenter.valid!
 
-      if MigratedFormats.indexable?(presenter.format)
-        if presenter.unpublishing_type?
-          logger.info("#{routing_key} -> DELETE #{presenter.base_path} #{presenter.type}")
-          actions.delete(presenter)
-        else
-          logger.info("#{routing_key} -> INDEX #{presenter.base_path} #{presenter.type}")
-          actions.save(presenter)
-        end
+      if presenter.unpublishing_type?
+        logger.info("#{routing_key} -> DELETE #{presenter.base_path} #{presenter.type}")
+        actions.delete(presenter)
+      elsif MigratedFormats.indexable?(presenter.format)
+        logger.info("#{routing_key} -> INDEX #{presenter.base_path} #{presenter.type}")
+        actions.save(presenter)
       else
         logger.info("#{routing_key} -> SKIPPED #{presenter.base_path} #{presenter.type}")
       end

--- a/test/integration/govuk_index/unpublishing_message_processing_test.rb
+++ b/test/integration/govuk_index/unpublishing_message_processing_test.rb
@@ -2,7 +2,8 @@ require 'integration_test_helper'
 
 class GovukIndex::UnpublishingMessageProcessing < IntegrationTest
   def test_unpublish_message_will_remove_record_from_elasticsearch
-    GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
+    GovukIndex::MigratedFormats.stubs(:migrated_formats?).returns(%w(answer))
+
     message = unpublishing_event_message(
       "gone",
       user_defined: {
@@ -28,7 +29,8 @@ class GovukIndex::UnpublishingMessageProcessing < IntegrationTest
   end
 
   def test_unpublish_withdrawn_messages_will_set_is_withdrawn_flag
-    GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
+    GovukIndex::MigratedFormats.stubs(:migrated_formats?).returns(%w(help_page))
+
     message = unpublishing_event_message(
       "help_page",
       user_defined: {

--- a/test/unit/govuk_index/publishing_event_worker_test.rb
+++ b/test/unit/govuk_index/publishing_event_worker_test.rb
@@ -9,7 +9,6 @@ class PublishingEventWorkerTest < Minitest::Test
     }
 
     actions = stub('actions')
-    GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
     actions.expects(:save)
     actions.expects(:commit).returns('items' => [{ 'index' => { 'status' => 200 } }])
@@ -28,7 +27,7 @@ class PublishingEventWorkerTest < Minitest::Test
     stub_document_type_inferer
 
     actions = stub('actions')
-    GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
+
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
     actions.expects(:delete)
     actions.expects(:commit).returns('items' => [{ 'delete' => { 'status' => 200 } }])
@@ -50,7 +49,6 @@ class PublishingEventWorkerTest < Minitest::Test
     }
 
     actions = stub('actions')
-    GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
     actions.expects(:save)
     actions.expects(:commit).returns('items' => [{ 'index' => { 'status' => 200 } }])
@@ -70,7 +68,6 @@ class PublishingEventWorkerTest < Minitest::Test
     stub_document_type_inferer
 
     actions = stub('actions')
-    GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
     actions.expects(:delete)
     actions.expects(:commit).returns('items' => [{ 'delete' => { 'status' => 500 } }])
@@ -93,7 +90,6 @@ class PublishingEventWorkerTest < Minitest::Test
     stub_document_type_inferer
 
     actions = stub('actions')
-    GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
     actions.expects(:delete)
     actions.expects(:commit).returns('items' => [{ 'delete' => { 'status' => 404 } }])
@@ -112,7 +108,6 @@ class PublishingEventWorkerTest < Minitest::Test
     stub_document_type_inferer
 
     actions = stub('actions')
-    GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
     GovukIndex::ElasticsearchProcessor.expects(:new).returns(actions)
     actions.expects(:delete)
     actions.expects(:commit).returns('items' => [{ 'index' => { 'status' => 200 } }, { 'delete' => { 'status' => 200 } }])
@@ -143,5 +138,6 @@ class PublishingEventWorkerTest < Minitest::Test
   def stub_document_type_inferer
     GovukIndex::DocumentTypeInferer.any_instance.stubs(:unpublishing_type).returns(true)
     GovukIndex::DocumentTypeInferer.any_instance.stubs(:type).returns('real_document_type')
+    GovukIndex::MigratedFormats.stubs(:migrated_formats?).returns(%w(real_document_type))
   end
 end


### PR DESCRIPTION
- `format` is the `unpublishing_type` when unpublishing, for example the format could be `redirect`.
- Previously unpublishing was being skipped as the format was not in the `migrated_formats` YAML.
- This PR removes the format check for unpublishing, as we always want to remove the document from the index when unpublishing.

Paired with @MatMoore 