### PR TITLE
Add another procfile worker for the bulk-reindex queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 worker: bundle exec sidekiq -C ./config/sidekiq.yml
 publishing-queue-listener: bundle exec rake message_queue:listen_to_publishing_queue
 govuk-index-queue-listener: bundle exec rake message_queue:insert_data_into_govuk
+bulk-reindex-queue-listener: bundle exec rake message_queue:bulk_insert_data_into_govuk

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -23,4 +23,13 @@ namespace :message_queue do
       statsd_client: Services.statsd_client,
     ).run
   end
+
+  desc "Gets data from RabbitMQ and insert into govuk index (bulk reindex queue)"
+  task :bulk_insert_data_into_govuk do
+    GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "rummager_bulk_reindex",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      statsd_client: Services.statsd_client,
+    ).run
+  end
 end


### PR DESCRIPTION
At the moment, this uses the same sidekiq queue, but I'm going to make sure
this works end to end before changing anything else.

Trello: https://trello.com/c/nPiykYmS/270-get-rummager-reindex-working-in-dev