### PR TITLE
Add migrated govuk index documents to site map

### DIFF
--- a/lib/sitemap/property_boost_calculator.rb
+++ b/lib/sitemap/property_boost_calculator.rb
@@ -7,8 +7,8 @@ class PropertyBoostCalculator
 
   def boost(document)
     raw_boosts = @boost_config.map do |property, boosts|
-      if document.has_field?(property) && boosts[document.get(property)]
-        boosts[document.get(property)]
+      if document[property] && boosts[document[property]]
+        boosts[document[property]]
       else
         1
       end

--- a/lib/sitemap/sitemap.rb
+++ b/lib/sitemap/sitemap.rb
@@ -8,12 +8,12 @@ class Sitemap
     @timestamp = timestamp
   end
 
-  def generate(content_indices)
+  def generate(search_config)
     FileUtils.mkdir_p(@output_path)
 
     # generate and link the sitemap data files
     sitemap_writer = SitemapWriter.new(@output_path, @timestamp)
-    sitemap_filenames_with_linkname = sitemap_writer.write_sitemaps(content_indices)
+    sitemap_filenames_with_linkname = sitemap_writer.write_sitemaps(search_config)
     update_links(sitemap_filenames_with_linkname)
 
     # generate and link the sitemap index file

--- a/lib/sitemap/sitemap_presenter.rb
+++ b/lib/sitemap/sitemap_presenter.rb
@@ -8,25 +8,25 @@ class SitemapPresenter
   end
 
   def url
-    if document.link.start_with?("http")
-      document.link
+    if document['link'].start_with?("http")
+      document['link']
     else
-      URI.join(base_url, document.link).to_s
+      URI.join(base_url, document['link']).to_s
     end
   end
 
   def last_updated
-    return nil unless document.public_timestamp
+    return nil unless document['public_timestamp']
 
     # Attempt to parse timestamp to validate it
-    parsed_date = DateTime.iso8601(document.public_timestamp)
+    parsed_date = DateTime.iso8601(document['public_timestamp'])
 
     # Limit timestamps for old documents to GOV.UK was launch date
     return GOVUK_LAUNCH_DATE.iso8601 if parsed_date < GOVUK_LAUNCH_DATE
 
-    document.public_timestamp
+    document['public_timestamp']
   rescue ArgumentError
-    @logger.warn("Invalid timestamp '#{document.public_timestamp}' for page '#{document.link}'")
+    @logger.warn("Invalid timestamp '#{document['public_timestamp']}' for page '#{document['link']}'")
     # Ignore invalid or missing timestamps
     nil
   end
@@ -44,6 +44,6 @@ private
   end
 
   def withdrawn_status_boost
-    document.is_withdrawn ? 0.25 : 1
+    document['is_withdrawn'] ? 0.25 : 1
   end
 end

--- a/lib/sitemap/sitemap_writer.rb
+++ b/lib/sitemap/sitemap_writer.rb
@@ -5,8 +5,8 @@ class SitemapWriter
     @sitemap_file_count = 0
   end
 
-  def write_sitemaps(content_indices)
-    sitemap_generator = SitemapGenerator.new(content_indices)
+  def write_sitemaps(search_config)
+    sitemap_generator = SitemapGenerator.new(search_config)
     # write our sitemap files and return an array of filenames
     sitemap_generator.sitemaps.map do |sitemap_xml|
       filename, link_filename = next_filename

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -8,7 +8,7 @@ namespace :sitemap do
 
     output_directory = File.join(PROJECT_ROOT, "public")
     sitemap = Sitemap.new(output_directory)
-    sitemap_index_path = sitemap.generate(search_server.content_indices)
+    sitemap.generate(SearchConfig.instance)
 
     sitemap.cleanup
   end

--- a/spec/unit/sitemap/property_boost_calculator_spec.rb
+++ b/spec/unit/sitemap/property_boost_calculator_spec.rb
@@ -103,11 +103,11 @@ RSpec.describe 'PropertyBoostCalculatorTest' do
 
     calculator = PropertyBoostCalculator.new
 
-    document = Document.new(sample_field_definitions, {
+    document = {
       "format" => "publication",
       "content_store_document_type" => "foi_release",
       "navigation_document_supertype" => "some_other_value"
-    })
+    }
 
     #   1 - 2^(-format boost * document type boost * navigation supertype boost)
     # = 1 - 2^(-0.5 * 0.2 * 1)
@@ -149,12 +149,10 @@ RSpec.describe 'PropertyBoostCalculatorTest' do
   end
 
   def build_document(format: nil, document_type: nil)
-    attributes = {
-      "_type" => "some_type",
-    }
+    attributes = {}
     attributes["format"] = format if format
     attributes["content_store_document_type"] = document_type if document_type
 
-    Document.new(sample_field_definitions, attributes)
+    attributes
   end
 end

--- a/spec/unit/sitemap/sitemap_generator_spec.rb
+++ b/spec/unit/sitemap/sitemap_generator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'SitemapGeneratorTest' do
   it "should_generate_sitemap" do
-    sitemap = SitemapGenerator.new('')
+    sitemap = SitemapGenerator.new(index_names: '')
 
     sitemap_xml = sitemap.generate_xml([
       build_document('https://www.gov.uk/page'),
@@ -18,7 +18,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "links_should_include_timestamps" do
-    sitemap = SitemapGenerator.new('')
+    sitemap = SitemapGenerator.new(index_names: '')
 
     sitemap_xml = sitemap.generate_xml([
       build_document('/some-page', timestamp: "2014-01-28T14:41:50+00:00"),
@@ -30,7 +30,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "missing_timestamps_are_ignored" do
-    sitemap = SitemapGenerator.new('')
+    sitemap = SitemapGenerator.new(index_names: '')
 
     sitemap_xml = sitemap.generate_xml([
       build_document('/page-without-date'),
@@ -42,7 +42,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "page_priority_is_document_priority" do
-    sitemap = SitemapGenerator.new('')
+    sitemap = SitemapGenerator.new(index_names: '')
 
     document = build_document('/some-path')
     document.stub(:priority).and_return(0.48)
@@ -63,7 +63,7 @@ RSpec.describe 'SitemapGeneratorTest' do
     attributes["is_withdrawn"] = is_withdrawn if !is_withdrawn.nil?
 
     SitemapPresenter.new(
-      Document.new(sample_field_definitions, attributes),
+      attributes,
       PropertyBoostCalculator.new
     )
   end

--- a/spec/unit/sitemap/sitemap_presenter_spec.rb
+++ b/spec/unit/sitemap/sitemap_presenter_spec.rb
@@ -120,14 +120,14 @@ RSpec.describe 'SitemapPresenterTest' do
   end
 
   def build_document(url:, timestamp: nil, format: nil, is_withdrawn: nil)
-    attributes = {
+    document = {
       "link" => url,
       "_type" => "some_type",
     }
-    attributes["public_timestamp"] = timestamp if timestamp
-    attributes["format"] = format if format
-    attributes["is_withdrawn"] = is_withdrawn if !is_withdrawn.nil?
+    document["public_timestamp"] = timestamp if timestamp
+    document["format"] = format if format
+    document["is_withdrawn"] = is_withdrawn if !is_withdrawn.nil?
 
-    Document.new(sample_field_definitions, attributes)
+    document
   end
 end


### PR DESCRIPTION
This uses filtering to add the migrated govuk index documents to the
site map.

We also refactorered the sitemap generator a little bit.

https://trello.com/c/gVTzUj6v

@Rosa-Fox and @dwhenry were also on The Scroll Train