### PR TITLE
Remove minitest expectations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ group :test do
   gem 'bunny-mock', '~> 1.7'
   gem "ci_reporter", "~> 1.7.1"
   gem 'govuk_schemas', '~> 2.2.0'
-  gem "minitest", "~> 5.6.0"
   gem "rack-test", "~> 0.6.3"
   gem 'rspec'
   gem "simplecov", "~> 0.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.6.1)
     mr-sparkle (0.3.0)
       listen (~> 1.0)
       rb-fsevent (>= 0.9)
@@ -215,7 +214,6 @@ DEPENDENCIES
   govuk_schemas (~> 2.2.0)
   logging (~> 2.1.0)
   loofah
-  minitest (~> 5.6.0)
   mr-sparkle (= 0.3.0)
   nokogiri (~> 1.7.2)
   plek (~> 1.12)

--- a/spec/integration/analytics_data_spec.rb
+++ b/spec/integration/analytics_data_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
         nil,
       ]
 
-    assert_equal [expected_row], rows.to_a
+    expect([expected_row]).to eq(rows.to_a)
   end
 
   it "missing_data_is_nil" do
@@ -48,7 +48,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     expected_row = [id, id, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
 
-    assert_equal [expected_row], rows.to_a
+    expect([expected_row]).to eq(rows.to_a)
   end
 
   it "content_id_is_preferred_to_link_for_product_id" do
@@ -60,7 +60,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    assert_equal "some_content_id", rows.first[0]
+    expect("some_content_id").to eq(rows.first[0])
   end
 
   it "product_id_falls_back_to_link_if_content_id_is_missing" do
@@ -71,7 +71,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    assert_equal "/some/page/path", rows.first[0]
+    expect("/some/page/path").to eq(rows.first[0])
   end
 
   it "document_type_is_preferred_to_format" do
@@ -83,7 +83,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    assert_equal "some_document_type", rows.first[5]
+    expect("some_document_type").to eq(rows.first[5])
   end
 
   it "document_type_falls_back_to_format_if_not_present" do
@@ -94,7 +94,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    assert_equal "some_format", rows.first[5]
+    expect("some_format").to eq(rows.first[5])
   end
 
   it "sanitises_unix_line_breaks_in_titles" do
@@ -109,7 +109,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    assert_equal "A page title with some line breaks", rows.first[4]
+    expect("A page title with some line breaks").to eq(rows.first[4])
   end
 
   it "sanitises_windows_line_breaks_in_titles" do
@@ -120,7 +120,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    assert_equal "A page title with some line breaks", rows.first[4]
+    expect("A page title with some line breaks").to eq(rows.first[4])
   end
 
   it "fetches_all_rows" do
@@ -132,7 +132,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     analytics_data = @analytics_data_fetcher.rows.to_a
 
-    assert_equal 30, analytics_data.size
+    expect(30).to eq(analytics_data.size)
   end
 
   it "headers_and_rows_are_consisent" do
@@ -146,6 +146,6 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
     rows = @analytics_data_fetcher.rows
     headers = @analytics_data_fetcher.headers
 
-    assert_equal headers.size, rows.first.size
+    expect(headers.size).to eq(rows.first.size)
   end
 end

--- a/spec/integration/app/content_endpoints_spec.rb
+++ b/spec/integration/app/content_endpoints_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'ContentEndpointsTest', tags: ['integration'] do
   it "content_document_not_found" do
     get "/content?link=/a-document/that-does-not-exist"
 
-    assert last_response.not_found?
+    expect(last_response).to be_not_found
   end
 
   it "that_getting_a_document_returns_the_document" do
@@ -15,11 +15,8 @@ RSpec.describe 'ContentEndpointsTest', tags: ['integration'] do
 
     get "/content?link=a-document/in-search"
 
-    assert last_response.ok?
-    assert_equal(
-      { "title" => "A nice title", "link" => "a-document/in-search" },
-      parsed_response['raw_source']
-    )
+    expect(last_response).to be_ok
+    expect("title" => "A nice title", "link" => "a-document/in-search").to eq parsed_response['raw_source']
   end
 
   it "deleting_a_document" do
@@ -30,13 +27,13 @@ RSpec.describe 'ContentEndpointsTest', tags: ['integration'] do
 
     delete "/content?link=a-document/in-search"
 
-    assert_equal 204, last_response.status
+    expect(204).to eq(last_response.status)
   end
 
   it "deleting_a_document_that_doesnt_exist" do
     delete "/content?link=a-document/in-search"
 
-    assert last_response.not_found?
+    expect(last_response).to be_not_found
   end
 
   it "deleting_a_document_from_locked_index" do
@@ -49,6 +46,6 @@ RSpec.describe 'ContentEndpointsTest', tags: ['integration'] do
 
     delete "/content?link=a-document/in-search"
 
-    assert_equal 423, last_response.status
+    expect(423).to eq(last_response.status)
   end
 end

--- a/spec/integration/app/status_spec.rb
+++ b/spec/integration/app/status_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
 
     get "/_status"
 
-    assert last_response.ok?
-    assert_equal ["bulk"], parsed_response["queues"].keys
-    assert_equal 12, parsed_response["queues"]["bulk"]["jobs"]
+    expect(last_response).to be_ok
+    expect(["bulk"]).to eq(parsed_response["queues"].keys)
+    expect(12).to eq(parsed_response["queues"]["bulk"]["jobs"])
   end
 
   it "shows_per_queue_retry_count" do
@@ -23,8 +23,8 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
 
     get "/_status"
 
-    assert last_response.ok?
-    assert_equal 2, parsed_response["queues"]["bulk"]["retries"]
+    expect(last_response).to be_ok
+    expect(2).to eq(parsed_response["queues"]["bulk"]["retries"])
   end
 
   it "shows_zero_retry_count" do
@@ -35,8 +35,8 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
 
     get "/_status"
 
-    assert last_response.ok?
-    assert_equal 0, parsed_response["queues"]["bulk"]["retries"]
+    expect(last_response).to be_ok
+    expect(0).to eq(parsed_response["queues"]["bulk"]["retries"])
   end
 
   it "shows_per_queue_scheduled_count" do
@@ -49,8 +49,8 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
 
     get "/_status"
 
-    assert last_response.ok?
-    assert_equal 2, parsed_response["queues"]["bulk"]["scheduled"]
+    expect(last_response).to be_ok
+    expect(2).to eq(parsed_response["queues"]["bulk"]["scheduled"])
   end
 
   it "shows_zero_retry_count_scheduled" do
@@ -61,7 +61,7 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
 
     get "/_status"
 
-    assert last_response.ok?
-    assert_equal 0, parsed_response["queues"]["bulk"]["scheduled"]
+    expect(last_response).to be_ok
+    expect(0).to eq(parsed_response["queues"]["bulk"]["scheduled"])
   end
 end

--- a/spec/integration/comparer_spec.rb
+++ b/spec/integration/comparer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'ComparerTest', tags: ['integration'] do
     results = Indexer::CompareEnumerator.new('mainstream_test', 'government_test')
 
     # ordered by type and the ID
-    assert_equal [
+    expect([
       [
         { 'some' => 'data', '_root_id' => 'ABC', '_root_type' => 'edition', 'link' => 'ABC' },
         { 'some' => 'data', '_root_id' => 'ABC', '_root_type' => 'edition', 'link' => 'ABC' },
@@ -30,7 +30,7 @@ RSpec.describe 'ComparerTest', tags: ['integration'] do
         { 'some' => 'data', '_root_id' => 'DEF', '_root_type' => 'hmrc_manual', 'link' => 'DEF' },
         :__no_value_found__,
       ],
-    ], results.to_a
+    ]).to eq results.to_a
   end
 
   it "only_compares_filtered_formats" do
@@ -45,7 +45,7 @@ RSpec.describe 'ComparerTest', tags: ['integration'] do
     query = { filter: { term: { format: 'edition' } } }
     results = Indexer::CompareEnumerator.new('mainstream_test', 'government_test', query)
 
-    assert_equal [
+    expect([
       [
         { 'some' => 'data', '_root_id' => 'ABC', '_root_type' => 'edition', 'format' => 'edition', 'link' => 'ABC' },
         { 'some' => 'data', '_root_id' => 'ABC', '_root_type' => 'edition', 'format' => 'edition', 'link' => 'ABC' },
@@ -54,7 +54,7 @@ RSpec.describe 'ComparerTest', tags: ['integration'] do
         :__no_value_found__,
         { 'some' => 'data', '_root_id' => 'GHI', '_root_type' => 'edition', 'format' => 'edition', 'link' => 'GHI' },
       ],
-    ], results.to_a
+    ]).to eq results.to_a
   end
 
   it "comparison_output_works" do
@@ -68,6 +68,6 @@ RSpec.describe 'ComparerTest', tags: ['integration'] do
 
     comparer = Indexer::Comparer.new('mainstream_test', 'government_test', filtered_format: 'edition', io: StringIO.new)
 
-    assert_equal comparer.run, { changed: 1, 'changes: field': 1, added_items: 1 }
+    expect(comparer.run).to eq(changed: 1, 'changes: field': 1, added_items: 1)
   end
 end

--- a/spec/integration/duplicate_deleter_spec.rb
+++ b/spec/integration/duplicate_deleter_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
 
-    assert_message(msg: "as less than 2 results found")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "edition")
+    expect_log_message(msg: "as less than 2 results found")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   it "can_delete_duplicate_documents_on_different_types" do
@@ -38,9 +38,9 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
 
-    assert_message(msg: "Deleted duplicate for content_id")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
-    assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
+    expect_log_message(msg: "Deleted duplicate for content_id")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    expect_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   it "cant_delete_a_type_that_doesnt_exist" do
@@ -63,9 +63,9 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('ab_case', io, search_config: SearchConfig.instance).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
 
-    assert_message(msg: "as type to delete ab_case not present in")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "edition")
+    expect_log_message(msg: "as type to delete ab_case not present in")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   it "cant_delete_duplicate_content_ids_when_id_doesnt_match" do
@@ -88,9 +88,9 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["3c824d6b-d982-4426-9a7d-43f2b865e77c"])
 
-    assert_message(msg: "as multiple _id's detected")
-    assert_document_present_in_rummager(id: "/not-an-example-page", type: "edition")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    expect_log_message(msg: "as multiple _id's detected")
+    expect_document_present_in_rummager(id: "/not-an-example-page", type: "edition")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
   end
 
   it "can_delete_duplicate_content_ids_when_contact_id_is_wrong" do
@@ -115,9 +115,9 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["e3eaa461-3a85-4881-b412-9c58e7ea4ebd"])
 
-    assert_message(msg: "Deleted duplicate for content_id")
-    assert_document_present_in_rummager(id: "contact-page", type: "contact")
-    assert_document_missing_in_rummager(id: "/contact-page", type: "edition")
+    expect_log_message(msg: "Deleted duplicate for content_id")
+    expect_document_present_in_rummager(id: "contact-page", type: "contact")
+    expect_document_missing_in_rummager(id: "/contact-page", type: "edition")
   end
 
   it "can_delete_duplicate_documents_on_different_types_using_link" do
@@ -140,9 +140,9 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["/an-example-page"], id_type: "link")
 
-    assert_message(msg: "Deleted duplicate for link")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
-    assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
+    expect_log_message(msg: "Deleted duplicate for link")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    expect_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   it "cant_delete_duplicate_documents_using_link_with_different_content_ids" do
@@ -165,9 +165,9 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["/an-example-page"], id_type: "link")
 
-    assert_message(msg: "as multiple non-null content_id's detected")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "edition")
+    expect_log_message(msg: "as multiple non-null content_id's detected")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   it "can_delete_duplicate_documents_if_bad_item_has_nil_content_id" do
@@ -187,9 +187,9 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["/an-example-page"], id_type: "link")
 
-    assert_message(msg: "Deleted duplicate for link")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
-    assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
+    expect_log_message(msg: "Deleted duplicate for link")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    expect_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   it "cant_delete_duplicate_documents_if_good_item_has_nil_content_id" do
@@ -209,9 +209,9 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["/an-example-page"], id_type: "link")
 
-    assert_message(msg: "indexed with a valid '_type' but a missing content ID")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "edition")
+    expect_log_message(msg: "indexed with a valid '_type' but a missing content ID")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
   it "can_delete_duplicate_documents_on_different_types_using_link_when_both_content_ids_are_missing" do
@@ -228,29 +228,29 @@ RSpec.describe 'DuplicateDeleterTest', tags: ['integration'] do
 
     DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["/an-example-page"], id_type: "link")
 
-    assert_message(msg: "Deleted duplicate for link")
-    assert_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
-    assert_document_missing_in_rummager(id: "/an-example-page", type: "edition")
+    expect_log_message(msg: "Deleted duplicate for link")
+    expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
+    expect_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
 private
 
-  def assert_document_present_in_rummager(id:, type:, index: "mainstream_test")
+  # TODO: change this to use global `expect_document_is_in_rummager` method
+  def expect_document_present_in_rummager(id:, type:, index: "mainstream_test")
     doc = fetch_document_from_rummager(id: id, type: type, index: index)
-    assert doc
+    expect(doc).to be_truthy
   end
 
-  def assert_document_missing_in_rummager(id:, type:)
-    assert_raises Elasticsearch::Transport::Transport::Errors::NotFound do
+  def expect_document_missing_in_rummager(id:, type:)
+    expect {
       fetch_document_from_rummager(id: id, type: type)
-    end
+    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 
-
-  def assert_message(msg:)
+  def expect_log_message(msg:)
     io.rewind
     log = io.read
-    assert log.include?(msg), "#{msg} not in #{log}"
+    expect(log).to include(msg), "#{msg} not in #{log}"
   end
 
   def io

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration']
 
     document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
 
-    assert_equal random_example["base_path"], document["_source"]["link"]
-    assert_equal random_example["base_path"], document["_id"]
-    assert_equal "edition", document["_type"]
+    expect(random_example["base_path"]).to eq(document["_source"]["link"])
+    expect(random_example["base_path"]).to eq(document["_id"])
+    expect("edition").to eq(document["_type"])
 
-    assert_equal 0, @queue.message_count
-    assert_equal 1, @channel.acknowledged_state[:acked].count
+    expect(0).to eq(@queue.message_count)
+    expect(1).to eq(@channel.acknowledged_state[:acked].count)
   end
 
   it "not_indexing_when_publishing_app_is_smart_answers" do
@@ -44,9 +44,9 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration']
     @queue.publish(random_example.to_json, content_type: "application/json")
     commit_index 'govuk_test'
 
-    assert_raises(Elasticsearch::Transport::Transport::Errors::NotFound) do
+    expect {
       fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test", type: 'edition')
-    end
+    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 
   it "should_include_popularity_when_available" do
@@ -68,7 +68,7 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration']
 
     document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
 
-    assert_equal popularity, document["_source"]["popularity"]
+    expect(popularity).to eq(document["_source"]["popularity"])
   end
 
   it "should_discard_message_when_invalid" do
@@ -80,7 +80,7 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration']
     expect(GovukError).to receive(:notify)
     @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
 
-    assert_equal 0, @queue.message_count
+    expect(0).to eq(@queue.message_count)
   end
 
   it "should_discard_message_when_withdrawn_and_invalid" do
@@ -92,7 +92,7 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration']
     expect(GovukError).to receive(:notify)
     @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
 
-    assert_equal 0, @queue.message_count
+    expect(0).to eq(@queue.message_count)
   end
 
   def client

--- a/spec/integration/govuk_index/specialist_formats_spec.rb
+++ b/spec/integration/govuk_index/specialist_formats_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'SpecialistFormatTest', tags: ['integration'] do
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 
-    assert_document_is_in_rummager({ "link" => random_example["base_path"] }, index: "govuk_test", type: 'edition')
+    expect_document_is_in_rummager({ "link" => random_example["base_path"] }, index: "govuk_test", type: 'edition')
   end
 
   it "specialist_documents_are_correctly_indexed" do
@@ -62,7 +62,7 @@ RSpec.describe 'SpecialistFormatTest', tags: ['integration'] do
 
       @queue.publish(random_example.to_json, content_type: "application/json")
 
-      assert_document_is_in_rummager({ "link" => random_example["base_path"] }, index: "govuk_test", type: specialist_document_type)
+      expect_document_is_in_rummager({ "link" => random_example["base_path"] }, index: "govuk_test", type: specialist_document_type)
     end
   end
 
@@ -79,7 +79,7 @@ RSpec.describe 'SpecialistFormatTest', tags: ['integration'] do
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 
-    assert_document_is_in_rummager({ "link" => random_example["base_path"] }, index: "govuk_test", type: search_document_type)
+    expect_document_is_in_rummager({ "link" => random_example["base_path"] }, index: "govuk_test", type: search_document_type)
   end
 
   it "finders_email_signup_are_never_indexed" do
@@ -91,8 +91,8 @@ RSpec.describe 'SpecialistFormatTest', tags: ['integration'] do
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 
-    assert_raises(Elasticsearch::Transport::Transport::Errors::NotFound) do
+    expect {
       fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
-    end
+    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 end

--- a/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
+++ b/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest', tags: ['integratio
 
     get "/search"
 
-    assert_equal(['mainstream answer', 'mainstream help'], parsed_response['results'].map { |r| r['title'] }.sort)
+    expect(['mainstream answer', 'mainstream help']).to eq(parsed_response['results'].map { |r| r['title'] }.sort)
   end
 
   it "can_enable_format_to_use_govuk_index" do
@@ -23,7 +23,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest', tags: ['integratio
 
     get "/search"
 
-    assert_equal(['govuk help', 'mainstream answer'], parsed_response['results'].map { |r| r['title'] }.sort)
+    expect(['govuk help', 'mainstream answer']).to eq(parsed_response['results'].map { |r| r['title'] }.sort)
   end
 
   it "can_enable_multiple_formats_to_use_govuk_index" do
@@ -31,6 +31,6 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest', tags: ['integratio
 
     get "/search"
 
-    assert_equal(['govuk answer', 'govuk help'], parsed_response['results'].map { |r| r['title'] }.sort)
+    expect(['govuk answer', 'govuk help']).to eq(parsed_response['results'].map { |r| r['title'] }.sort)
   end
 end

--- a/spec/integration/govuk_index/sync_data_spec.rb
+++ b/spec/integration/govuk_index/sync_data_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'GovukIndex::SyncDataTest', tags: ['integration'] do
 
     GovukIndex::SyncUpdater.update(source_index: 'mainstream_test', destination_index: 'govuk_test')
 
-    assert_document_is_in_rummager({ 'link' => '/test' }, type: 'edition', index: 'govuk_test')
+    expect_document_is_in_rummager({ 'link' => '/test' }, type: 'edition', index: 'govuk_test')
   end
 
   it "syncs_will_overwrite_existing_data" do
@@ -22,7 +22,7 @@ RSpec.describe 'GovukIndex::SyncDataTest', tags: ['integration'] do
 
     GovukIndex::SyncUpdater.update(source_index: 'mainstream_test', destination_index: 'govuk_test')
 
-    assert_document_is_in_rummager({ 'link' => '/test', 'popularity' => 0.3 }, type: 'edition', index: 'govuk_test')
+    expect_document_is_in_rummager({ 'link' => '/test', 'popularity' => 0.3 }, type: 'edition', index: 'govuk_test')
   end
 
 
@@ -34,6 +34,6 @@ RSpec.describe 'GovukIndex::SyncDataTest', tags: ['integration'] do
 
     GovukIndex::SyncUpdater.update(source_index: 'mainstream_test', destination_index: 'govuk_test')
 
-    assert_document_is_in_rummager({ 'link' => '/test', 'popularity' => 0.4 }, type: 'edition', index: 'govuk_test')
+    expect_document_is_in_rummager({ 'link' => '/test', 'popularity' => 0.4 }, type: 'edition', index: 'govuk_test')
   end
 end

--- a/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
+++ b/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe 'GovukIndex::UnpublishingMessageProcessing', tags: ['integration'
     base_path = message.payload['base_path']
 
     commit_document('govuk_test', { 'link' => base_path }, id: base_path, type: 'answer')
-    assert_document_is_in_rummager({ 'link' => base_path }, index: 'govuk_test', type: 'answer')
+    expect_document_is_in_rummager({ 'link' => base_path }, index: 'govuk_test', type: 'answer')
 
     processor = GovukIndex::PublishingEventProcessor.new
 
     processor.process(message)
     commit_index('govuk_test')
 
-    assert_raises(Elasticsearch::Transport::Transport::Errors::NotFound) do
+    expect {
       fetch_document_from_rummager(id: base_path, index: 'govuk_test', type: 'answer')
-    end
+    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 
   it "unpublish_withdrawn_messages_will_set_is_withdrawn_flag" do
@@ -47,13 +47,13 @@ RSpec.describe 'GovukIndex::UnpublishingMessageProcessing', tags: ['integration'
 
     commit_document('govuk_test', { 'link' => base_path }, id: base_path, type: type)
 
-    assert_document_is_in_rummager({ 'link' => base_path, 'is_withdrawn' => nil }, index: 'govuk_test', type: type)
+    expect_document_is_in_rummager({ 'link' => base_path, 'is_withdrawn' => nil }, index: 'govuk_test', type: type)
     processor = GovukIndex::PublishingEventProcessor.new
 
     processor.process(message)
     commit_index('govuk_test')
 
-    assert_document_is_in_rummager({ 'link' => base_path, 'is_withdrawn' => true }, index: 'govuk_test', type: type)
+    expect_document_is_in_rummager({ 'link' => base_path, 'is_withdrawn' => true }, index: 'govuk_test', type: type)
   end
 
   def unpublishing_event_message(schema_name, user_defined: {}, excluded_fields: [])

--- a/spec/integration/govuk_index/updating_popularity_data_spec.rb
+++ b/spec/integration/govuk_index/updating_popularity_data_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest', tags: ['integration'] d
 
     GovukIndex::PopularityUpdater.update('govuk_test')
 
-    assert_document_is_in_rummager({ 'link' => id, 'popularity' => popularity }, type: 'edition', index: 'govuk_test')
+    expect_document_is_in_rummager({ 'link' => id, 'popularity' => popularity }, type: 'edition', index: 'govuk_test')
   end
 
   it "set_the_popularity_to_the_lowest_popularity_when_it_doesnt_exist" do
@@ -32,7 +32,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest', tags: ['integration'] d
 
     GovukIndex::PopularityUpdater.update('govuk_test')
 
-    assert_document_is_in_rummager({ 'link' => id, 'popularity' => popularity }, type: 'edition', index: 'govuk_test')
+    expect_document_is_in_rummager({ 'link' => id, 'popularity' => popularity }, type: 'edition', index: 'govuk_test')
   end
 
   it "ignores_popularity_update_if_version_has_moved_on" do
@@ -51,7 +51,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest', tags: ['integration'] d
 
     GovukIndex::PopularityUpdater.update('govuk_test')
 
-    assert_document_is_in_rummager({ 'link' => id, 'popularity' => 0.222 }, type: 'edition', index: 'govuk_test')
+    expect_document_is_in_rummager({ 'link' => id, 'popularity' => 0.222 }, type: 'edition', index: 'govuk_test')
   end
 
   it "copies_version_information" do
@@ -60,7 +60,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest', tags: ['integration'] d
     GovukIndex::PopularityUpdater.update('govuk_test')
 
     document = fetch_document_from_rummager(id: id, index: 'govuk_test')
-    assert_equal 3, document['_version']
+    expect(3).to eq(document['_version'])
   end
 
   it "skips_non_indexable_formats" do
@@ -69,7 +69,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest', tags: ['integration'] d
     GovukIndex::PopularityUpdater.update('govuk_test')
 
     document = fetch_document_from_rummager(id: id, index: 'govuk_test')
-    assert_equal 0.222, document['_source']['popularity']
+    expect(0.222).to eq(document['_source']['popularity'])
   end
 
   it "does_not_skips_non_indexable_formats_if_process_all_flag_is_set" do
@@ -83,6 +83,6 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest', tags: ['integration'] d
     popularity = 1.0 / (document_count + SearchConfig.instance.popularity_rank_offset)
 
     document = fetch_document_from_rummager(id: id, index: 'govuk_test')
-    assert_equal popularity, document['_source']['popularity']
+    expect(popularity).to eq(document['_source']['popularity'])
   end
 end

--- a/spec/integration/govuk_index/versioning_spec.rb
+++ b/spec/integration/govuk_index/versioning_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 123, document["_version"]
+    expect(123).to eq(document["_version"])
 
     version2 = version1.merge(title: "new title", payload_version: 124)
     process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 124, document["_version"]
-    assert_equal "new title", document["_source"]["title"]
+    expect(124).to eq(document["_version"])
+    expect("new title").to eq(document["_source"]["title"])
   end
 
   it "should_discard_message_with_same_version_as_existing_document" do
@@ -40,14 +40,14 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 123, document["_version"]
+    expect(123).to eq(document["_version"])
 
     version2 = version1.merge(title: "new title", payload_version: 123)
     process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 123, document["_version"]
-    assert_equal version1["title"], document["_source"]["title"]
+    expect(123).to eq(document["_version"])
+    expect(version1["title"]).to eq(document["_source"]["title"])
   end
 
   it "should_discard_message_with_earlier_version_than_existing_document" do
@@ -62,14 +62,14 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 123, document["_version"]
+    expect(123).to eq(document["_version"])
 
     version2 = version1.merge(title: "new title", payload_version: 122)
     process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 123, document["_version"]
-    assert_equal version1["title"], document["_source"]["title"]
+    expect(123).to eq(document["_version"])
+    expect(version1["title"]).to eq(document["_source"]["title"])
   end
 
   it "should_delete_and_recreate_document_when_unpublished_and_republished" do
@@ -84,7 +84,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 1, document["_version"]
+    expect(1).to eq(document["_version"])
 
     version2 = generate_random_example(
       schema: 'gone',
@@ -97,15 +97,15 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     )
     process_message(version2, unpublishing: true)
 
-    assert_raises(Elasticsearch::Transport::Transport::Errors::NotFound) do
+    expect {
       fetch_document_from_rummager(id: base_path, index: 'govuk_test')
-    end
+    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
 
     version3 = version1.merge(payload_version: 3)
     process_message(version3)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 3, document["_version"]
+    expect(3).to eq(document["_version"])
   end
 
   it "should_discard_unpublishing_message_with_earlier_version" do
@@ -119,7 +119,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 2, document["_version"]
+    expect(2).to eq(document["_version"])
 
     version2 = generate_random_example(
       schema: 'gone',
@@ -133,7 +133,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version2, unpublishing: true)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 2, document["_version"]
+    expect(2).to eq(document["_version"])
   end
 
   it "should_ignore_event_for_non_indexable_formats" do
@@ -149,7 +149,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
 
-    assert_equal 123, document["_version"]
+    expect(123).to eq(document["_version"])
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(false)
 
@@ -157,8 +157,8 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    assert_equal 123, document["_version"]
-    assert_equal version1["title"], document["_source"]["title"]
+    expect(123).to eq(document["_version"])
+    expect(version1["title"]).to eq(document["_source"]["title"])
   end
 
   def process_message(example_document, unpublishing: false)

--- a/spec/integration/indexer/amendment_spec.rb
+++ b/spec/integration/indexer/amendment_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'ElasticsearchAmendmentTest', tags: ['integration'] do
 
     post "/documents/%2Fan-example-answer", "title=A+new+title"
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "title" => "A new title",
       "link" => "/an-example-answer",
     }, type: "edition")
@@ -27,7 +27,7 @@ RSpec.describe 'ElasticsearchAmendmentTest', tags: ['integration'] do
 
     post "/documents/%2Fan-example-answer", "title=A+new+title"
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "title" => "A new title",
       "link" => "/an-example-answer",
     }, type: "aaib_report")
@@ -41,6 +41,6 @@ RSpec.describe 'ElasticsearchAmendmentTest', tags: ['integration'] do
 
     post "/documents/%2Fan-example-answer", "title=A+new+title"
 
-    assert_equal 202, last_response.status
+    expect(202).to eq(last_response.status)
   end
 end

--- a/spec/integration/indexer/bulk_loader_spec.rb
+++ b/spec/integration/indexer/bulk_loader_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'BulkLoaderTest', tags: ['integration'] do
       "link" => "/some-link",
     )
 
-    assert_document_is_in_rummager(
+    expect_document_is_in_rummager(
       "title" => "The old title",
       "link" => "/some-link",
     )
@@ -31,7 +31,7 @@ RSpec.describe 'BulkLoaderTest', tags: ['integration'] do
       "link" => "/some-link",
     )
 
-    assert_document_is_in_rummager(
+    expect_document_is_in_rummager(
       "title" => "The new title",
       "link" => "/some-link",
     )
@@ -54,7 +54,7 @@ RSpec.describe 'BulkLoaderTest', tags: ['integration'] do
       "link" => "/some-popular-link",
     )
 
-    assert_document_is_in_rummager(
+    expect_document_is_in_rummager(
       "title" => "The new title",
       "link" => "/some-popular-link",
       "popularity" => 1.0 / 12,

--- a/spec/integration/indexer/change_notification_processor_spec.rb
+++ b/spec/integration/indexer/change_notification_processor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'ChangeNotificationProcessorTest', tags: ['integration'] do
 
     commit_index
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "link" => "/foo",
       "mainstream_browse_pages" => [],
     })
@@ -39,7 +39,7 @@ RSpec.describe 'ChangeNotificationProcessorTest', tags: ['integration'] do
 
     commit_index
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "link" => "/foo",
       "mainstream_browse_pages" => ['my-browse'],
     })

--- a/spec/integration/indexer/closing_spec.rb
+++ b/spec/integration/indexer/closing_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'ElasticsearchClosingTest', tags: ['integration'] do
     index = search_server.index_group(SearchConfig.instance.default_index_name).current
     index.close
 
-    assert_raises Indexer::BulkIndexFailure do
+    expect {
       index.add([sample_document])
-    end
+    }.to raise_error(Indexer::BulkIndexFailure)
 
     # Re-opening the index again, as they are not recreated on each test run
     # anymore.

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'ElasticsearchDeletionTest', tags: ['integration'] do
 
     delete "/documents/%2Fan-example-page"
 
-    assert_document_missing_in_rummager(id: "/an-example-page")
+    expect_document_missing_in_rummager(id: "/an-example-page")
   end
 
   it "removes_a_document_from_the_index_queued" do
@@ -18,7 +18,7 @@ RSpec.describe 'ElasticsearchDeletionTest', tags: ['integration'] do
 
     delete "/documents/%2Fan-example-page"
 
-    assert_equal 202, last_response.status
+    expect(202).to eq(last_response.status)
   end
 
   it "removes_document_with_url" do
@@ -28,7 +28,7 @@ RSpec.describe 'ElasticsearchDeletionTest', tags: ['integration'] do
 
     delete "/documents/edition/http:%2F%2Fexample.com%2F"
 
-    assert_document_missing_in_rummager(id: "http://example.com/")
+    expect_document_missing_in_rummager(id: "http://example.com/")
   end
 
   it "should_delete_a_best_bet_by_type_and_id" do
@@ -42,20 +42,20 @@ RSpec.describe 'ElasticsearchDeletionTest', tags: ['integration'] do
 
     delete "/metasearch_test/documents/best_bet/jobs_exact"
 
-    assert_raises Elasticsearch::Transport::Transport::Errors::NotFound do
+    expect {
       client.get(
         index: 'metasearch_test',
         type: 'best_bet',
         id: 'jobs_exact'
       )
-    end
+    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 
 private
 
-  def assert_document_missing_in_rummager(id:)
-    assert_raises Elasticsearch::Transport::Transport::Errors::NotFound do
+  def expect_document_missing_in_rummager(id:)
+    expect {
       fetch_document_from_rummager(id: id)
-    end
+    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 end

--- a/spec/integration/indexer/index_group_spec.rb
+++ b/spec/integration/indexer/index_group_spec.rb
@@ -17,22 +17,21 @@ RSpec.describe 'ElasticsearchIndexGroupTest', tags: ['integration'] do
   end
 
   it "should_create_index" do
-    assert @index_group.index_names.empty?
+    expect(@index_group.index_names).to be_empty
     index = @index_group.create_index
 
-    assert_equal 1, @index_group.index_names.count
-    assert_equal index.index_name, @index_group.index_names[0]
-    assert_equal(
-      SearchConfig.instance.search_server.schema.elasticsearch_mappings("mainstream"),
-      index.mappings
-    )
+    expect(1).to eq(@index_group.index_names.count)
+    expect(index.index_name).to eq(@index_group.index_names[0])
+    expect(
+      SearchConfig.instance.search_server.schema.elasticsearch_mappings("mainstream")
+    ).to eq(index.mappings)
   end
 
   it "should_alias_index" do
     index = @index_group.create_index
     @index_group.switch_to(index)
 
-    assert_equal index.real_name, @index_group.current.real_name
+    expect(index.real_name).to eq(@index_group.current.real_name)
   end
 
   it "should_switch_index" do
@@ -42,15 +41,15 @@ RSpec.describe 'ElasticsearchIndexGroupTest', tags: ['integration'] do
     new_index = @index_group.create_index
     @index_group.switch_to(new_index)
 
-    assert_equal new_index.real_name, @index_group.current.real_name
+    expect(new_index.real_name).to eq(@index_group.current.real_name)
   end
 
   it "should_clean_indices" do
     @index_group.create_index
     @index_group.switch_to(@index_group.create_index)
 
-    assert_equal 2, @index_group.index_names.count
+    expect(2).to eq(@index_group.index_names.count)
     @index_group.clean
-    assert_equal 1, @index_group.index_names.count
+    expect(1).to eq(@index_group.index_names.count)
   end
 end

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'ElasticsearchIndexingTest', tags: ['integration'] do
       "licence_short_description" => "A short description of a licence",
     }.to_json
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "content_id" => "6b965b82-2e33-4587-a70c-60204cbb3e29",
       "title" => "TITLE",
       "format" => "answer",
@@ -59,7 +59,7 @@ RSpec.describe 'ElasticsearchIndexingTest', tags: ['integration'] do
       "link" => "/an-example-answer",
     }.to_json
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "content_id" => "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
       "link" => "/an-example-answer",
     }, type: "edition")
