### PR TITLE
Reduce the number of Sidekiq workers used by bulk processing

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,4 +10,5 @@ production:
   - default
   - bulk
 :limits:
-  bulk: 12
+  bulk: 4
+  default: 4


### PR DESCRIPTION
Queries have been timing out when the popularity update runs it bulk indexing. This change to the Sidekiq worker count reduces the indexing load in the hope that it improves parallel search queries.

https://trello.com/c/saDruTlG/307-investigate-1-day-intermittent-rummager-timeouts

Surprisingly, this didn't change the time taken for the queue to be processed (45 minutes in each case).

There are still slow requests and frontend 500 errors with this change, but still it's a clear improvement.

Before:
<img width="1421" alt="screen shot 2017-09-20 at 13 44 50" src="https://user-images.githubusercontent.com/754712/30644341-fc0ea744-9e09-11e7-9978-b39261e8dd07.png">

After:
<img width="1420" alt="screen shot 2017-09-20 at 13 45 17" src="https://user-images.githubusercontent.com/754712/30644350-00fc6a98-9e0a-11e7-97b2-6d6a792159c2.png">

Marked as "do not merge" while we look into disk I/O issues, because we still think the underlying problem might be in the VM rather than the code.