### PR TITLE
Use same number of Sidekiq threads on staging and production

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,7 @@
 ---
 :concurrency: 5
+staging:
+  :concurrency:  16
 production:
   :concurrency:  16
 :require: ./lib/rummager.rb


### PR DESCRIPTION
Increase the number of Sidekiq threads on staging to be consistent with production. This will let us test batch processing in a more realistic way.

https://trello.com/c/saDruTlG/307-investigate-1-day-intermittent-rummager-timeouts