@@ -73,7 +73,7 @@ RSpec.describe 'ElasticsearchIndexingTest', tags: ['integration'] do
       "link" => "/an-example-organisation",
     }.to_json
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "title" => "TITLE",
       "format" => "organisation",
       "slug" => "my-organisation",
@@ -92,7 +92,7 @@ RSpec.describe 'ElasticsearchIndexingTest', tags: ['integration'] do
       "end_date" => "2017-01-01T00:00:00Z"
     }.to_json
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "title" => "TITLE",
       "format" => "topical_event",
       "slug" => "/government/topical-events/foo",
@@ -111,7 +111,7 @@ RSpec.describe 'ElasticsearchIndexingTest', tags: ['integration'] do
       'organisations' => [],
     }.to_json
 
-    assert_document_is_in_rummager({
+    expect_document_is_in_rummager({
       "link" => "/government/organisations/hmrc",
       "organisations" => ["hmrc"],
     })
@@ -120,7 +120,7 @@ RSpec.describe 'ElasticsearchIndexingTest', tags: ['integration'] do
   it "adding_a_document_to_the_search_index_with_queue" do
     post "/documents", SAMPLE_DOCUMENT.to_json
 
-    assert_equal 202, last_response.status
-    assert_document_is_in_rummager(SAMPLE_DOCUMENT)
+    expect(202).to eq(last_response.status)
+    expect_document_is_in_rummager(SAMPLE_DOCUMENT)
   end
 end

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'TaglookupDuringIndexingTest', tags: ['integration'] do
       "link" => "/something-not-in-publishing-api",
     }.to_json
 
-    assert_document_is_in_rummager(
+    expect_document_is_in_rummager(
       "link" => "/something-not-in-publishing-api",
     )
   end
@@ -23,7 +23,7 @@ RSpec.describe 'TaglookupDuringIndexingTest', tags: ['integration'] do
       "link" => "http://example.com/some-link",
     }.to_json
 
-    assert_document_is_in_rummager(
+    expect_document_is_in_rummager(
       "link" => "http://example.com/some-link",
     )
   end
@@ -81,7 +81,7 @@ RSpec.describe 'TaglookupDuringIndexingTest', tags: ['integration'] do
       "link" => "/foo/bar",
     }.to_json
 
-    assert_document_is_in_rummager(
+    expect_document_is_in_rummager(
       "link" => "/foo/bar",
       "specialist_sectors" => ["my-topic/a", "my-topic/b"],
       "mainstream_browse_pages" => ["my-browse/1"],
@@ -113,7 +113,7 @@ RSpec.describe 'TaglookupDuringIndexingTest', tags: ['integration'] do
       "content_id" => "CONTENT-ID-OF-DOCUMENT",
     }.to_json
 
-    assert_document_is_in_rummager(
+    expect_document_is_in_rummager(
       "link" => "/my-base-path",
       "content_id" => "CONTENT-ID-OF-DOCUMENT",
       "specialist_sectors" => ["my-topic/a"],
@@ -193,7 +193,7 @@ RSpec.describe 'TaglookupDuringIndexingTest', tags: ['integration'] do
       "link" => "/foo/bar",
     }.to_json
 
-    assert_document_is_in_rummager(
+    expect_document_is_in_rummager(
       "link" => "/foo/bar",
       "part_of_taxonomy_tree" => [
         grandparent_1_content_id, parent_1_content_id, taxon_1_content_id,

--- a/spec/integration/indexer/locking_spec.rb
+++ b/spec/integration/indexer/locking_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe 'ElasticsearchLockingTest', tags: ['integration'] do
   it "should_fail_to_insert_when_index_locked" do
     index = search_server.index_group(SearchConfig.instance.default_index_name).current
     with_lock(index) do
-      assert_raises SearchIndices::IndexLocked do
+      expect {
         index.add([sample_document])
-      end
+      }.to raise_error(SearchIndices::IndexLocked)
     end
   end
 
@@ -19,9 +19,9 @@ RSpec.describe 'ElasticsearchLockingTest', tags: ['integration'] do
     index.add([sample_document])
 
     with_lock(index) do
-      assert_raises SearchIndices::IndexLocked do
+      expect {
         index.amend(sample_document.link, "title" => "New title")
-      end
+      }.to raise_error(SearchIndices::IndexLocked)
     end
   end
 
@@ -30,9 +30,9 @@ RSpec.describe 'ElasticsearchLockingTest', tags: ['integration'] do
     index.add([sample_document])
 
     with_lock(index) do
-      assert_raises SearchIndices::IndexLocked do
+      expect {
         index.delete("edition", sample_document.link)
-      end
+      }.to raise_error(SearchIndices::IndexLocked)
     end
   end
 

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'MissingMetadataTest', tags: ['integration'] do
     runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.instance, logger: io)
     results = runner.retrieve_records_with_missing_value
 
-    assert_equal [{ _id: '/path/to_page', index: 'mainstream_test' }], results
+    expect([{ _id: '/path/to_page', index: 'mainstream_test' }]).to eq results
   end
 
   it "ignores_already_set_content_id" do
@@ -23,7 +23,7 @@ RSpec.describe 'MissingMetadataTest', tags: ['integration'] do
     runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.instance, logger: io)
     results = runner.retrieve_records_with_missing_value
 
-    assert_empty results
+    expect(results).to be_empty
   end
 
   it "finds_missing_document_type" do
@@ -36,7 +36,7 @@ RSpec.describe 'MissingMetadataTest', tags: ['integration'] do
     runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.instance, logger: io)
     results = runner.retrieve_records_with_missing_value
 
-    assert_equal [{ _id: '/path/to_page', index: 'mainstream_test', content_id: '8aea1742-9cc6-4dfb-a63b-12c3e66a601f' }], results
+    expect([{ _id: '/path/to_page', index: 'mainstream_test', content_id: '8aea1742-9cc6-4dfb-a63b-12c3e66a601f' }]).to eq results
   end
 
   it "ignores_already_set_document_type" do
@@ -50,7 +50,7 @@ RSpec.describe 'MissingMetadataTest', tags: ['integration'] do
     runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.instance, logger: io)
     results = runner.retrieve_records_with_missing_value
 
-    assert_empty results
+    expect(results).to be_empty
   end
 
   def io

--- a/spec/integration/schema/stemming_spec.rb
+++ b/spec/integration/schema/stemming_spec.rb
@@ -2,55 +2,55 @@ require 'spec_helper'
 
 RSpec.describe 'SettingsTest', tags: ['integration'] do
   it "default" do
-    assert_tokenisation :default,
+    expect_tokenisation :default,
       "It's A Small’s World" => %w(it small world),
       "It's Mitt’s" => %w(it mitt)
   end
 
   it "uses_correct_stemming" do
-    assert_tokenisation :default,
+    expect_tokenisation :default,
       "news" => ["news"]
   end
 
   it "query_default" do
-    assert_tokenisation :query_default,
+    expect_tokenisation :query_default,
       "It's A Small World" => %w(it small world),
       "It's, It’s Mr. O'Neill" => %w(it it mr oneil)
   end
 
   it "shingled_query_analyzer" do
-    assert_tokenisation :shingled_query_analyzer,
+    expect_tokenisation :shingled_query_analyzer,
       "Hello Hallo" => ["hello", "hello hallo", "hallo"],
       "H'lo ’Hallo" => ["h'lo", "h'lo hallo", "hallo"]
   end
 
   it "exact_match" do
-    assert_tokenisation :exact_match,
+    expect_tokenisation :exact_match,
       "It’s A Small W'rld" => ["it's a small w'rld"]
   end
 
   it "best_bet_stemmed_match" do
-    assert_tokenisation :best_bet_stemmed_match,
+    expect_tokenisation :best_bet_stemmed_match,
       "It’s A Small W'rld" => %w(it a small wrld)
   end
 
   it "spelling_analyzer" do
-    assert_tokenisation :spelling_analyzer,
+    expect_tokenisation :spelling_analyzer,
       "It’s Grammed" => ["its", "its grammed", "grammed"]
   end
 
   it "string_for_sorting" do
-    assert_tokenisation :string_for_sorting,
+    expect_tokenisation :string_for_sorting,
       "It's A Small W’rld" => ["its a small wrld"]
   end
 
   it "with_shingles_analyzer" do
-    assert_tokenisation :with_shingles,
+    expect_tokenisation :with_shingles,
       "The small brown dog" => ["the small", "small brown", "brown dog"]
   end
 
   it "with_id_codes_analyzer" do
-    assert_tokenisation :with_id_codes,
+    expect_tokenisation :with_id_codes,
       "You will need forms A.10, P11,  P 12, P 13D, P45X and P-60. Z:90, \"V 50\" B_52 C4 3/2007  M\\18. :/!  (RA) 1002" =>
       %w{a10 10 p11 p12 12 p13d 13d p45xand p45x p60 60 z90 90 v50 50 b52 52c4 52 c43 c4 32007 2007m 2007 m18 18 ra1002 1002}
   end
@@ -59,10 +59,10 @@ private
 
   # Verifies that certain input will be tokenised as expected by the specified
   # analyzer.
-  def assert_tokenisation(analyzer, assertions)
+  def expect_tokenisation(analyzer, assertions)
     assertions.each do |query, expected_output|
       tokens = fetch_tokens_for_analyzer(query, analyzer)
-      assert_equal expected_output, tokens
+      expect(expected_output).to eq(tokens)
     end
   end
 

--- a/spec/integration/scroll_enumerator_spec.rb
+++ b/spec/integration/scroll_enumerator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'ScrollEnumeratorTest', tags: ['integration'] do
       batch_size: 4
     ) { |d| d }
 
-    assert_equal results.count, 10
+    expect(results.count).to eq(10)
   end
 
   it "returns_expected_results_for_sorted_search" do
@@ -28,7 +28,7 @@ RSpec.describe 'ScrollEnumeratorTest', tags: ['integration'] do
       batch_size: 4
     ) { |d| d }
 
-    assert_equal results.count, 10
+    expect(results.count).to eq(10)
   end
 
   it "returns_expected_results_when_empty_result_set" do
@@ -39,6 +39,6 @@ RSpec.describe 'ScrollEnumeratorTest', tags: ['integration'] do
       batch_size: 4
     ) { |d| d }
 
-    assert_equal results.count, 0
+    expect(results.count).to eq(0)
   end
 end

--- a/spec/integration/search/best_bets_spec.rb
+++ b/spec/integration/search/best_bets_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'BestBetsTest', tags: ['integration'] do
 
     links = get_links "/search?q=a+forced+best+bet"
 
-    assert_equal ["/the-link-that-should-surface", "/an-organic-result"], links
+    expect(["/the-link-that-should-surface", "/an-organic-result"]).to eq(links)
   end
 
   it "exact_worst_bet" do
@@ -39,7 +39,7 @@ RSpec.describe 'BestBetsTest', tags: ['integration'] do
 
     links = get_links "/search?q=shown"
 
-    refute links.include?("/we-never-show-this")
+    expect(links).not_to include("/we-never-show-this")
   end
 
   it "stemmed_best_bet" do
@@ -56,7 +56,7 @@ RSpec.describe 'BestBetsTest', tags: ['integration'] do
 
     links = get_links "/search?q=best+bet+and+such"
 
-    assert_equal ["/the-link-that-should-surface"], links
+    expect(["/the-link-that-should-surface"]).to eq(links)
   end
 
   it "stemmed_best_bet_variant" do
@@ -74,7 +74,7 @@ RSpec.describe 'BestBetsTest', tags: ['integration'] do
     # note that we're searching for "bests bet", not "best bet" here.
     links = get_links "/search?q=bests+bet"
 
-    assert_equal ["/the-link-that-should-surface"], links
+    expect(["/the-link-that-should-surface"]).to eq(links)
   end
 
   it "stemmed_best_bet_words_not_in_phrase_order" do
@@ -92,7 +92,7 @@ RSpec.describe 'BestBetsTest', tags: ['integration'] do
     # note that we're searching for "bet best", not "best bet" here.
     links = get_links "/search?q=bet+best"
 
-    refute links.include?("/only-shown-for-exact-matches")
+    expect(links).not_to include("/only-shown-for-exact-matches")
   end
 
 private

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe 'BoosterTest', tags: ['integration'] do
 
     get "/search?q=agile"
 
-    assert_equal ["Can we be agile?", "Agile is good", "Being agile is good"],
-      result_titles
+    expect(["Can we be agile?", "Agile is good", "Being agile is good"]).to eq(result_titles)
   end
 
   def result_titles

--- a/spec/integration/search/expands_values_from_schema_spec.rb
+++ b/spec/integration/search/expands_values_from_schema_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe 'ExpandsValuesFromSchemaTest', tags: ['integration'] do
     get "/search?filter_document_type=cma_case&fields=case_type,description,title"
     first_result = parsed_response["results"].first
 
-    assert_equal [{ "label" => "Mergers", "value" => "mergers" }], first_result["case_type"]
+    expect([{ "label" => "Mergers", "value" => "mergers" }]).to eq(first_result["case_type"])
   end
 end

--- a/spec/integration/search/legacy_search_spec.rb
+++ b/spec/integration/search/legacy_search_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest', tags: ['integration'] do
     end
   end
 
-  def assert_result_links(*links)
+  def expect_result_links(*links)
     order = true
     if links[-1].is_a?(Hash)
       hash = links.pop
@@ -73,72 +73,72 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest', tags: ['integration'] do
     end
     parsed_links = parsed_response['results'].map { |r| r["link"] }
     if order
-      assert_equal links, parsed_links
+      expect(links).to eq(parsed_links)
     else
-      assert_equal links.sort, parsed_links.sort
+      expect(links.sort).to eq(parsed_links.sort)
     end
   end
 
-  def assert_result_total(total)
-    assert_equal total, parsed_response['total']
+  def expect_result_total(total)
+    expect(total).to eq(parsed_response['total'])
   end
 
   it "should_search_by_keywords" do
     get "/#{@index_name}/advanced_search.json?per_page=1&page=1&keywords=cheese"
-    assert last_response.ok?
-    assert_result_total 2
-    assert_result_links "/an-example-answer"
+    expect(last_response).to be_ok
+    expect_result_total 2
+    expect_result_links "/an-example-answer"
   end
 
   it "should_search_by_nested_data" do
     get "/#{@index_name}/advanced_search.json?per_page=1&page=1&keywords=#{CGI.escape('Special thing')}"
 
-    assert last_response.ok?
-    assert_result_total 1
-    assert_result_links "/doc-with-attachments"
+    expect(last_response).to be_ok
+    expect_result_total 1
+    expect_result_links "/doc-with-attachments"
   end
 
   it "should_escape_lucene_characters" do
     ["badger)", "badger\\"].each do |problem|
       get "/#{@index_name}/advanced_search.json?per_page=1&page=1&keywords=#{CGI.escape(problem)}"
-      assert last_response.ok?
-      assert_result_links "/an-example-answer"
+      expect(last_response).to be_ok
+      expect_result_links "/an-example-answer"
     end
   end
 
   it "should_allow_paging_through_keyword_search" do
     get "/#{@index_name}/advanced_search.json?per_page=1&page=2&keywords=cheese"
-    assert last_response.ok?
-    assert_result_total 2
-    assert_result_links "/yet-another-example-answer"
+    expect(last_response).to be_ok
+    expect_result_total 2
+    expect_result_links "/yet-another-example-answer"
   end
 
   it "should_filter_results_by_a_property" do
     get "/#{@index_name}/advanced_search.json?per_page=2&page=1&mainstream_browse_pages=crime/example"
-    assert last_response.ok?
-    assert_result_total 2
-    assert_result_links "/another-example-answer", "/yet-another-example-answer", order: false
+    expect(last_response).to be_ok
+    expect_result_total 2
+    expect_result_links "/another-example-answer", "/yet-another-example-answer", order: false
   end
 
   it "should_filter_results_by_a_nested_property" do
     get "/#{@index_name}/advanced_search.json?per_page=2&page=1&attachments.command_paper_number=1234"
-    assert last_response.ok?
-    assert_result_total 1
-    assert_result_links "/doc-with-attachments"
+    expect(last_response).to be_ok
+    expect_result_total 1
+    expect_result_links "/doc-with-attachments"
   end
 
   it "should_allow_boolean_filtering" do
     get "/#{@index_name}/advanced_search.json?per_page=3&page=1&relevant_to_local_government=true"
-    assert last_response.ok?
-    assert_result_total 3
-    assert_result_links "/an-example-answer", "/yet-another-example-answer", "/pork-pies", order: false
+    expect(last_response).to be_ok
+    expect_result_total 3
+    expect_result_links "/an-example-answer", "/yet-another-example-answer", "/pork-pies", order: false
   end
 
   it "should_allow_date_filtering" do
     get "/#{@index_name}/advanced_search.json?per_page=3&page=1&updated_at[before]=2012-01-03"
-    assert last_response.ok?
-    assert_result_total 3
-    assert_result_links "/an-example-answer", "/another-example-answer", "/pork-pies", order: false
+    expect(last_response).to be_ok
+    expect_result_total 3
+    expect_result_links "/an-example-answer", "/another-example-answer", "/pork-pies", order: false
   end
 
   it "should_allow_combining_all_filters" do
@@ -164,9 +164,9 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest', tags: ['integration'] do
 
     get "/#{@index_name}/advanced_search.json?per_page=3&page=1&relevant_to_local_government=true&updated_at[after]=2012-01-02&keywords=tax&mainstream_browse_pages=crime/example"
 
-    assert last_response.ok?
-    assert_result_total 1
-    assert_result_links "/yet-another-example-answer"
+    expect(last_response).to be_ok
+    expect_result_total 1
+    expect_result_links "/yet-another-example-answer"
   end
 
   it "should_not_expand_organisations" do
@@ -175,21 +175,21 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest', tags: ['integration'] do
     # configured (and until clients can handle either format).
     get "/#{@index_name}/advanced_search.json?per_page=3&page=1&relevant_to_local_government=true&updated_at[after]=2012-01-02&keywords=tax&mainstream_browse_pages=crime/example"
 
-    assert last_response.ok?
-    assert_result_total 1
-    assert_equal ["ministry-of-cheese"], parsed_response["results"][0]["organisations"]
+    expect(last_response).to be_ok
+    expect_result_total 1
+    expect(["ministry-of-cheese"]).to eq(parsed_response["results"][0]["organisations"])
   end
 
   it "should_allow_ordering_by_properties" do
     get "/#{@index_name}/advanced_search.json?per_page=4&page=1&order[updated_at]=desc"
-    assert last_response.ok?
-    assert_result_total 5
-    assert_result_links "/yet-another-example-answer", "/another-example-answer", "/pork-pies", "/an-example-answer"
+    expect(last_response).to be_ok
+    expect_result_total 5
+    expect_result_links "/yet-another-example-answer", "/another-example-answer", "/pork-pies", "/an-example-answer"
   end
 
   it "does_not_allow_page_to_be_super_high" do
     get "/#{@index_name}/advanced_search.json?per_page=4&page=500001&order[updated_at]=desc"
 
-    assert_equal 422, last_response.status
+    expect(422).to eq(last_response.status)
   end
 end

--- a/spec/integration/search/more_like_this_spec.rb
+++ b/spec/integration/search/more_like_this_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe 'MoreLikeThisTest', tags: ['integration'] do
   it "returns_success" do
     get "/search?similar_to=/mainstream-1"
 
-    assert last_response.ok?
+    expect(last_response).to be_ok
   end
 
   it "returns_no_results_without_documents" do
     get "/search?similar_to=/mainstream-1"
 
-    assert result_links.empty?
+    expect(result_links).to be_empty
   end
 
   it "returns_results_from_mainstream_index" do
@@ -18,8 +18,8 @@ RSpec.describe 'MoreLikeThisTest', tags: ['integration'] do
 
     get "/search?similar_to=/mainstream-1&count=20&start=0"
 
-    refute result_links.include? "/mainstream-1"
-    assert_equal(result_links.count, 14)
+    expect(result_links).not_to include "/mainstream-1"
+    expect(result_links.count).to eq(14)
   end
 
   it "returns_results_from_government_index" do
@@ -27,8 +27,8 @@ RSpec.describe 'MoreLikeThisTest', tags: ['integration'] do
 
     get "/search?similar_to=/government-1&count=20&start=0"
 
-    refute result_links.include? "/government-1"
-    assert_equal(result_links.count, 14)
+    expect(result_links).not_to include "/government-1"
+    expect(result_links.count).to eq(14)
   end
 
   it "returns_similar_docs" do
@@ -41,18 +41,18 @@ RSpec.describe 'MoreLikeThisTest', tags: ['integration'] do
     # should be returned. The government links should also be returned as they
     # are similar enough (in this case, the test factories produce similar
     # looking records).
-    refute result_links.include? "/mainstream-1"
-    assert_equal(result_links.count, 29)
+    expect(result_links).not_to include "/mainstream-1"
+    expect(result_links.count).to eq(29)
 
     mainstream_results = result_links.select do |result|
       result.match(/mainstream-\d+/)
     end
-    assert_equal(mainstream_results.count, 14)
+    expect(mainstream_results.count).to eq(14)
 
     government_results = result_links.select do |result|
       result.match(/government-\d+/)
     end
-    assert_equal(government_results.count, 15)
+    expect(government_results.count).to eq(15)
   end
 
 private

--- a/spec/integration/search/quoted_and_unquoted_searches_spec.rb
+++ b/spec/integration/search/quoted_and_unquoted_searches_spec.rb
@@ -12,57 +12,57 @@ RSpec.describe 'QuotedAndUnquotedSearchTest', tags: ['integration'] do
   it "new_weighting_three_matches_found_for_london" do
     commit_london_transport_docs
     get "/search?q=london&debug=new_weighting"
-    assert_equal 200, last_response.status
-    assert_equal 3, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(3).to eq(parsed_response["results"].size)
   end
 
   it "new_weighting_three_matches_found_for_transport" do
     commit_london_transport_docs
     get "/search?q=transport&debug=new_weighting"
-    assert_equal 200, last_response.status
-    assert_equal 3, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(3).to eq(parsed_response["results"].size)
   end
 
   it "new_weighting_three_matches_found_for_unquoted_london_transport" do
     commit_london_transport_docs
     get "/search?q=london+transport&debug=new_weighting"
-    assert_equal 200, last_response.status
-    assert_equal 3, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(3).to eq(parsed_response["results"].size)
   end
 
   it "new_weighting_one_match_found_for_quoted_london_transport" do
     commit_london_transport_docs
     get "/search?q=%22london+transport%22&debug=new_weighting"
-    assert_equal 200, last_response.status
-    assert_equal 1, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(1).to eq(parsed_response["results"].size)
   end
 
   it "new_weighting_synonyms_are_returned_with_unquoted_phrases" do
     commit_synonym_documents
     get "/search?q=driving+abroad&debug=new_weighting"
-    assert_equal 200, last_response.status
-    assert_equal 2, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(2).to eq(parsed_response["results"].size)
   end
 
   it "new_weighting_synonyms_are_not_returned_with_quoted_phrases" do
     commit_synonym_documents
     get "/search?q=%22driving+abroad%22&debug=new_weighting"
-    assert_equal 200, last_response.status
-    assert_equal 1, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(1).to eq(parsed_response["results"].size)
   end
 
   it "new_weighting_stemming_is_in_place_for_unquoted_phrases" do
     commit_stemming_documents
     get "/search?q=dog&debug=new_weighting"
-    assert_equal 200, last_response.status
-    assert_equal 2, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(2).to eq(parsed_response["results"].size)
   end
 
   it "new_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
     commit_stemming_documents
     get "/search?q=%22dog%22&debug=new_weighting"
-    assert_equal 200, last_response.status
-    assert_equal 2, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(2).to eq(parsed_response["results"].size)
   end
 
 
@@ -71,50 +71,50 @@ RSpec.describe 'QuotedAndUnquotedSearchTest', tags: ['integration'] do
   it "old_weighting_three_matches_found_for_london" do
     commit_london_transport_docs
     get "/search?q=london"
-    assert_equal 200, last_response.status
-    assert_equal 3, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(3).to eq(parsed_response["results"].size)
   end
 
   it "old_weighting_three_matches_found_for_transport" do
     commit_london_transport_docs
     get "/search?q=transport"
-    assert_equal 200, last_response.status
-    assert_equal 3, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(3).to eq(parsed_response["results"].size)
   end
 
   it "old_weighting_three_matches_found_for_unquoted_london_transport" do
     commit_london_transport_docs
     get "/search?q=london+transport"
-    assert_equal 200, last_response.status
-    assert_equal 3, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(3).to eq(parsed_response["results"].size)
   end
 
   it "old_weighting_one_match_found_for_quoted_london_transport" do
     commit_london_transport_docs
     get "/search?q=%22london+transport%22"
-    assert_equal 200, last_response.status
-    assert_equal 1, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(1).to eq(parsed_response["results"].size)
   end
 
   it "old_weighting_synonyms_are_returned_with_unquoted_phrases" do
     commit_synonym_documents
     get "/search?q=driving+abroad"
-    assert_equal 200, last_response.status
-    assert_equal 2, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(2).to eq(parsed_response["results"].size)
   end
 
   it "old_weighting_stemming_is_in_place_for_unquoted_phrases" do
     commit_stemming_documents
     get "/search?q=dog"
-    assert_equal 200, last_response.status
-    assert_equal 2, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(2).to eq(parsed_response["results"].size)
   end
 
   it "old_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
     commit_stemming_documents
     get "/search?q=%22dog%22"
-    assert_equal 200, last_response.status
-    assert_equal 2, parsed_response["results"].size
+    expect(200).to eq(last_response.status)
+    expect(2).to eq(parsed_response["results"].size)
   end
 
 

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
 
     get "/search?q=result&fields[]=title_with_highlighting"
 
-    refute first_search_result.key?('title')
-    assert_equal "I am the <mark>result</mark>",
-      first_search_result['title_with_highlighting']
+    expect(first_search_result.key?('title')).to be_falsey
+    expect("I am the <mark>result</mark>").to eq(first_search_result['title_with_highlighting'])
   end
 
   it "returns_highlighted_title_fallback" do
@@ -23,9 +22,8 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
 
     get "/search?q=result&fields[]=title_with_highlighting"
 
-    refute first_search_result.key?('title')
-    assert_equal "Thing without",
-      first_search_result['title_with_highlighting']
+    expect(first_search_result.key?('title')).to be_falsey
+    expect("Thing without").to eq(first_search_result['title_with_highlighting'])
   end
 
   it "returns_highlighted_description" do
@@ -36,9 +34,10 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
 
     get "/search?q=result&fields[]=description_with_highlighting"
 
-    refute first_search_result.key?('description')
-    assert_equal "This is a test search <mark>result</mark> of many <mark>results</mark>.",
+    expect(first_search_result.key?('description')).to be_falsey
+    expect("This is a test search <mark>result</mark> of many <mark>results</mark>.").to eq(
       first_search_result['description_with_highlighting']
+    )
   end
 
   it "returns_documents_html_escaped" do
@@ -50,10 +49,12 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
 
     get "/search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
 
-    assert_equal "Escape &amp; <mark>highlight</mark> the description as well.",
+    expect("Escape &amp; <mark>highlight</mark> the description as well.").to eq(
       first_search_result['description_with_highlighting']
-    assert_equal "Escape &amp; <mark>highlight</mark> my title",
+    )
+    expect("Escape &amp; <mark>highlight</mark> my title").to eq(
       first_search_result['title_with_highlighting']
+    )
   end
 
   it "returns_truncated_correctly_where_result_at_start_of_description" do
@@ -65,8 +66,8 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
     get "/search?q=word&fields[]=description_with_highlighting"
     description = first_search_result['description_with_highlighting']
 
-    assert description.starts_with?("<mark>word</mark>")
-    assert description.ends_with?("…")
+    expect(description.starts_with?("<mark>word</mark>")).to be_truthy
+    expect(description.ends_with?("…")).to be_truthy
   end
 
   it "returns_truncated_correctly_where_result_at_end_of_description" do
@@ -78,8 +79,8 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
     get "/search?q=word&fields[]=description_with_highlighting"
     description = first_search_result['description_with_highlighting']
 
-    assert description.starts_with?("…")
-    assert description.size < 350
+    expect(description.starts_with?("…")).to be_truthy
+    expect(description.size < 350).to be_truthy
   end
 
   it "returns_truncated_correctly_where_result_in_middle_of_description" do
@@ -91,8 +92,8 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
     get "/search?q=word&fields[]=description_with_highlighting"
     description = first_search_result['description_with_highlighting']
 
-    assert description.ends_with?("…")
-    assert description.starts_with?("…")
+    expect(description.ends_with?("…")).to be_truthy
+    expect(description.starts_with?("…")).to be_truthy
   end
 
 private

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
   it "returns_success" do
     get "/search?q=important"
 
-    assert last_response.ok?
+    expect(last_response).to be_ok
   end
 
   it "id_code_with_space" do
@@ -21,11 +21,11 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=p+60&debug=use_id_codes"
 
-    assert_equal(parsed_response['results'].size, 1)
-    assert_equal(parsed_response["results"][0]["link"], "/get-paye-forms-p45-p60")
+    expect(parsed_response['results'].size).to eq(1)
+    expect(parsed_response["results"][0]["link"]).to eq("/get-paye-forms-p45-p60")
 
     get "/search?q=p+60"
-    assert_equal(parsed_response['results'].size, 0)
+    expect(parsed_response['results'].size).to eq(0)
   end
 
   it "spell_checking_with_typo" do
@@ -37,7 +37,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=serch&suggest=spelling"
 
-    assert_equal ['search'], parsed_response['suggested_queries']
+    expect(['search']).to eq(parsed_response['suggested_queries'])
   end
 
   it "spell_checking_with_blacklisted_typo" do
@@ -48,7 +48,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=brexit&suggest=spelling"
 
-    assert_equal [], parsed_response['suggested_queries']
+    expect([]).to eq(parsed_response['suggested_queries'])
   end
 
   it "spell_checking_without_typo" do
@@ -56,7 +56,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=milliband"
 
-    assert_equal [], parsed_response['suggested_queries']
+    expect([]).to eq(parsed_response['suggested_queries'])
   end
 
   it "returns_docs_from_all_indexes" do
@@ -64,8 +64,8 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important"
 
-    assert result_links.include? "/government-1"
-    assert result_links.include? "/mainstream-1"
+    expect(result_links).to include "/government-1"
+    expect(result_links).to include "/mainstream-1"
   end
 
   it "sort_by_date_ascending" do
@@ -73,8 +73,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&order=public_timestamp"
 
-    assert_equal ["/government-1", "/government-2"],
-      result_links.take(2)
+    expect(["/government-1", "/government-2"]).to eq(result_links.take(2))
   end
 
   it "sort_by_date_descending" do
@@ -84,8 +83,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     # The government links have dates, so appear before all the other links.
     # The other documents have no dates, so appear in an undefined order
-    assert_equal ["/government-2", "/government-1"],
-      result_links.take(2)
+    expect(["/government-2", "/government-1"]).to eq(result_links.take(2))
   end
 
   it "sort_by_title_ascending" do
@@ -94,7 +92,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?order=title"
     lowercase_titles = result_titles.map(&:downcase)
 
-    assert_equal lowercase_titles, lowercase_titles.sort
+    expect(lowercase_titles).to eq(lowercase_titles.sort)
   end
 
   it "filter_by_field" do
@@ -102,8 +100,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_mainstream_browse_pages=browse/page/1"
 
-    assert_equal ["/government-1", "/mainstream-1"],
-      result_links.sort
+    expect(["/government-1", "/mainstream-1"]).to eq(result_links.sort)
   end
 
   it "reject_by_field" do
@@ -111,8 +108,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?reject_mainstream_browse_pages=browse/page/1"
 
-    assert_equal ["/government-2", "/mainstream-2"],
-      result_links.sort
+    expect(["/government-2", "/mainstream-2"]).to eq(result_links.sort)
   end
 
   it "can_filter_for_missing_field" do
@@ -120,8 +116,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_specialist_sectors=_MISSING"
 
-    assert_equal ["/government-1", "/mainstream-1"],
-      result_links.sort
+    expect(["/government-1", "/mainstream-1"]).to eq(result_links.sort)
   end
 
   it "can_filter_for_missing_or_specific_value_in_field" do
@@ -129,8 +124,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
 
-    assert_equal ["/government-1", "/mainstream-1"],
-      result_links.sort
+    expect(["/government-1", "/mainstream-1"]).to eq(result_links.sort)
   end
 
   it "can_filter_and_reject" do
