### PR TITLE
[DO NOT MERGE] Remove global stub

### DIFF
--- a/spec/integration/analytics_data_spec.rb
+++ b/spec/integration/analytics_data_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
+  allow_elasticsearch_connection(scroll: true)
+
   before do
     @analytics_data_fetcher = AnalyticsData.new(SearchConfig.instance.base_uri, ["mainstream_test"])
   end

--- a/spec/integration/app/content_endpoints_spec.rb
+++ b/spec/integration/app/content_endpoints_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ContentEndpointsTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "content_document_not_found" do
     get "/content?link=/a-document/that-does-not-exist"
 

--- a/spec/integration/comparer_spec.rb
+++ b/spec/integration/comparer_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ComparerTest', tags: ['integration'] do
+  allow_elasticsearch_connection(scroll: true)
+
   it "for_sort_ordering" do
     insert_document('mainstream_test', { some: 'data' }, id: 'ABC', type: 'edition')
     insert_document('mainstream_test', { some: 'data' }, id: 'DEF', type: 'hmrc_manual')

--- a/spec/integration/duplicate_deleter_spec.rb
+++ b/spec/integration/duplicate_deleter_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "can_not_delete_when_only_a_single_document" do
     commit_document(
       "mainstream_test",

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     bunny_mock = BunnyMock.new
     @channel = bunny_mock.start.channel

--- a/spec/integration/govuk_index/specialist_formats_spec.rb
+++ b/spec/integration/govuk_index/specialist_formats_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'SpecialistFormatTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     bunny_mock = BunnyMock.new
     @channel = bunny_mock.start.channel

--- a/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
+++ b/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     insert_document('mainstream_test', title: 'mainstream answer', link: '/mainstream/answer', format: 'answer')
     insert_document('mainstream_test', title: 'mainstream help', link: '/mainstream/help', format: 'help_page')

--- a/spec/integration/govuk_index/sync_data_spec.rb
+++ b/spec/integration/govuk_index/sync_data_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'GovukIndex::SyncDataTest', tags: ['integration'] do
+  allow_elasticsearch_connection(scroll: true)
+
   before do
     GovukIndex::MigratedFormats.stub(:indexable_formats).and_return(['help_page'])
   end

--- a/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
+++ b/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'GovukIndex::UnpublishingMessageProcessing', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "unpublish_message_will_remove_record_from_elasticsearch" do
     GovukIndex::MigratedFormats.stub(:migrated_formats).and_return(%w(answer))
 

--- a/spec/integration/govuk_index/updating_popularity_data_spec.rb
+++ b/spec/integration/govuk_index/updating_popularity_data_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'GovukIndex::UpdatingPopularityDataTest', tags: ['integration'] do
+  allow_elasticsearch_connection(scroll: true)
+
   before do
     GovukIndex::MigratedFormats.stub(:indexable_formats).and_return(['help_page'])
   end

--- a/spec/integration/govuk_index/versioning_spec.rb
+++ b/spec/integration/govuk_index/versioning_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 require 'govuk_index/publishing_event_processor'
 
 RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     @processor = GovukIndex::PublishingEventProcessor.new
   end

--- a/spec/integration/indexer/amendment_spec.rb
+++ b/spec/integration/indexer/amendment_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ElasticsearchAmendmentTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     stub_tagging_lookup
   end

--- a/spec/integration/indexer/bulk_loader_spec.rb
+++ b/spec/integration/indexer/bulk_loader_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'BulkLoaderTest', tags: ['integration'] do
+  allow_elasticsearch_connection(aliases: true)
+
   before do
     stub_tagging_lookup
     comparer = double(:comparer)

--- a/spec/integration/indexer/change_notification_processor_spec.rb
+++ b/spec/integration/indexer/change_notification_processor_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ChangeNotificationProcessorTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "triggering_a_reindex" do
     publishing_api_has_lookups(
       "/foo" => "DOCUMENT-CONTENT-ID"

--- a/spec/integration/indexer/closing_spec.rb
+++ b/spec/integration/indexer/closing_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ElasticsearchClosingTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     stub_tagging_lookup
   end

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ElasticsearchDeletionTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "removes_a_document_from_the_index" do
     commit_document("mainstream_test", {
       "link" => "/an-example-page"

--- a/spec/integration/indexer/index_group_spec.rb
+++ b/spec/integration/indexer/index_group_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ElasticsearchIndexGroupTest', tags: ['integration'] do
+  allow_elasticsearch_connection(aliases: true)
+
   before do
     @group_name = "mainstream_test"
     IndexHelpers.clean_index_group(@group_name)

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ElasticsearchIndexingTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   include GdsApi::TestHelpers::PublishingApiV2
 
   SAMPLE_DOCUMENT = {

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require "gds_api/test_helpers/publishing_api_v2"
 
 RSpec.describe 'TaglookupDuringIndexingTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   include GdsApi::TestHelpers::PublishingApiV2
 
   it "indexes_document_without_publishing_api_content_unchanged" do

--- a/spec/integration/indexer/locking_spec.rb
+++ b/spec/integration/indexer/locking_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ElasticsearchLockingTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     stub_tagging_lookup
   end

--- a/spec/integration/indexer/migration_spec.rb
+++ b/spec/integration/indexer/migration_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 # The "Migration" in the name means creating new indexes and copying data from
 # the existing ones.
 RSpec.describe 'ElasticsearchMigrationTest', tags: ['integration'] do
+  allow_elasticsearch_connection(aliases: true, scroll: true)
+
   before do
     # MigratedFormats are the formats using the `govuk` index.
     GovukIndex::MigratedFormats.stub(:migrated_formats).and_return([])

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'MissingMetadataTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "finds_missing_content_id" do
     commit_document(
       'mainstream_test',

--- a/spec/integration/schema/stemming_spec.rb
+++ b/spec/integration/schema/stemming_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'SettingsTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "default" do
     assert_tokenisation :default,
       "It's A Small’s World" => %w(it small world),

--- a/spec/integration/scroll_enumerator_spec.rb
+++ b/spec/integration/scroll_enumerator_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ScrollEnumeratorTest', tags: ['integration'] do
+  allow_elasticsearch_connection(scroll: true)
+
   it "returns_expected_results_for_unsorted_search" do
     10.times.each do |id|
       commit_document("mainstream_test", { some: 'data' }, id: "id-#{id}", type: "edition")

--- a/spec/integration/search/best_bets_spec.rb
+++ b/spec/integration/search/best_bets_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'BestBetsTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "exact_best_bet" do
     commit_document("mainstream_test",
       "link" => '/an-organic-result',

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'BoosterTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "service_manual_formats_are_weighted_down" do
     commit_document("mainstream_test",
       "title" => "Agile is good",

--- a/spec/integration/search/expands_values_from_schema_spec.rb
+++ b/spec/integration/search/expands_values_from_schema_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ExpandsValuesFromSchemaTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "extra_fields_decorated_by_schema" do
     commit_document("mainstream_test", {
       "link" => "/cma-cases/sample-cma-case",

--- a/spec/integration/search/legacy_search_spec.rb
+++ b/spec/integration/search/legacy_search_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ElasticsearchAdvancedSearchTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     @index_name = "mainstream_test"
 

--- a/spec/integration/search/more_like_this_spec.rb
+++ b/spec/integration/search/more_like_this_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'MoreLikeThisTest', tags: ['integration'] do
+  allow_elasticsearch_connection(scroll: true)
+
   it "returns_success" do
     get "/search?similar_to=/mainstream-1"
 

--- a/spec/integration/search/quoted_and_unquoted_searches_spec.rb
+++ b/spec/integration/search/quoted_and_unquoted_searches_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'QuotedAndUnquotedSearchTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   before do
     # `@@registries` are set in Rummager and is *not* reset between tests. To
     # prevent caching issues we manually clear them here to make a "new" app.

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
+  allow_elasticsearch_connection
+
   it "returns_highlighted_title" do
     commit_document("mainstream_test",
       "title" => "I am the result",

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'SearchTest', tags: ['integration'] do
+  allow_elasticsearch_connection(scroll: true)
+
   it "returns_success" do
     get "/search?q=important"
 

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
+  allow_elasticsearch_connection(scroll: true)
 
   it "should_generate_multiple_sitemaps" do
     SitemapGenerator.stub(:sitemap_limit).and_return(2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,10 +39,6 @@ Sidekiq::Logging.logger = nil
 
 require 'webmock/rspec'
 
-# Prevent tests from messing with development/production data.
-only_test_databases = %r{http://localhost:9200/(_search/scroll|_aliases|_bulk|[a-z_-]+(_|-)test.*)}
-WebMock.disable_net_connect!(allow: only_test_databases)
-
 require "#{__dir__}/support/default_mappings"
 require "#{__dir__}/support/spec_helpers"
 require "#{__dir__}/support/hash_including_helpers"
@@ -82,6 +78,11 @@ RSpec.configure do |config|
     # is automatically reset, the index_names or passed into children object and
     # cached there.
     SearchConfig.instance = SearchConfig.new
+  end
+
+  config.after do
+    # reset allowed connections to ES so that we avoid global stubbing
+    WebMock.disable_net_connect!(allow: nil)
   end
 
   if config.files_to_run.one?

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -9,16 +9,22 @@ module IntegrationSpecHelper
     "_type" => "edition",
   }.freeze
 
-  def self.included(base)
-    base.after do
-      teardown
-    end
+  module ClassMethods
+    def allow_elasticsearch_connection(aliases: false, bulk: false, scroll: false)
+      self.before do
+        IntegrationSpecHelper.allow_elasticsearch_connection(aliases: aliases, bulk: bulk, scroll: scroll)
+      end
 
-    base.around do |example|
-      IntegrationSpecHelper.with_real_elasticsearch_connection(aliases: true, bulk: true, scroll: true) do
-        example.run
+      self.after do
+        IntegrationSpecHelper.allow_elasticsearch_connection(bulk: true)
+        teardown
+        IntegrationSpecHelper.disallow_elasticsearch_connection
       end
     end
+  end
+
+  def self.included(base)
+    base.extend ClassMethods
 
     @before_suite_setup ||= setup_before_suite
   end
@@ -27,31 +33,30 @@ module IntegrationSpecHelper
     # we want this process to run before the suite when integration tests are run. :)
     RSpec.configure do |config|
       config.before(:suite) do
-        IntegrationSpecHelper.with_real_elasticsearch_connection(aliases: true) do
-          IndexHelpers.setup_test_indexes
-        end
+        IntegrationSpecHelper.allow_elasticsearch_connection(aliases: true)
+        IndexHelpers.setup_test_indexes
+        IntegrationSpecHelper.disallow_elasticsearch_connection
       end
 
       config.after(:suite) do
-        IntegrationSpecHelper.with_real_elasticsearch_connection do
-          IndexHelpers.clean_all
-        end
+        IntegrationSpecHelper.allow_elasticsearch_connection
+        IndexHelpers.clean_all
+        IntegrationSpecHelper.disallow_elasticsearch_connection
       end
     end
   end
 
-  def self.with_real_elasticsearch_connection(aliases: false, bulk: false, scroll: false)
+  def self.allow_elasticsearch_connection(aliases: false, bulk: false, scroll: false)
     parts = ['[a-z_-]+[_-]test.*']
     parts << '_aliases' if aliases
     parts << '_bulk' if bulk
     parts << '_search/scroll' if scroll
 
-    # Prevent tests from messing with development/production data.
-    # only_test_databases = %r{http://localhost:9200/(_search/scroll|_aliases|_bulk|[a-z_-]+(_|-)test.*)}
     only_test_databases = %r{http://localhost:9200/(#{parts.join('|')})}
-    # puts only_test_databases
     WebMock.disable_net_connect!(allow: only_test_databases)
-    yield
+  end
+
+  def self.disallow_elasticsearch_connection
     WebMock.disable_net_connect!(allow: nil)
   end
 

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -14,6 +14,12 @@ module IntegrationSpecHelper
       teardown
     end
 
+    base.around do |example|
+      IntegrationSpecHelper.with_real_elasticsearch_connection(aliases: true, bulk: true, scroll: true) do
+        example.run
+      end
+    end
+
     @before_suite_setup ||= setup_before_suite
   end
 
@@ -21,13 +27,32 @@ module IntegrationSpecHelper
     # we want this process to run before the suite when integration tests are run. :)
     RSpec.configure do |config|
       config.before(:suite) do
-        IndexHelpers.setup_test_indexes
+        IntegrationSpecHelper.with_real_elasticsearch_connection(aliases: true) do
+          IndexHelpers.setup_test_indexes
+        end
       end
 
       config.after(:suite) do
-        IndexHelpers.clean_all
+        IntegrationSpecHelper.with_real_elasticsearch_connection do
+          IndexHelpers.clean_all
+        end
       end
     end
+  end
+
+  def self.with_real_elasticsearch_connection(aliases: false, bulk: false, scroll: false)
+    parts = ['[a-z_-]+[_-]test.*']
+    parts << '_aliases' if aliases
+    parts << '_bulk' if bulk
+    parts << '_search/scroll' if scroll
+
+    # Prevent tests from messing with development/production data.
+    # only_test_databases = %r{http://localhost:9200/(_search/scroll|_aliases|_bulk|[a-z_-]+(_|-)test.*)}
+    only_test_databases = %r{http://localhost:9200/(#{parts.join('|')})}
+    # puts only_test_databases
+    WebMock.disable_net_connect!(allow: only_test_databases)
+    yield
+    WebMock.disable_net_connect!(allow: nil)
   end
 
   def teardown


### PR DESCRIPTION
I have achieved this by adding a global method `allow_elasticsearch_connection` which needs to be called at the top of any test files that require access to the ES instance (i.e. most integration test files).

I think this is an improvement, but am happy to abandon this change depending on how others feel.

I am open to suggestions if anyone has a better idea on how to achieve the removal of the global stub.