### PR TITLE
Surpress server errors when benchmarking search

### DIFF
--- a/bin/health_check
+++ b/bin/health_check
@@ -40,6 +40,9 @@ class HealthCheckCLI
       on 'type=', "Which tests to run. 'suggestions' or 'results' (default)"
       run(health_checker)
     end
+  rescue Net::HTTPServerError => e
+    $stderr.puts "Unable to continue: bad response from search API:"
+    $sterr.puts e.backtrace
   end
 
   def call(opts, args)


### PR DESCRIPTION
There is a jenkins job that runs this nightly, but it can fail if
search is not responding properly. This is best monitored by other checks,
and the benchmark results are not something we depend on, so we'd
prefer for this not to trigger a 2nd line alert.