@@ -138,10 +132,10 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?reject_mainstream_browse_pages=1&filter_specialist_sectors[]=farming"
 
-    assert_equal [
+    expect([
       "/government-2",
       "/mainstream-2",
-    ], result_links.sort
+    ]).to eq(result_links.sort)
   end
 
   it "only_contains_fields_which_are_present" do
@@ -150,8 +144,8 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?q=important&order=public_timestamp"
 
     results = parsed_response["results"]
-    refute_includes results[0].keys, "specialist_sectors"
-    assert_equal [{ "slug" => "farming" }], results[1]["specialist_sectors"]
+    expect(results[0].keys).not_to include("specialist_sectors")
+    expect([{ "slug" => "farming" }]).to eq(results[1]["specialist_sectors"])
   end
 
   it "aggregate_counting" do
@@ -159,11 +153,11 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2"
 
-    assert_equal 4, parsed_response["total"]
+    expect(4).to eq(parsed_response["total"])
 
     aggregate = parsed_response["aggregates"]
 
-    assert_equal({
+    expect(
       "mainstream_browse_pages" => {
         "options" => [
           { "value" => { "slug" => "browse/page/1" }, "documents" => 2 },
@@ -174,7 +168,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
         "missing_options" => 0,
         "scope" => "exclude_field_filter",
       }
-    }, aggregate)
+    ).to eq(aggregate)
   end
 
   # we changed facet -> aggregate but still support both
@@ -184,11 +178,11 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&facet_mainstream_browse_pages=2"
 
-    assert_equal 4, parsed_response["total"]
+    expect(4).to eq(parsed_response["total"])
 
     facets = parsed_response["facets"]
 
-    assert_equal({
+    expect(
       "mainstream_browse_pages" => {
         "options" => [
           { "value" => { "slug" => "browse/page/1" }, "documents" => 2 },
@@ -199,8 +193,8 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
         "missing_options" => 0,
         "scope" => "exclude_field_filter",
       }
-    }, facets)
-    assert_nil(parsed_response['aggregates'])
+    ).to eq(facets)
+    expect(parsed_response['aggregates']).to be_nil
   end
 
   # TODO: The `mainstream_browse_pages` fields are populated with a number, 1
@@ -210,16 +204,16 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2"
 
-    assert_equal 4, parsed_response["total"]
+    expect(4).to eq(parsed_response["total"])
     aggregates_without_filter = parsed_response["aggregates"]
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2&filter_mainstream_browse_pages=browse/page/1"
-    assert_equal 2, parsed_response["total"]
+    expect(2).to eq(parsed_response["total"])
 
     aggregates_with_filter = parsed_response["aggregates"]
 
-    assert_equal(aggregates_with_filter, aggregates_without_filter)
-    assert_equal(2, aggregates_without_filter["mainstream_browse_pages"]["options"].size)
+    expect(aggregates_with_filter).to eq(aggregates_without_filter)
+    expect(2).to eq(aggregates_without_filter["mainstream_browse_pages"]["options"].size)
   end
 
   it "aggregate_counting_missing_options" do
@@ -227,9 +221,9 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=1"
 
-    assert_equal 4, parsed_response["total"]
+    expect(4).to eq(parsed_response["total"])
     aggregates = parsed_response["aggregates"]
-    assert_equal({
+    expect(
       "mainstream_browse_pages" => {
         "options" => [
           { "value" => { "slug" => "browse/page/1" }, "documents" => 2 },
@@ -239,7 +233,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
         "missing_options" => 1,
         "scope" => "exclude_field_filter",
       }
-    }, aggregates)
+    ).to eq(aggregates)
   end
 
   it "aggregate_counting_with_filter_on_field_and_all_filters_scope" do
@@ -247,10 +241,10 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2,scope:all_filters&filter_mainstream_browse_pages=browse/page/1"
 
-    assert_equal 2, parsed_response["total"]
+    expect(2).to eq(parsed_response["total"])
     aggregates = parsed_response["aggregates"]
 
-    assert_equal({
+    expect(
       "mainstream_browse_pages" => {
         "options" => [
           { "value" => { "slug" => "browse/page/1" }, "documents" => 2 },
@@ -260,7 +254,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
         "missing_options" => 0,
         "scope" => "all_filters",
       }
-    }, aggregates)
+    ).to eq(aggregates)
   end
 
   it "aggregate_examples" do
@@ -268,8 +262,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=1,examples:5,example_scope:global,example_fields:link:title:mainstream_browse_pages"
 
-    assert_equal(
-      ["/government-1", "/mainstream-1"],
+    expect(["/government-1", "/mainstream-1"]).to eq(
       parsed_response["aggregates"]["mainstream_browse_pages"]["options"].first["value"]["example_info"]["examples"].map { |h| h["link"] }.sort
     )
   end
@@ -287,7 +280,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     options = parsed_response["aggregates"]["mainstream_browse_pages"]["options"]
     actual_results = options.first["value"]["example_info"]["examples"].map { |h| h["link"] }.sort
 
-    assert_equal expected_results, actual_results
+    expect(expected_results).to eq(actual_results)
   end
 
   it "aggregate_examples_after_migration" do
@@ -303,7 +296,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     options = parsed_response["aggregates"]["mainstream_browse_pages"]["options"]
     actual_results = options.first["value"]["example_info"]["examples"].map { |h| h["link"] }.sort
 
-    assert_equal expected_results, actual_results
+    expect(expected_results).to eq(actual_results)
   end
 
   it "aggregate_examples_before_migration_with_query_scope" do
@@ -319,7 +312,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     options = parsed_response["aggregates"]["mainstream_browse_pages"]["options"]
     actual_results = options.first["value"]["example_info"]["examples"].map { |h| h["link"] }.sort
 
-    assert_equal expected_results, actual_results
+    expect(expected_results).to eq(actual_results)
   end
 
   it "aggregate_examples_after_migration_with_query_scope" do
@@ -335,27 +328,27 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     options = parsed_response["aggregates"]["mainstream_browse_pages"]["options"]
     actual_results = options.first["value"]["example_info"]["examples"].map { |h| h["link"] }.sort
 
-    assert_equal expected_results, actual_results
+    expect(expected_results).to eq(actual_results)
   end
 
   it "validates_integer_params" do
     get "/search?start=a"
 
-    assert_equal last_response.status, 422
-    assert_equal parsed_response, { "error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)" }
+    expect(last_response.status).to eq(422)
+    expect(parsed_response).to eq({ "error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)" })
   end
 
   it "allows_integer_params_leading_zeros" do
     get "/search?start=09"
 
-    assert last_response.ok?
+    expect(last_response).to be_ok
   end
 
   it "validates_unknown_params" do
     get "/search?foo&bar=1"
 
-    assert_equal last_response.status, 422
-    assert_equal parsed_response, { "error" => "Unexpected parameters: foo, bar" }
+    expect(last_response.status).to eq(422)
+    expect(parsed_response).to eq("error" => "Unexpected parameters: foo, bar")
   end
 
   it "debug_explain_returns_explanations" do
@@ -364,10 +357,10 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?debug=explain"
 
     first_hit_explain = parsed_response["results"].first["_explanation"]
-    refute_nil first_hit_explain
-    assert first_hit_explain.keys.include?("value")
-    assert first_hit_explain.keys.include?("description")
-    assert first_hit_explain.keys.include?("details")
+    expect(first_hit_explain).not_to be_nil
+    expect(first_hit_explain.keys).to include("value")
+    expect(first_hit_explain.keys).to include("description")
+    expect(first_hit_explain.keys).to include("details")
   end
 
   it "can_scope_by_elasticsearch_type" do
@@ -375,14 +368,15 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_document_type=cma_case"
 
-    assert last_response.ok?
-    assert_equal 1, parsed_response.fetch("total")
-    assert_equal(
+    expect(last_response).to be_ok
+    expect(1).to eq(parsed_response.fetch("total"))
+    expect(
       hash_including(
         "document_type" => "cma_case",
         "title" => cma_case_attributes.fetch("title"),
         "link" => cma_case_attributes.fetch("link"),
-      ),
+      )
+    ).to eq(
       parsed_response.fetch("results").fetch(0),
     )
   end
@@ -392,13 +386,14 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
 
-    assert last_response.ok?
-    assert_equal 1, parsed_response.fetch("total")
-    assert_equal(
+    expect(last_response).to be_ok
+    expect(1).to eq(parsed_response.fetch("total"))
+    expect(
       hash_including(
         "title" => cma_case_attributes.fetch("title"),
         "link" => cma_case_attributes.fetch("link"),
-      ),
+      )
+    ).to eq(
       parsed_response.fetch("results").fetch(0),
     )
   end
@@ -408,13 +403,14 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
 
-    assert last_response.ok?
-    assert_equal 1, parsed_response.fetch("total")
-    assert_equal(
+    expect(last_response).to be_ok
+    expect(1).to eq(parsed_response.fetch("total"))
+    expect(
       hash_including(
         "title" => cma_case_attributes.fetch("title"),
         "link" => cma_case_attributes.fetch("link"),
-      ),
+      )
+    ).to eq(
       parsed_response.fetch("results").fetch(0),
     )
   end
@@ -424,13 +420,14 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
 
-    assert last_response.ok?
-    assert_equal 1, parsed_response.fetch("total")
-    assert_equal(
+    expect(last_response).to be_ok
+    expect(1).to eq(parsed_response.fetch("total"))
+    expect(
       hash_including(
         "title" => cma_case_attributes.fetch("title"),
         "link" => cma_case_attributes.fetch("link"),
-      ),
+      )
+    ).to eq(
       parsed_response.fetch("results").fetch(0),
     )
   end
@@ -440,13 +437,14 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
 
-    assert last_response.ok?
-    assert_equal 1, parsed_response.fetch("total")
-    assert_equal(
+    expect(last_response).to be_ok
+    expect(1).to eq(parsed_response.fetch("total"))
+    expect(
       hash_including(
         "title" => cma_case_attributes.fetch("title"),
         "link" => cma_case_attributes.fetch("link"),
-      ),
+      )
+    ).to eq(
       parsed_response.fetch("results").fetch(0),
     )
   end
@@ -454,9 +452,10 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
   it "cannot_provide_date_filter_key_multiple_times" do
     get "/search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
 
-    assert_equal 422, last_response.status
-    assert_equal(
-      { "error" => %{Too many values (2) for parameter "opened_date" (must occur at most once)} },
+    expect(422).to eq(last_response.status)
+    expect(
+      { "error" => %{Too many values (2) for parameter "opened_date" (must occur at most once)} }
+    ).to eq(
       parsed_response,
     )
   end
@@ -464,9 +463,10 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
   it "cannot_provide_invalid_dates_for_date_filter" do
     get "/search?filter_document_type=cma_case&filter_opened_date=from:not-a-date"
 
-    assert_equal 422, last_response.status
-    assert_equal(
-      { "error" => %{Invalid value "not-a-date" for parameter "opened_date" (expected ISO8601 date} },
+    expect(422).to eq(last_response.status)
+    expect(
+      { "error" => %{Invalid value "not-a-date" for parameter "opened_date" (expected ISO8601 date} }
+    ).to eq(
       parsed_response,
     )
   end
@@ -487,10 +487,11 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search.json?q=dragons"
 
-    assert_equal first_result['organisations'],
+    expect(first_result['organisations']).to eq(
       [{ "slug" => "/ministry-of-magic",
          "link" => "/ministry-of-magic-site",
          "title" => "Ministry of Magic" }]
+    )
   end
 
   it "expandinging_of_organisations_via_content_id" do
@@ -513,8 +514,9 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search.json?q=dragons"
 
     # Adds a new key with the expanded organisations
-    assert_equal(
-      first_result['expanded_organisations'],
+    expect(
+      first_result['expanded_organisations']
+    ).to eq(
       [
         {
           "content_id" => 'organisation-content-id',
@@ -526,8 +528,9 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     # Keeps the organisation content ids
-    assert_equal(
-      first_result['organisation_content_ids'],
+    expect(
+      first_result['organisation_content_ids']
+    ).to eq(
       ['organisation-content-id']
     )
   end
@@ -551,7 +554,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search.json?q=dragons&fields[]=expanded_organisations"
 
-    assert(first_result['expanded_organisations'])
+    expect(first_result['expanded_organisations']).to be_truthy
   end
 
   it "filter_by_organisation_content_ids_works" do
@@ -573,7 +576,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search.json?filter_organisation_content_ids[]=organisation-content-id"
 
-    assert(first_result['expanded_organisations'])
+    expect(first_result['expanded_organisations']).to be_truthy
   end
 
   it "expandinging_of_topics" do
@@ -595,8 +598,9 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search.json?q=dragons"
 
     # Adds a new key with the expanded topics
-    assert_equal(
-      first_result['expanded_topics'],
+    expect(
+      first_result['expanded_topics']
+    ).to eq(
       [
         {
           "content_id" => 'topic-content-id',
@@ -608,7 +612,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     # Keeps the topic content ids
-    assert_equal(first_result['topic_content_ids'], ['topic-content-id'])
+    expect(first_result['topic_content_ids']).to eq(['topic-content-id'])
   end
 
   it "filter_by_topic_content_ids_works" do
@@ -628,7 +632,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
     get "/search.json?filter_topic_content_ids[]=topic-content-id"
 
-    assert(first_result['expanded_topics'])
+    expect(first_result['expanded_topics']).to be_truthy
   end
 
   it "id_search" do
@@ -636,7 +640,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=id1&debug=new_weighting"
 
-    assert result_links.include? "/mainstream-1"
+    expect(result_links).to include "/mainstream-1"
   end
 
   it "withdrawn_content" do
@@ -648,7 +652,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     get "/search?q=test"
-    assert_equal 0, parsed_response.fetch("total")
+    expect(0).to eq(parsed_response.fetch("total"))
   end
 
   it "withdrawn_content_with_flag" do
@@ -660,8 +664,8 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     get "/search?q=test&debug=include_withdrawn&fields[]=is_withdrawn"
-    assert_equal 1, parsed_response.fetch("total")
-    assert_equal true, parsed_response.dig("results", 0, "is_withdrawn")
+    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.dig("results", 0, "is_withdrawn")).to be true
   end
 
   it "withdrawn_content_with_flag_with_aggregations" do
@@ -674,13 +678,13 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     get "/search?q=test&debug=include_withdrawn&aggregate_mainstream_browse_pages=2"
-    assert_equal 1, parsed_response.fetch("total")
+    expect(1).to eq(parsed_response.fetch("total"))
   end
 
   it "show_the_query" do
     get "/search?q=test&debug=show_query"
 
-    assert parsed_response.fetch("elasticsearch_query")
+    expect(parsed_response.fetch("elasticsearch_query")).to be_truthy
   end
 
   it "dfid_can_search_by_every_aggregate" do
@@ -694,14 +698,15 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     aggregate_queries.each do |filter_query|
       get "/search?filter_document_type=dfid_research_output&#{filter_query}"
 
-      assert last_response.ok?
-      assert_equal 1, parsed_response.fetch("total"), "Failure to search by #{filter_query}"
-      assert_equal(
+      expect(last_response).to be_ok
+      expect(1).to eq(parsed_response.fetch("total")), "Failure to search by #{filter_query}"
+      expect(
         hash_including(
           "document_type" => "dfid_research_output",
           "title" => dfid_research_output_attributes.fetch("title"),
           "link" => dfid_research_output_attributes.fetch("link"),
-        ),
+        )
+      ).to eq(
         parsed_response.fetch("results").fetch(0),
       )
     end
@@ -716,10 +721,10 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     get "/search?q=test&fields[]=taxons"
-    assert_equal 1, parsed_response.fetch("total")
+    expect(1).to eq(parsed_response.fetch("total"))
 
     taxons = parsed_response.dig("results", 0, "taxons")
-    assert_equal ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"], taxons
+    expect(["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]).to eq(taxons)
   end
 
   it "taxonomy_can_be_filtered" do
@@ -732,13 +737,14 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_taxons=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
 
-    assert last_response.ok?
-    assert_equal 1, parsed_response.fetch("total")
-    assert_equal(
+    expect(last_response).to be_ok
+    expect(1).to eq(parsed_response.fetch("total"))
+    expect(
       hash_including(
         "title" => "I am the result",
         "link" => "/some-nice-link",
-      ),
+      )
+    ).to eq(
       parsed_response.fetch("results").fetch(0),
     )
   end
@@ -754,28 +760,28 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_part_of_taxonomy_tree=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
 
-    assert last_response.ok?
-    assert_equal 1, parsed_response.fetch("total")
+    expect(last_response).to be_ok
+    expect(1).to eq(parsed_response.fetch("total"))
 
     get "/search?filter_part_of_taxonomy_tree=aa2093ef-778c-4105-9f33-9aa03d14bc5c"
 
-    assert last_response.ok?
-    assert_equal 1, parsed_response.fetch("total")
+    expect(last_response).to be_ok
+    expect(1).to eq(parsed_response.fetch("total"))
   end
 
   it "return_400_response_for_integers_out_of_range" do
     get '/search.json?count=50&start=7599999900'
 
-    assert last_response.bad_request?
-    assert_equal('Integer value of 7599999900 exceeds maximum allowed', last_response.body)
+    expect(last_response).to be_bad_request
+    expect('Integer value of 7599999900 exceeds maximum allowed').to eq(last_response.body)
   end
 
   it "return_400_response_for_query_term_length_too_long" do
     terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
     get "/search.json?q=#{terms}"
 
-    assert last_response.bad_request?
-    assert_equal('Query must be less than 1024 words', last_response.body)
+    expect(last_response).to be_bad_request
+    expect('Query must be less than 1024 words').to eq(last_response.body)
   end
 
 private

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
     sitemap_xml = generator.sitemaps
 
     expected_sitemap_count = 2 # sample_document.count + homepage / sitemap_limit rounded up
-    assert_equal expected_sitemap_count, sitemap_xml.length
+    expect(expected_sitemap_count).to eq(sitemap_xml.length)
   end
 
   it "does_not_include_migrated_formats_from_mainstream" do
@@ -56,9 +56,9 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
     )
     generator = SitemapGenerator.new(SearchConfig.instance)
     sitemap_xml = generator.sitemaps
-    assert_equal 1, sitemap_xml.length
+    expect(1).to eq(sitemap_xml.length)
 
-    refute_includes sitemap_xml[0], "/an-example-answer"
+    expect(sitemap_xml[0]).not_to include("/an-example-answer")
   end
 
   it "should_include_homepage" do
@@ -69,8 +69,8 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
       .css("url")
       .select { |item| item.css("loc").text == "http://www.dev.gov.uk/" }
 
-    assert_equal 1, pages.count
-    assert_equal "0.5", pages[0].css("priority").text
+    expect(1).to eq(pages.count)
+    expect("0.5").to eq(pages[0].css("priority").text)
   end
 
   it "should_not_include_recommended_links" do
@@ -90,9 +90,9 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
 
     sitemap_xml = generator.sitemaps
 
-    assert_equal 1, sitemap_xml.length
+    expect(1).to eq(sitemap_xml.length)
 
-    refute_includes sitemap_xml[0], "/external-example-answer"
+    expect(sitemap_xml[0]).not_to include("/external-example-answer")
   end
 
   it "should_not_include_inside_government_links" do
@@ -111,8 +111,8 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
 
     sitemap_xml = generator.sitemaps
 
-    assert_equal 1, sitemap_xml.length
-    refute_includes sitemap_xml[0], "/government/some-content"
+    expect(1).to eq(sitemap_xml.length)
+    expect(sitemap_xml[0]).not_to include("/government/some-content")
   end
 
   it "links_should_include_timestamps" do
@@ -137,8 +137,8 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
       .css("url")
       .select { |item| item.css("loc").text == "http://www.dev.gov.uk/an-example-answer" }
 
-    assert_equal 1, pages.count
-    assert_equal "2017-07-01T12:41:34+00:00", pages[0].css("lastmod").text
+    expect(1).to eq(pages.count)
+    expect("2017-07-01T12:41:34+00:00").to eq(pages[0].css("lastmod").text)
   end
 
   it "links_should_include_priorities" do
@@ -163,8 +163,8 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
       .css("url")
       .select { |item| item.css("loc").text == "http://www.dev.gov.uk/an-example-answer" }
 
-    assert_equal 1, pages.count
-    assert_includes 0..10, pages[0].css("priority").text.to_i
+    expect(1).to eq(pages.count)
+    expect(0..10).to include(pages[0].css("priority").text.to_i)
   end
 
 private

--- a/spec/integration/sitemap/sitemap_spec.rb
+++ b/spec/integration/sitemap/sitemap_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe 'SitemapTest', tags: ['integration'] do
     link_full_name = "#{@path}/sitemaps/sitemap_1.xml"
     allow_any_instance_of(SitemapWriter).to receive(:write_sitemaps).and_return([[filename, link_name]])
 
-    assert_equal File.exist?(link_name), false
+    expect(File.exist?(link_name)).to eq(false)
 
     Sitemap.new(@path).generate(double(:content_indices))
 
-    assert_equal File.symlink?(link_full_name), true
-    assert_equal File.readlink(link_full_name), "#{@path}/sitemaps/#{filename}"
+    expect(File.symlink?(link_full_name)).to eq(true)
+    expect(File.readlink(link_full_name)).to eq("#{@path}/sitemaps/#{filename}")
   end
 
   it "it_creates_an_index_pointing_to_the_symbolic_links" do
@@ -45,8 +45,8 @@ RSpec.describe 'SitemapTest', tags: ['integration'] do
       </sitemapindex>
     XML
 
-    assert_equal File.read(index_filename), expected_xml
-    assert_equal File.readlink(index_linkname), index_filename
+    expect(File.read(index_filename)).to eq(expected_xml)
+    expect(File.readlink(index_linkname)).to eq(index_filename)
   end
 
   it "it_does_not_cleanup_the_symbolic_link_files_or_linked_files" do
@@ -62,12 +62,12 @@ RSpec.describe 'SitemapTest', tags: ['integration'] do
 
     Sitemap.new(@path).cleanup
 
-    assert_equal File.exist?("#{@path}/sitemaps/sitemap_1_2017-01-01T06.xml"), false
-    assert_equal File.exist?("#{@path}/sitemaps/sitemap_1_2017-01-06T06.xml"), true
-    assert_equal File.exist?("#{@path}/sitemaps/sitemap_1.xml"), true
+    expect(File.exist?("#{@path}/sitemaps/sitemap_1_2017-01-01T06.xml")).to eq(false)
+    expect(File.exist?("#{@path}/sitemaps/sitemap_1_2017-01-06T06.xml")).to eq(true)
+    expect(File.exist?("#{@path}/sitemaps/sitemap_1.xml")).to eq(true)
 
-    assert_equal File.exist?("#{@path}/sitemaps/sitemap_2017-01-01T06.xml"), true
-    assert_equal File.exist?("#{@path}/sitemaps/sitemap.xml"), true
+    expect(File.exist?("#{@path}/sitemaps/sitemap_2017-01-01T06.xml")).to eq(true)
+    expect(File.exist?("#{@path}/sitemaps/sitemap.xml")).to eq(true)
   end
 
   it "it_can_overwrite_existing_links" do
@@ -82,7 +82,7 @@ RSpec.describe 'SitemapTest', tags: ['integration'] do
 
     Sitemap.new(@path, time).generate(double)
 
-    assert_equal File.readlink("#{@path}/sitemap.xml"), "#{@path}/sitemaps/sitemap_#{time.strftime('%FT%H')}.xml"
+    expect(File.readlink("#{@path}/sitemap.xml")).to eq("#{@path}/sitemaps/sitemap_#{time.strftime('%FT%H')}.xml")
   end
 
   def create_test_file(name = "#{SecureRandom.uuid}.xml")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ if ENV["USE_SIMPLECOV"]
   require "simplecov"
   require "simplecov-rcov"
   SimpleCov.start do
-    add_filter '/test/'
     add_filter '/spec/'
   end
 
@@ -64,7 +63,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
-  config.expect_with :minitest
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -108,18 +108,14 @@ module IntegrationSpecHelper
     JSON.parse(last_response.body)
   end
 
-  def assert_document_is_in_rummager(document, type: "edition", index: 'mainstream_test')
+  def expect_document_is_in_rummager(document, type: "edition", index: 'mainstream_test')
     retrieved = fetch_document_from_rummager(id: document['link'], index: index)
 
-    assert_equal type, retrieved["_type"]
+    expect(type).to eq(retrieved["_type"])
 
     retrieved_source = retrieved["_source"]
     document.each do |key, value|
-      assert_equal(
-        value,
-        retrieved_source[key],
-        "Field #{key} should be '#{value}' but was '#{retrieved_source[key]}'"
-      )
+      expect(value).to eq(retrieved_source[key]), "Field #{key} should be '#{value}' but was '#{retrieved_source[key]}'"
     end
   end
 

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Document do
 
     document = described_class.from_hash(hash, sample_elasticsearch_types)
 
-    assert_equal "TITLE", document.title
-    assert_equal "DESCRIPTION", document.description
-    assert_equal "answer", document.format
-    assert_equal "/an-example-answer", document.link
-    assert_equal "HERE IS SOME CONTENT", document.indexable_content
+    expect("TITLE").to eq(document.title)
+    expect("DESCRIPTION").to eq(document.description)
+    expect("answer").to eq(document.format)
+    expect("/an-example-answer").to eq(document.link)
+    expect("HERE IS SOME CONTENT").to eq(document.indexable_content)
   end
 
   it "should_permit_nonedition_documents" do
@@ -29,14 +29,14 @@ RSpec.describe Document do
 
     document = described_class.from_hash(hash, sample_elasticsearch_types)
 
-    assert_equal "jobs", document.to_hash["stemmed_query"]
-    assert_equal "jobs", document.stemmed_query
-    assert_equal "jobs", document.elasticsearch_export["stemmed_query"]
+    expect("jobs").to eq(document.to_hash["stemmed_query"])
+    expect("jobs").to eq(document.stemmed_query)
+    expect("jobs").to eq(document.elasticsearch_export["stemmed_query"])
 
-    refute document.to_hash.has_key?("_type")
-    refute document.to_hash.has_key?("_id")
-    assert_equal "jobs_exact", document.elasticsearch_export["_id"]
-    assert_equal "best_bet", document.elasticsearch_export["_type"]
+    expect(document.to_hash.has_key?("_type")).to be_falsey
+    expect(document.to_hash.has_key?("_id")).to be_falsey
+    expect("jobs_exact").to eq(document.elasticsearch_export["_id"])
+    expect("best_bet").to eq(document.elasticsearch_export["_type"])
   end
 
   it "should_reject_document_with_no_type" do
@@ -44,10 +44,9 @@ RSpec.describe Document do
       "_id" => "some_id",
     }
 
-    error = assert_raises RuntimeError do
+    expect {
       described_class.from_hash(hash, sample_elasticsearch_types)
-    end
-    assert_match(/missing/i, error.message)
+    }.to raise_error(/missing/i)
   end
 
   it "should_raise_helpful_error_for_unconfigured_types" do
@@ -56,9 +55,9 @@ RSpec.describe Document do
       "_type" => "cheese"
     }
 
-    assert_raises RuntimeError do
+    expect {
       described_class.from_hash(hash, sample_elasticsearch_types)
-    end
+    }.to raise_error(RuntimeError)
   end
 
   it "should_ignore_fields_not_in_mappings" do
@@ -73,8 +72,8 @@ RSpec.describe Document do
 
     document = described_class.from_hash(hash, sample_elasticsearch_types)
 
-    refute_includes document.to_hash.keys, "some_other_field"
-    refute document.respond_to?("some_other_field")
+    expect(document.to_hash.keys).not_to include("some_other_field")
+    expect(document.respond_to?("some_other_field")).to be_falsey
   end
 
   it "should_recognise_symbol_keys_in_hash" do
@@ -89,7 +88,7 @@ RSpec.describe Document do
 
     document = described_class.from_hash(hash, sample_elasticsearch_types)
 
-    assert_equal "TITLE", document.title
+    expect("TITLE").to eq(document.title)
   end
 
   it "should_skip_metadata_fields_in_to_hash" do
@@ -103,12 +102,12 @@ RSpec.describe Document do
     input_hash = expected_hash.merge("_type" => "edition")
 
     document = described_class.from_hash(input_hash, sample_elasticsearch_types)
-    assert_equal expected_hash, document.to_hash
+    expect(expected_hash).to eq(document.to_hash)
   end
 
   it "should_skip_missing_fields_in_to_hash" do
     document = described_class.from_hash({ "_type" => "edition" }, sample_elasticsearch_types)
-    assert_equal [], document.to_hash.keys
+    expect([]).to eq(document.to_hash.keys)
   end
 
   it "should_skip_missing_fields_in_elasticsearch_export" do
@@ -121,28 +120,28 @@ RSpec.describe Document do
     }
     document = described_class.from_hash(hash, sample_elasticsearch_types)
 
-    assert_equal hash.keys.sort, document.elasticsearch_export.keys.sort
+    expect(hash.keys.sort).to eq(document.elasticsearch_export.keys.sort)
   end
 
   it "should_include_result_score" do
     hash = { "link" => "/batman" }
     field_names = ["link"]
 
-    assert_equal 5.2, described_class.new(sample_field_definitions(field_names), hash, 5.2).es_score
+    expect(5.2).to eq(described_class.new(sample_field_definitions(field_names), hash, 5.2).es_score)
   end
 
   it "includes_elasticsearch_score_in_hash" do
     hash = { "link" => "/batman" }
     field_names = ["link"]
 
-    assert_equal 5.2, described_class.new(sample_field_definitions(field_names), hash, 5.2).to_hash["es_score"]
+    expect(5.2).to eq(described_class.new(sample_field_definitions(field_names), hash, 5.2).to_hash["es_score"])
   end
 
   it "leaves_out_blank_score" do
     hash = { "link" => "/batman" }
     field_names = ["link"]
 
-    refute_includes described_class.new(sample_field_definitions(field_names), hash).to_hash, "es_score"
+    expect(described_class.new(sample_field_definitions(field_names), hash).to_hash).not_to include("es_score")
   end
 
   it "should_handle_opaque_object_fields" do
@@ -152,6 +151,6 @@ RSpec.describe Document do
     }
     doc = described_class.new(sample_field_definitions(%w(metadata)), document_hash)
 
-    assert_equal metadata, doc.metadata
+    expect(metadata).to eq(doc.metadata)
   end
 end

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SearchIndices::Index do
         headers: { 'Content-Type' => 'application/json' },
       )
 
-    assert_equal "real-name", @index.real_name
+    expect("real-name").to eq(@index.real_name)
   end
 
   it "real_name_when_no_index" do
@@ -25,7 +25,7 @@ RSpec.describe SearchIndices::Index do
         headers: { 'Content-Type' => 'application/json' },
       )
 
-    assert_nil @index.real_name
+    expect(@index.real_name).to be_nil
   end
 
   it "real_name_when_no_index_es0_20" do
@@ -37,7 +37,7 @@ RSpec.describe SearchIndices::Index do
         headers: { 'Content-Type' => 'application/json' },
       )
 
-    assert_nil @index.real_name
+    expect(@index.real_name).to be_nil
   end
 
   it "exists" do
@@ -47,7 +47,7 @@ RSpec.describe SearchIndices::Index do
         headers: { 'Content-Type' => 'application/json' },
       )
 
-    assert @index.exists?
+    expect(@index).to be_exists
   end
 
   it "should_raise_error_for_failures_in_bulk_update" do
@@ -79,7 +79,7 @@ RSpec.describe SearchIndices::Index do
       @index.add(documents)
       flunk("No exception raised")
     rescue Indexer::BulkIndexFailure => e
-      assert_equal "Indexer::BulkIndexFailure", e.message
+      expect("Indexer::BulkIndexFailure").to eq(e.message)
     end
   end
 
@@ -144,7 +144,7 @@ RSpec.describe SearchIndices::Index do
     ).then.to_raise("should never happen")
 
     result = @index.documents_by_format("organisation", sample_field_definitions(%w(link title)))
-    assert_equal (1..10).map { |i| "Organisation #{i}" }, result.map { |r| r['title'] }
+    expect((1..10).map { |i| "Organisation #{i}" }).to eq(result.map { |r| r['title'] })
   end
 
   it "can_fetch_documents_by_format_with_certain_fields" do
@@ -171,8 +171,8 @@ RSpec.describe SearchIndices::Index do
     ).then.to_raise("should never happen")
 
     result = @index.documents_by_format("organisation", sample_field_definitions(%w(link title))).to_a
-    assert_equal (1..10).map { |i| "Organisation #{i}" }, result.map { |r| r['title'] }
-    assert_equal (1..10).map { |i| "/organisation-#{i}" }, result.map { |r| r['link'] }
+    expect((1..10).map { |i| "Organisation #{i}" }).to eq(result.map { |r| r['title'] })
+    expect((1..10).map { |i| "/organisation-#{i}" }).to eq(result.map { |r| r['link'] })
   end
 
   it "all_documents_size" do
@@ -184,7 +184,7 @@ RSpec.describe SearchIndices::Index do
       body: { _scroll_id: "abcdefgh", hits: { total: 100 } }.to_json,
       headers: { 'Content-Type' => 'application/json' },
     ).then.to_raise("should never happen")
-    assert_equal @index.all_documents.size, 100
+    expect(@index.all_documents.size).to eq(100)
   end
 
   it "all_documents" do
@@ -212,9 +212,9 @@ RSpec.describe SearchIndices::Index do
       headers: { 'Content-Type' => 'application/json' },
     ).then.to_raise("should never happen")
     all_documents = @index.all_documents.to_a
-    assert_equal 100, all_documents.size
-    assert_equal "/foo-1", all_documents.first.link
-    assert_equal "/foo-100", all_documents.last.link
+    expect(100).to eq(all_documents.size)
+    expect("/foo-1").to eq(all_documents.first.link)
+    expect("/foo-100").to eq(all_documents.last.link)
   end
 
   it "changing_scroll_id" do
@@ -259,7 +259,7 @@ RSpec.describe SearchIndices::Index do
     ).then.to_raise("should never happen")
 
     all_documents = @index.all_documents.to_a
-    assert_equal ["/foo-1", "/foo-2", "/foo-3"], all_documents.map(&:link)
+    expect(["/foo-1", "/foo-2", "/foo-3"]).to eq(all_documents.map(&:link))
   end
 
 private

--- a/spec/unit/govuk_index/document_type_inferer_spec.rb
+++ b/spec/unit/govuk_index/document_type_inferer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GovukIndex::DocumentTypeInferer do
 
     document_type_inferer = described_class.new(payload)
 
-    assert_equal "edition", document_type_inferer.type
+    expect("edition").to eq(document_type_inferer.type)
   end
 
   it "should_raise_not_found_error" do
@@ -17,9 +17,9 @@ RSpec.describe GovukIndex::DocumentTypeInferer do
 
     allow_any_instance_of(described_class).to receive(:existing_document).and_return(nil)
 
-    assert_raises(GovukIndex::NotFoundError) do
+    expect {
       described_class.new(payload).type
-    end
+    }.to raise_error(GovukIndex::NotFoundError)
   end
 
   it "should_raise_unknown_document_type_error" do
@@ -27,9 +27,9 @@ RSpec.describe GovukIndex::DocumentTypeInferer do
 
     allow_any_instance_of(described_class).to receive(:elasticsearch_document_type).and_return(nil)
 
-    assert_raises(GovukIndex::UnknownDocumentTypeError) do
+    expect {
       described_class.new(payload).type
-    end
+    }.to raise_error(GovukIndex::UnknownDocumentTypeError)
   end
 
   it "infer_existing_document_type" do
@@ -47,6 +47,6 @@ RSpec.describe GovukIndex::DocumentTypeInferer do
 
     document_type_inferer = described_class.new(payload)
 
-    assert_equal existing_document["_type"], document_type_inferer.type
+    expect(existing_document["_type"]).to eq(document_type_inferer.type)
   end
 end

--- a/spec/unit/govuk_index/indexable_content_sanitiser_spec.rb
+++ b/spec/unit/govuk_index/indexable_content_sanitiser_spec.rb
@@ -9,25 +9,25 @@ RSpec.describe GovukIndex::IndexableContentSanitiser do
       ]
     ]
 
-    assert_equal "hello marmaduke", subject.clean(payload)
+    expect("hello marmaduke").to eq(subject.clean(payload))
   end
 
   it "passes_single_string_content_unchanged" do
     payload = ["hello marmaduke"]
 
-    assert_equal "hello marmaduke", subject.clean(payload)
+    expect("hello marmaduke").to eq(subject.clean(payload))
   end
 
   it "passes_multiple_string_items_unchanged" do
     payload = ["hello marmaduke", "hello marley"]
 
-    assert_equal "hello marmaduke\n\n\nhello marley", subject.clean(payload)
+    expect("hello marmaduke\n\n\nhello marley").to eq(subject.clean(payload))
   end
 
   it "strips_html_tags_from_string_content" do
     payload = ["<h1>hello marmaduke</h1>"]
 
-    assert_equal "hello marmaduke", subject.clean(payload)
+    expect("hello marmaduke").to eq(subject.clean(payload))
   end
 
   it "multiple_html_text_payload_items" do
@@ -43,7 +43,7 @@ RSpec.describe GovukIndex::IndexableContentSanitiser do
     ]
 
 
-    assert_equal "hello\ngoodbye", subject.clean(payload)
+    expect("hello\ngoodbye").to eq(subject.clean(payload))
   end
 
   it "notifies_if_no_text_html_content" do
@@ -61,7 +61,7 @@ RSpec.describe GovukIndex::IndexableContentSanitiser do
       extra: { content_types: ["text/govspeak"] }
     )
 
-    assert_equal nil, subject.clean(payload)
+    expect(nil).to eq(subject.clean(payload))
   end
 
   it "content_with_text_and_html_parts" do
@@ -80,6 +80,6 @@ RSpec.describe GovukIndex::IndexableContentSanitiser do
 
     expected_content = "title 1\n\nhello\n\ntitle 2\n\ngoodbye"
 
-    assert_equal expected_content, subject.clean(payload)
+    expect(expected_content).to eq(subject.clean(payload))
   end
 end

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     presenter = common_fields_presenter(payload)
 
     @directly_mapped_fields.each do |field|
-      assert_equal presenter.public_send(field), payload[field]
+      expect(presenter.public_send(field)).to eq(payload[field])
     end
   end
 
@@ -48,9 +48,9 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     presenter = common_fields_presenter(payload)
 
-    assert_equal presenter.format, payload["document_type"]
-    assert_equal presenter.is_withdrawn, false
-    assert_equal presenter.link, payload["base_path"]
+    expect(presenter.format).to eq(payload["document_type"])
+    expect(presenter.is_withdrawn).to eq(false)
+    expect(presenter.link).to eq(payload["base_path"])
   end
 
   it "withdrawn_when_withdrawn_notice_present" do
@@ -64,7 +64,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     presenter = common_fields_presenter(payload)
 
-    assert_equal presenter.is_withdrawn, true
+    expect(presenter.is_withdrawn).to eq(true)
   end
 
   it "popularity_when_value_is_returned_from_lookup" do
@@ -77,7 +77,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     presenter = common_fields_presenter(payload)
 
-    assert_equal popularity, presenter.popularity
+    expect(popularity).to eq(presenter.popularity)
   end
 
   it "no_popularity_when_no_value_is_returned_from_lookup" do
@@ -88,7 +88,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     presenter = common_fields_presenter(payload)
 
-    assert_equal nil, presenter.popularity
+    expect(nil).to eq(presenter.popularity)
   end
 
   def common_fields_presenter(payload)

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       ]
     }
 
