### PR TITLE
Update govuk-document-types to 0.1.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_document_types (0.1.6)
+    govuk_document_types (0.1.7)
     govuk_message_queue_consumer (3.0.2)
       bunny (~> 2.2.0)
     govuk_schemas (2.2.0)


### PR DESCRIPTION
Bump gem to include https://github.com/alphagov/govuk_document_types/pull/20