### PR TITLE
Make popularity updater work for non-migrated indices

### DIFF
--- a/lib/govuk_index/popularity_updater.rb
+++ b/lib/govuk_index/popularity_updater.rb
@@ -1,9 +1,10 @@
 module GovukIndex
   class PopularityUpdater < Updater
-    def self.update(index_name)
+    def self.update(index_name, process_all: false)
       new(
         source_index: index_name,
         destination_index: index_name,
+        process_all: process_all,
       ).run
     end
 
@@ -31,14 +32,24 @@ module GovukIndex
       end
     end
 
-  private
+    def initialize(source_index:, destination_index:, process_all: false)
+      @process_all = process_all
 
+      super(
+        source_index: source_index,
+        destination_index: destination_index,
+      )
+    end
+
+  private
 
     def worker
       PopularityWorker
     end
 
     def search_body
+      return { query: { match_all: {} } } if @process_all
+
       # only sync migrated formats as the rest will be updated via the sync job.
       {
         query: {

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -67,7 +67,7 @@ This does not update the schema.
 "
   task :update_popularity do
     index_names.each do |index_name|
-      GovukIndex::PopularityUpdater.update(index_name)
+      GovukIndex::PopularityUpdater.update(index_name, process_all: ENV.key?('PROCESS_ALL_DATA'))
     end
   end
 


### PR DESCRIPTION
This allow us to pass in an override which causes all data
to be processed by the popularity updater.

This requires a change in search_analytics to pass in the
`PROCESS_ALL_DATA` env variable to work for non govuk indices.

https://trello.com/c/IeU8rFj3/293-switch-indexes-to-use-update-popularity-instead-of-bulk-update