-    assert_equal "hello", details_presenter(details).indexable_content
+    expect("hello").to eq(details_presenter(details).indexable_content)
   end
 
   it "details_with_parts" do
@@ -34,7 +34,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       ]
     }
 
-    assert_equal "title 1\n\nhello\n\ntitle 2\n\ngoodbye", details_presenter(details).indexable_content
+    expect("title 1\n\nhello\n\ntitle 2\n\ngoodbye").to eq(details_presenter(details).indexable_content)
   end
 
   it "mapped_licence_fields" do
@@ -52,8 +52,8 @@ RSpec.describe GovukIndex::DetailsPresenter do
 
     presenter = details_presenter(details, "licence")
 
-    assert_equal presenter.licence_identifier, details["licence_identifier"]
-    assert_equal presenter.licence_short_description, details["licence_short_description"]
+    expect(presenter.licence_identifier).to eq(details["licence_identifier"])
+    expect(presenter.licence_short_description).to eq(details["licence_short_description"])
   end
 
   it "when_additional_indexable_content_keys_are_specified" do
@@ -67,7 +67,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       "start_button_text" => "Start now",
     }
 
-    assert_equal "introductory paragraph\n\nmore information", details_presenter(details, %w(introductory_paragraph more_information)).indexable_content
+    expect("introductory paragraph\n\nmore information").to eq(details_presenter(details, %w(introductory_paragraph more_information)).indexable_content)
   end
 
   def details_presenter(details, indexable_content_keys = %w(body parts))

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
 
     presenter = elasticsearch_presenter(payload, "help_page")
 
-    assert_equal expected_identifier, presenter.identifier
+    expect(expected_identifier).to eq(presenter.identifier)
   end
 
   it "raise_validation_error" do
@@ -22,9 +22,9 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
 
     presenter = elasticsearch_presenter(payload)
 
-    assert_raises GovukIndex::ValidationError do
+    expect {
       presenter.valid!
-    end
+    }.to raise_error(GovukIndex::ValidationError)
   end
 
   def elasticsearch_presenter(payload, type = "aaib_report")

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
       "5f42c670-5b82-4f1f-ab52-0e100428d430", "4ab4764d-d9ce-425f-a8cc-aaba4a38be09"
     ]
 
-    assert_equal presenter.mainstream_browse_pages, expected_mainstream_browse_pages
-    assert_equal presenter.mainstream_browse_page_content_ids, expected_mainstream_browse_page_content_ids
+    expect(presenter.mainstream_browse_pages).to eq(expected_mainstream_browse_pages)
+    expect(presenter.mainstream_browse_page_content_ids).to eq(expected_mainstream_browse_page_content_ids)
   end
 
   it "organisations" do
@@ -59,9 +59,9 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expected_organisation_content_ids = ["04148522-b0c1-4137-b687-5f3c3bdd561a"]
     expected_primary_publishing_organisation = ["uk-visas-and-immigration"]
 
-    assert_equal presenter.organisations, expected_organisations
-    assert_equal presenter.organisation_content_ids, expected_organisation_content_ids
-    assert_equal presenter.primary_publishing_organisation, expected_primary_publishing_organisation
+    expect(presenter.organisations).to eq(expected_organisations)
+    expect(presenter.organisation_content_ids).to eq(expected_organisation_content_ids)
+    expect(presenter.primary_publishing_organisation).to eq(expected_primary_publishing_organisation)
   end
 
   it "taxons" do
@@ -106,8 +106,8 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     ]
     expected_taxons = ["13bba81c-b2b1-4b13-a3de-b24748977198"]
 
-    assert_equal presenter.part_of_taxonomy_tree, expected_taxonomy_tree
-    assert_equal presenter.taxons, expected_taxons
+    expect(presenter.part_of_taxonomy_tree).to eq(expected_taxonomy_tree)
+    expect(presenter.taxons).to eq(expected_taxons)
   end
 
   it "topics" do
@@ -127,8 +127,8 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expected_specialist_sectors = ["benefits-credits/tax-credits"]
     expected_topic_content_ids = ["f881f972-6094-4c7d-849c-9143461a9307"]
 
-    assert_equal presenter.specialist_sectors, expected_specialist_sectors
-    assert_equal presenter.topic_content_ids, expected_topic_content_ids
+    expect(presenter.specialist_sectors).to eq(expected_specialist_sectors)
+    expect(presenter.topic_content_ids).to eq(expected_topic_content_ids)
   end
 
   def expanded_links_presenter(expanded_links)

--- a/spec/unit/govuk_index/publishing_event_worker_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_worker_spec.rb
@@ -76,9 +76,9 @@ RSpec.describe GovukIndex::PublishingEventWorker do
     expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete_error')
     expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
 
-    assert_raises(GovukIndex::ElasticsearchError) do
+    expect {
       subject.perform('routing.unpublish', payload)
-    end
+    }.to raise_error(GovukIndex::ElasticsearchError)
   end
 
   it "does_not_raise_error_when_document_not_found_while_attempting_to_delete" do
@@ -116,9 +116,9 @@ RSpec.describe GovukIndex::PublishingEventWorker do
     expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.multiple_responses')
     expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
 
-    assert_raises(GovukIndex::MultipleMessagesInElasticsearchResponse) do
+    expect {
       subject.perform('routing.unpublish', payload)
-    end
+    }.to raise_error(GovukIndex::MultipleMessagesInElasticsearchResponse)
   end
 
   it "notify_when_validation_error" do

--- a/spec/unit/govuk_index/specialist_formats_spec.rb
+++ b/spec/unit/govuk_index/specialist_formats_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "location" => ["Near Popham Airfield, Hampshire"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata.merge(special_formated_output))
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
   it "asylum_support_decision" do
@@ -38,8 +38,8 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     # * tribunal_decision_sub_category
 
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
-    assert_equal document[:indexable_content], "Test body\n\n\nsome hidden content"
+    expect_document_include_hash(document, custom_metadata)
+    expect(document[:indexable_content]).to eq("Test body\n\n\nsome hidden content")
   end
 
   it "business_finance_support_scheme" do
@@ -52,7 +52,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "will_continue_on" => "on GOV.UK",
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
   it "cma_case" do
@@ -65,7 +65,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "outcome_type" => "ca98-no-grounds-for-action-non-infringement",
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
   it "countryside_stewardship_grant" do
@@ -76,7 +76,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "funding_amount" => ["201-to-300"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
   it "dfid_research_output" do
@@ -88,7 +88,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "first_published_at" => "2016-04-28",
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
   it "drug_safety_update" do
@@ -96,7 +96,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "therapeutic_area" => ["cancer", "haematology", "immunosuppression-transplantation"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
   it "employment_appeal_tribunal_decision" do
@@ -108,8 +108,8 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "tribunal_decision_sub_categories" => ["contract-of-employment-apprenticeship"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
-    assert_equal document[:indexable_content], "Test body\n\n\nhidden content"
+    expect_document_include_hash(document, custom_metadata)
+    expect(document[:indexable_content]).to eq("Test body\n\n\nhidden content")
   end
 
   it "employment_tribunal_decision" do
@@ -120,8 +120,8 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "tribunal_decision_decision_date" => "2015-07-30",
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
-    assert_equal document[:indexable_content], "Test body\n\n\nhidden etd content"
+    expect_document_include_hash(document, custom_metadata)
+    expect(document[:indexable_content]).to eq("Test body\n\n\nhidden etd content")
   end
 
   it "european_structural_investment_fund" do
@@ -133,7 +133,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "funding_source" => ["european-regional-development-fund"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
   it "international_development_fund" do
@@ -145,7 +145,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "funding_source" => ["european-regional-development-fund"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
   it "maib_report" do
@@ -158,7 +158,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "report_type" => ["investigation-report"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata.merge(special_formated_output))
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
   it "medical_safety_alert" do
@@ -168,7 +168,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "medical_specialism" => %w(anaesthetics cardiology),
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
   it "raib_report" do
@@ -181,7 +181,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "report_type" => ["investigation-report"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata.merge(special_formated_output))
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
   it "service_standard_report" do
@@ -189,7 +189,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "assessment_date" => "2016-10-10"
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
 
@@ -200,8 +200,8 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "tribunal_decision_decision_date" => "2015-07-30",
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
-    assert_equal document[:indexable_content], "Test body\n\n\nhidden ttd content"
+    expect_document_include_hash(document, custom_metadata)
+    expect(document[:indexable_content]).to eq("Test body\n\n\nhidden ttd content")
   end
 
   it "utaac_decision" do
@@ -213,8 +213,8 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "tribunal_decision_sub_categories" => ["benefits-for-children-benefit-increases-for-children"],
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
-    assert_equal document[:indexable_content], "Test body\n\n\nhidden utaac content"
+    expect_document_include_hash(document, custom_metadata)
+    expect(document[:indexable_content]).to eq("Test body\n\n\nhidden utaac content")
   end
 
   it "vehicle_recalls_and_faults_alert" do
@@ -229,7 +229,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "serial_number" => "SN123",
     }
     document = build_example_with_metadata(custom_metadata)
-    assert_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata)
   end
 
 private
@@ -248,13 +248,10 @@ private
   end
 
 
-  def assert_document_include_hash(document, hash)
+  def expect_document_include_hash(document, hash)
     hash.each do |key, value|
-      assert_equal(
-        document[key.to_sym],
-        value,
+      expect(document[key.to_sym]).to eq(value),
         "Value for #{key}: `#{document[key.to_sym]}` did not match expected value `#{value}`"
-      )
     end
   end
 end

--- a/spec/unit/health_check/basic_auth_credentials_spec.rb
+++ b/spec/unit/health_check/basic_auth_credentials_spec.rb
@@ -3,20 +3,20 @@ require 'spec_helper'
 RSpec.describe HealthCheck::BasicAuthCredentials do
   it "be callable with a user:password string" do
     creds = HealthCheck::BasicAuthCredentials.call "bob:horseradish"
-    assert_equal "bob", creds.user
-    assert_equal "horseradish", creds.password
+    expect("bob").to eq(creds.user)
+    expect("horseradish").to eq(creds.password)
   end
 
   it "fail on a malformed string" do
-    assert_raises ArgumentError do
+    expect {
       HealthCheck::BasicAuthCredentials.call "spoons"
-    end
+    }.to raise_error(ArgumentError)
   end
 
   it "fail on a nil value" do
-    assert_raises ArgumentError do
+    expect {
       HealthCheck::BasicAuthCredentials.call nil
-    end
+    }.to raise_error(ArgumentError)
   end
 
   it "be splattable" do

--- a/spec/unit/health_check/check_file_parser_spec.rb
+++ b/spec/unit/health_check/check_file_parser_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe HealthCheck::CheckFileParser do
       HealthCheck::SearchCheck.new("a", "should", "/a", 1, 1, %w(test)),
       HealthCheck::SearchCheck.new("b", "should", "/b", 1, 1, %w(test))
     ]
-    assert_equal expected, checks(data)
+    expect(expected).to eq(checks(data))
   end
 
   it "skip rows that don't have an integer for the top N number" do
@@ -27,7 +27,7 @@ RSpec.describe HealthCheck::CheckFileParser do
     END
 
     expected = []
-    assert_equal expected, checks(data)
+    expect(expected).to eq(checks(data))
   end
 
   it "skip rows that don't have a URL" do
@@ -37,7 +37,7 @@ RSpec.describe HealthCheck::CheckFileParser do
     END
 
     expected = []
-    assert_equal expected, checks(data)
+    expect(expected).to eq(checks(data))
   end
 
   it "skip rows that don't have a imperative" do
@@ -47,7 +47,7 @@ RSpec.describe HealthCheck::CheckFileParser do
     END
 
     expected = []
-    assert_equal expected, checks(data)
+    expect(expected).to eq(checks(data))
   end
 
   it "skip rows that don't have a search term" do
@@ -57,6 +57,6 @@ RSpec.describe HealthCheck::CheckFileParser do
     END
 
     expected = []
-    assert_equal expected, checks(data)
+    expect(expected).to eq(checks(data))
   end
 end

--- a/spec/unit/health_check/json_search_client_spec.rb
+++ b/spec/unit/health_check/json_search_client_spec.rb
@@ -28,7 +28,7 @@ B)
     expected = { results: ["/a", "/b"], suggested_queries: %w[A B] }
     base_url = URI.parse("http://www.gov.uk/api/search.json")
 
-    assert_equal expected, described_class.new(base_url: base_url).search("cheese")
+    expect(expected).to eq(described_class.new(base_url: base_url).search("cheese"))
   end
 
   it "call the search API with a rate limit token if provided" do
@@ -39,6 +39,6 @@ B)
 
     response = described_class.new(base_url: base_url, rate_limit_token: "some_token").search("cheese")
 
-    assert_equal expected, response
+    expect(expected).to eq(response)
   end
 end

--- a/spec/unit/health_check/search_check_result_spec.rb
+++ b/spec/unit/health_check/search_check_result_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe HealthCheck::SearchCheckResult do
         let(:search_results) { ["https://www.gov.uk/a"] }
 
         it "return a successful Result" do
-          assert_equal true, subject.success
-          assert_equal "FOUND", subject.found_label
-          assert_equal "PASS", subject.success_label
+          expect(true).to eq(subject.success)
+          expect("FOUND").to eq(subject.found_label)
+          expect("PASS").to eq(subject.success_label)
         end
       end
 
@@ -21,9 +21,9 @@ RSpec.describe HealthCheck::SearchCheckResult do
         let(:search_results) { ["https://www.gov.uk/b", "https://www.gov.uk/a"] }
 
         it "return a failure Result" do
-          refute subject.success
-          assert_equal "FOUND", subject.found_label
-          assert_equal "FAIL", subject.success_label
+          expect(subject.success).to be_falsey
+          expect("FOUND").to eq(subject.found_label)
+          expect("FAIL").to eq(subject.success_label)
         end
       end
 
@@ -32,9 +32,9 @@ RSpec.describe HealthCheck::SearchCheckResult do
         let(:search_results) { ["https://www.gov.uk/b", "https://www.gov.uk/c"] }
 
         it "return a failure Result" do
-          refute subject.success
-          assert_equal "NOT FOUND", subject.found_label
-          assert_equal "FAIL", subject.success_label
+          expect(subject.success).to be_falsey
+          expect("NOT FOUND").to eq(subject.found_label)
+          expect("FAIL").to eq(subject.success_label)
         end
       end
     end
@@ -47,9 +47,9 @@ RSpec.describe HealthCheck::SearchCheckResult do
       let(:search_results) { ["https://www.gov.uk/a", "https://www.gov.uk/b"] }
 
       it "fail" do
-        refute subject.success
-        assert_equal "FOUND", subject.found_label
-        assert_equal "FAIL", subject.success_label
+        expect(subject.success).to be_falsey
+        expect("FOUND").to eq(subject.found_label)
+        expect("FAIL").to eq(subject.success_label)
       end
     end
 
@@ -58,9 +58,9 @@ RSpec.describe HealthCheck::SearchCheckResult do
       let(:search_results) { ["https://www.gov.uk/b", "https://www.gov.uk/a"] }
 
       it "pass" do
-        assert subject.success
-        assert_equal "FOUND", subject.found_label
-        assert_equal "PASS", subject.success_label
+        expect(subject.success).to be_truthy
+        expect("FOUND").to eq(subject.found_label)
+        expect("PASS").to eq(subject.success_label)
       end
     end
 
@@ -69,9 +69,9 @@ RSpec.describe HealthCheck::SearchCheckResult do
       let(:search_results) { ["https://www.gov.uk/a", "https://www.gov.uk/b"] }
 
       it "pass" do
-        assert subject.success
-        assert_equal "NOT FOUND", subject.found_label
-        assert_equal "PASS", subject.success_label
+        expect(subject.success).to be_truthy
+        expect("NOT FOUND").to eq(subject.found_label)
+        expect("PASS").to eq(subject.success_label)
       end
     end
   end

--- a/spec/unit/health_check/search_check_spec.rb
+++ b/spec/unit/health_check/search_check_spec.rb
@@ -15,34 +15,34 @@ RSpec.describe HealthCheck::SearchCheck do
 
   context "#valid_imperative?" do
     it "be true only for valid imperatives" do
-      assert subject.tap { |c| c.imperative = "should" }.valid_imperative?
-      assert subject.tap { |c| c.imperative = "should not" }.valid_imperative?
-      refute subject.tap { |c| c.imperative = "anything else" }.valid_imperative?
+      expect(subject.tap { |c| c.imperative = "should" }).to be_valid_imperative
+      expect(subject.tap { |c| c.imperative = "should not" }).to be_valid_imperative
+      expect(subject.tap { |c| c.imperative = "anything else" }).not_to be_valid_imperative
     end
   end
 
   context "#valid_path?" do
     it "be true only for valid paths" do
-      assert subject.tap { |c| c.path = "/" }.valid_path?
-      refute subject.tap { |c| c.path = "foo" }.valid_path?
-      refute subject.tap { |c| c.path = "" }.valid_path?
-      refute subject.tap { |c| c.path = nil }.valid_path?
+      expect(subject.tap { |c| c.path = "/" }).to be_valid_path
+      expect(subject.tap { |c| c.path = "foo" }).not_to be_valid_path
+      expect(subject.tap { |c| c.path = "" }).not_to be_valid_path
+      expect(subject.tap { |c| c.path = nil }).not_to be_valid_path
     end
   end
 
   context "#valid_search_term?" do
     it "be true only for non-blank search terms" do
-      assert subject.tap { |c| c.search_term = "foo" }.valid_search_term?
-      refute subject.tap { |c| c.search_term = "" }.valid_search_term?
-      refute subject.tap { |c| c.search_term = nil }.valid_search_term?
+      expect(subject.tap { |c| c.search_term = "foo" }).to be_valid_search_term
+      expect(subject.tap { |c| c.search_term = "" }).not_to be_valid_search_term
+      expect(subject.tap { |c| c.search_term = nil }).not_to be_valid_search_term
     end
   end
 
   context "valid_weight?" do
     it "be true only for weights greater than 0" do
-      refute subject.tap { |c| c.weight = -1 }.valid_weight?
-      refute subject.tap { |c| c.weight = 0 }.valid_weight?
-      assert subject.tap { |c| c.weight = 1 }.valid_weight?
+      expect(subject.tap { |c| c.weight = -1 }).not_to be_valid_weight
+      expect(subject.tap { |c| c.weight = 0 }).not_to be_valid_weight
+      expect(subject.tap { |c| c.weight = 1 }).to be_valid_weight
     end
   end
 end

--- a/spec/unit/health_check/suggestion_check_spec.rb
+++ b/spec/unit/health_check/suggestion_check_spec.rb
@@ -6,25 +6,25 @@ RSpec.describe HealthCheck::SuggestionCheck do
     it "be true when the result and query match" do
       check = described_class.new(expected_result: 'x', suggested_query: 'x')
 
-      assert check.success?
+      expect(check).to be_success
     end
 
     it "be false when the result and query do not match" do
       check = described_class.new(expected_result: 'A', suggested_query: 'B')
 
-      refute check.success?
+      expect(check).not_to be_success
     end
 
     it "accept lowercase expected results" do
       check = described_class.new(expected_result: 'A', suggested_query: 'a')
 
-      assert check.success?
+      expect(check).to be_success
     end
 
     it "accept empty results" do
       check = described_class.new(expected_result: '', suggested_query: nil)
 
-      assert check.success?
+      expect(check).to be_success
     end
   end
 end

--- a/spec/unit/health_check/suggestion_checker_spec.rb
+++ b/spec/unit/health_check/suggestion_checker_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe HealthCheck::SuggestionChecker do
         test_data: StringIO.new(data)
       ).run!
 
-      assert result.success_count == 3
-      assert result.total_count == 5
+      expect(result.success_count).to eq 3
+      expect(result.total_count).to eq 5
     end
   end
 end

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Helpers do
     expect(subject).to receive(:content_type).with(:json)
     # 200 is the default status: whether it gets called or not, we don't mind
     expect(subject).to receive(:status).with(200).once
-    assert_equal '{"result":"OK"}', subject.simple_json_result(true)
+    expect('{"result":"OK"}').to eq(subject.simple_json_result(true))
   end
 
   it "simple_json_result_error" do
     expect(subject).to receive(:content_type).with(:json)
     expect(subject).to receive(:status).with(500)
-    assert_equal '{"result":"error"}', subject.simple_json_result(false)
+    expect('{"result":"error"}').to eq(subject.simple_json_result(false))
   end
 
   it "parse_query_string" do
@@ -31,7 +31,7 @@ RSpec.describe Helpers do
       ["foo=baz&&q=more", { "foo" => ["baz"], "q" => ["more"] }],
       ["foo=baz&boo&q=more", { "foo" => ["baz"], "boo" => [], "q" => ["more"] }],
     ].each do |qs, expected|
-      assert_equal expected, subject.parse_query_string(qs)
+      expect(expected).to eq(subject.parse_query_string(qs))
     end
   end
 end

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe SearchIndices::IndexGroup do
     index = @server.index_group("mainstream").create_index
 
     assert_requested(stub)
-    assert index.is_a? SearchIndices::Index
-    assert_match(/^mainstream-/, index.index_name)
+    expect(index).to be_a SearchIndices::Index
+    expect(index.index_name).to match(/^mainstream-/)
   end
 
   it "switch_index_with_no_existing_alias" do
@@ -135,9 +135,9 @@ RSpec.describe SearchIndices::IndexGroup do
         }.to_json
       )
 
-    assert_raises RuntimeError do
+    expect {
       @server.index_group("test").switch_to(new_index)
-    end
+    }.to raise_error(RuntimeError)
   end
 
   it "index_names_with_no_indices" do
@@ -148,7 +148,7 @@ RSpec.describe SearchIndices::IndexGroup do
         body: {}.to_json
       )
 
-    assert_equal [], @server.index_group("test").index_names
+    expect([]).to eq(@server.index_group("test").index_names)
   end
 
   it "index_names_with_index" do
@@ -162,7 +162,7 @@ RSpec.describe SearchIndices::IndexGroup do
         }.to_json
       )
 
-    assert_equal [index_name], @server.index_group("test").index_names
+    expect([index_name]).to eq(@server.index_group("test").index_names)
   end
 
   it "index_names_with_other_groups" do
@@ -179,7 +179,7 @@ RSpec.describe SearchIndices::IndexGroup do
         }.to_json
       )
 
-    assert_equal [this_name], @server.index_group("test").index_names
+    expect([this_name]).to eq(@server.index_group("test").index_names)
   end
 
   it "clean_with_no_indices" do

--- a/spec/unit/indexer/bulk_loader_spec.rb
+++ b/spec/unit/indexer/bulk_loader_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Indexer::BulkLoader do
       batches << batch
     end
 
-    assert_equal [%W(a\n b\n), %W(c\n d\n)], batches
+    expect([%W(a\n b\n), %W(c\n d\n)]).to eq(batches)
   end
 
   it "line_pairs_are_not_split_if_batch_size_too_small_to_fit_first_pair_of_lines" do
@@ -20,7 +20,7 @@ RSpec.describe Indexer::BulkLoader do
       batches << batch
     end
 
-    assert_equal [%W(a\n b\n), %W(c\n d\n)], batches
+    expect([%W(a\n b\n), %W(c\n d\n)]).to eq(batches)
   end
 
   it "line_pairs_are_not_split_if_batch_boundary_falls_in_second_pair_of_lines" do
@@ -31,6 +31,6 @@ RSpec.describe Indexer::BulkLoader do
       batches << batch
     end
 
-    assert_equal [%W(a\n b\n c\n d\n), %W(e\n f\n)], batches
+    expect([%W(a\n b\n c\n d\n), %W(e\n f\n)]).to eq(batches)
   end
 end

--- a/spec/unit/indexer/change_notification_processor_spec.rb
+++ b/spec/unit/indexer/change_notification_processor_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Indexer::ChangeNotificationProcessor do
 
     result = described_class.trigger(message_payload)
 
-    assert_equal(:rejected, result)
+    expect(:rejected).to eq(result)
   end
 
   it "rejects_invalid_documents" do
@@ -21,7 +21,7 @@ RSpec.describe Indexer::ChangeNotificationProcessor do
 
     result = described_class.trigger(message_payload)
 
-    assert_equal(:rejected, result)
+    expect(:rejected).to eq(result)
   end
 
   it "rejects_missing_documents" do
@@ -40,7 +40,7 @@ RSpec.describe Indexer::ChangeNotificationProcessor do
 
     result = described_class.trigger(message_payload)
 
-    assert_equal(:rejected, result)
+    expect(:rejected).to eq(result)
   end
 
   it "accepts_existing_documents" do
@@ -64,6 +64,6 @@ RSpec.describe Indexer::ChangeNotificationProcessor do
     expect(Indexer::AmendWorker).to receive(:perform_async).with("index_name-123", "document_id_345", {})
     result = described_class.trigger(message_payload)
 
-    assert_equal(:accepted, result)
+    expect(:accepted).to eq(result)
   end
 end

--- a/spec/unit/indexer/compare_enumerator_spec.rb
+++ b/spec/unit/indexer/compare_enumerator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Indexer::CompareEnumerator do
     stub_scroll_enumerator(left_request: [data_left], right_request: [data_right])
 
     results = described_class.new('index_a', 'index_b').to_a
-    assert_equal results, [[data_left, data_right]]
+    expect(results).to eq([[data_left, data_right]])
   end
 
   it "when_key_only_exists_in_left_index" do
@@ -17,7 +17,7 @@ RSpec.describe Indexer::CompareEnumerator do
     stub_scroll_enumerator(left_request: [data], right_request: [])
 
     results = described_class.new('index_a', 'index_b').to_a
-    assert_equal results, [[data, described_class::NO_VALUE]]
+    expect(results).to eq([[data, described_class::NO_VALUE]])
   end
 
 
@@ -27,7 +27,7 @@ RSpec.describe Indexer::CompareEnumerator do
     stub_scroll_enumerator(left_request: [], right_request: [data])
 
     results = described_class.new('index_a', 'index_b').to_a
-    assert_equal results, [[described_class::NO_VALUE, data]]
+    expect(results).to eq([[described_class::NO_VALUE, data]])
   end
 
   it "with_matching_ids_but_different_types" do
@@ -37,10 +37,10 @@ RSpec.describe Indexer::CompareEnumerator do
     stub_scroll_enumerator(left_request: [data_left], right_request: [data_right])
 
     results = described_class.new('index_a', 'index_b').to_a
-    assert_equal results, [
+    expect(results).to eq([
       [described_class::NO_VALUE, data_right],
       [data_left, described_class::NO_VALUE],
-    ]
+    ])
   end
 
   it "with_different_ids" do
@@ -50,10 +50,10 @@ RSpec.describe Indexer::CompareEnumerator do
     stub_scroll_enumerator(left_request: [data_left], right_request: [data_right])
 
     results = described_class.new('index_a', 'index_b').to_a
