### PR TITLE
Prevent duplicate smart answers results

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -52,7 +52,7 @@ module GovukIndex
       if presenter.unpublishing_type?
         logger.info("#{routing_key} -> DELETE #{presenter.base_path} #{presenter.type}")
         actions.delete(presenter)
-      elsif MigratedFormats.indexable?(presenter.format)
+      elsif MigratedFormats.indexable?(presenter.format) && payload['publishing_app'] != 'smartanswers'
         logger.info("#{routing_key} -> INDEX #{presenter.base_path} #{presenter.type}")
         actions.save(presenter)
       else

--- a/lib/health_check/search_checker.rb
+++ b/lib/health_check/search_checker.rb
@@ -45,6 +45,7 @@ module HealthCheck
     end
 
   private
+
     attr_reader :overall_calculator, :tag_calculators, :word_count_calculators
 
     def checks

--- a/test/integration/govuk_index/updating_popularity_data_test.rb
+++ b/test/integration/govuk_index/updating_popularity_data_test.rb
@@ -5,6 +5,7 @@ class GovukIndex::UpdatingPopularityDataTest < IntegrationTest
     super
     GovukIndex::MigratedFormats.stubs(:indexable_formats).returns(['help_page'])
   end
+
   def test_updates_the_popularity_when_it_exists
     insert_document('govuk_test', { link: '/test', popularity: 0.3, format: 'help_page' }, id: '/test', type: 'edition')
     commit_index('govuk_test')


### PR DESCRIPTION
- The smart-answers application is sending items to Rummager with type smart-answer.

- The smart-answers application is also sending items to content store and Rummager via the publishing-api with type transaction. This has caused duplication in results for smart-answer pages.

- We still allowed for the deletion of smart answers as when a smart answer is deleted, the entry for it in the govuk index which had been synced across from mainstream is also deleted. This mirrors the functionality for other unmigrated formats. This is needed as the sync process does not delete data from the govuk index.

- This is a temporary fix to filter smart-answers from the govuk index within Rummager. We will investigate a permanent solution later in the sprint, during our spike work for migrating other formats to govuk index.

Paired with @brenetic @dwhenry 