### PR TITLE
Fix the rummager:clean rake task after 2.4 upgrade

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,7 +68,7 @@ end
 def index_names
   case ENV["RUMMAGER_INDEX"]
   when "all"
-    search_config.index_names
+    search_config.all_index_names
   when String
     [ENV["RUMMAGER_INDEX"]]
   else

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -41,6 +41,12 @@ class SearchConfig
     content_index_names + auxiliary_index_names
   end
 
+  def all_index_names
+    # this is used to process data in the rake file when `all` is passed in as previous we skipped `govuk`
+    # we can't update index_names at this stage as it is used in multiple spots including the index filtering
+    content_index_names + auxiliary_index_names + [govuk_index_name]
+  end
+
   def elasticsearch
     @elasticsearch ||= config_for("elasticsearch")
   end

--- a/test/unit/index_group_test.rb
+++ b/test/unit/index_group_test.rb
@@ -141,7 +141,7 @@ class IndexGroupTest < Minitest::Test
   end
 
   def test_index_names_with_no_indices
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -153,7 +153,7 @@ class IndexGroupTest < Minitest::Test
 
   def test_index_names_with_index
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -169,7 +169,7 @@ class IndexGroupTest < Minitest::Test
     this_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     other_name = "fish-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"
 
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -183,7 +183,7 @@ class IndexGroupTest < Minitest::Test
   end
 
   def test_clean_with_no_indices
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -195,7 +195,7 @@ class IndexGroupTest < Minitest::Test
 
   def test_clean_with_dead_index
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -214,7 +214,7 @@ class IndexGroupTest < Minitest::Test
 
   def test_clean_with_live_index
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -231,7 +231,7 @@ class IndexGroupTest < Minitest::Test
       "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012",
       "test-2012-03-01t12:00:00z-abcdefab-abcd-abcd-abcd-abcdefabcdef"
     ]
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -255,7 +255,7 @@ class IndexGroupTest < Minitest::Test
     live_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     dead_name = "test-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"
 
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -276,7 +276,7 @@ class IndexGroupTest < Minitest::Test
   def test_clean_with_other_alias
     # If there's an alias we don't know about, that should save the index
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -293,7 +293,7 @@ class IndexGroupTest < Minitest::Test
     this_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     other_name = "fish-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"
 
-    stub_request(:get, "#{ELASTICSEARCH_TESTING_HOST}/_aliases")
+    stub_request(:get, %r{#{ELASTICSEARCH_TESTING_HOST}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },


### PR DESCRIPTION
This fixes two issues with the clean command
* ES 2.4 does not return closed indices for the `get_aliases` method
* govuk was being excluded from the list of indices when run with RUMMAGER_INDEX=all

https://trello.com/c/k1wSV5AM/325-fix-clean-command-es-24-cleanup