### PR TITLE
Make message queue listener handle content items without base_path

### DIFF
--- a/lib/indexer/change_notification_processor.rb
+++ b/lib/indexer/change_notification_processor.rb
@@ -19,10 +19,9 @@ module Indexer
     end
 
     def self.find_document(content_item)
-      # Note that in the future the publishing-api may allow items without
-      # `base_path`. When that starts we should bail out here instead of
-      # crashing.
-      document_base_path = content_item.fetch("base_path")
+      document_base_path = content_item["base_path"]
+      return nil if document_base_path.nil?
+
       index = IndexFinder.content_index
       index.get_document_by_link(document_base_path)
     end

--- a/test/unit/indexer/change_notification_processor_test.rb
+++ b/test/unit/indexer/change_notification_processor_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class ChangeNotificationProcessorTest < Minitest::Test
+  def test_rejects_base_pathless_documents
+    message_payload = {
+      "content_id" => "4711fc53-673a-4211-bae6-e0a3d3afd82f",
+      "base_path" => nil,
+      "document_type" => "contact",
+      "title" => "Mr Contact",
+      "update_type" => nil,
+      "publishing_app" => "whitehall"
+    }
+
+    result = Indexer::ChangeNotificationProcessor.trigger(message_payload)
+
+    assert_equal(:rejected, result)
+  end
+
+  def test_rejects_invalid_documents
+    message_payload = {}
+
+    result = Indexer::ChangeNotificationProcessor.trigger(message_payload)
+
+    assert_equal(:rejected, result)
+  end
+
+  def test_rejects_missing_documents
+    message_payload = {
+      "content_id" => "4711fc53-673a-4211-bae6-e0a3d3afd82f",
+      "base_path" => "/does-not-exist",
+      "document_type" => "publication",
+      "title" => "How to care for your rabbit",
+      "update_type" => nil,
+      "publishing_app" => "whitehall"
+    }
+
+    index_mock = mock
+    index_mock.stubs(:get_document_by_link).with("/does-not-exist").returns(nil)
+    IndexFinder.expects(:content_index).returns(index_mock)
+
+    result = Indexer::ChangeNotificationProcessor.trigger(message_payload)
+
+    assert_equal(:rejected, result)
+  end
+
+  def test_accepts_existing_documents
+    message_payload = {
+      "content_id" => "4711fc53-673a-4211-bae6-e0a3d3afd82f",
+      "base_path" => "/does-exist",
+      "document_type" => "publication",
+      "title" => "How to care for your rabbit",
+      "update_type" => nil,
+      "publishing_app" => "whitehall"
+    }
+
+    index_mock = mock
+    index_mock.stubs(:get_document_by_link).with("/does-exist").returns({ "link" => "/does-exist" })
+    IndexFinder.expects(:content_index).returns(index_mock)
+
+    result = Indexer::ChangeNotificationProcessor.trigger(message_payload)
+
+    assert_equal(:accepted, result)
+  end
+end


### PR DESCRIPTION
The worker that listens to *.links updates never worked with content items that
don't have base_paths.

This causes the elasticsearch lookup to fail, because the term filter gets
passed null, which isn't valid. This causes messages to backup in the RabbitMQ
queue.

We're not sure why this has never caused problems before; it could be a change
in behaviour since updating elasticsearch.

Paired with @suzannehamilton 