-    assert_equal results, [
+    expect(results).to eq([
       [data_left, described_class::NO_VALUE],
       [described_class::NO_VALUE, data_right],
-    ]
+    ])
   end
 
   it "correct_aligns_records_with_matching_keys" do
@@ -66,13 +66,13 @@ RSpec.describe Indexer::CompareEnumerator do
     stub_scroll_enumerator(left_request: [key1, key3, key5], right_request: [key2, key3, key4, key5])
 
     results = described_class.new('index_a', 'index_b').to_a
-    assert_equal results, [
+    expect(results).to eq([
       [key1, described_class::NO_VALUE],
       [described_class::NO_VALUE, key2],
       [key3, key3],
       [described_class::NO_VALUE, key4],
       [key5, key5],
-    ]
+    ])
   end
 
   it "scroll_enumerator_mappings" do
@@ -81,9 +81,9 @@ RSpec.describe Indexer::CompareEnumerator do
 
     enum = described_class.new('index_a', 'index_b').get_enum('index_name')
 
-    assert_equal enum.to_a, [
+    expect(enum.to_a).to eq([
       { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data' }
-    ]
+    ])
   end
 
   it "scroll_enumerator_mappings_when_filter_is_passed_in" do
@@ -94,9 +94,9 @@ RSpec.describe Indexer::CompareEnumerator do
 
     enum = described_class.new('index_a', 'index_b').get_enum('index_name', search_body)
 
-    assert_equal enum.to_a, [
+    expect(enum.to_a).to eq([
       { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data' }
-    ]
+    ])
   end
 
   it "scroll_enumerator_mappings_without_sorting" do
@@ -107,9 +107,9 @@ RSpec.describe Indexer::CompareEnumerator do
 
     enum = described_class.new('index_a', 'index_b').get_enum('index_name', search_body)
 
-    assert_equal enum.to_a, [
+    expect(enum.to_a).to eq([
       { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data' }
-    ]
+    ])
   end
 
 private

--- a/spec/unit/indexer/comparer_spec.rb
+++ b/spec/unit/indexer/comparer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Indexer::Comparer do
       io: StringIO.new
     )
     outcome = comparer.run
-    assert_equal outcome, { added_items: 1 }
+    expect(outcome).to eq({ added_items: 1 })
   end
 
   it "can_detect_when_a_record_is_removed" do
@@ -22,7 +22,7 @@ RSpec.describe Indexer::Comparer do
       io: StringIO.new
     )
     outcome = comparer.run
-    assert_equal outcome, { removed_items: 1 }
+    expect(outcome).to eq({ removed_items: 1 })
   end
 
   it "can_detect_when_a_record_has_changed" do
@@ -34,7 +34,7 @@ RSpec.describe Indexer::Comparer do
       io: StringIO.new
     )
     outcome = comparer.run
-    assert_equal outcome, { changed: 1, 'changes: data': 1 }
+    expect(outcome).to eq(changed: 1, 'changes: data': 1)
   end
 
   it "can_detect_when_a_record_is_unchanged" do
@@ -46,7 +46,7 @@ RSpec.describe Indexer::Comparer do
       io: StringIO.new
     )
     outcome = comparer.run
-    assert_equal outcome, { unchanged: 1 }
+    expect(outcome).to eq({ unchanged: 1 })
   end
 
   it "can_detect_when_a_record_is_unchanged_apart_from_ignored_fields" do
@@ -59,7 +59,7 @@ RSpec.describe Indexer::Comparer do
       io: StringIO.new
     )
     outcome = comparer.run
-    assert_equal outcome, { unchanged: 1 }
+    expect(outcome).to eq({ unchanged: 1 })
   end
 
   it "can_detect_when_a_record_is_unchanged_apart_from_default_ignored_fields" do
@@ -71,7 +71,7 @@ RSpec.describe Indexer::Comparer do
       io: StringIO.new
     )
     outcome = comparer.run
-    assert_equal outcome, { unchanged: 1 }
+    expect(outcome).to eq({ unchanged: 1 })
   end
 
 private

--- a/spec/unit/indexer/document_preparer_spec.rb
+++ b/spec/unit/indexer/document_preparer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Indexer::DocumentPreparer do
         { "/some-link" => 0.5 }, true
       )
 
-      assert_equal 0.5, updated_doc_hash["popularity"]
+      expect(0.5).to eq(updated_doc_hash["popularity"])
     end
 
     it "adds document type groupings" do
@@ -31,7 +31,7 @@ RSpec.describe Indexer::DocumentPreparer do
         true
       )
 
-      assert_equal "guidance", updated_doc_hash["navigation_document_supertype"]
+      expect("guidance").to eq(updated_doc_hash["navigation_document_supertype"])
     end
   end
 end

--- a/spec/unit/indexer/links_lookup_spec.rb
+++ b/spec/unit/indexer/links_lookup_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Indexer::LinksLookup do
     expanded_links_url = endpoint + "/expanded-links/" + content_id
     stub_request(:get, expanded_links_url).to_timeout
 
-    assert_raises(Indexer::PublishingApiError) do
+    expect {
       described_class.prepare_tags({
         "content_id" => content_id,
         "link" => "/my-base-path",
       })
-    end
+    }.to raise_error(Indexer::PublishingApiError)
 
     assert_requested :get, expanded_links_url, times: 5
   end

--- a/spec/unit/legacy_client/multivalue_converter_spec.rb
+++ b/spec/unit/legacy_client/multivalue_converter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe LegacyClient::MultivalueConverter do
 
     converted_hash = described_class.new(fields, sample_field_definitions).converted_hash
 
-    assert_equal %w(hmrc dvla), converted_hash["organisations"]
+    expect(%w(hmrc dvla)).to eq(converted_hash["organisations"])
   end
 
   it "converts_single_value_fields_as_single_value" do
@@ -20,7 +20,7 @@ RSpec.describe LegacyClient::MultivalueConverter do
 
     converted_hash = described_class.new(fields, sample_field_definitions).converted_hash
 
-    assert_equal "the title", converted_hash["title"]
+    expect("the title").to eq(converted_hash["title"])
   end
 
   # This might not be necessary since the new ES.
@@ -32,6 +32,6 @@ RSpec.describe LegacyClient::MultivalueConverter do
 
     converted_hash = described_class.new(fields, sample_field_definitions).converted_hash
 
-    assert_equal "the title", converted_hash["title"]
+    expect("the title").to eq(converted_hash["title"])
   end
 end

--- a/spec/unit/legacy_search/advanced_search_query_builder_spec.rb
+++ b/spec/unit/legacy_search/advanced_search_query_builder_spec.rb
@@ -11,12 +11,9 @@ RSpec.describe LegacySearch::AdvancedSearchQueryBuilder do
     builder = build_builder
     query_hash = builder.filter_query_hash
 
-    assert_equal(
-      query_hash,
-      {
-        "filter" => {
-          "not" => { "term" => { "is_withdrawn" => true } }
-        }
+    expect(query_hash).to eq(
+      "filter" => {
+        "not" => { "term" => { "is_withdrawn" => true } }
       }
     )
   end
@@ -26,15 +23,12 @@ RSpec.describe LegacySearch::AdvancedSearchQueryBuilder do
     builder = build_builder("how to drive", { "format" => "organisation" })
     query_hash = builder.filter_query_hash
 
-    assert_equal(
-      query_hash,
-      {
-        "filter" => {
-          "and" => [
-            { "term" => { "format" => "organisation" } },
-            { "not" => { "term" => { "is_withdrawn" => true } } }
-          ]
-        }
+    expect(query_hash).to eq(
+      "filter" => {
+        "and" => [
+          { "term" => { "format" => "organisation" } },
+          { "not" => { "term" => { "is_withdrawn" => true } } }
+        ]
       }
     )
   end
@@ -43,16 +37,13 @@ RSpec.describe LegacySearch::AdvancedSearchQueryBuilder do
     builder = build_builder("how to drive", { "format" => "organisation", "specialist_sectors" => "driving" })
     query_hash = builder.filter_query_hash
 
-    assert_equal(
-      query_hash,
-      {
-        "filter" => {
-          "and" => [
-            { "term" => { "format" => "organisation" } },
-            { "term" => { "specialist_sectors" => "driving" } },
-            { "not" => { "term" => { "is_withdrawn" => true } } }
-          ]
-        }
+    expect(query_hash).to eq(
+      "filter" => {
+        "and" => [
+          { "term" => { "format" => "organisation" } },
+          { "term" => { "specialist_sectors" => "driving" } },
+          { "not" => { "term" => { "is_withdrawn" => true } } }
+        ]
       }
     )
   end

--- a/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
+++ b/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
   it "pagination_params_are_required" do
     stub_empty_search
 
-    assert_rejected_search("Pagination params are required.", {})
-    assert @wrapper.advanced_search({ 'page' => '1', 'per_page' => '1' })
+    expect_rejected_search("Pagination params are required.", {})
+    expect(@wrapper.advanced_search({ 'page' => '1', 'per_page' => '1' })).to be_truthy
   end
 
   it "pagination_params_are_converted_to_from_and_to_correctly" do
@@ -112,11 +112,11 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
     stub_empty_search
 
-    assert_rejected_search('Invalid value "falsey" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'falsey'))
-    assert_rejected_search('Invalid value "truey" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'truey'))
-    assert_rejected_search('Invalid value "true facts" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'true facts'))
-    assert_rejected_search('Invalid value "101" for boolean property "boolean_property"', default_params.merge('boolean_property' => '101'))
-    assert_rejected_search('Invalid value "cheese" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'cheese'))
+    expect_rejected_search('Invalid value "falsey" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'falsey'))
+    expect_rejected_search('Invalid value "truey" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'truey'))
+    expect_rejected_search('Invalid value "true facts" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'true facts'))
+    expect_rejected_search('Invalid value "101" for boolean property "boolean_property"', default_params.merge('boolean_property' => '101'))
+    expect_rejected_search('Invalid value "cheese" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'cheese'))
   end
 
   it "filter_params_on_a_date_mapping_property_are_turned_into_a_range_filter_with_order_based_on_the_key_in_the_value" do
@@ -143,25 +143,25 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     @wrapper.mappings['edition']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
     stub_empty_search
 
-    assert_rejected_search('Invalid value {} for date property "date_property"', default_params.merge('date_property' => {}))
-    assert_rejected_search('Invalid value "2013-02-02" for date property "date_property"', default_params.merge('date_property' => '2013-02-02'))
-    assert_rejected_search('Invalid value ["2013-02-02"] for date property "date_property"', default_params.merge('date_property' => ['2013-02-02']))
-    assert_rejected_search('Invalid value {"between"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => { 'between' => '2013-02-02' }))
-    assert_rejected_search('Invalid value {"before"=>"2013-02-02", "up-to"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2013-02-02', 'up-to' => '2013-02-02' }))
+    expect_rejected_search('Invalid value {} for date property "date_property"', default_params.merge('date_property' => {}))
+    expect_rejected_search('Invalid value "2013-02-02" for date property "date_property"', default_params.merge('date_property' => '2013-02-02'))
+    expect_rejected_search('Invalid value ["2013-02-02"] for date property "date_property"', default_params.merge('date_property' => ['2013-02-02']))
+    expect_rejected_search('Invalid value {"between"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => { 'between' => '2013-02-02' }))
+    expect_rejected_search('Invalid value {"before"=>"2013-02-02", "up-to"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2013-02-02', 'up-to' => '2013-02-02' }))
   end
 
   it "filter_params_on_a_date_mapping_property_without_a_incorrectly_formatted_date_are_rejected" do
     @wrapper.mappings['edition']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
     stub_empty_search
 
-    assert_rejected_search('Invalid value {"before"=>"2 Feb 2013"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2 Feb 2013' }))
-    assert_rejected_search('Invalid value {"before"=>"2/2/2013"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2/2/2013' }))
-    assert_rejected_search('Invalid value {"before"=>"2013/2/2"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2013/2/2' }))
-    assert_rejected_search('Invalid value {"before"=>"2013-2-2"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2013-2-2' }))
+    expect_rejected_search('Invalid value {"before"=>"2 Feb 2013"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2 Feb 2013' }))
+    expect_rejected_search('Invalid value {"before"=>"2/2/2013"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2/2/2013' }))
+    expect_rejected_search('Invalid value {"before"=>"2013/2/2"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2013/2/2' }))
+    expect_rejected_search('Invalid value {"before"=>"2013-2-2"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2013-2-2' }))
   end
 
   it "filter_params_that_are_not_index_properties_are_not_allowed" do
-    assert_rejected_search('Querying unknown properties ["brian", "keith"]', default_params.merge('brian' => 'jones', 'keith' => 'richards'))
+    expect_rejected_search('Querying unknown properties ["brian", "keith"]', default_params.merge('brian' => 'jones', 'keith' => 'richards'))
   end
 
   it "order_params_are_turned_into_a_sort_query" do
@@ -170,14 +170,14 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
   end
 
   it "order_params_on_properties_not_in_the_mappings_are_not_allowed" do
-    assert_rejected_search('Sorting on unknown property ["brian"]', default_params.merge('order' => { 'brian' => 'asc' }))
+    expect_rejected_search('Sorting on unknown property ["brian"]', default_params.merge('order' => { 'brian' => 'asc' }))
   end
 
   it "returns_the_total_and_the_hits" do
     stub_empty_search
     result_set = @wrapper.advanced_search(default_params)
-    assert_equal 0, result_set.total
-    assert_equal [], result_set.results
+    expect(0).to eq(result_set.total)
+    expect([]).to eq(result_set.results)
   end
 
   it "returns_the_hits_converted_into_documents" do
@@ -188,9 +188,9 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
         headers: { "Content-Type" => "application/json" }
       )
     result_set = @wrapper.advanced_search(default_params)
-    assert_equal 10, result_set.total
-    assert_equal 1, result_set.results.size
-    assert_equal "some_content", result_set.results.first.get("indexable_content")
+    expect(10).to eq(result_set.total)
+    expect(1).to eq(result_set.results.size)
+    expect("some_content").to eq(result_set.results.first.get("indexable_content"))
   end
 
   def default_params
@@ -207,10 +207,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     )
   end
 
