### PR TITLE
Revise README and search API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # Rummager
 
-Rummager is the internal GOV.UK API for search.
+Rummager is the GOV.UK API for search.
 
 ## Live examples
 
-- [alphagov/frontend](https://github.com/alphagov/frontend) uses Rummager to
-	serve the GOV.UK search at [gov.uk/search](https://www.gov.uk/search).
-- [alphagov/finder-frontend](https://github.com/alphagov/finder-frontend) uses
-	Rummager to serve document finders like
-	[gov.uk/aaib-reports](https://www.gov.uk/aaib-reports).
-
-This API is publicly accessible:
-
+### The public search API
 https://www.gov.uk/api/search.json?q=taxes
 ![Screenshot of API Response](doc/api-screenshot.png)
 
-You can read how to use the API in the blog post: ["Use the search API to get useful information about GOV.UK content"](https://gdsdata.blog.gov.uk/2016/05/26/use-the-search-api-to-get-useful-information-about-gov-uk-content/).
+For the most up to date query syntax and API output see the [Search API documentation](https://docs.publishing.service.gov.uk/apis/search/search-api.html).
+
+You can also find some examples in the blog post: ["Use the search API to get useful information about GOV.UK content"](https://gdsdata.blog.gov.uk/2016/05/26/use-the-search-api-to-get-useful-information-about-gov-uk-content/).
+
+### GOV.UK site search
+
+[alphagov/frontend](https://github.com/alphagov/frontend) uses the search API
+to render search results.
+
+### Finders
+[alphagov/finder-frontend](https://github.com/alphagov/finder-frontend) uses
+the search API to serve document finders like [gov.uk/aaib-reports](https://www.gov.uk/aaib-reports).
 
 ## Technical documentation
 
@@ -112,14 +116,13 @@ After changing the schema, you'll need to migrate the index.
 
     RUMMAGER_INDEX=all bundle exec rake rummager:migrate_index
 
-### API documentation
+#### Internal only APIs
 
-For the most up to date query syntax and API output:
+There are some other APIs that are only exposed internally:
 
-- [doc/search-api.md](doc/search-api.md) for the search
-	endpoint (`/search.json`).
 - [doc/content-api.md](doc/content-api.md) for the `/content/*` endpoint.
 - [doc/documents.md](doc/documents.md) for the `*/documents/` endpoint.
+
 
 ### Additional Docs
 

--- a/doc/search-api.md
+++ b/doc/search-api.md
@@ -1,34 +1,47 @@
-# Search API
+# Using the search API
 
-This API is the main endpoint for performing searches on GOV.UK.  It supports
-keyword searching, ordering by relevance or date fields, filtering and
-aggregating.
+## Quickstart
 
-At the time of writing, there is one other endpoint, the `advanced_search`
-endpoint, which is slowly being replaced by the `search` endpoint.  The
-`advanced_search` endpoint shouldn't be used by new code.
+The user entered search query is specified using the `q` parameter. This should be exactly what the user typed into a search box, encoded as UTF-8. Any well-formed UTF-8 values are allowed.
 
-## Parameters
+```
+curl 'https://www.gov.uk/api/search.json?q=taxes&count=1'
+```
 
-The search API supports many query string parameters.  It validates
-parameters strictly - any unknown parameters, or parameters with invalid
-options, will cause an HTTP 422 error.  This makes it likely that typos do not
-result in silently returning the wrong results, and also makes it easier to
-modify the API to add new features without risking breaking old calls.
+```json
+{
+    "facets": {},
+    "results": [
+        {
+            "_id": "/vehicle-tax",
+            "description": "Renew or tax your vehicle for the first time, apply online, by phone or at the Post Office",
+            "document_type": "edition",
+            "es_score": 0.191312,
+            "format": "transaction",
+            "index": "mainstream",
+            "link": "/vehicle-tax",
+            "organisations": [
+                {
+                    "acronym": "DVLA",
+                    "content_id": "70580624-93b5-4aed-823b-76042486c769",
+                    "link": "/government/organisations/driver-and-vehicle-licensing-agency",
+                    "organisation_state": "live",
+                    "slug": "driver-and-vehicle-licensing-agency",
+                    "title": "Driver and Vehicle Licensing Agency"
+                }
+            ],
+            "public_timestamp": "2014-12-09T16:21:03+00:00",
+            "title": "Tax your vehicle"
+        }
+    ],
+    "start": 0,
+    "suggested_queries": [],
+    "total": 45118
+}
+```
 
-Note that query parameters which are repeated may be specified in standard HTTP
-style (ie, `name=value&name=value`, where the same name may be used multiple
-times), or in Ruby/PHP array style (ie, `name[]=value&name[]=value`).  The `[]`
-is simply ignored. This allows for easy calling from Ruby-style frameworks, or
-from other languages which use standard HTTP conventions.  No more complex
-structures are passed in the API.
-
-The parameters supported are:
-
- - `q`: (single string) User-entered search query.  This should be exactly what
-   the user typed into a search box, encoded as `UTF-8`.  Any well-formed
-   `UTF-8` values are allowed.  Lots of complex processing will be performed on
-   this field to try to determine the best matching documents for the query.
+## Pagination
+Pagination is controlled using the `start`, `count`, and `order` parameters.
 
  - `start`: (single integer) Position in search result list to start returning
    results (0-based)  If the `start` offset is greater than the number of
@@ -46,176 +59,192 @@ The parameters supported are:
    is relevance.  Only some fields can be sorted on - an HTTP 422 error will be
    returned if the requested field is not a valid sort field.
 
- - `filter_FIELD`: (single string, where `FIELD` is a field name); a filter to
-   apply to a field.
 
-   Multiple values may be given, and filters may be specified for multiple
-   fields at once.  The filters are grouped by field name; documents will only
-   be returned if they match all of these filter groups, and they will be
-   considered to match a filter group if any of the individual filters in that
-   group match (ie, only one of the values specified for a field needs to
-   match, but all fields with any filters specified must match at least one
-   value).
+## Error reporting
 
-   The special value `_MISSING` may be specified as a filter value - this will
-   match documents where the field is not present at all.
+The search API supports many query string parameters.  It validates
+parameters strictly - any unknown parameters, or parameters with invalid
+options, will cause an HTTP 422 error.  This means that typos do not make the
+API silently return the wrong results, and new features can be added to the API
+without changing what existing clients see.
 
-   For string fields, values are the field value to match.
+## Returning specific document fields
 
-   For date fields, values are date ranges.  These are specified as comma
-   separated lists of `key:value` parameters, where `key` is one of `from` or
-   `to`, and the value is an ISO formatted date (with no timezone).  UTC is
-   assumed for all dates handled by rummager.  Date ranges are inclusive of
-   their endpoints.
+See the [field reference](https://docs.publishing.service.gov.uk/apis/search/fields.html) for a list of all fields returned by the search API.
 
-   For example: `from:2014-04-01 00:00,to:2014-04-02 00:00` is a range for 24
-   hours from midnight at the start of April the 1st 2014, including midnight
-   that day or the following day.
+Only a few fields are returned by default. You can override the fields returned using the `fields` parameter. For example:
 
-   Currently, it is not permitted to specify multiple values for a date field
-   filter.
+```
+https://www.gov.uk/api/search.json?q=passport&fields=mainstream_browse_pages&fields=title
+```
 
-   Only some fields can be filtered on - an HTTP 422 error will be returned if
-   the requested field is not a value sort field.
+Note that query parameters which are repeated may be specified in standard HTTP
+style (ie, `name=value&name=value`, where the same name may be used multiple
+times), or in Ruby/PHP array style (ie, `name[]=value&name[]=value`).
 
- - `reject_FIELD`: (single string where `FIELD` is a field name); a
-   reject-filter to apply to a field.  This behaves just like a filter, but
-   will return documents which don't match any of the supplied values for a
-   field.
+## Building facetted search with filters and aggregations
 
-   If a filter and a reject are specified for the same field, an HTTP 422 error
-   will be returned.  However, it is valid to specify a reject for some fields
-   and a filter for others - documents will be required to match the criteria
-   on both fields.
+### Filter parameters
+You can filter search results using any of the filter_<field name> or reject_<field name> query parameters.
 
- - `facet_FIELD`: (single string where `FIELD` is a field name); count up
-   values which are present in the field in the documents matched by the
-   search, and return information about these.
+- filter is used to only return documents that match a value
+- reject excludes documents that match a value
 
-   The value of this parameter is a comma separated list of options; the first
-   option in the list is an integer which controls the requested number of
-   distinct field values to be returned for the field.  Regardless of the
-   number set here, a value will be returned for any filter which is in place
-   on the field. This may cause the requested number of values to be exceeded.
+Multiple values may be given, and filters may be specified for multiple fields at once. The filters are grouped by field name; documents will only be returned if they match all of these filter groups, and they will be considered to match a filter group if any of the individual filters in that group match (ie, only one of the values specified for a field needs to match, but all fields with any filters specified must match at least one value).
 
-   Subsequent options are optional, and are represented as colon separated
-   key:value pairs (note, colon separated instead of comma, since commas are
-   used to separate options).
+The special value `_MISSING` may be specified as a filter value - this will match documents where the field is not present at all.
 
-   - `scope`: One of `all_filters` and `exclude_field_filter` (the default).
+For string fields, values are the field value to match.
 
-     If set to `all_filters`, the aggregate counts are made after applying all the
-     filters.  If set to `exclude_field_filter`, the aggregate counts are made
-     after applying all filters _except_ for those applied to the field that
-     the aggregates are being counted for.  This is a convenient option for
-     calculating values to show in common interfaces which use aggregate for
-     narrowing down search results.
+For date fields, values are date ranges. These are specified as comma separated lists of key:value parameters, where key is one of `from` or `to`, and the value is an ISO formatted date (with no timezone). UTC is assumed for all dates handled by rummager. Date ranges are inclusive of their endpoints.
 
-   - `order`: Colon separated list of ordering types.
+For example: `from:2014-04-01 00:00,to:2014-04-02 00:00` is a range for 24 hours from midnight at the start of April the 1st 2014, including midnight that day or the following day.
 
-     The available ordering types are:
+Currently, it is not permitted to specify multiple values for a date field filter.
 
-      - `filtered`: whether the value is used in an active filter.  This can be
-	used to sort such that the values which are being filtered on come
-	first.
-      - `count`: order by the number of documents in the search matching the
-	facet value.
-      - `value`: sort by value if the field values are string, sort by the
-	`title` field in the value object if the value is an object.  Sorting
-	is case insensitive in either case.
-      - `value.slug`: the slug in the facet value object
-      - `value.link`: the link in the facet value object
-      - `value.title`: the title in the facet value object (case insensitive)
+Only some fields can be filtered on - an HTTP 422 error will be returned if the requested field is not a value sort field.
 
-     Each ordering may be preceded by a "-" to sort in descending order.
-     Multiple orderings can be specified, in priority order, separated by a
-     colon.  The default ordering is "filtered:-count:slug".
+If a filter and a reject are specified for the same field, an HTTP 422 error will be returned. However, it is valid to specify a reject for some fields and a filter for others - documents will be required to match the criteria on both fields.
 
-   - `examples`: integer number of example values to return
+### Aggregation parameters
 
-     This causes facet values to contain an "examples" hash as an additional
-     field, which contains details of example documents which match the query.
-     The examples are sorted by decreasing popularity.  An example facet value
-     in a response with this option set as "examples:1" might look like:
+Aggregations look at all the values of a a field and count up the number of times each one appears in documents matching the search.
 
-        "value" => {
-          "slug" => "an-example-facet-slug",
-          "example_info" => {
-            "total" => 3,  # The total number of matching examples
-            "examples" => [
-              {"title" => "Title of the first example", "link" => "/foo"},
-            ],
-          }
-        }
+You can include facets in any search by specifying one of the aggregate_<field name> query parameters.
 
-   - `example_scope`: `global` or `query`.  If the `examples` option is supplied, the
-     `example_scope` option must be supplied too.
+For example, to group by organisation:
 
-     The value of `global` causes the returned examples to be taken from all
-     documents in which the facet field has the given slug.
-
-     The value of `query` causes the returned examples to be taken only from
-     those documents which match the query (and all filters).
-
-   - `example_fields`: colon separated list of fields.
-
-     If the examples option is supplied, this lists the fields which are
-     returned for each example.  By default, only a small number of fields are
-     returned for each.
-
- - fields: fields to be returned in the result documents.  By default, and for
-   backwards compatibility, a fairly long set of fields is currently returned,
-   but it is good practice to set this to only the fields you actually want
-   information on (doing this will normally increase performance).
-
- - ab_tests: a/b test with selected variant type. This allows test to be configured
-   from upstream apps.
-
-   Each a/b test name should be followed by a ':' and then the variant type to
-   be used. If multiple a/b test setting are being passed in they should be
-   comma separated.
-
-   No validation is done to ensure the a/b test name provided is current implemented.
-
-## Examples
-
-For example:
-
-    /search.json?
-     q=foo&
-     start=0&
-     count=20&
-     order=-public_timestamp&
-     filter_organisations[]=cabinet-office&
-     filter_organisations[]=driver-vehicle-licensing-agency&
-     filter_section[]=driving&
-     facet_organisations=10&
-     ab_tests=test1:B,test2:A
-
-Returns something like:
+```
+curl 'https://www.gov.uk/api/search.json?count=0&aggregate_organisations=3'
+```
 
 ```json
 {
-  "results": [
-    {...},
-    {...}
-  ],
-  "total": 19,
-  "offset": 0,
-  "spelling_suggestions": [
-    ...
-  ],
-  "facets": {
-    "organisations": {
-      "options": [
-        {
-          "value": "department-for-business-innovation-skills",
-          "documents": 788
-        }, ...],
-      "documents_with_no_value": 1610,
-      "total_options": 94,
-      "missing_options": 84
-    }
-  }
+    "aggregates": {
+        "organisations": {
+            "documents_with_no_value": 15996,
+            "missing_options": 1033,
+            "options": [
+                {
+                    "documents": 80911,
+                    "value": {
+                        "acronym": "HMRC",
+                        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+                        "link": "/government/organisations/hm-revenue-customs",
+                        "organisation_state": "live",
+                        "slug": "hm-revenue-customs",
+                        "title": "HM Revenue & Customs"
+                    }
+                },
+                {
+                    "documents": 34463,
+                    "value": {
+                        "acronym": "DFID",
+                        "content_id": "db994552-7644-404d-a770-a2fe659c661f",
+                        "link": "/government/organisations/department-for-international-development",
+                        "organisation_state": "live",
+                        "slug": "department-for-international-development",
+                        "title": "Department for International Development"
+                    }
+                },
+                {
+                    "documents": 13469,
+                    "value": {
+                        "acronym": "FCO",
+                        "content_id": "9adfc4ed-9f6c-4976-a6d8-18d34356367c",
+                        "link": "/government/organisations/foreign-commonwealth-office",
+                        "organisation_state": "live",
+                        "slug": "foreign-commonwealth-office",
+                        "title": "Foreign & Commonwealth Office"
+                    }
+                }
+            ],
+            "scope": "exclude_field_filter",
+            "total_options": 1036
+        }
+    },
+    "results": [],
+    "start": 0,
+    "suggested_queries": [],
+    "total": 301755
 }
 ```
+
+The value of this parameter is a comma separated list of options; the first option in the list is an integer which controls the requested number of distinct field values to be returned for the field. Regardless of the number set here, a value will be returned for any filter which is in place on the field. This may cause the requested number of values to be exceeded.
+
+Subsequent options are optional, and are represented as colon separated key:value pairs (note, colon separated instead of comma, since commas are used to separate options).
+
+
+ - `scope`: One of `all_filters` and `exclude_field_filter` (the default).
+
+   If set to `all_filters`, the aggregate counts are made after applying all the
+   filters.  If set to `exclude_field_filter`, the aggregate counts are made
+   after applying all filters _except_ for those applied to the field that
+   the aggregates are being counted for.  This is a convenient option for
+   calculating values to show in common interfaces which use aggregate for
+   narrowing down search results.
+
+ - `order`: Colon separated list of ordering types.
+
+   The available ordering types are:
+
+    - `filtered`: whether the value is used in an active filter.  This can be
+used to sort such that the values which are being filtered on come
+first.
+    - `count`: order by the number of documents in the search matching the
+facet value.
+    - `value`: sort by value if the field values are string, sort by the
+`title` field in the value object if the value is an object.  Sorting
+is case insensitive in either case.
+    - `value.slug`: the slug in the facet value object
+    - `value.link`: the link in the facet value object
+    - `value.title`: the title in the facet value object (case insensitive)
+
+   Each ordering may be preceded by a "-" to sort in descending order.
+   Multiple orderings can be specified, in priority order, separated by a
+   colon.  The default ordering is "filtered:-count:slug".
+
+ - `examples`: integer number of example values to return
+
+   This causes facet values to contain an "examples" hash as an additional
+   field, which contains details of example documents which match the query.
+   The examples are sorted by decreasing popularity.  An example facet value
+   in a response with this option set as "examples:1" might look like:
+
+      "value" => {
+        "slug" => "an-example-facet-slug",
+        "example_info" => {
+          "total" => 3,  # The total number of matching examples
+          "examples" => [
+            {"title" => "Title of the first example", "link" => "/foo"},
+          ],
+        }
+      }
+
+ - `example_scope`: `global` or `query`.  If the `examples` option is supplied, the
+   `example_scope` option must be supplied too.
+
+   The value of `global` causes the returned examples to be taken from all
+   documents in which the facet field has the given slug.
+
+   The value of `query` causes the returned examples to be taken only from
+   those documents which match the query (and all filters).
+
+ - `example_fields`: colon separated list of fields.
+
+   If the examples option is supplied, this lists the fields which are
+   returned for each example.  By default, only a small number of fields are
+   returned for each.
+
+## Other parameters
+- `ab_tests`: a/b test with selected variant type. This allows test to be configured
+  from upstream apps.
+
+  Each a/b test name should be followed by a ':' and then the variant type to
+  be used. If multiple a/b test setting are being passed in they should be
+  comma separated.
+
+  No validation is done to ensure the a/b test name provided is current implemented.
+
+- `c`: does nothing. By setting it to unique string, you can
+  use it to bypass caching when testing.


### PR DESCRIPTION
Split the search API guide into sections so it's easier to find stuff.

This'll be rendered at https://docs.publishing.service.gov.uk/apis/search/search-api.html

I'll probably split the stuff about filtering/aggregating into a separate page later,
but for now I've just separated it into its own section.