### PR TITLE
Fix intermittent test failures

### DIFF
--- a/test/integration/govuk_index/versioning_test.rb
+++ b/test/integration/govuk_index/versioning_test.rb
@@ -10,7 +10,12 @@ class GovukIndex::VersioningTest < IntegrationTest
 
   def test_should_successfully_index_increasing_version_numbers
     GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
-    version1 = generate_random_example(payload: { payload_version: 123 })
+
+    version1 = generate_random_example(
+      payload: { payload_version: 123 },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
+    )
+
     base_path = version1["base_path"]
     process_message(version1)
 
@@ -27,7 +32,11 @@ class GovukIndex::VersioningTest < IntegrationTest
 
   def test_should_discard_message_with_same_version_as_existing_document
     GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
-    version1 = generate_random_example(payload: { payload_version: 123 })
+    version1 = generate_random_example(
+      payload: { payload_version: 123 },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
+    )
+
     base_path = version1["base_path"]
     process_message(version1)
 
@@ -44,7 +53,12 @@ class GovukIndex::VersioningTest < IntegrationTest
 
   def test_should_discard_message_with_earlier_version_than_existing_document
     GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
-    version1 = generate_random_example(payload: { payload_version: 123 })
+
+    version1 = generate_random_example(
+      payload: { payload_version: 123 },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
+    )
+
     base_path = version1["base_path"]
     process_message(version1)
 
@@ -63,8 +77,10 @@ class GovukIndex::VersioningTest < IntegrationTest
     GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
     version1 = generate_random_example(
       payload: { payload_version: 1 },
-      excluded_fields: ["withdrawn_notice"]
+      excluded_fields: ["withdrawn_notice"],
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
+
     base_path = version1["base_path"]
     process_message(version1)
 
@@ -77,7 +93,8 @@ class GovukIndex::VersioningTest < IntegrationTest
         base_path: base_path,
         payload_version: 2
       },
-      excluded_fields: ["withdrawn_notice"]
+      excluded_fields: ["withdrawn_notice"],
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
     process_message(version2, unpublishing: true)
 
@@ -94,7 +111,11 @@ class GovukIndex::VersioningTest < IntegrationTest
 
   def test_should_discard_unpublishing_message_with_earlier_version
     GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
-    version1 = generate_random_example(payload: { payload_version: 2 })
+    version1 = generate_random_example(
+      payload: { payload_version: 2 },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
+    )
+
     base_path = version1["base_path"]
     process_message(version1)
 
@@ -107,7 +128,8 @@ class GovukIndex::VersioningTest < IntegrationTest
         base_path: base_path,
         payload_version: 1
       },
-      excluded_fields: ["withdrawn_notice"]
+      excluded_fields: ["withdrawn_notice"],
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
     process_message(version2, unpublishing: true)
 
@@ -117,11 +139,17 @@ class GovukIndex::VersioningTest < IntegrationTest
 
   def test_should_ignore_event_for_non_indexable_formats
     GovukIndex::MigratedFormats.stubs(:indexable?).returns(true)
-    version1 = generate_random_example(payload: { payload_version: 123 })
+
+    version1 = generate_random_example(
+      payload: { payload_version: 123 },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
+    )
+
     base_path = version1["base_path"]
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
+
     assert_equal 123, document["_version"]
 
     GovukIndex::MigratedFormats.stubs(:indexable?).returns(false)

--- a/test/unit/govuk_index/presenters/common_fields_presenter_test.rb
+++ b/test/unit/govuk_index/presenters/common_fields_presenter_test.rb
@@ -24,7 +24,8 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
   def test_directly_mapped_fields
     payload = generate_random_example(
       payload: { expanded_links: {} },
-      excluded_fields: ["withdrawn_notice"]
+      excluded_fields: ["withdrawn_notice"],
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
 
     presenter = common_fields_presenter(payload)
@@ -43,7 +44,8 @@ class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
 
     payload = generate_random_example(
       payload: defined_fields,
-      excluded_fields: ["withdrawn_notice"]
+      excluded_fields: ["withdrawn_notice"],
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     presenter = common_fields_presenter(payload)

--- a/test/unit/govuk_index/presenters/elasticsearch_presenter_test.rb
+++ b/test/unit/govuk_index/presenters/elasticsearch_presenter_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class GovukIndex::ElasticsearchPresenterTest < Minitest::Test
   def test_identifier
-    payload = generate_random_example(payload: { payload_version: 1 })
+    payload = generate_random_example(payload: { payload_version: 1 },
+    regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" })
 
     expected_identifier = {
       _type: payload["document_type"],


### PR DESCRIPTION
[Trello](https://trello.com/c/r88Bmytd/310-fix-intermittent-integration-test-failures-caused-by-smart-answers-exclusion)

- Tests generate a publishing API message based on a random schema.
- The failures happened when the random schema generator generated a message with the publishing_app set to `smartanswers`, because we [deliberately exclude smart answers](https://github.com/alphagov/rummager/pull/916) in the new search index.

Paired with @dwhenry 