-  def assert_rejected_search(expected_error, search_args)
-    e = assert_raises(LegacySearch::InvalidQuery) do
-      @wrapper.advanced_search(search_args)
-    end
-    assert_equal expected_error, e.message
+  def expect_rejected_search(expected_error, search_args)
+    expect { @wrapper.advanced_search(search_args) }.to raise_error(expected_error)
   end
 end

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -69,226 +69,227 @@ RSpec.describe SearchParameterParser do
   it "return valid params given nothing" do
     p = described_class.new({}, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about an unknown parameter" do
     p = described_class.new({ "p" => ["extra"] }, @schema)
 
-    assert_equal("Unexpected parameters: p", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("Unexpected parameters: p").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "allow the c parameter to be anything" do
     p = described_class.new({ "c" => ["1234567890"] }, @schema)
 
-    assert p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(p).to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about multiple unknown parameters" do
     p = described_class.new({ "p" => ["extra"], "boo" => ["goose"] }, @schema)
 
-    assert_equal("Unexpected parameters: p, boo", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("Unexpected parameters: p, boo").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "understand the start parameter" do
     p = described_class.new({ "start" => ["5"] }, @schema)
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(start: 5), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(start: 5)).to eq(p.parsed_params)
   end
 
   it "complain about a non-integer start parameter" do
     p = described_class.new({ "start" => ["5.5"] }, @schema)
 
-    assert_equal("Invalid value \"5.5\" for parameter \"start\" (expected positive integer)", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("Invalid value \"5.5\" for parameter \"start\" (expected positive integer)").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a negative start parameter" do
     p = described_class.new({ "start" => ["-1"] }, @schema)
 
-    assert_equal("Invalid negative value \"-1\" for parameter \"start\" (expected positive integer)", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("Invalid negative value \"-1\" for parameter \"start\" (expected positive integer)").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a non-decimal start parameter" do
     p = described_class.new({ "start" => ["x"] }, @schema)
 
-    assert_equal("Invalid value \"x\" for parameter \"start\" (expected positive integer)", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("Invalid value \"x\" for parameter \"start\" (expected positive integer)").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a repeated start parameter" do
     p = described_class.new({ "start" => %w(2 3) }, @schema)
 
-    assert_equal(%{Too many values (2) for parameter "start" (must occur at most once)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params(start: 2), p.parsed_params)
+    expect(%{Too many values (2) for parameter "start" (must occur at most once)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(start: 2)).to eq(p.parsed_params)
   end
 
   it "understand the count parameter" do
     p = described_class.new({ "count" => ["5"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(count: 5), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(count: 5)).to eq(p.parsed_params)
   end
 
   it "complain about a non-integer count parameter" do
     p = described_class.new({ "count" => ["5.5"] }, @schema)
 
-    assert_equal("Invalid value \"5.5\" for parameter \"count\" (expected positive integer)", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("Invalid value \"5.5\" for parameter \"count\" (expected positive integer)").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a negative count parameter" do
     p = described_class.new({ "count" => ["-1"] }, @schema)
 
-    assert_equal("Invalid negative value \"-1\" for parameter \"count\" (expected positive integer)", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("Invalid negative value \"-1\" for parameter \"count\" (expected positive integer)").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a non-decimal count parameter" do
     p = described_class.new({ "count" => ["x"] }, @schema)
 
-    assert_equal("Invalid value \"x\" for parameter \"count\" (expected positive integer)", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("Invalid value \"x\" for parameter \"count\" (expected positive integer)").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a repeated count parameter" do
     p = described_class.new({ "count" => %w(2 3) }, @schema)
 
-    assert_equal(%{Too many values (2) for parameter "count" (must occur at most once)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params(count: 2), p.parsed_params)
+    expect(%{Too many values (2) for parameter "count" (must occur at most once)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(count: 2)).to eq(p.parsed_params)
   end
 
   it "complain about an overly large count parameter" do
     p = described_class.new({ "count" => %w(1001) }, @schema)
 
-    assert_equal(%{Maximum result set size (as specified in 'count') is 1000}, p.error)
-    refute p.valid?
-    assert_equal(expected_params(count: 10), p.parsed_params)
+    expect(%{Maximum result set size (as specified in 'count') is 1000}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(count: 10)).to eq(p.parsed_params)
   end
 
   it "understand the q parameter" do
     p = described_class.new({ "q" => ["search-term"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(query: "search-term"), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(query: "search-term")).to eq(p.parsed_params)
   end
 
   it "complain about a repeated q parameter" do
     p = described_class.new({ "q" => %w(hello world) }, @schema)
 
-    assert_equal(%{Too many values (2) for parameter "q" (must occur at most once)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params(query: "hello"), p.parsed_params)
+    expect(%{Too many values (2) for parameter "q" (must occur at most once)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(query: "hello")).to eq(p.parsed_params)
   end
 
   it "strip whitespace from the query" do
     p = described_class.new({ "q" => ["cheese "] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(query: "cheese"), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(query: "cheese")).to eq(p.parsed_params)
   end
 
   it "put the query in normalized form" do
     p = described_class.new({ "q" => ["cafe\u0300 "] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(query: "caf\u00e8"), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(query: "caf\u00e8")).to eq(p.parsed_params)
   end
 
   it "complain about invalid unicode in the query" do
     p = described_class.new({ "q" => ["\xff"] }, @schema)
 
-    assert_equal("Invalid unicode in query", p.error)
-    assert !p.valid?
-    assert_equal(expected_params(query: nil), p.parsed_params)
+    expect("Invalid unicode in query").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(query: nil)).to eq(p.parsed_params)
   end
 
   it "understand the similar_to parameter" do
     p = described_class.new({ "similar_to" => ["/search-term"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(similar_to: "/search-term"), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(similar_to: "/search-term")).to eq(p.parsed_params)
   end
 
   it "complain about a repeated similar_to parameter" do
     p = described_class.new({ "similar_to" => %w(/hello /world) }, @schema)
 
-    assert_equal(%{Too many values (2) for parameter "similar_to" (must occur at most once)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params(similar_to: "/hello"), p.parsed_params)
+    expect(%{Too many values (2) for parameter "similar_to" (must occur at most once)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(similar_to: "/hello")).to eq(p.parsed_params)
   end
 
   it "strip whitespace from similar_to parameter" do
     p = described_class.new({ "similar_to" => ["/cheese "] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(similar_to: "/cheese"), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(similar_to: "/cheese")).to eq(p.parsed_params)
   end
 
   it "put the similar_to parameter in normalized form" do
     p = described_class.new({ "similar_to" => ["/cafe\u0300 "] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(similar_to: "/caf\u00e8"), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(similar_to: "/caf\u00e8")).to eq(p.parsed_params)
   end
 
   it "complain about invalid unicode in the similar_to parameter" do
     p = described_class.new({ "similar_to" => ["\xff"] }, @schema)
 
-    assert_equal("Invalid unicode in similar_to", p.error)
-    assert !p.valid?
-    assert_equal(expected_params(similar_to: nil), p.parsed_params)
+    expect("Invalid unicode in similar_to").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(similar_to: nil)).to eq(p.parsed_params)
   end
 
   it "complain when both q and similar_to parameters are provided" do
     p = described_class.new({ "q" => ["hello"], "similar_to" => ["/world"] }, @schema)
 
-    assert_equal("Parameters 'q' and 'similar_to' cannot be used together", p.error)
-    assert !p.valid?
-    assert_equal(expected_params(query: "hello", similar_to: "/world"), p.parsed_params)
+    expect("Parameters 'q' and 'similar_to' cannot be used together").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(query: "hello", similar_to: "/world")).to eq(p.parsed_params)
   end
 
   it "set the order parameter to nil when the similar_to parameter is provided" do
     p = described_class.new({ "similar_to" => ["/hello"], "order" => ["title"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params(similar_to: "/hello"), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(similar_to: "/hello")).to eq(p.parsed_params)
   end
 
   it "understand filter paramers" do
     p = described_class.new({ "filter_organisations" => ["hm-magic"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(
       hash_including(filters: [
         text_filter("organisations", ["hm-magic"])
-      ]),
+      ])
+    ).to eq(
       p.parsed_params,
     )
   end
@@ -296,12 +297,13 @@ RSpec.describe SearchParameterParser do
   it "understand reject paramers" do
     p = described_class.new({ "reject_organisations" => ["hm-magic"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(
       hash_including(filters: [
         text_filter("organisations", ["hm-magic"], true)
-      ]),
+      ])
+    ).to eq(
       p.parsed_params,
     )
   end
@@ -312,13 +314,14 @@ RSpec.describe SearchParameterParser do
       "filter_mainstream_browse_pages" => ["cheese"],
     }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(
       hash_including(filters: [
         text_filter("mainstream_browse_pages", ["cheese"]),
         text_filter("organisations", ["hm-magic"], true),
-      ]),
+      ])
+    ).to eq(
       p.parsed_params,
     )
   end
@@ -326,9 +329,9 @@ RSpec.describe SearchParameterParser do
   it "understand multiple filter paramers" do
     p = described_class.new({ "filter_organisations" => ["hm-magic", "hmrc"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(
       expected_params(
         filters: [
           text_filter("organisations", [
@@ -337,7 +340,8 @@ RSpec.describe SearchParameterParser do
             ]
           )
         ],
-      ),
+      )
+    ).to eq(
       p.parsed_params,
     )
   end
@@ -345,27 +349,27 @@ RSpec.describe SearchParameterParser do
   it "understand filter for missing field" do
     p = described_class.new({ "filter_organisations" => ["_MISSING"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
+    expect("").to eq(p.error)
+    expect(p).to be_valid
 
     filters = p.parsed_params[:filters]
-    assert_equal 1, filters.size
-    assert_equal "organisations", filters[0].field_name
-    assert_equal true, filters[0].include_missing
-    assert_equal [], filters[0].values
+    expect(1).to eq(filters.size)
+    expect("organisations").to eq(filters[0].field_name)
+    expect(true).to eq(filters[0].include_missing)
+    expect([]).to eq(filters[0].values)
   end
 
   it "understand filter for missing field or specific value" do
     p = described_class.new({ "filter_organisations" => %w(_MISSING hmrc) }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
+    expect("").to eq(p.error)
+    expect(p).to be_valid
 
     filters = p.parsed_params[:filters]
-    assert_equal 1, filters.size
-    assert_equal "organisations", filters[0].field_name
-    assert_equal true, filters[0].include_missing
-    assert_equal ["hmrc"], filters[0].values
+    expect(1).to eq(filters.size)
+    expect("organisations").to eq(filters[0].field_name)
+    expect(true).to eq(filters[0].include_missing)
+    expect(["hmrc"]).to eq(filters[0].values)
   end
 
   it "complain about disallowed filter fields" do
@@ -377,10 +381,11 @@ RSpec.describe SearchParameterParser do
       @schema,
     )
 
-    assert_equal(%{"spells" is not a valid filter field}, p.error)
-    assert !p.valid?
-    assert_equal(
-      expected_params(filters: [text_filter("organisations", ["hm-magic"])]),
+    expect(%{"spells" is not a valid filter field}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(
+      expected_params(filters: [text_filter("organisations", ["hm-magic"])])
+    ).to eq(
       p.parsed_params,
     )
   end
@@ -394,10 +399,11 @@ RSpec.describe SearchParameterParser do
       @schema,
     )
 
-    assert_equal(%{"spells" is not a valid reject field}, p.error)
-    assert !p.valid?
-    assert_equal(
-      expected_params(filters: [text_filter("organisations", ["hm-magic"], true)]),
+    expect(%{"spells" is not a valid reject field}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(
+      expected_params(filters: [text_filter("organisations", ["hm-magic"], true)])
+    ).to eq(
       p.parsed_params,
     )
   end
@@ -409,8 +415,9 @@ RSpec.describe SearchParameterParser do
       @schema,
     )
 
-    assert_equal(
-      hash_including(filters: [text_filter("_type", ["cma_case"])]),
+    expect(
+      hash_including(filters: [text_filter("_type", ["cma_case"])])
+    ).to eq(
       parser.parsed_params,
     )
   end
@@ -424,18 +431,20 @@ RSpec.describe SearchParameterParser do
 
       parser = described_class.new(params, @schema)
 
-      assert parser.valid?, "Parameters should be valid: #{parser.errors}"
+      expect(parser).to be_valid, "Parameters should be valid: #{parser.errors}"
 
       opened_date_filter = parser.parsed_params.fetch(:filters)
         .find { |filter| filter.field_name == "opened_date" }
 
-      assert_equal(
-        Date.parse("2014-04-01 00:00"),
+      expect(
+        Date.parse("2014-04-01 00:00")
+      ).to eq(
         opened_date_filter.values.first.from,
       )
 
-      assert_equal(
-        Date.parse("2014-04-02 00:00"),
+      expect(
+        Date.parse("2014-04-02 00:00")
+      ).to eq(
         opened_date_filter.values.first.to,
       )
     end
@@ -446,22 +455,24 @@ RSpec.describe SearchParameterParser do
         "filter_opened_date" => ["_MISSING", "from:2014-04-01 00:00,to:2014-04-02 00:00"],
       }, @schema)
 
-      assert_equal("", parser.error)
-      assert parser.valid?
+      expect("").to eq(parser.error)
+      expect(parser).to be_valid
 
       opened_date_filter = parser.parsed_params.fetch(:filters)
         .find { |filter| filter.field_name == "opened_date" }
 
-      assert_equal "opened_date", opened_date_filter.field_name
-      assert_equal true, opened_date_filter.include_missing
+      expect("opened_date").to eq(opened_date_filter.field_name)
+      expect(true).to eq(opened_date_filter.include_missing)
 
-      assert_equal(
-        Date.parse("2014-04-01 00:00"),
+      expect(
+        Date.parse("2014-04-01 00:00")
+      ).to eq(
         opened_date_filter.values.first.from,
       )
 
-      assert_equal(
-        Date.parse("2014-04-02 00:00"),
+      expect(
+        Date.parse("2014-04-02 00:00")
+      ).to eq(
         opened_date_filter.values.first.to,
       )
     end
@@ -479,58 +490,58 @@ RSpec.describe SearchParameterParser do
       opened_date_filter = parser.parsed_params.fetch(:filters)
         .find { |filter| filter.field_name == "opened_date" }
 
-      assert_nil opened_date_filter
+      expect(opened_date_filter).to be_nil
     end
   end
 
   it "understand an ascending sort" do
     p = described_class.new({ "order" => ["public_timestamp"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({ order: %w(public_timestamp asc) }), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params({ order: %w(public_timestamp asc) })).to eq(p.parsed_params)
   end
 
   it "understand a descending sort" do
     p = described_class.new({ "order" => ["-public_timestamp"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({ order: %w(public_timestamp desc) }), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params({ order: %w(public_timestamp desc) })).to eq(p.parsed_params)
   end
 
   it "complain about disallowed sort fields" do
     p = described_class.new({ "order" => ["spells"] }, @schema)
 
-    assert_equal(%{"spells" is not a valid sort field}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(%{"spells" is not a valid sort field}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about disallowed descending sort fields" do
     p = described_class.new({ "order" => ["-spells"] }, @schema)
 
-    assert_equal(%{"spells" is not a valid sort field}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(%{"spells" is not a valid sort field}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a repeated sort parameter" do
     p = described_class.new({ "order" => %w(public_timestamp something_else) }, @schema)
 
-    assert_equal(%{Too many values (2) for parameter "order" (must occur at most once)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params(order: %w(public_timestamp asc)), p.parsed_params)
+    expect(%{Too many values (2) for parameter "order" (must occur at most once)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(order: %w(public_timestamp asc))).to eq(p.parsed_params)
   end
 
   it "understand a aggregate field" do
     p = described_class.new({ "aggregate_organisations" => ["10"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({ aggregates: {
-      "organisations" => expected_aggregate_params({ requested: 10 })
-    } }), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(
+      expected_params(aggregates: { "organisations" => expected_aggregate_params(requested: 10) })
+    ).to eq(p.parsed_params)
   end
 
   it "understand multiple aggregate fields" do
@@ -539,12 +550,16 @@ RSpec.describe SearchParameterParser do
       "aggregate_mainstream_browse_pages" => ["5"],
     }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({ aggregates: {
-      "organisations" => expected_aggregate_params({ requested: 10 }),
-      "mainstream_browse_pages" => expected_aggregate_params({ requested: 5 })
-    } }), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(
+      expected_params(
+        aggregates: {
+          "organisations" => expected_aggregate_params(requested: 10),
+          "mainstream_browse_pages" => expected_aggregate_params(requested: 5)
+        }
+      )
+    ).to eq(p.parsed_params)
   end
 
   it "complain about disallowed aggregates fields" do
@@ -553,11 +568,11 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10"],
     }, @schema)
 
-    assert_equal(%{"spells" is not a valid aggregate field}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({ aggregates: {
-      "organisations" => expected_aggregate_params({ requested: 10 })
-    } }), p.parsed_params)
+    expect(%{"spells" is not a valid aggregate field}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(
+      expected_params(aggregates: { "organisations" => expected_aggregate_params(requested: 10) })
+    ).to eq(p.parsed_params)
   end
 
   it "complain about invalid values for aggregate parameter" do
@@ -566,27 +581,27 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["magic"],
     }, @schema)
 
-    assert_equal(%{"spells" is not a valid aggregate field. Invalid value "magic" for first parameter for aggregate "organisations" (expected positive integer)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(%{"spells" is not a valid aggregate field. Invalid value "magic" for first parameter for aggregate "organisations" (expected positive integer)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about empty values for aggregate parameter" do
     p = described_class.new({ "aggregate_organisations" => [""] }, @schema)
 
-    assert_equal(%{Invalid value "" for first parameter for aggregate "organisations" (expected positive integer)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(%{Invalid value "" for first parameter for aggregate "organisations" (expected positive integer)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a repeated aggregate parameter" do
     p = described_class.new({ "aggregate_organisations" => %w(5 6) }, @schema)
 
-    assert_equal(%{Too many values (2) for parameter "aggregate_organisations" (must occur at most once)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params(aggregates: {
-      "organisations" => expected_aggregate_params(requested: 5)
-    }), p.parsed_params)
+    expect(%{Too many values (2) for parameter "aggregate_organisations" (must occur at most once)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(
+      expected_params(aggregates: { "organisations" => expected_aggregate_params(requested: 5) })
+    ).to eq(p.parsed_params)
   end
 
   it "allow options in the values for the aggregate parameter" do
@@ -594,16 +609,17 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:global"],
     }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(
       aggregates: {
-        "organisations" => expected_aggregate_params({
+        "organisations" => expected_aggregate_params(
           requested: 10,
           examples: 5,
           example_fields: %w(slug title),
           example_scope: :global,
-      }) } }), p.parsed_params)
+      ) }
+    )).to eq(p.parsed_params)
   end
 
   it "understand the order option in aggregate parameters" do
@@ -611,14 +627,15 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,order:filtered:value.link:-count"],
     }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(
       aggregates: {
-        "organisations" => expected_aggregate_params({
+        "organisations" => expected_aggregate_params(
           requested: 10,
           order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
-      }) } }), p.parsed_params)
+      ) }
+    )).to eq(p.parsed_params)
   end
 
   it "complain about invalid order options in aggregate parameters" do
@@ -626,9 +643,9 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,order:filt:value.unknown"],
     }, @schema)
 
-    assert_equal(%{"filt" is not a valid sort option in aggregate "organisations". "value.unknown" is not a valid sort option in aggregate "organisations"}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(%{"filt" is not a valid sort option in aggregate "organisations". "value.unknown" is not a valid sort option in aggregate "organisations"}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
 
@@ -637,14 +654,15 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,order:filtered,order:value.link:-count"],
     }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(
       aggregates: {
-        "organisations" => expected_aggregate_params({
+        "organisations" => expected_aggregate_params(
           requested: 10,
           order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
-      }) } }), p.parsed_params)
+      ) }
+    )).to eq(p.parsed_params)
   end
 
   it "understand the scope option in aggregate parameters" do
@@ -652,16 +670,15 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,scope:all_filters"],
     }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(
       aggregates: {
-        "organisations" => expected_aggregate_params({
+        "organisations" => expected_aggregate_params(
           requested: 10,
           scope: :all_filters,
-        })
-      }
-    }), p.parsed_params)
+      ) }
+    )).to eq(p.parsed_params)
   end
 
   it "complain about invalid scope options in aggregate parameters" do
@@ -669,9 +686,9 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,scope:unknown"],
     }, @schema)
 
-    assert_equal(%{"unknown" is not a valid scope option in aggregate "organisations"}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(%{"unknown" is not a valid scope option in aggregate "organisations"}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a repeated examples option" do
@@ -679,9 +696,9 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,examples:6,example_scope:global"],
     }, @schema)
 
-    assert_equal(%{Too many values (2) for parameter "examples" in aggregate "organisations" (must occur at most once)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(%{Too many values (2) for parameter "examples" in aggregate "organisations" (must occur at most once)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "merge fields from repeated example_fields options" do
@@ -689,16 +706,17 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_fields:slug,example_fields:title:link,example_scope:global"],
     }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(
       aggregates: {
-        "organisations" => expected_aggregate_params({
+        "organisations" => expected_aggregate_params(
           requested: 10,
           examples: 5,
           example_fields: %w(slug title link),
           example_scope: :global,
-      }) } }), p.parsed_params)
+      ) }
+    )).to eq(p.parsed_params)
   end
 
   it "require the example_scope to be set" do
@@ -706,9 +724,9 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title"],
     }, @schema)
 
-    assert_equal("example_scope parameter must be set to 'query' or 'global' when requesting examples", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({ aggregates: {} }), p.parsed_params)
+    expect("example_scope parameter must be set to 'query' or 'global' when requesting examples").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({ aggregates: {} })).to eq(p.parsed_params)
   end
 
   it "allow example_scope to be set to 'query'" do
@@ -716,17 +734,16 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:query"],
     }, @schema)
 
-    assert p.valid?
-    assert_equal(expected_params({
+    expect(p).to be_valid
+    expect(expected_params(
       aggregates: {
-        "organisations" => expected_aggregate_params({
+        "organisations" => expected_aggregate_params(
           requested: 10,
           examples: 5,
           example_fields: %w(slug title),
           example_scope: :query,
-        })
-      }
-    }), p.parsed_params)
+      ) }
+    )).to eq(p.parsed_params)
   end
 
   it "complain about an invalid example_scope option" do
@@ -734,9 +751,9 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_scope:invalid"],
     }, @schema)
 
-    assert_equal("example_scope parameter must be set to 'query' or 'global' when requesting examples", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect("example_scope parameter must be set to 'query' or 'global' when requesting examples").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "complain about a repeated example_scope option" do
@@ -744,9 +761,9 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_scope:global,example_scope:global"],
     }, @schema)
 
-    assert_equal(%{Too many values (2) for parameter "example_scope" in aggregate "organisations" (must occur at most once)}, p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    expect(%{Too many values (2) for parameter "example_scope" in aggregate "organisations" (must occur at most once)}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "validate options in the values for the aggregate parameter" do
@@ -754,13 +771,13 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,example:5,examples:lots,example_fields:unknown:title"],
     }, @schema)
 
-    assert_equal([
+    expect([
       %{Invalid value "lots" for parameter "examples" in aggregate "organisations" (expected positive integer)},
       %{Some requested fields are not valid return fields: ["unknown"] in parameter "example_fields" in aggregate "organisations"},
       %{Unexpected options in aggregate "organisations": example},
-    ].join(". "), p.error)
-    assert !p.valid?
-    assert_equal(expected_params({}), p.parsed_params)
+    ].join(". ")).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "accept facets as a alias for aggregates" do
@@ -771,9 +788,9 @@ RSpec.describe SearchParameterParser do
       "facet_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:query"],
     }, @schema)
 
-    assert aggregate_p.valid?
-    assert facet_p.valid?
-    assert_equal(aggregate_p.parsed_params['aggregates'], facet_p.parsed_params['facets'])
+    expect(aggregate_p).to be_valid
+    expect(facet_p).to be_valid
+    expect(aggregate_p.parsed_params['aggregates']).to eq(facet_p.parsed_params['facets'])
   end
 
   it "compalin with facets are used in combination with aggregates" do
@@ -782,82 +799,84 @@ RSpec.describe SearchParameterParser do
       "facet_mainstream_browse_pages" => ["10"],
     }, @schema)
 
-    assert_equal("aggregates can not be used in conjuction with facets, please switch to using aggregates as facets are deprecated.", p.error)
-    assert !p.valid?
+    expect(
+      "aggregates can not be used in conjuction with facets, please switch to using aggregates as facets are deprecated."
+    ).to eq(p.error)
+    expect(p).not_to be_valid
   end
 
   it "understand the fields parameter" do
     p = described_class.new({ "fields" => %w(title description) }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal(expected_params({ return_fields: %w(title description) }), p.parsed_params)
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(return_fields: %w(title description))).to eq(p.parsed_params)
   end
 
   it "complain about invalid fields parameters" do
     p = described_class.new({ "fields" => %w(title waffle) }, @schema)
 
-    assert_equal("Some requested fields are not valid return fields: [\"waffle\"]", p.error)
-    assert !p.valid?
-    assert_equal(expected_params({ return_fields: ["title"] }), p.parsed_params)
+    expect("Some requested fields are not valid return fields: [\"waffle\"]").to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(return_fields: ["title"])).to eq(p.parsed_params)
   end
 
   it "understand the debug parameter" do
     p = described_class.new({ "debug" => ["disable_best_bets,disable_popularity,,unknown_option"] }, @schema)
 
-    assert_equal(%{Unknown debug option "unknown_option"}, p.error)
-    assert !p.valid?
-    assert_equal expected_params({ debug: { disable_best_bets: true, disable_popularity: true } }), p.parsed_params
+    expect(%{Unknown debug option "unknown_option"}).to eq(p.error)
+    expect(p).not_to be_valid
+    expect(expected_params(debug: { disable_best_bets: true, disable_popularity: true })).to eq(p.parsed_params)
   end
 
   it "merge values from repeated debug parameters" do
     p = described_class.new({ "debug" => ["disable_best_bets,explain", "disable_popularity"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal expected_params({ debug: { disable_best_bets: true, explain: true, disable_popularity: true } }), p.parsed_params
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(debug: { disable_best_bets: true, explain: true, disable_popularity: true })).to eq(p.parsed_params)
   end
 
   it "ignore empty options in the debug parameter" do
     p = described_class.new({ "debug" => [",,"] }, @schema)
 
-    assert_equal("", p.error)
-    assert p.valid?
-    assert_equal expected_params({ debug: {} }), p.parsed_params
+    expect("").to eq(p.error)
+    expect(p).to be_valid
+    expect(expected_params(debug: {})).to eq(p.parsed_params)
   end
 
   it "understand explain in the debug parameter" do
     p = described_class.new({ "debug" => ["explain"] }, @schema)
 
-    assert p.valid?
-    assert_equal expected_params({ debug: { explain: true } }), p.parsed_params
+    expect(p).to be_valid
+    expect(expected_params(debug: { explain: true })).to eq(p.parsed_params)
   end
 
   it "understand disable_synonyms in the debug parameter" do
     p = described_class.new({ "debug" => ["disable_synonyms"] }, @schema)
 
-    assert p.valid?
-    assert_equal expected_params({ debug: { disable_synonyms: true } }), p.parsed_params
+    expect(p).to be_valid
+    expect(expected_params(debug: { disable_synonyms: true })).to eq(p.parsed_params)
   end
 
   it "understand the test_variant parameter" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length:A"] }, @schema)
 
-    assert p.valid?
-    assert_equal expected_params({ ab_tests: { min_should_match_length: 'A' } }), p.parsed_params
+    expect(p).to be_valid
+    expect(expected_params(ab_tests: { min_should_match_length: 'A' })).to eq(p.parsed_params)
   end
 
   it "understand multiple test_variant parameters" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length:A,other_test_case:B"] }, @schema)
 
-    assert p.valid?
-    assert_equal expected_params({ ab_tests: { min_should_match_length: 'A', other_test_case: 'B' } }), p.parsed_params
+    expect(p).to be_valid
+    expect(expected_params(ab_tests: { min_should_match_length: 'A', other_test_case: 'B' })).to eq(p.parsed_params)
   end
 
   it "complain about invalid test_variant where no variant_type is provided" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length"] }, @schema)
 
-    assert !p.valid?
-    assert_equal("Invalid ab_tests, missing type \"min_should_match_length\"", p.error)
+    expect(p).not_to be_valid
+    expect("Invalid ab_tests, missing type \"min_should_match_length\"").to eq(p.error)
   end
 end

--- a/spec/unit/query_components/aggregates_spec.rb
+++ b/spec/unit/query_components/aggregates_spec.rb
@@ -17,31 +17,28 @@ RSpec.describe QueryComponents::Aggregates do
 
       result = builder.payload
 
-      assert_equal(
-        {
-          "organisations" => {
-            filter: { match_all: {} },
-            aggs: {
-              "filtered_aggregations" => {
-                terms: {
-                  field: "organisations",
-                  order: { _count: "desc" },
-                  size: 100000,
-                }
+      expect(
+        "organisations" => {
+          filter: { match_all: {} },
+          aggs: {
+            "filtered_aggregations" => {
+              terms: {
+                field: "organisations",
+                order: { _count: "desc" },
+                size: 100000,
               }
             }
-          },
-          "organisations_with_missing_value" => {
-            filter: { match_all: {} },
-            aggs: {
-              "filtered_aggregations" => {
-                missing: { field: "organisations" }
-              }
-            }
-          },
+          }
         },
-        result
-      )
+        "organisations_with_missing_value" => {
+          filter: { match_all: {} },
+          aggs: {
+            "filtered_aggregations" => {
+              missing: { field: "organisations" }
+            }
+          }
+        },
+      ).to eq(result)
     end
   end
 
@@ -56,30 +53,28 @@ RSpec.describe QueryComponents::Aggregates do
     end
 
     it "have correct aggregate in payload" do
-      assert_equal(
-        {
-          "organisations" => {
-            filter: { match_all: {} },
-            aggs: {
-              "filtered_aggregations" => {
-                terms: {
-                  field: "organisations",
-                  order: { _count: "desc" },
-                  size: 100000,
-                }
+      expect(
+        "organisations" => {
+          filter: { match_all: {} },
+          aggs: {
+            "filtered_aggregations" => {
+              terms: {
+                field: "organisations",
+                order: { _count: "desc" },
+                size: 100000,
               }
             }
-          },
-          "organisations_with_missing_value" => {
-            filter: { match_all: {} },
-            aggs: {
-              "filtered_aggregations" => {
-                missing: { field: "organisations" }
-              }
-            }
-          },
+          }
         },
-        @builder.payload)
+        "organisations_with_missing_value" => {
+          filter: { match_all: {} },
+          aggs: {
+            "filtered_aggregations" => {
+              missing: { field: "organisations" }
+            }
+          }
+        },
+      ).to eq(@builder.payload)
     end
   end
 
@@ -94,34 +89,32 @@ RSpec.describe QueryComponents::Aggregates do
     end
 
     it "have correct aggregate in payload" do
-      assert_equal(
-        {
-          "organisations" => {
-            filter: {
-              "terms" => { "organisations" => ["hm-magic"] },
-            },
-            aggs: {
-              'filtered_aggregations' => {
-                terms: {
-                  field: "organisations",
-                  order: { _count: "desc" },
-                  size: 100000,
-                }
-              }
-            },
+      expect(
+        "organisations" => {
+          filter: {
+            "terms" => { "organisations" => ["hm-magic"] },
           },
-          "organisations_with_missing_value" => {
-            filter: {
-              "terms" => { "organisations" => ["hm-magic"] }
-            },
-            aggs: {
-              'filtered_aggregations' => {
-                missing: { field: "organisations" }
+          aggs: {
+            'filtered_aggregations' => {
+              terms: {
+                field: "organisations",
+                order: { _count: "desc" },
+                size: 100000,
               }
             }
-          }
+          },
         },
-        @builder.payload)
+        "organisations_with_missing_value" => {
+          filter: {
+            "terms" => { "organisations" => ["hm-magic"] }
+          },
+          aggs: {
+            'filtered_aggregations' => {
+              missing: { field: "organisations" }
+            }
+          }
+        }
+      ).to eq(@builder.payload)
     end
   end
 
@@ -136,36 +129,34 @@ RSpec.describe QueryComponents::Aggregates do
     end
 
     it "have aggregate with aggregate_filter in payload" do
-      assert_equal(
-        {
-          "organisations" => {
-            filter: {
-              "terms" => { "mainstream_browse_pages" => ["levitation"] },
-            },
-            aggs: {
-              'filtered_aggregations' => {
-                terms: {
-                  field: "organisations",
-                  order: { _count: "desc" },
-                  size: 100000,
-                }
-              },
-            },
+      expect(
+        "organisations" => {
+          filter: {
+            "terms" => { "mainstream_browse_pages" => ["levitation"] },
           },
-          "organisations_with_missing_value" => {
-            filter: {
-              "terms" => {
-                "mainstream_browse_pages" => ["levitation"]
+          aggs: {
+            'filtered_aggregations' => {
+              terms: {
+                field: "organisations",
+                order: { _count: "desc" },
+                size: 100000,
               }
             },
-            aggs: {
-              'filtered_aggregations' => {
-                missing: { field: "organisations" }
-              }
-            }
           },
         },
-        @builder.payload)
+        "organisations_with_missing_value" => {
+          filter: {
+            "terms" => {
+              "mainstream_browse_pages" => ["levitation"]
+            }
+          },
+          aggs: {
+            'filtered_aggregations' => {
+              missing: { field: "organisations" }
+            }
+          }
+        },
+      ).to eq(@builder.payload)
     end
   end
 

--- a/spec/unit/query_components/best_bets_spec.rb
+++ b/spec/unit/query_components/best_bets_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe QueryComponents::BestBets do
 
       result = builder.wrap('QUERY')
 
-      assert_equal result, 'QUERY'
+      expect(result).to eq('QUERY')
     end
   end
 
@@ -22,7 +22,7 @@ RSpec.describe QueryComponents::BestBets do
       result = builder.wrap('QUERY')
 
       expected = { bool: { should: ['QUERY', { function_score: { query: { ids: { values: ["/best-bet"] } }, boost_factor: 1000000 } }] } }
-      assert_equal expected, result
+      expect(expected).to eq(result)
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe QueryComponents::BestBets do
         }
       }
 
-      assert_equal expected, result
+      expect(expected).to eq(result)
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe QueryComponents::BestBets do
       result = builder.wrap('QUERY')
 
       expected = { bool: { should: ['QUERY', { function_score: { query: { ids: { values: ["/best-bet", "/other-best-bet"] } }, boost_factor: 1000000 } }] } }
-      assert_equal expected, result
+      expect(expected).to eq(result)
     end
   end
 
@@ -66,7 +66,7 @@ RSpec.describe QueryComponents::BestBets do
       result = builder.wrap({})
 
       expected = { bool: { should: [{}], must_not: [{ ids: { values: ["/worst-bet", "/other-worst-bet"] } }] } }
-      assert_equal expected, result
+      expect(expected).to eq(result)
     end
   end
 end

--- a/spec/unit/query_components/booster_spec.rb
+++ b/spec/unit/query_components/booster_spec.rb
@@ -5,40 +5,40 @@ RSpec.describe QueryComponents::Booster do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_equal :multiply, result[:function_score][:boost_mode]
-    assert_equal :multiply, result[:function_score][:score_mode]
+    expect(:multiply).to eq(result[:function_score][:boost_mode])
+    expect(:multiply).to eq(result[:function_score][:score_mode])
   end
 
   it "boost results by individual format weightings" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_format_boost(result, "contact", 0.3)
-    assert_format_boost(result, "service_manual_guide", 0.3)
-    assert_format_boost(result, "smart-answer", 1.5)
+    expect_format_boost(result, "contact", 0.3)
+    expect_format_boost(result, "service_manual_guide", 0.3)
+    expect_format_boost(result, "smart-answer", 1.5)
   end
 
   it "not apply a boost to unspecified formats" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_no_format_boost(result, "guide")
-    assert_no_format_boost(result, "some_other_format")
+    expect_no_format_boost(result, "guide")
+    expect_no_format_boost(result, "some_other_format")
   end
 
   it "downweight old organisations" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_organisation_state_boost(result, "closed", 0.2)
-    assert_organisation_state_boost(result, "devolved", 0.3)
+    expect_organisation_state_boost(result, "closed", 0.2)
+    expect_organisation_state_boost(result, "devolved", 0.3)
   end
 
   it "downweight historic pages" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_boost_for_field(result, :is_historic, true, 0.5)
+    expect_boost_for_field(result, :is_historic, true, 0.5)
   end
 
   it "boost announcements by date" do
@@ -47,13 +47,13 @@ RSpec.describe QueryComponents::Booster do
       result = builder.wrap({ some: 'query' })
 
       announcement_boost = result[:function_score][:functions].detect { |f| f[:filter][:term][:search_format_types] == "announcement" }
-      refute_nil announcement_boost, "Could not find boost for announcements"
+      expect(announcement_boost).not_to be_nil, "Could not find boost for announcements"
 
       script_score = announcement_boost[:script_score]
 
       expected_time_in_millis = 1457712000000
-      assert_equal expected_time_in_millis, script_score[:params][:now]
-      assert_match(/doc\['public_timestamp'\]/, script_score[:script])
+      expect(expected_time_in_millis).to eq(script_score[:params][:now])
+      expect(script_score[:script]).to match(/doc\['public_timestamp'\]/)
     end
   end
 
@@ -61,61 +61,61 @@ RSpec.describe QueryComponents::Booster do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_no_format_boost(result, "case_study")
-    assert_no_format_boost(result, "take_part")
-    assert_no_format_boost(result, "worldwide_organisation")
+    expect_no_format_boost(result, "case_study")
+    expect_no_format_boost(result, "take_part")
+    expect_no_format_boost(result, "worldwide_organisation")
   end
 
   it "apply only individual format weightings for government formats" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_format_boost(result, "minister", 1.7)
-    assert_format_boost(result, "organisation", 2.5)
-    assert_format_boost(result, "topic", 1.5)
+    expect_format_boost(result, "minister", 1.7)
+    expect_format_boost(result, "organisation", 2.5)
+    expect_format_boost(result, "topic", 1.5)
   end
 
   it "boost guidance content" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_boost_for_field(result, :navigation_document_supertype, "guidance", 2.5)
+    expect_boost_for_field(result, :navigation_document_supertype, "guidance", 2.5)
   end
 
   it "downweight service assessments by large amount" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_format_boost(result, "service_standard_report", 0.05)
+    expect_format_boost(result, "service_standard_report", 0.05)
   end
 
   it "downweight FOI requests" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: 'query' })
 
-    assert_boost_for_field(result, :content_store_document_type, "foi_release", 0.2)
+    expect_boost_for_field(result, :content_store_document_type, "foi_release", 0.2)
   end
 
-  def assert_format_boost(result, content_format, expected_boost_factor)
-    assert_boost_for_field(result, :format, content_format, expected_boost_factor)
+  def expect_format_boost(result, content_format, expected_boost_factor)
+    expect_boost_for_field(result, :format, content_format, expected_boost_factor)
   end
 
-  def assert_no_format_boost(result, content_format)
-    assert_no_boost_for_field(result, :format, content_format)
+  def expect_no_format_boost(result, content_format)
+    expect_no_boost_for_field(result, :format, content_format)
   end
 
-  def assert_organisation_state_boost(result, state, expected_boost_factor)
-    assert_boost_for_field(result, :organisation_state, state, expected_boost_factor)
+  def expect_organisation_state_boost(result, state, expected_boost_factor)
+    expect_boost_for_field(result, :organisation_state, state, expected_boost_factor)
   end
 
-  def assert_boost_for_field(result, field, value, expected_boost_factor)
+  def expect_boost_for_field(result, field, value, expected_boost_factor)
     boost = result[:function_score][:functions].detect { |f| f[:filter][:term][field] == value }
-    refute_nil boost, "Could not find boost for '#{field}': '#{value}'"
-    assert_in_delta expected_boost_factor, boost[:boost_factor], 0.001
+    expect(boost).not_to be_nil, "Could not find boost for '#{field}': '#{value}'"
+    expect(expected_boost_factor).to be_within(0.001).of(boost[:boost_factor])
   end
 
-  def assert_no_boost_for_field(result, field, value)
+  def expect_no_boost_for_field(result, field, value)
     format_boost = result[:function_score][:functions].select { |f| f[:filter][:term][field] == value }
-    assert_empty format_boost, "Found unexpected boost for '#{field}' #{value}"
+    expect(format_boost).to be_empty, "Found unexpected boost for '#{field}' #{value}"
   end
 end

--- a/spec/unit/query_components/core_query_spec.rb
+++ b/spec/unit/query_components/core_query_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe QueryComponents::CoreQuery do
 
       query = builder.minimum_should_match("_all")
 
-      assert_match(/query_with_old_synonyms/, query.to_s)
+      expect(query.to_s).to match(/query_with_old_synonyms/)
     end
 
     it "not use the query_with_old_synonyms analyzer" do
@@ -15,7 +15,7 @@ RSpec.describe QueryComponents::CoreQuery do
 
       query = builder.minimum_should_match("_all")
 
-      refute_match(/query_with_old_synonyms/, query.to_s)
+      expect(query.to_s).not_to match(/query_with_old_synonyms/)
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe QueryComponents::CoreQuery do
       builder = described_class.new(search_query_params)
 
       query = builder.minimum_should_match("_all")
-      assert_match(/"2<2 3<3 7<50%"/, query.to_s)
+      expect(query.to_s).to match(/"2<2 3<3 7<50%"/)
     end
   end
 end

--- a/spec/unit/query_components/filter_spec.rb
+++ b/spec/unit/query_components/filter_spec.rb
@@ -25,10 +25,7 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      assert_equal(
-        result,
-        { "terms" => { "organisations" => ["hm-magic"] } }
-      )
+      expect(result).to eq("terms" => { "organisations" => ["hm-magic"] })
     end
 
     it "append the correct date filters" do
@@ -38,10 +35,7 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      assert_equal(
-        result,
-        { "range" => { "field_with_date" => { "from" => "2014-04-01", "to" => "2014-04-02" } } }
-      )
+      expect(result).to eq("range" => { "field_with_date" => { "from" => "2014-04-01", "to" => "2014-04-02" } })
     end
   end
 
@@ -53,10 +47,7 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      assert_equal(
-        result,
-        { "terms" => { "organisations" => ["hm-magic", "hmrc"] } }
-      )
+      expect(result).to eq("terms" => { "organisations" => ["hm-magic", "hmrc"] })
     end
   end
 
@@ -73,12 +64,11 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      assert_equal(
-        result,
-        { bool: {
+      expect(result).to eq(
+        bool: {
           must: { "terms" => { "organisations" => ["hm-magic", "hmrc"] } },
           must_not: { "terms" => { "mainstream_browse_pages" => ["benefits"] } },
-        } }
+        }
       )
     end
   end
@@ -96,14 +86,11 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      assert_equal(
-        result,
-        {
-          and: [
-            { "terms" => { "organisations" => ["hm-magic", "hmrc"] } },
-            { "terms" => { "mainstream_browse_pages" => ["levitation"] } },
-          ].compact
-        }
+      expect(result).to eq(
+        and: [
+          { "terms" => { "organisations" => ["hm-magic", "hmrc"] } },
+          { "terms" => { "mainstream_browse_pages" => ["levitation"] } },
+        ].compact
       )
     end
   end

--- a/spec/unit/query_components/highlight_spec.rb
+++ b/spec/unit/query_components/highlight_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe QueryComponents::Highlight do
 
       payload = QueryComponents::Highlight.new(parameters).payload
 
-      assert payload[:fields].keys.include?(:title)
+      expect(payload[:fields].keys).to include(:title)
     end
 
     it 'enables highlighting on description' do
@@ -15,7 +15,7 @@ RSpec.describe QueryComponents::Highlight do
 
       payload = QueryComponents::Highlight.new(parameters).payload
 
-      assert payload[:fields].keys.include?(:description)
+      expect(payload[:fields].keys).to include(:description)
     end
 
     it 'does not enable highlighting when not requested' do
@@ -23,7 +23,7 @@ RSpec.describe QueryComponents::Highlight do
 
       payload = QueryComponents::Highlight.new(parameters).payload
 
-      assert payload.nil?
+      expect(payload).to be_nil
     end
   end
 end

--- a/spec/unit/query_components/popularity_spec.rb
+++ b/spec/unit/query_components/popularity_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe QueryComponents::Popularity do
 
     result = builder.wrap({ some: 'query' })
 
-    assert result.key?(:function_score)
+    expect(result.key?(:function_score)).to be_truthy
   end
 
   context "with disabling of popularity" do
@@ -17,7 +17,7 @@ RSpec.describe QueryComponents::Popularity do
 
       result = builder.wrap({ some: 'query' })
 
-      refute result.key?(:function_score)
+      expect(result.key?(:function_score)).to be_falsey
     end
   end
 end

--- a/spec/unit/query_components/sort_spec_spec.rb
+++ b/spec/unit/query_components/sort_spec_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      assert_equal result, [{ "popularity" => { order: "desc" } }]
+      expect(result).to eq([{ "popularity" => { order: "desc" } }])
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      assert_nil result
+      expect(result).to be_nil
     end
   end
 
@@ -27,10 +27,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      assert_equal(
-        [{ "public_timestamp" => { order: "asc", missing: "_last" } }],
-        result
-      )
+      expect([{ "public_timestamp" => { order: "asc", missing: "_last" } }]).to eq(result)
     end
   end
 
@@ -40,10 +37,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      assert_equal(
-        [{ "public_timestamp" => { order: "desc", missing: "_last" } }],
-        result
-      )
+      expect([{ "public_timestamp" => { order: "desc", missing: "_last" } }]).to eq(result)
     end
   end
 
@@ -53,7 +47,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      assert_nil result
+      expect(result).to be_nil
     end
   end
 end

--- a/spec/unit/query_components/text_query_spec.rb
+++ b/spec/unit/query_components/text_query_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe QueryComponents::TextQuery do
 
       query = builder.payload
 
-      assert_match(/all_searchable_text.synonym/, query.to_s)
+      expect(query.to_s).to match(/all_searchable_text.synonym/)
     end
 
     it "not use the all_searchable_text.synonym field" do
@@ -15,7 +15,7 @@ RSpec.describe QueryComponents::TextQuery do
 
       query = builder.payload
 
-      refute_match(/all_searchable_text.synonym/, query.to_s)
+      expect(query.to_s).not_to match(/all_searchable_text.synonym/)
     end
   end
 

--- a/spec/unit/result_set_presenter_spec.rb
+++ b/spec/unit/result_set_presenter_spec.rb
@@ -170,15 +170,15 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "present empty list of results" do
-      assert_equal [], @output[:results]
+      expect([]).to eq(@output[:results])
     end
 
     it "have total of 0" do
-      assert_equal 0, @output[:total]
+      expect(0).to eq(@output[:total])
     end
 
     it "have no aggregates" do
-      assert_equal({}, @output[:aggregates])
+      expect({}).to eq(@output[:aggregates])
     end
   end
 
@@ -194,11 +194,11 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct total" do
-      assert_equal 3, @output[:total]
+      expect(3).to eq(@output[:total])
     end
 
     it "have correct number of results" do
-      assert_equal 3, @output[:results].length
+      expect(3).to eq(@output[:results].length)
     end
 
     it "have short index names" do
@@ -210,8 +210,8 @@ RSpec.describe Search::ResultSetPresenter do
     it "have the score in es_score" do
       @output[:results].zip(sample_docs).each do |result, doc|
         expect(result.keys).not_to include("_score")
-        assert result[:es_score] != nil
-        assert_equal doc["_score"], result[:es_score]
+        expect(result[:es_score]).not_to be_nil
+        expect(doc["_score"]).to eq(result[:es_score])
       end
     end
 
@@ -219,7 +219,7 @@ RSpec.describe Search::ResultSetPresenter do
       @output[:results].zip(sample_docs).each do |result, _doc|
         doc_fields = result.keys - [:_type, :_id]
         returned_fields = result.keys - [:esscore, :_type, :_id]
-        assert_equal doc_fields, returned_fields
+        expect(doc_fields).to eq(returned_fields)
       end
     end
   end
@@ -245,7 +245,7 @@ RSpec.describe Search::ResultSetPresenter do
     it "return only basic metadata of fields" do
       expected_keys = [:index, :es_score, :_id, :elasticsearch_type, :document_type]
 
-      assert_equal expected_keys, @output[:results].first.keys
+      expect(expected_keys).to eq(@output[:results].first.keys)
     end
   end
 
@@ -270,11 +270,11 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct total" do
-      assert_equal 3, @output[:total]
+      expect(3).to eq(@output[:total])
     end
 
     it "have correct number of results" do
-      assert_equal 3, @output[:results].length
+      expect(3).to eq(@output[:results].length)
     end
 
     it "have short index names" do
@@ -286,8 +286,8 @@ RSpec.describe Search::ResultSetPresenter do
     it "have the score in es_score" do
       @output[:results].zip(sample_docs).each do |result, doc|
         expect(result.keys).not_to include("_score")
-        assert result[:es_score] != nil
-        assert_equal doc["_score"], result[:es_score]
+        expect(result[:es_score]).not_to be_nil
+        expect(doc["_score"]).to eq(result[:es_score])
       end
     end
 
@@ -295,17 +295,17 @@ RSpec.describe Search::ResultSetPresenter do
       @output[:results].zip(sample_docs).each do |result, _doc|
         doc_fields = result.keys - [:_type, :_id]
         returned_fields = result.keys - [:esscore, :_type, :_id]
-        assert_equal doc_fields, returned_fields
+        expect(doc_fields).to eq(returned_fields)
       end
     end
 
     it "have the expanded topic" do
       result = @output[:results][2]
-      assert_equal([{
+      expect([{
         "link" => "/government/topics/farming",
         "title" => "Farming",
         "slug" => "farming",
-      }], result["policy_areas"])
+      }]).to eq result["policy_areas"]
     end
   end
 
@@ -326,35 +326,35 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      assert_equal 1, @output[:aggregates].length
+      expect(1).to eq(@output[:aggregates].length)
     end
 
     it "have correct number of aggregate values" do
-      assert_equal 1, @output[:aggregates]["organisations"][:options].length
+      expect(1).to eq(@output[:aggregates]["organisations"][:options].length)
     end
 
     it "include requested aggregate scope" do
       aggregate = @output[:aggregates]["organisations"]
-      assert_equal :exclude_field_filter, aggregate[:scope]
+      expect(:exclude_field_filter).to eq(aggregate[:scope])
     end
 
     it "have correct top aggregate value value" do
-      assert_equal({
+      expect(
         value: { "slug" => "hm-magic" },
         documents: 7,
-      }, @output[:aggregates]["organisations"][:options][0])
+      ).to eq @output[:aggregates]["organisations"][:options][0]
     end
 
     it "have correct number of documents with no value" do
-      assert_equal(8, @output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
     end
 
     it "have correct total number of options" do
-      assert_equal(2, @output[:aggregates]["organisations"][:total_options])
+      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
     end
 
     it "have correct number of missing options" do
-      assert_equal(1, @output[:aggregates]["organisations"][:missing_options])
+      expect(1).to eq(@output[:aggregates]["organisations"][:missing_options])
     end
   end
 
@@ -376,37 +376,37 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      assert_equal 1, @output[:aggregates].length
+      expect(1).to eq(@output[:aggregates].length)
     end
 
     it "have correct number of aggregate values" do
-      assert_equal 2, @output[:aggregates]["organisations"][:options].length
+      expect(2).to eq(@output[:aggregates]["organisations"][:options].length)
     end
 
     it "have selected aggregate first" do
-      assert_equal({
+      expect(
         value: { "slug" => "hmrc" },
         documents: 5,
-      }, @output[:aggregates]["organisations"][:options][0])
+      ).to eq @output[:aggregates]["organisations"][:options][0]
     end
 
     it "have unapplied aggregate value second" do
-      assert_equal({
+      expect(
         value: { "slug" => "hm-magic" },
         documents: 7,
-      }, @output[:aggregates]["organisations"][:options][1])
+      ).to eq @output[:aggregates]["organisations"][:options][1]
     end
 
     it "have correct number of documents with no value" do
-      assert_equal(8, @output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
     end
 
     it "have correct total number of options" do
-      assert_equal(2, @output[:aggregates]["organisations"][:total_options])
+      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
     end
 
     it "have correct number of missing options" do
-      assert_equal(0, @output[:aggregates]["organisations"][:missing_options])
+      expect(0).to eq(@output[:aggregates]["organisations"][:missing_options])
     end
   end
 
@@ -428,37 +428,37 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      assert_equal 1, @output[:aggregates].length
+      expect(1).to eq(@output[:aggregates].length)
     end
 
     it "have correct number of aggregate values" do
-      assert_equal 2, @output[:aggregates]["organisations"][:options].length
+      expect(2).to eq(@output[:aggregates]["organisations"][:options].length)
     end
 
     it "have selected aggregate first" do
-      assert_equal({
+      expect(
         value: { "slug" => "hm-cheesemakers" },
         documents: 0,
-      }, @output[:aggregates]["organisations"][:options][0])
+      ).to eq @output[:aggregates]["organisations"][:options][0]
     end
 
     it "have unapplied aggregate value second" do
-      assert_equal({
+      expect(
         value: { "slug" => "hm-magic" },
         documents: 7,
-      }, @output[:aggregates]["organisations"][:options][1])
+      ).to eq @output[:aggregates]["organisations"][:options][1]
     end
 
     it "have correct number of documents with no value" do
-      assert_equal(8, @output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
     end
 
     it "have correct total number of options" do
-      assert_equal(2, @output[:aggregates]["organisations"][:total_options])
+      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
     end
 
     it "have correct number of missing options" do
-      assert_equal(1, @output[:aggregates]["organisations"][:missing_options])
+      expect(1).to eq(@output[:aggregates]["organisations"][:missing_options])
     end
   end
 
@@ -475,23 +475,23 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      assert_equal 1, @output[:aggregates].length
+      expect(1).to eq(@output[:aggregates].length)
     end
 
     it "have no aggregate values" do
-      assert_equal 0, @output[:aggregates]["organisations"][:options].length
+      expect(0).to eq(@output[:aggregates]["organisations"][:options].length)
     end
 
     it "have correct number of documents with no value" do
-      assert_equal(8, @output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
     end
 
     it "have correct total number of options" do
-      assert_equal(2, @output[:aggregates]["organisations"][:total_options])
+      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
     end
 
     it "have correct number of missing options" do
-      assert_equal(2, @output[:aggregates]["organisations"][:missing_options])
+      expect(2).to eq(@output[:aggregates]["organisations"][:missing_options])
     end
   end
 
@@ -506,10 +506,10 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have aggregates sorted by ascending count" do
-      assert_equal [
+      expect([
         aggregate_response_hmrc,
         aggregate_response_magic,
-      ], @output[:aggregates]["organisations"][:options]
+      ]).to eq @output[:aggregates]["organisations"][:options]
     end
   end
 
@@ -524,10 +524,10 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have aggregates sorted by descending count" do
-      assert_equal [
+      expect([
         aggregate_response_magic,
         aggregate_response_hmrc,
-      ], @output[:aggregates]["organisations"][:options]
+      ]).to eq @output[:aggregates]["organisations"][:options]
     end
   end
 
@@ -543,10 +543,10 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have aggregates sorted by ascending slug" do
-      assert_equal [
+      expect([
         aggregate_response_magic,
         aggregate_response_hmrc,
-      ], @output[:aggregates]["organisations"][:options]
+      ]).to eq @output[:aggregates]["organisations"][:options]
     end
   end
 
@@ -561,10 +561,10 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have aggregates sorted by ascending link" do
-      assert_equal [
+      expect([
         aggregate_response_magic,
         aggregate_response_hmrc,
-      ], @output[:aggregates]["organisations"][:options]
+      ]).to eq @output[:aggregates]["organisations"][:options]
     end
   end
 
@@ -579,10 +579,10 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have aggregates sorted by ascending title" do
-      assert_equal [
+      expect([
         aggregate_response_hmrc,
         aggregate_response_magic,
-      ], @output[:aggregates]["organisations"][:options]
+      ]).to eq @output[:aggregates]["organisations"][:options]
     end
   end
 
@@ -606,45 +606,45 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      assert_equal 2, @output[:aggregates].length
+      expect(2).to eq(@output[:aggregates].length)
     end
 
     it "have correct number of aggregate values" do
-      assert_equal 1, @output[:aggregates]["organisations"][:options].length
-      assert_equal 1, @output[:aggregates]["policy_areas"][:options].length
+      expect(1).to eq(@output[:aggregates]["organisations"][:options].length)
+      expect(1).to eq(@output[:aggregates]["policy_areas"][:options].length)
     end
 
     it "have org aggregate value expanded" do
-      assert_equal({
+      expect(
         value: {
           "link" => "/government/departments/hm-magic",
           "title" => "Ministry of Magic",
           "slug" => "hm-magic",
         },
         documents: 7,
-      }, @output[:aggregates]["organisations"][:options][0])
+      ).to eq @output[:aggregates]["organisations"][:options][0]
     end
 
     it "have topic aggregate value un-expanded" do
-      assert_equal({
+      expect(
         value: { "slug" => "unknown_topic" },
         documents: 5,
-      }, @output[:aggregates]["policy_areas"][:options][0])
+      ).to eq @output[:aggregates]["policy_areas"][:options][0]
     end
 
     it "have correct number of documents with no value" do
-      assert_equal(8, @output[:aggregates]["organisations"][:documents_with_no_value])
-      assert_equal(3, @output[:aggregates]["policy_areas"][:documents_with_no_value])
+      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(3).to eq(@output[:aggregates]["policy_areas"][:documents_with_no_value])
     end
 
     it "have correct total number of options" do
-      assert_equal(2, @output[:aggregates]["organisations"][:total_options])
-      assert_equal(2, @output[:aggregates]["policy_areas"][:total_options])
+      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
+      expect(2).to eq(@output[:aggregates]["policy_areas"][:total_options])
     end
 
     it "have correct number of missing options" do
-      assert_equal(1, @output[:aggregates]["organisations"][:missing_options])
-      assert_equal(1, @output[:aggregates]["policy_areas"][:missing_options])
+      expect(1).to eq(@output[:aggregates]["organisations"][:missing_options])
+      expect(1).to eq(@output[:aggregates]["policy_areas"][:missing_options])
     end
   end
 
@@ -674,15 +674,15 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      assert_equal 1, @output[:aggregates].length
+      expect(1).to eq(@output[:aggregates].length)
     end
 
     it "have correct number of aggregate values" do
-      assert_equal 1, @output[:aggregates]["organisations"][:options].length
+      expect(1).to eq(@output[:aggregates]["organisations"][:options].length)
     end
 
     it "have org aggregate value expanded, and include examples" do
-      assert_equal({
+      expect(
         value: {
           "link" => "/government/departments/hm-magic",
           "title" => "Ministry of Magic",
@@ -695,19 +695,19 @@ RSpec.describe Search::ResultSetPresenter do
           },
         },
         documents: 7,
-      }, @output[:aggregates]["organisations"][:options][0])
+      ).to eq @output[:aggregates]["organisations"][:options][0]
     end
 
     it "have correct number of documents with no value" do
-      assert_equal(8, @output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
     end
 
     it "have correct total number of options" do
-      assert_equal(2, @output[:aggregates]["organisations"][:total_options])
+      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
     end
 
     it "have correct number of missing options" do
-      assert_equal(1, @output[:aggregates]["organisations"][:missing_options])
+      expect(1).to eq(@output[:aggregates]["organisations"][:missing_options])
     end
   end
 

--- a/spec/unit/schema/combined_index_schema_spec.rb
+++ b/spec/unit/schema/combined_index_schema_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe CombinedIndexSchema do
   it "basic_field_definitions" do
     # The title and public_timestamp fields are defined in the
     # base_elasticsearch_type, so are available in all documents holding content.
-    assert_equal "searchable_sortable_text", @combined_schema.field_definitions["title"].type.name
-    assert_equal "searchable_text", @combined_schema.field_definitions["description"].type.name
-    assert_equal "date", @combined_schema.field_definitions["public_timestamp"].type.name
+    expect("searchable_sortable_text").to eq(@combined_schema.field_definitions["title"].type.name)
+    expect("searchable_text").to eq(@combined_schema.field_definitions["description"].type.name)
+    expect("date").to eq(@combined_schema.field_definitions["public_timestamp"].type.name)
   end
 
   it "merged_field_definitions" do
@@ -22,12 +22,12 @@ RSpec.describe CombinedIndexSchema do
     # european_structural_investment_fund document type, with different
     # expanded_search_result_fields.  Check that expansion values from both lists are present.
     locations = @combined_schema.field_definitions["location"].expanded_search_result_fields
-    assert locations.include?({ "label" => "Afghanistan", "value" => "afghanistan" })
-    assert locations.include?({ "label" => "North East", "value" => "north-east" })
+    expect(locations).to include({ "label" => "Afghanistan", "value" => "afghanistan" })
+    expect(locations).to include({ "label" => "North East", "value" => "north-east" })
   end
 
   it "allowed_filter_fields" do
-    refute @combined_schema.allowed_filter_fields.include? "title"
-    assert @combined_schema.allowed_filter_fields.include? "organisations"
+    expect(@combined_schema.allowed_filter_fields).not_to include "title"
+    expect(@combined_schema.allowed_filter_fields).to include "organisations"
   end
 end

--- a/spec/unit/schema/elasticsearch_types_parser_spec.rb
+++ b/spec/unit/schema/elasticsearch_types_parser_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe ElasticsearchTypesParser do
-  def assert_raises_message(message)
-    exc = assert_raises(RuntimeError) { yield }
-    assert_equal message, exc.message
+  def expect_raises_message(message)
+    expect { yield }.to raise_error(message)
   end
 
   def schema_dir
@@ -31,48 +30,49 @@ RSpec.describe ElasticsearchTypesParser do
     end
 
     it "recognise the `manual_section` type" do
-      assert_equal "manual_section", @types["manual_section"].name
+      expect("manual_section").to eq(@types["manual_section"].name)
     end
 
     it "know that the `manual_section` type has a `manual` field" do
       manual_field = @types["manual_section"].fields["manual"]
-      refute manual_field.nil?
-      assert_equal "manual", manual_field.name
+      expect(manual_field).not_to be_nil
+      expect("manual").to eq(manual_field.name)
     end
 
     it "know that the `manual_section` type inherits the `link` field from the base type" do
       link_field = @types["manual_section"].fields["link"]
-      refute link_field.nil?
-      assert_equal "link", link_field.name
-      assert_equal false, link_field.type.multivalued
-      assert_equal "identifier", link_field.type.name
+      expect(link_field).not_to be_nil
+      expect("link").to eq(link_field.name)
+      expect(false).to eq(link_field.type.multivalued)
+      expect("identifier").to eq(link_field.type.name)
     end
 
     it "produce appropriate elasticsearch configuration for the `manual_section` type" do
       es_config = @types["manual_section"].es_config
-      assert_equal(
+      expect(
         hash_including({
           "manual" => @identifier_es_config,
           "link" => @identifier_es_config,
-        }),
-        es_config
-      )
+        })
+      ).to eq(es_config)
     end
 
     it "not specify expanded_search_result_fields for the `organisations` field" do
-      assert_nil @types["manual_section"].fields["organisations"].expanded_search_result_fields
+      expect(@types["manual_section"].fields["organisations"].expanded_search_result_fields).to be_nil
     end
 
     it "include expanded_search_result_fields in the cma_case `case_state` field" do
-      assert_equal(
-        cma_case_expanded_search_result_fields,
+      expect(
+        cma_case_expanded_search_result_fields
+      ).to eq(
         @types["cma_case"].fields["case_state"].expanded_search_result_fields
       )
     end
 
     it "expanded_search_result_fields on a field should also be available from the document type" do
-      assert_equal(
-        @types["cma_case"].fields["case_state"].expanded_search_result_fields,
+      expect(
+        @types["cma_case"].fields["case_state"].expanded_search_result_fields
+      ).to eq(
         @types["cma_case"].expanded_search_result_fields["case_state"]
       )
     end
@@ -86,14 +86,14 @@ RSpec.describe ElasticsearchTypesParser do
 
     it "fail if document type doesn't specify `fields`" do
       allow_any_instance_of(ElasticsearchTypeParser).to receive(:load_json).and_return({})
-      assert_raises_message(%{Missing "fields", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
+      expect_raises_message(%{Missing "fields", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
 
     it "fail if document type specifies unknown entries in `fields`" do
       allow_any_instance_of(ElasticsearchTypeParser).to receive(:load_json).and_return({
         "fields" => ["unknown_field"],
       })
-      assert_raises_message(%{Undefined field \"unknown_field\", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
+      expect_raises_message(%{Undefined field \"unknown_field\", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
 
     it "fail if document type has an unknown property" do
@@ -101,7 +101,7 @@ RSpec.describe ElasticsearchTypesParser do
         "fields" => [],
         "unknown" => [],
       })
-      assert_raises_message(%{Unknown keys (unknown), in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
+      expect_raises_message(%{Unknown keys (unknown), in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
 
     it "fail if `expanded_search_result_fields` are specified in base type" do
@@ -116,7 +116,7 @@ RSpec.describe ElasticsearchTypesParser do
       subtype_parser = ElasticsearchTypeParser.new("/config/path/subtype.json", base_type, @definitions)
       allow_any_instance_of(ElasticsearchTypeParser).to receive(:load_json).and_return({ "fields" => [] })
 
-      assert_raises_message(%{Specifying `expanded_search_result_fields` in base document type is not supported, in document type definition in "/config/path/subtype.json"}) { subtype_parser.parse }
+      expect_raises_message(%{Specifying `expanded_search_result_fields` in base document type is not supported, in document type definition in "/config/path/subtype.json"}) { subtype_parser.parse }
     end
 
     it "fail if expanded_search_result_fields are set for fields which aren't known" do
@@ -127,7 +127,7 @@ RSpec.describe ElasticsearchTypesParser do
         },
       })
 
-      assert_raises_message(%{Field "unknown_field" set in "expanded_search_result_fields", but not in "fields", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
+      expect_raises_message(%{Field "unknown_field" set in "expanded_search_result_fields", but not in "fields", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
   end
 end

--- a/spec/unit/schema/field_definition_parser_spec.rb
+++ b/spec/unit/schema/field_definition_parser_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe FieldDefinitionParser do
     end
 
     it "recognise the `link` field definition" do
-      assert_equal "link", @definitions["link"].name
+      expect("link").to eq(@definitions["link"].name)
     end
 
     it "know that the `link` field has type `identifier`" do
-      assert_equal "identifier", @definitions["link"].type.name
+      expect("identifier").to eq(@definitions["link"].type.name)
     end
 
     it "know that the `link` field has a description" do
-      refute @definitions["link"].description.empty?
+      expect(@definitions["link"].description).not_to be_empty
     end
 
     it "know that the `link` field has no children" do
-      assert @definitions["link"].children.nil?
+      expect(@definitions["link"].children).to be_nil
     end
 
     it "know that the `attachments` field has a child of `title` of type searchable_text" do
-      assert_equal "searchable_text", @definitions["attachments"].children["title"].type.name
+      expect("searchable_text").to eq(@definitions["attachments"].children["title"].type.name)
     end
 
     it "be able to merge two field definitions" do
@@ -34,9 +34,9 @@ RSpec.describe FieldDefinitionParser do
       definition2 = FieldDefinition.new("foo", "string", {}, "", nil, [value2, value3])
       merged = definition2.merge(definition1)
 
-      assert_equal "foo", merged.name
-      assert_equal "string", merged.type
-      assert_equal [value1, value2, value3], merged.expanded_search_result_fields.sort_by { |item| item["value"] }
+      expect("foo").to eq(merged.name)
+      expect("string").to eq(merged.type)
+      expect([value1, value2, value3]).to eq(merged.expanded_search_result_fields.sort_by { |item| item["value"] })
     end
   end
 end

--- a/spec/unit/schema/field_types_spec.rb
+++ b/spec/unit/schema/field_types_spec.rb
@@ -7,38 +7,37 @@ RSpec.describe FieldTypes do
     end
 
     it "recognise the `identifier` type" do
-      assert_equal "identifier", @types.get("identifier").name
+      expect("identifier").to eq(@types.get("identifier").name)
     end
 
     it "know that the `identifier` type is single-valued" do
-      refute @types.get("identifier").multivalued
+      expect(@types.get("identifier").multivalued).to be_falsey
     end
 
     it "know that the `identifiers` type is multi-valued" do
-      assert @types.get("identifiers").multivalued
+      expect(@types.get("identifiers").multivalued).to be_truthy
     end
 
     it "know that the `identifiers` type has a `text` filter type" do
-      assert_equal "text", @types.get("identifiers").filter_type
+      expect("text").to eq(@types.get("identifiers").filter_type)
     end
 
     it "know that the `identifiers` type does not have children" do
-      assert_nil @types.get("identifiers").children
+      expect(@types.get("identifiers").children).to be_nil
     end
 
     it "know that the `objects` type has named children" do
-      assert_equal "named", @types.get("objects").children
+      expect("named").to eq(@types.get("objects").children)
     end
 
     it "know that the `opaque_object` type has dynamic children" do
-      assert_equal "dynamic", @types.get("opaque_object").children
+      expect("dynamic").to eq(@types.get("opaque_object").children)
     end
 
     it "raise an error for unknown types" do
-      exc = assert_raises(RuntimeError) do
+      expect_raises_message(%{Unknown field type "unknown"}) do
         @types.get("unknown")
       end
-      assert_equal %{Unknown field type "unknown"}, exc.message
     end
   end
 
@@ -49,40 +48,40 @@ RSpec.describe FieldTypes do
 
     it "fail if a field type has no es_config property" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return({ "identifier" => {} })
-      exc = assert_raises(RuntimeError) do
+      expect_raises_message(%{Missing "es_config" in field type "identifier" in "/config/path/field_types.json"}) do
         @types.get("identifier")
       end
-      assert_equal %{Missing "es_config" in field type "identifier" in "/config/path/field_types.json"}, exc.message
     end
 
     it "fail if a field type has an invalid `filter_type` property" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return(
         { "identifier" => { "es_config" => {}, "filter_type" => "bad value" } }
       )
-      exc = assert_raises(RuntimeError) do
+      expect_raises_message(%{Invalid value for "filter_type" ("bad value") in field type "identifier" in "/config/path/field_types.json"}) do
         @types.get("identifier")
       end
-      assert_equal %{Invalid value for "filter_type" ("bad value") in field type "identifier" in "/config/path/field_types.json"}, exc.message
     end
 
     it "fail if a field type has an invalid `children` property" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return(
         { "identifier" => { "es_config" => {}, "children" => "bad value" } }
       )
-      exc = assert_raises(RuntimeError) do
+      expect_raises_message(%{Invalid value for "children" ("bad value") in field type "identifier" in "/config/path/field_types.json"}) do
         @types.get("identifier")
       end
-      assert_equal %{Invalid value for "children" ("bad value") in field type "identifier" in "/config/path/field_types.json"}, exc.message
     end
 
     it "fail if a field type has an unknown property" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return(
         { "identifier" => { "es_config" => {}, "foo" => true } }
       )
-      exc = assert_raises(RuntimeError) do
+      expect_raises_message(%{Unknown keys (foo) in field type "identifier" in "/config/path/field_types.json"}) do
         @types.get("identifier")
       end
-      assert_equal %{Unknown keys (foo) in field type "identifier" in "/config/path/field_types.json"}, exc.message
     end
+  end
+
+  def expect_raises_message(message)
+    expect { yield }.to raise_error(message)
   end
 end

--- a/spec/unit/schema/index_schema_parser_spec.rb
+++ b/spec/unit/schema/index_schema_parser_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe IndexSchemaParser do
-  def assert_raises_message(message)
-    exc = assert_raises(RuntimeError) { yield }
-    assert_equal message, exc.message
+  def expect_raises_message(message)
+    expect { yield }.to raise_error(message)
   end
 
   def schema_dir
@@ -19,17 +18,18 @@ RSpec.describe IndexSchemaParser do
     end
 
     it "have a schema for the mainstream index" do
-      assert_equal "mainstream", @index_schemas["mainstream"].name
+      expect("mainstream").to eq(@index_schemas["mainstream"].name)
     end
 
     it "include configuration for the `manual_section` type in the `mainstream` index" do
       es_mappings = @index_schemas["mainstream"].es_mappings
-      assert es_mappings.keys.include?("manual_section")
-      assert_equal(
+      expect(es_mappings.keys).to include("manual_section")
+      expect(
         hash_including({
           "manual" => @identifier_es_config,
           "link" => @identifier_es_config,
-        }),
+        })
+      ).to eq(
         es_mappings["manual_section"]["properties"]
       )
     end
@@ -46,12 +46,12 @@ RSpec.describe IndexSchemaParser do
       allow_any_instance_of(described_class).to receive(:load_json).and_return({
         "elasticsearch_types" => ["unknown_doc_type"],
       })
-      assert_raises_message(%{Unknown document type "unknown_doc_type", in index definition in "index.json"}) { @parser.parse }
+      expect_raises_message(%{Unknown document type "unknown_doc_type", in index definition in "index.json"}) { @parser.parse }
     end
 
     it "fail if index schema doesn't specify `elasticsearch_types`" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return({})
-      assert_raises_message(%{Missing "elasticsearch_types", in index definition in "index.json"}) { @parser.parse }
+      expect_raises_message(%{Missing "elasticsearch_types", in index definition in "index.json"}) { @parser.parse }
     end
 
     it "fail if index schema includes unknown keys" do
@@ -59,7 +59,7 @@ RSpec.describe IndexSchemaParser do
         "elasticsearch_types" => [],
         "foo" => "bar",
       })
-      assert_raises_message(%{Unknown keys (foo), in index definition in "index.json"}) { @parser.parse }
+      expect_raises_message(%{Unknown keys (foo), in index definition in "index.json"}) { @parser.parse }
     end
   end
 end

--- a/spec/unit/schema/synonyms_spec.rb
+++ b/spec/unit/schema/synonyms_spec.rb
@@ -4,50 +4,50 @@ RSpec.describe SynonymParser do
   it "map a single word synonym to the same synonym group at index and search time" do
     parse_synonyms(["one"])
 
-    assert_search_synonyms_contain "one=>!S0"
-    assert_index_synonyms_contain "one=>!S0"
+    expect_search_synonyms_contain "one=>!S0"
+    expect_index_synonyms_contain "one=>!S0"
   end
 
   it "number the synonym groups differently" do
     parse_synonyms(%w(one two))
 
-    assert_search_synonyms_contain "one=>!S0"
-    assert_search_synonyms_contain "two=>!S1"
+    expect_search_synonyms_contain "one=>!S0"
+    expect_search_synonyms_contain "two=>!S1"
   end
 
   it "map a two word synonym to the same synonym group at index and search time" do
     parse_synonyms(["two, 2"])
 
-    assert_search_synonyms_contain "two,2=>!S0"
-    assert_index_synonyms_contain "two,2=>!S0"
+    expect_search_synonyms_contain "two,2=>!S0"
+    expect_index_synonyms_contain "two,2=>!S0"
   end
 
   it "understand mapping a search phrase to a different phrase in documents" do
     parse_synonyms(["motorbike => motorcycle"])
 
-    assert_search_synonyms_contain "motorbike=>!S0"
-    assert_index_synonyms_contain "motorcycle=>!S0"
+    expect_search_synonyms_contain "motorbike=>!S0"
+    expect_index_synonyms_contain "motorcycle=>!S0"
   end
 
   it "understand mapping one search phrase to multiple phrases in documents" do
     parse_synonyms(["opening times => opening times, opening hours"])
 
-    assert_search_synonyms_contain "opening times=>!S0"
-    assert_index_synonyms_contain "opening times,opening hours=>!S0"
+    expect_search_synonyms_contain "opening times=>!S0"
+    expect_index_synonyms_contain "opening times,opening hours=>!S0"
   end
 
   it "understand mapping multiple search phrases to one phrase in documents" do
     parse_synonyms(["my, your => your"])
 
-    assert_search_synonyms_contain "my,your=>!S0"
-    assert_index_synonyms_contain "your=>!S0"
+    expect_search_synonyms_contain "my,your=>!S0"
+    expect_index_synonyms_contain "your=>!S0"
   end
 
   it "produce correct config for protecting all the generated synonym terms" do
     parse_synonyms(["one", "two, 2"])
 
     protected_terms = @search_synonyms.protwords_config[:keywords]
-    assert_equal %w{!S0 !S1}, protected_terms
+    expect(%w{!S0 !S1}).to eq(protected_terms)
   end
 
   def parse_synonyms(synonyms)
@@ -61,11 +61,11 @@ RSpec.describe SynonymParser do
     end
   end
 
-  def assert_search_synonyms_contain(expected)
+  def expect_search_synonyms_contain(expected)
     expect(@search_synonyms.es_config[:synonyms]).to include(expected)
   end
 
-  def assert_index_synonyms_contain(expected)
+  def expect_index_synonyms_contain(expected)
     expect(@index_synonyms.es_config[:synonyms]).to include(expected)
   end
 end

--- a/spec/unit/search/aggregate_example_fetcher_spec.rb
+++ b/spec/unit/search/aggregate_example_fetcher_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Search::AggregateExampleFetcher do
 
       response = fetcher.send(:prepare_response, [], [])
 
-      assert_equal response, {}
+      expect(response).to eq({})
     end
 
     it "map a response to aggregates without fields" do
@@ -71,7 +71,7 @@ RSpec.describe Search::AggregateExampleFetcher do
 
       response = fetcher.send(:prepare_response, slugs, response_list)
 
-      assert_equal response, { "a-slug-name" => { total: 1, examples: [{}] } }
+      expect(response).to eq("a-slug-name" => { total: 1, examples: [{}] })
     end
   end
 
@@ -83,7 +83,7 @@ RSpec.describe Search::AggregateExampleFetcher do
     end
 
     it "get an empty hash of examples" do
-      assert_equal({}, @fetcher.fetch)
+      expect({}).to eq(@fetcher.fetch)
     end
   end
 
@@ -126,7 +126,7 @@ RSpec.describe Search::AggregateExampleFetcher do
           response_for_example(1, ["example_3"]),
         ] })
 
-      assert_equal({
+      expect(
         "sector" => {
           "sector_1" => { total: 3, examples: [
               { "title" => "example_1" },
@@ -136,7 +136,7 @@ RSpec.describe Search::AggregateExampleFetcher do
               { "title" => "example_3" }
             ] },
         }
-      }, @fetcher.fetch)
+      ).to eq(@fetcher.fetch)
     end
   end
 
@@ -186,7 +186,7 @@ RSpec.describe Search::AggregateExampleFetcher do
           response_for_example(1, ["example_3"]),
         ] })
 
-      assert_equal({
+      expect(
         "sector" => {
           "sector_1" => { total: 3, examples: [
               { "title" => "example_1" },
@@ -196,7 +196,7 @@ RSpec.describe Search::AggregateExampleFetcher do
               { "title" => "example_3" }
             ] },
         }
-      }, @fetcher.fetch)
+      ).to eq(@fetcher.fetch)
     end
   end
 
@@ -227,7 +227,7 @@ RSpec.describe Search::AggregateExampleFetcher do
     end
 
     it "request and return aggregate examples" do
-      assert_equal({ "sector" => {} }, @fetcher.fetch)
+      expect({ "sector" => {} }).to eq(@fetcher.fetch)
     end
   end
 
@@ -281,7 +281,7 @@ RSpec.describe Search::AggregateExampleFetcher do
           .with(expected_queries).and_return({ "responses" => stub_responses })
       end
 
-      assert_equal({
+      expect(
         "sector" => Hash[
           (0..999).map { |sector_num|
             [
@@ -290,7 +290,7 @@ RSpec.describe Search::AggregateExampleFetcher do
             ]
           }
         ]
-      }, @fetcher.fetch)
+      ).to eq(@fetcher.fetch)
     end
   end
 end

--- a/spec/unit/search/aggregate_option_spec.rb
+++ b/spec/unit/search/aggregate_option_spec.rb
@@ -2,129 +2,115 @@ require 'spec_helper'
 
 RSpec.describe Search::AggregateOption do
   it "convert_to_hash" do
-    assert_equal(
-      { value: { "title" => "Hello" }, documents: 1 },
+    expect(
+      value: { "title" => "Hello" }, documents: 1
+    ).to eq(
       described_class.new({ "title" => "Hello" }, 1, true, []).as_hash,
     )
   end
 
   it "id_is_slug" do
-    assert_equal(
-      "a_slug",
+    expect("a_slug").to eq(
       described_class.new({ "title" => "Hello", "slug" => "a_slug" }, 1, true, []).id,
     )
   end
 
   it "compare_by_filtered_first" do
     orderings = [[:filtered, 1]]
-    assert(
-      described_class.new({}, 0, true, orderings) <
-      described_class.new({}, 0, false, orderings)
-    )
+    expect(
+      described_class.new({}, 0, true, orderings)
+    ).to be < described_class.new({}, 0, false, orderings)
   end
 
   it "compare_by_filtered_last" do
     orderings = [[:filtered, -1]]
-    assert(
-      described_class.new({}, 0, false, orderings) <
-      described_class.new({}, 0, true, orderings)
-    )
+    expect(
+      described_class.new({}, 0, false, orderings)
+    ).to be < described_class.new({}, 0, true, orderings)
   end
 
   it "compare_by_count_ascending" do
     orderings = [[:count, 1]]
-    assert(
-      described_class.new({}, 5, false, orderings) <
-      described_class.new({}, 6, false, orderings)
-    )
+    expect(
+      described_class.new({}, 5, false, orderings)
+    ).to be < described_class.new({}, 6, false, orderings)
   end
 
   it "compare_by_count_descending" do
     orderings = [[:count, -1]]
-    assert(
-      described_class.new({}, 6, false, orderings) <
-      described_class.new({}, 5, false, orderings)
-    )
+    expect(
+      described_class.new({}, 6, false, orderings)
+    ).to be < described_class.new({}, 5, false, orderings)
   end
 
 
   it "compare_by_slug_ascending" do
     orderings = [[:"value.slug", 1]]
-    assert(
-      described_class.new({ "slug" => "a" }, 0, false, orderings) <
-      described_class.new({ "slug" => "b" }, 0, false, orderings)
-    )
+    expect(
+      described_class.new({ "slug" => "a" }, 0, false, orderings)
+    ).to be < described_class.new({ "slug" => "b" }, 0, false, orderings)
   end
 
   it "compare_by_slug_descending" do
     orderings = [[:"value.slug", -1]]
-    assert(
-      described_class.new({ "slug" => "b" }, 0, false, orderings) <
-      described_class.new({ "slug" => "a" }, 0, false, orderings)
-    )
+    expect(
+      described_class.new({ "slug" => "b" }, 0, false, orderings)
+    ).to be < described_class.new({ "slug" => "a" }, 0, false, orderings)
   end
 
   it "compare_by_title_ascending" do
     orderings = [[:"value.title", 1]]
-    assert(
-      described_class.new({ "title" => "a" }, 0, false, orderings) <
-      described_class.new({ "title" => "b" }, 0, false, orderings)
-    )
+    expect(
+      described_class.new({ "title" => "a" }, 0, false, orderings)
+    ).to be < described_class.new({ "title" => "b" }, 0, false, orderings)
   end
 
   it "compare_by_title_descending" do
     orderings = [[:"value.title", -1]]
-    assert(
-      described_class.new({ "title" => "b" }, 0, false, orderings) <
-      described_class.new({ "title" => "a" }, 0, false, orderings)
-    )
+    expect(
+      described_class.new({ "title" => "b" }, 0, false, orderings)
+    ).to be < described_class.new({ "title" => "a" }, 0, false, orderings)
   end
 
   it "compare_by_title_ignores_case" do
     orderings = [[:"value.title", 1]]
-    assert(
-      described_class.new({ "title" => "a" }, 0, false, orderings) <
-      described_class.new({ "title" => "Z" }, 0, false, orderings)
-    )
+    expect(
+      described_class.new({ "title" => "a" }, 0, false, orderings)
+    ).to be < described_class.new({ "title" => "Z" }, 0, false, orderings)
   end
 
   it "compare_by_link_ascending" do
     orderings = [[:"value.link", 1]]
-    assert(
-      described_class.new({ "link" => "a" }, 0, false, orderings) <
-      described_class.new({ "link" => "b" }, 0, false, orderings)
-    )
+    expect(
+      described_class.new({ "link" => "a" }, 0, false, orderings)
+    ).to be < described_class.new({ "link" => "b" }, 0, false, orderings)
   end
 
   it "compare_by_link_descending" do
     orderings = [[:"value.link", -1]]
-    assert(
-      described_class.new({ "link" => "b" }, 0, false, orderings) <
-      described_class.new({ "link" => "a" }, 0, false, orderings)
-    )
+    expect(
+      described_class.new({ "link" => "b" }, 0, false, orderings)
+    ).to be < described_class.new({ "link" => "a" }, 0, false, orderings)
   end
 
   it "compare_by_value" do
     orderings = [[:value, 1]]
-    assert(
-      described_class.new("a", 0, false, orderings) <
-      described_class.new("b", 0, false, orderings)
-    )
+    expect(
+      described_class.new("a", 0, false, orderings)
+    ).to be < described_class.new("b", 0, false, orderings)
   end
 
   it "compare_by_value_with_title" do
     orderings = [[:value, 1]]
-    assert(
-      described_class.new({ "title" => "a" }, 0, false, orderings) <
-      described_class.new({ "title" => "b" }, 0, false, orderings)
-    )
+    expect(
+      described_class.new({ "title" => "a" }, 0, false, orderings)
+    ).to be < described_class.new({ "title" => "b" }, 0, false, orderings)
   end
 
   it "fall_back_to_slug_ordering" do
     orderings = [[:count, 1]]
-    assert(
-      described_class.new({ "slug" => "a" }, 5, false, orderings) <
-      described_class.new({ "slug" => "b" }, 5, false, orderings)
-    )
+    expect(
+      described_class.new({ "slug" => "a" }, 5, false, orderings)
+    ).to be < described_class.new({ "slug" => "b" }, 5, false, orderings)
   end
 end

--- a/spec/unit/search/base_registry_spec.rb
+++ b/spec/unit/search/base_registry_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Search::BaseRegistry do
       .and_return([example_document])
 
     fetched_document = @base_registry["example-document"]
-    assert_equal example_document, fetched_document
+    expect(example_document).to eq(fetched_document)
   end
 
   it "only_required_fields_are_requested_from_index" do
@@ -42,7 +42,7 @@ RSpec.describe Search::BaseRegistry do
     allow(@index).to receive(:documents_by_format)
       .with("example-format", anything)
       .and_return([example_document])
-    assert_nil @base_registry["non-existent-document"]
+    expect(@base_registry["non-existent-document"]).to be_nil
   end
 
   it "document_enumerator_is_traversed_only_once" do
@@ -52,15 +52,15 @@ RSpec.describe Search::BaseRegistry do
       .with("example-format", anything)
       .once
       .and_return(document_enumerator)
-    assert @base_registry["example-document"]
-    assert @base_registry["example-document"]
+    expect(@base_registry["example-document"]).to be_truthy
+    expect(@base_registry["example-document"]).to be_truthy
   end
 
   it "uses_cache" do
     # Make sure we're using TimedCache#get; TimedCache is tested elsewhere, so
     # we don't need to worry about cache expiry tests here.
     expect_any_instance_of(Search::TimedCache).to receive(:get).with(no_args).and_return([example_document])
-    assert @base_registry["example-document"]
+    expect(@base_registry["example-document"]).to be_truthy
   end
 
   it "find_by_content_id" do
@@ -68,9 +68,8 @@ RSpec.describe Search::BaseRegistry do
       .with("example-format", anything)
       .and_return([example_document])
 
-    assert_equal(
-      @base_registry.by_content_id("example-content-id"),
-      example_document
-    )
+    expect(
+      @base_registry.by_content_id("example-content-id")
+    ).to eq(example_document)
   end
 end

--- a/spec/unit/search/best_bets_checker_spec.rb
+++ b/spec/unit/search/best_bets_checker_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "not find any best bets" do
-      assert_equal({}, @checker.best_bets)
+      expect({}).to eq(@checker.best_bets)
     end
 
     it "not find any worst bets" do
-      assert_equal([], @checker.worst_bets)
+      expect([]).to eq(@checker.worst_bets)
     end
   end
 
@@ -72,11 +72,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "find one best bet" do
-      assert_equal({ 1 => ["/jobsearch"] }, @checker.best_bets)
+      expect({ 1 => ["/jobsearch"] }).to eq(@checker.best_bets)
     end
 
     it "not find any worst bets" do
-      assert_equal([], @checker.worst_bets)
+      expect([]).to eq(@checker.worst_bets)
     end
   end
 
@@ -88,11 +88,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "not find any best bets" do
-      assert_equal({}, @checker.best_bets)
+      expect({}).to eq(@checker.best_bets)
     end
 
     it "find one worst bet" do
-      assert_equal(["/jobsearch"], @checker.worst_bets)
+      expect(["/jobsearch"]).to eq(@checker.worst_bets)
     end
   end
 
@@ -105,11 +105,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "find just the exact best bet" do
-      assert_equal({ 1 => ["/jobsearch"] }, @checker.best_bets)
+      expect({ 1 => ["/jobsearch"] }).to eq(@checker.best_bets)
     end
 
     it "not find any worst bets" do
-      assert_equal([], @checker.worst_bets)
+      expect([]).to eq(@checker.worst_bets)
     end
   end
 
@@ -122,11 +122,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "find both best bets" do
-      assert_equal({ 1 => ["/jobs", "/jobsearch"] }, @checker.best_bets)
+      expect(1 => ["/jobs", "/jobsearch"]).to eq(@checker.best_bets)
     end
 
     it "not find any worst bets" do
-      assert_equal([], @checker.worst_bets)
+      expect([]).to eq(@checker.worst_bets)
     end
   end
 
@@ -139,14 +139,14 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "use highest position for all best bets" do
-      assert_equal({
+      expect(
         1 => ["/jobs", "/jobsearch"],
         4 => ["/working"],
-      }, @checker.best_bets)
+      ).to eq(@checker.best_bets)
     end
 
     it "not find any worst bets" do
-      assert_equal([], @checker.worst_bets)
+      expect([]).to eq(@checker.worst_bets)
     end
   end
 
@@ -160,13 +160,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "use just the positions from the exact bet" do
-      assert_equal({
-        4 => ["/jobs"],
-      }, @checker.best_bets)
+      expect(4 => ["/jobs"]).to eq(@checker.best_bets)
     end
 
     it "find worst bets only from the exact bet" do
-      assert_equal(["/jobsearch"], @checker.worst_bets)
+      expect(["/jobsearch"]).to eq(@checker.worst_bets)
     end
   end
 end

--- a/spec/unit/search/elasticsearch_escaping_spec.rb
+++ b/spec/unit/search/elasticsearch_escaping_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Search::Escaping do
   end
 
   it "escapes_the_query_for_lucene_chars" do
-    assert_equal "how\\?", subject.escape("how?")
+    expect("how\\?").to eq(subject.escape("how?"))
   end
 
   it "escapes_the_query_for_lucene_booleans" do
-    assert_equal 'fish "AND" chips', subject.escape("fish AND chips")
+    expect('fish "AND" chips').to eq(subject.escape("fish AND chips"))
   end
 end

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Search::FormatMigrator do
         no_match_filter: 'none'
       }
     }
-    assert_equal expected, described_class.new(base_query).call
+    expect(expected).to eq(described_class.new(base_query).call)
   end
 
   it "when_base_query_with_migrated_formats" do
@@ -36,7 +36,7 @@ RSpec.describe Search::FormatMigrator do
         }
       }
     }
-    assert_equal expected, described_class.new(base_query).call
+    expect(expected).to eq(described_class.new(base_query).call)
   end
 
   it "when_no_base_query_without_migrated_formats" do
@@ -48,7 +48,7 @@ RSpec.describe Search::FormatMigrator do
         no_match_filter: 'none'
       }
     }
-    assert_equal expected, described_class.new(nil).call
+    expect(expected).to eq(described_class.new(nil).call)
   end
 
   it "when_no_base_query_with_migrated_formats" do
@@ -68,6 +68,6 @@ RSpec.describe Search::FormatMigrator do
         }
       }
     }
-    assert_equal expected, described_class.new(nil).call
+    expect(expected).to eq(described_class.new(nil).call)
   end
 end

--- a/spec/unit/search/matcher_set_spec.rb
+++ b/spec/unit/search/matcher_set_spec.rb
@@ -3,25 +3,25 @@ require 'spec_helper'
 RSpec.describe Search::MatcherSet do
   it "should_match_strings" do
     matcher_set = described_class.new(%w(foo bang))
-    assert matcher_set.include?("foo")
-    refute matcher_set.include?("baz")
+    expect(matcher_set).to include("foo")
+    expect(matcher_set).not_to include("baz")
   end
 
   it "should_match_strings_case_insensitively" do
     matcher_set = described_class.new(["foo"])
-    assert matcher_set.include?("Foo")
+    expect(matcher_set).to include("Foo")
   end
 
   it "should_match_regexes" do
     matcher_set = described_class.new([/oo/])
-    assert matcher_set.include?("Foo")
-    refute matcher_set.include?("Fopo")
+    expect(matcher_set).to include("Foo")
+    expect(matcher_set).not_to include("Fopo")
   end
 
   it "matchers_should_be_immutable" do
     members = ["foo"]
     matcher_set = described_class.new(members)
     members.pop
-    assert matcher_set.include?("foo")
+    expect(matcher_set).to include("foo")
   end
 end

--- a/spec/unit/search/presenters/entity_expander_spec.rb
+++ b/spec/unit/search/presenters/entity_expander_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe Search::EntityExpander do
       { "organisations" => ["rail-statistics"] }
     )
 
-    assert_equal result["organisations"].first, expandable_target
+    expect(result["organisations"].first).to eq(expandable_target)
   end
 end

--- a/spec/unit/search/presenters/highlighted_description_spec.rb
+++ b/spec/unit/search/presenters/highlighted_description_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Search::HighlightedDescription do
 
     highlighted_description = described_class.new(raw_result).text
 
-    assert_equal "I will be <mark>hightlighted</mark>.", highlighted_description
+    expect("I will be <mark>hightlighted</mark>.").to eq(highlighted_description)
   end
 
   it "uses_default_description_if_hightlight_not_found" do
@@ -19,7 +19,7 @@ RSpec.describe Search::HighlightedDescription do
 
     highlighted_description = described_class.new(raw_result).text
 
-    assert_equal "I will not be hightlighted &amp; escaped.", highlighted_description
+    expect("I will not be hightlighted &amp; escaped.").to eq(highlighted_description)
   end
 
   it "truncates_default_description_if_hightlight_not_found" do
@@ -29,8 +29,8 @@ RSpec.describe Search::HighlightedDescription do
 
     highlighted_description = described_class.new(raw_result).text
 
-    assert_equal 225, highlighted_description.size
-    assert highlighted_description.ends_with?('…')
+    expect(225).to eq(highlighted_description.size)
+    expect(highlighted_description.ends_with?('…')).to be_truthy
   end
 
   it "returns_empty_string_if_theres_no_description" do
@@ -40,6 +40,6 @@ RSpec.describe Search::HighlightedDescription do
 
     highlighted_description = described_class.new(raw_result).text
 
-    assert_equal "", highlighted_description
+    expect("").to eq(highlighted_description)
   end
 end

--- a/spec/unit/search/presenters/highlighted_title_spec.rb
+++ b/spec/unit/search/presenters/highlighted_title_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Search::HighlightedTitle do
       "highlight" => { "title" => ["A Highlighted Title"] }
     })
 
-    assert_equal "A Highlighted Title", title.text
+    expect("A Highlighted Title").to eq(title.text)
   end
 
   it "fallback_title_is_escaped" do
@@ -15,6 +15,6 @@ RSpec.describe Search::HighlightedTitle do
       "fields" => { "title" => "A & Title" },
     })
 
-    assert_equal "A &amp; Title", title.text
+    expect("A &amp; Title").to eq(title.text)
   end
 end

--- a/spec/unit/search/presenters/result_presenter_spec.rb
+++ b/spec/unit/search/presenters/result_presenter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::ResultPresenter do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[format])).present
 
-    assert_equal "a-string", result["format"]
+    expect("a-string").to eq(result["format"])
   end
 
   it "conversion_values_to_labelled_objects" do
@@ -22,7 +22,11 @@ RSpec.describe Search::ResultPresenter do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[railway_type])).present
 
-    assert_equal [{ "label" => "Heavy rail", "value" => "heavy-rail" },
-                  { "label" => "Light rail", "value" => "light-rail" }], result["railway_type"]
+    expect(
+      [
+        { "label" => "Heavy rail", "value" => "heavy-rail" },
+        { "label" => "Light rail", "value" => "light-rail" }
+      ]
+    ).to eq(result["railway_type"])
   end
 end

--- a/spec/unit/search/presenters/temporary_link_fix_spec.rb
+++ b/spec/unit/search/presenters/temporary_link_fix_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
 
-    assert_equal "/some/link", result["link"]
+    expect("/some/link").to eq(result["link"])
   end
 
   it "keep_http_links_intact" do
@@ -22,7 +22,7 @@ RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
 
-    assert_equal "http://example.org/some-link", result["link"]
+    expect("http://example.org/some-link").to eq(result["link"])
   end
 
   it "keep_correct_links_intact" do
@@ -34,6 +34,6 @@ RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
 
-    assert_equal "/some-link", result["link"]
+    expect("/some-link").to eq(result["link"])
   end
 end

--- a/spec/unit/search/query_builder_spec.rb
+++ b/spec/unit/search/query_builder_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Search::QueryBuilder do
       builder = builder_with_params(start: 11, count: 34, return_fields: ['a_field'])
 
       result = builder.payload
-      assert_equal 11, result[:from]
-      assert_equal 34, result[:size]
-      assert result[:fields].include?('a_field')
-      assert result.key?(:query)
+      expect(11).to eq(result[:from])
+      expect(34).to eq(result[:size])
+      expect(result[:fields]).to include('a_field')
+      expect(result.key?(:query)).to be_truthy
     end
   end
 

--- a/spec/unit/search/query_parameters_spec.rb
+++ b/spec/unit/search/query_parameters_spec.rb
@@ -4,74 +4,74 @@ RSpec.describe Search::QueryParameters do
   context "quoted_search_phrase?" do
     it "return false if query isn't quote enclosed" do
       params = described_class.new(query: "my query")
-      assert_equal false, params.quoted_search_phrase?
+      expect(false).to eq(params.quoted_search_phrase?)
     end
 
     it "return false if entire query isn't quote enclosed" do
       params = described_class.new(query: %{This is "part of my" query})
-      assert_equal false, params.quoted_search_phrase?
+      expect(false).to eq(params.quoted_search_phrase?)
     end
 
     it "return false if query doesn't have ending quotes" do
       params = described_class.new(query: %{"unclosed quotes})
-      assert_equal false, params.quoted_search_phrase?
+      expect(false).to eq(params.quoted_search_phrase?)
     end
 
     it "return false if query doesn't have starting quotes" do
       params = described_class.new(query: %{unclosed quotes"})
-      assert_equal false, params.quoted_search_phrase?
+      expect(false).to eq(params.quoted_search_phrase?)
     end
 
     it "return true if query enclosed with quotes" do
       params = described_class.new(query: %{"phrase enclosed with quotes"})
-      assert_equal true, params.quoted_search_phrase?
+      expect(true).to eq(params.quoted_search_phrase?)
     end
 
     it "return false if enclosed with quotes but has intervening quotes" do
       params = described_class.new(query: %{"phrase enclosed with quotes and "quotes" in the middle})
-      assert_equal false, params.quoted_search_phrase?
+      expect(false).to eq(params.quoted_search_phrase?)
     end
 
     it "return true if query enclosed with quotes but with leading whitespace" do
       params = described_class.new(query: %{  \t  "phrase enclosed with quotes"})
-      assert_equal true, params.quoted_search_phrase?
+      expect(true).to eq(params.quoted_search_phrase?)
     end
 
     it "return true if query enclosed with quotes but with trailing whitespace" do
       params = described_class.new(query: %{"phrase enclosed with quotes"  \t  })
-      assert_equal true, params.quoted_search_phrase?
+      expect(true).to eq(params.quoted_search_phrase?)
     end
 
     it "return false if the query is nil" do
       params = described_class.new
-      assert_equal false, params.quoted_search_phrase?
+      expect(false).to eq(params.quoted_search_phrase?)
     end
   end
 
   context "query" do
     it "return the query if there are no enclosing quotes" do
       params = described_class.new(query: %{my query})
-      assert_equal %{my query}, params.query
+      expect(%{my query}).to eq(params.query)
     end
 
     it "return the query with enclosing quotes if there are embedded quotes" do
       params = described_class.new(query: %{"Enclosing quotes but with "embedded" quotes"})
-      assert_equal %{"Enclosing quotes but with "embedded" quotes"}, params.query
+      expect(%{"Enclosing quotes but with "embedded" quotes"}).to eq(params.query)
     end
 
     it "not strip leading and trailing whitespace if phrase is enclosed in quotes" do
       params = described_class.new(query: %{  \t "Enclosing quotes"\t  })
-      assert_equal %{  \t "Enclosing quotes"\t  }, params.query
+      expect(%{  \t "Enclosing quotes"\t  }).to eq(params.query)
     end
 
     it "not strip leading and trailing whitespace if not enclosed in quotes" do
       params = described_class.new(query: %{  my query  })
-      assert_equal %{  my query  }, params.query
+      expect(%{  my query  }).to eq(params.query)
     end
 
     it "not strip leading and trailing whitespace if phrase contains embedded quotes" do
       params = described_class.new(query: %{  \t"Enclosing quotes but with "embedded" quotes"  })
-      assert_equal %{  \t"Enclosing quotes but with "embedded" quotes"  }, params.query
+      expect(%{  \t"Enclosing quotes but with "embedded" quotes"  }).to eq(params.query)
     end
   end
 end

--- a/spec/unit/search/result_set_spec.rb
+++ b/spec/unit/search/result_set_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Search::ResultSet do
     end
 
     it "report zero results" do
-      assert_equal 0, described_class.from_elasticsearch(sample_elasticsearch_types, @response).total
+      expect(0).to eq(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total)
     end
 
     it "have an empty result set" do
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
-      assert_equal 0, result_set.results.size
+      expect(0).to eq(result_set.results.size)
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe Search::ResultSet do
     end
 
     it "report one result" do
-      assert_equal 1, described_class.from_elasticsearch(sample_elasticsearch_types, @response).total
+      expect(1).to eq(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total)
     end
 
     it "pass the fields to Document.from_hash" do
@@ -47,14 +47,14 @@ RSpec.describe Search::ResultSet do
       expect(Document).to receive(:from_hash).with(expected_hash, sample_elasticsearch_types, anything).and_return(:doc)
 
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
-      assert_equal [:doc], result_set.results
+      expect([:doc]).to eq(result_set.results)
     end
 
     it "pass the result score to Document.from_hash" do
       expect(Document).to receive(:from_hash).with(an_instance_of(Hash), sample_elasticsearch_types, 12).and_return(:doc)
 
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
-      assert_equal [:doc], result_set.results
+      expect([:doc]).to eq(result_set.results)
     end
 
     it "populate the document id and type from the metafields" do
@@ -62,7 +62,7 @@ RSpec.describe Search::ResultSet do
       expect(Document).to receive(:from_hash).with(expected_hash, sample_elasticsearch_types, anything).and_return(:doc)
 
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
-      assert_equal [:doc], result_set.results
+      expect([:doc]).to eq(result_set.results)
     end
   end
 end

--- a/spec/unit/search/specialist_sector_registry_spec.rb
+++ b/spec/unit/search/specialist_sector_registry_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Search::BaseRegistry, 'Specialist Sector' do
       .with("specialist_sector", anything)
       .and_return([oil_and_gas])
     sector = @specialist_sector_registry["oil-and-gas/licensing"]
-    assert_equal oil_and_gas, sector
+    expect(oil_and_gas).to eq(sector)
   end
 
   it "only_required_fields_are_requested_from_index" do
@@ -34,7 +34,7 @@ RSpec.describe Search::BaseRegistry, 'Specialist Sector' do
       .with("specialist_sector", anything)
       .and_return([oil_and_gas])
     sector = @specialist_sector_registry["foo"]
-    assert_nil sector
+    expect(sector).to be_nil
   end
 
   it "uses_300_second_cache_lifetime" do

--- a/spec/unit/search/spell_check_presenter_spec.rb
+++ b/spec/unit/search/spell_check_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Search::SpellCheckPresenter do
 
       presenter = described_class.new(es_response)
 
-      assert_equal presenter.present, ["the first suggestion", "the second suggestion"]
+      expect(presenter.present).to eq(["the first suggestion", "the second suggestion"])
     end
   end
 end

--- a/spec/unit/search/suggestion_blacklist_spec.rb
+++ b/spec/unit/search/suggestion_blacklist_spec.rb
@@ -20,23 +20,23 @@ RSpec.describe Search::SuggestionBlacklist do
 
   context "#should_correct?" do
     it "correct normal strings" do
-      assert blacklist.should_correct?("some test")
+      expect(blacklist.should_correct?("some test")).to be_truthy
     end
 
     it "not correct strings with numbers" do
-      refute blacklist.should_correct?("86asrdv")
+      expect(blacklist.should_correct?("86asrdv")).to be_falsey
     end
 
     it "not correct words added to ignore.yml" do
-      refute blacklist.should_correct?("bodrum")
+      expect(blacklist.should_correct?("bodrum")).to be_falsey
     end
 
     it "not correct names added to ignore.yml" do
-      refute blacklist.should_correct?("Alan Turing")
+      expect(blacklist.should_correct?("Alan Turing")).to be_falsey
     end
 
     it "correct words in the organization" do
-      refute blacklist.should_correct?("mod")
+      expect(blacklist.should_correct?("mod")).to be_falsey
     end
   end
 end

--- a/spec/unit/search/timed_cache_spec.rb
+++ b/spec/unit/search/timed_cache_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Search::TimedCache do
     expect(fetch).to receive(:call).and_return("foo").once
 
     cache = described_class.new(5) { fetch.call }
-    2.times { assert_equal "foo", cache.get }
+    2.times { expect("foo").to eq(cache.get) }
   end
 
   it "cache_does_not_expire_within_lifetime" do

--- a/spec/unit/search_server_spec.rb
+++ b/spec/unit/search_server_spec.rb
@@ -11,35 +11,35 @@ RSpec.describe SearchIndices::SearchServer do
   it "returns_an_index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index("mainstream_test")
-    assert index.is_a?(SearchIndices::Index)
-    assert_equal "mainstream_test", index.index_name
+    expect(index).to be_a(SearchIndices::Index)
+    expect("mainstream_test").to eq(index.index_name)
   end
 
   it "returns_an_index_for_govuk_index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index("govuk_test")
-    assert index.is_a?(SearchIndices::Index)
-    assert_equal "govuk_test", index.index_name
+    expect(index).to be_a(SearchIndices::Index)
+    expect("govuk_test").to eq(index.index_name)
   end
 
   it "raises_an_error_for_unknown_index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
-    assert_raises SearchIndices::NoSuchIndex do
+    expect {
       search_server.index("z")
-    end
+    }.to raise_error(SearchIndices::NoSuchIndex)
   end
 
   it "can_get_multi_index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index_for_search(%w{mainstream_test page-traffic_test})
-    assert index.is_a?(LegacyClient::IndexForSearch)
-    assert_equal ["mainstream_test", "page-traffic_test"], index.index_names
+    expect(index).to be_a(LegacyClient::IndexForSearch)
+    expect(["mainstream_test", "page-traffic_test"]).to eq(index.index_names)
   end
 
   it "raises_an_error_for_unknown_index_in_multi_index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
-    assert_raises SearchIndices::NoSuchIndex do
+    expect {
       search_server.index_for_search(%w{mainstream_test unknown})
-    end
+    }.to raise_error(SearchIndices::NoSuchIndex)
   end
 end

--- a/spec/unit/sitemap/property_boost_calculator_spec.rb
+++ b/spec/unit/sitemap/property_boost_calculator_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    assert_equal 0, calculator.boost(build_document(format: "format1"))
-    assert_equal 0.5, calculator.boost(build_document(format: "format2"))
-    assert_equal 0.75, calculator.boost(build_document(format: "format3"))
-    assert_equal 0.88, calculator.boost(build_document(format: "format4"))
-    assert_equal 1, calculator.boost(build_document(format: "format5"))
+    expect(0).to eq(calculator.boost(build_document(format: "format1")))
+    expect(0.5).to eq(calculator.boost(build_document(format: "format2")))
+    expect(0.75).to eq(calculator.boost(build_document(format: "format3")))
+    expect(0.88).to eq(calculator.boost(build_document(format: "format4")))
+    expect(1).to eq(calculator.boost(build_document(format: "format5")))
   end
 
   it "unboosted_format_has_default_boost" do
@@ -31,7 +31,7 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    assert_equal 0.5, calculator.boost(build_document(format: "some_format"))
+    expect(0.5).to eq(calculator.boost(build_document(format: "some_format")))
   end
 
   it "boosts_limit_is_1" do
@@ -45,9 +45,9 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    assert_equal 1, calculator.boost(build_document(format: "format1"))
-    assert_equal 1, calculator.boost(build_document(format: "format2"))
-    assert_equal 1, calculator.boost(build_document(format: "format3"))
+    expect(1).to eq(calculator.boost(build_document(format: "format1")))
+    expect(1).to eq(calculator.boost(build_document(format: "format2")))
+    expect(1).to eq(calculator.boost(build_document(format: "format3")))
   end
 
   it "unconfigured_format_has_default_boost" do
@@ -59,7 +59,7 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    assert_equal 0.5, calculator.boost(build_document(format: "other_format"))
+    expect(0.5).to eq(calculator.boost(build_document(format: "other_format")))
   end
 
   it "unconfigured_property_has_default_boost" do
@@ -71,7 +71,7 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    assert_equal 0.5, calculator.boost(build_document(document_type: "some_doc_type"))
+    expect(0.5).to eq(calculator.boost(build_document(document_type: "some_doc_type")))
   end
 
   it "boosts_are_rounded" do
@@ -84,8 +84,8 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    assert_equal 0.08, calculator.boost(build_document(format: "format1"))
-    assert_equal 0.27, calculator.boost(build_document(format: "format2"))
+    expect(0.08).to eq(calculator.boost(build_document(format: "format1")))
+    expect(0.27).to eq(calculator.boost(build_document(format: "format2")))
   end
 
   it "boosts_for_different_fields_are_combined" do
@@ -112,7 +112,7 @@ RSpec.describe PropertyBoostCalculator do
     #   1 - 2^(-format boost * document type boost * navigation supertype boost)
     # = 1 - 2^(-0.5 * 0.2 * 1)
     # = 0.07
-    assert_equal 0.07, calculator.boost(document)
+    expect(0.07).to eq(calculator.boost(document))
   end
 
   it "external_search_overrides_are_applied" do
@@ -135,7 +135,7 @@ RSpec.describe PropertyBoostCalculator do
     # 1 - 2^(-boost_override) = 1 - 2^(-2) = 0.75
     expected_boost_override = 0.75
     actual_boost = calculator.boost(build_document(format: "service_manual_guide"))
-    assert_equal expected_boost_override, actual_boost
+    expect(expected_boost_override).to eq(actual_boost)
   end
 
   def stub_boost_config(boosts)

--- a/spec/unit/sitemap/sitemap_generator_spec.rb
+++ b/spec/unit/sitemap/sitemap_generator_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe SitemapGenerator do
 
     doc = Nokogiri::XML(sitemap_xml)
     urls = doc.css('url > loc').map(&:inner_html)
-    assert_equal "https://www.gov.uk/page", urls[0]
-    assert_equal "http://www.dev.gov.uk/another-page", urls[1]
-    assert_equal "http://www.dev.gov.uk/yet-another-page", urls[2]
+    expect("https://www.gov.uk/page").to eq(urls[0])
+    expect("http://www.dev.gov.uk/another-page").to eq(urls[1])
+    expect("http://www.dev.gov.uk/yet-another-page").to eq(urls[2])
   end
 
   it "links_should_include_timestamps" do
@@ -26,7 +26,7 @@ RSpec.describe SitemapGenerator do
 
     pages = Nokogiri::XML(sitemap_xml).css("url")
 
-    assert_equal "2014-01-28T14:41:50+00:00", pages[0].css("lastmod").text
+    expect("2014-01-28T14:41:50+00:00").to eq(pages[0].css("lastmod").text)
   end
 
   it "missing_timestamps_are_ignored" do
@@ -38,7 +38,7 @@ RSpec.describe SitemapGenerator do
 
     pages = Nokogiri::XML(sitemap_xml).css("url")
 
-    assert_page_has_no_lastmod(pages[0])
+    expect_page_has_no_lastmod(pages[0])
   end
 
   it "page_priority_is_document_priority" do
@@ -51,7 +51,7 @@ RSpec.describe SitemapGenerator do
 
     pages = Nokogiri::XML(sitemap_xml).css("url")
 
-    assert_equal("0.48", pages[0].css("priority").text)
+    expect("0.48").to eq(pages[0].css("priority").text)
   end
 
   def build_document(url, timestamp: nil, is_withdrawn: nil)
@@ -68,9 +68,8 @@ RSpec.describe SitemapGenerator do
     )
   end
 
-  def assert_page_has_no_lastmod(page)
+  def expect_page_has_no_lastmod(page)
     last_modified = page.css("lastmod").text
-    assert last_modified.empty?,
-      "Page in sitemap has unexpected 'lastmod' date: '#{last_modified}'"
+    expect(last_modified).to be_empty, "Page in sitemap has unexpected 'lastmod' date: '#{last_modified}'"
   end
 end

--- a/spec/unit/sitemap/sitemap_index_spec.rb
+++ b/spec/unit/sitemap/sitemap_index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Sitemap, 'Index' do
     sitemap.write_index(sitemaps)
     doc = Nokogiri::XML(index_file.string)
     doc.css('sitemapindex > sitemap').zip(sitemaps) do |sitemap_xml, filename|
-      assert sitemap_xml.css('loc').first.text.end_with? filename
+      expect(sitemap_xml.css('loc').first.text).to match(/#{filename}$/)
     end
   end
 end

--- a/spec/unit/sitemap/sitemap_presenter_spec.rb
+++ b/spec/unit/sitemap/sitemap_presenter_spec.rb
@@ -12,19 +12,19 @@ RSpec.describe SitemapPresenter do
   it "url_is_document_link_if_link_is_http_url" do
     document = build_document(url: "http://some.url")
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal "http://some.url", presenter.url
+    expect("http://some.url").to eq(presenter.url)
   end
 
   it "url_is_document_link_if_link_is_https_url" do
     document = build_document(url: "https://some.url")
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal "https://some.url", presenter.url
+    expect("https://some.url").to eq(presenter.url)
   end
 
   it "url_appends_host_name_if_link_is_a_path" do
     document = build_document(url: "/some/path")
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal "https://website_root/some/path", presenter.url
+    expect("https://website_root/some/path").to eq(presenter.url)
   end
 
   it "last_updated_is_timestamp_if_timestamp_is_date_time" do
@@ -33,7 +33,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "2014-01-28T14:41:50+00:00"
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal "2014-01-28T14:41:50+00:00", presenter.last_updated
+    expect("2014-01-28T14:41:50+00:00").to eq(presenter.last_updated)
   end
 
   it "last_updated_is_timestamp_if_timestamp_is_date" do
@@ -42,7 +42,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "2017-07-12"
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal "2017-07-12", presenter.last_updated
+    expect("2017-07-12").to eq(presenter.last_updated)
   end
 
   it "last_updated_is_limited_to_recent_date" do
@@ -51,7 +51,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "1995-06-01"
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal "2012-10-17T00:00:00+00:00", presenter.last_updated
+    expect("2012-10-17T00:00:00+00:00").to eq(presenter.last_updated)
   end
 
   it "last_updated_is_omitted_if_timestamp_is_missing" do
@@ -60,7 +60,7 @@ RSpec.describe SitemapPresenter do
       timestamp: nil
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_nil presenter.last_updated
+    expect(presenter.last_updated).to be_nil
   end
 
   it "last_updated_is_omitted_if_timestamp_is_invalid" do
@@ -69,7 +69,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "not-a-date"
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_nil presenter.last_updated
+    expect(presenter.last_updated).to be_nil
   end
 
   it "last_updated_is_omitted_if_timestamp_is_in_invalid_format" do
@@ -78,7 +78,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "01-01-2017"
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_nil presenter.last_updated
+    expect(presenter.last_updated).to be_nil
   end
 
   it "default_page_priority_is_maximum_value" do
@@ -87,7 +87,7 @@ RSpec.describe SitemapPresenter do
       is_withdrawn: false
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal 1, presenter.priority
+    expect(1).to eq(presenter.priority)
   end
 
   it "withdrawn_page_has_lower_priority" do
@@ -96,7 +96,7 @@ RSpec.describe SitemapPresenter do
       is_withdrawn: true
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal 0.25, presenter.priority
+    expect(0.25).to eq(presenter.priority)
   end
 
   it "page_with_no_withdrawn_flag_has_maximum_priority" do
@@ -104,7 +104,7 @@ RSpec.describe SitemapPresenter do
       url: "/some/path"
     )
     presenter = described_class.new(document, @boost_calculator)
-    assert_equal 1, presenter.priority
+    expect(1).to eq(presenter.priority)
   end
 
   it "page_with_boosted_format_has_adjusted_priority" do
@@ -116,7 +116,7 @@ RSpec.describe SitemapPresenter do
     allow(property_boost_calculator).to receive(:boost).with(document).and_return(0.72)
 
     presenter = described_class.new(document, property_boost_calculator)
-    assert_equal 0.72, presenter.priority
+    expect(0.72).to eq(presenter.priority)
   end
 
   def build_document(url:, timestamp: nil, format: nil, is_withdrawn: nil)


### PR DESCRIPTION
* extract `.include?` to `include`
* extract `.<method>?` to `be_<method>`
* `.is_a?` to `be_a`
* remained to `be_truthy`
* replace assert_equal
* replace assert_nil
* replace assert_document_is_in_rummager -> expect_document_is_in_rummager
* replace custom test methods rename assert_* to expect_*
* replace assert_match
* replace assert_raises
* replace refute_*