### PR TITLE
Fix expect(A).to eq(B) ordering

### DIFF
--- a/spec/integration/analytics_data_spec.rb
+++ b/spec/integration/analytics_data_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
         nil,
       ]
 
-    expect([expected_row]).to eq(rows.to_a)
+    expect(rows.to_a).to eq([expected_row])
   end
 
   it "missing_data_is_nil" do
@@ -48,7 +48,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     expected_row = [id, id, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
 
-    expect([expected_row]).to eq(rows.to_a)
+    expect(rows.to_a).to eq([expected_row])
   end
 
   it "content_id_is_preferred_to_link_for_product_id" do
@@ -60,7 +60,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    expect("some_content_id").to eq(rows.first[0])
+    expect(rows.first[0]).to eq("some_content_id")
   end
 
   it "product_id_falls_back_to_link_if_content_id_is_missing" do
@@ -71,7 +71,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    expect("/some/page/path").to eq(rows.first[0])
+    expect(rows.first[0]).to eq("/some/page/path")
   end
 
   it "document_type_is_preferred_to_format" do
@@ -83,7 +83,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    expect("some_document_type").to eq(rows.first[5])
+    expect(rows.first[5]).to eq("some_document_type")
   end
 
   it "document_type_falls_back_to_format_if_not_present" do
@@ -94,7 +94,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    expect("some_format").to eq(rows.first[5])
+    expect(rows.first[5]).to eq("some_format")
   end
 
   it "sanitises_unix_line_breaks_in_titles" do
@@ -109,7 +109,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    expect("A page title with some line breaks").to eq(rows.first[4])
+    expect(rows.first[4]).to eq("A page title with some line breaks")
   end
 
   it "sanitises_windows_line_breaks_in_titles" do
@@ -120,7 +120,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     rows = @analytics_data_fetcher.rows
 
-    expect("A page title with some line breaks").to eq(rows.first[4])
+    expect(rows.first[4]).to eq("A page title with some line breaks")
   end
 
   it "fetches_all_rows" do
@@ -132,7 +132,7 @@ RSpec.describe 'AnalyticsDataTest', tags: ['integration'] do
 
     analytics_data = @analytics_data_fetcher.rows.to_a
 
-    expect(30).to eq(analytics_data.size)
+    expect(analytics_data.size).to eq(30)
   end
 
   it "headers_and_rows_are_consisent" do

--- a/spec/integration/app/content_endpoints_spec.rb
+++ b/spec/integration/app/content_endpoints_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'ContentEndpointsTest', tags: ['integration'] do
 
     delete "/content?link=a-document/in-search"
 
-    expect(204).to eq(last_response.status)
+    expect(last_response.status).to eq(204)
   end
 
   it "deleting_a_document_that_doesnt_exist" do
@@ -46,6 +46,6 @@ RSpec.describe 'ContentEndpointsTest', tags: ['integration'] do
 
     delete "/content?link=a-document/in-search"
 
-    expect(423).to eq(last_response.status)
+    expect(last_response.status).to eq(423)
   end
 end

--- a/spec/integration/app/status_spec.rb
+++ b/spec/integration/app/status_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
     get "/_status"
 
     expect(last_response).to be_ok
-    expect(["bulk"]).to eq(parsed_response["queues"].keys)
-    expect(12).to eq(parsed_response["queues"]["bulk"]["jobs"])
+    expect(parsed_response["queues"].keys).to eq(["bulk"])
+    expect(parsed_response["queues"]["bulk"]["jobs"]).to eq(12)
   end
 
   it "shows_per_queue_retry_count" do
@@ -24,7 +24,7 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
     get "/_status"
 
     expect(last_response).to be_ok
-    expect(2).to eq(parsed_response["queues"]["bulk"]["retries"])
+    expect(parsed_response["queues"]["bulk"]["retries"]).to eq(2)
   end
 
   it "shows_zero_retry_count" do
@@ -36,7 +36,7 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
     get "/_status"
 
     expect(last_response).to be_ok
-    expect(0).to eq(parsed_response["queues"]["bulk"]["retries"])
+    expect(parsed_response["queues"]["bulk"]["retries"]).to eq(0)
   end
 
   it "shows_per_queue_scheduled_count" do
@@ -50,7 +50,7 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
     get "/_status"
 
     expect(last_response).to be_ok
-    expect(2).to eq(parsed_response["queues"]["bulk"]["scheduled"])
+    expect(parsed_response["queues"]["bulk"]["scheduled"]).to eq(2)
   end
 
   it "shows_zero_retry_count_scheduled" do
@@ -62,6 +62,6 @@ RSpec.describe 'StatusTest', tags: ['integration'] do
     get "/_status"
 
     expect(last_response).to be_ok
-    expect(0).to eq(parsed_response["queues"]["bulk"]["scheduled"])
+    expect(parsed_response["queues"]["bulk"]["scheduled"]).to eq(0)
   end
 end

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration']
 
     expect(random_example["base_path"]).to eq(document["_source"]["link"])
     expect(random_example["base_path"]).to eq(document["_id"])
-    expect("edition").to eq(document["_type"])
+    expect(document["_type"]).to eq("edition")
 
-    expect(0).to eq(@queue.message_count)
-    expect(1).to eq(@channel.acknowledged_state[:acked].count)
+    expect(@queue.message_count).to eq(0)
+    expect(@channel.acknowledged_state[:acked].count).to eq(1)
   end
 
   it "not_indexing_when_publishing_app_is_smart_answers" do
@@ -80,7 +80,7 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration']
     expect(GovukError).to receive(:notify)
     @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
 
-    expect(0).to eq(@queue.message_count)
+    expect(@queue.message_count).to eq(0)
   end
 
   it "should_discard_message_when_withdrawn_and_invalid" do
@@ -92,7 +92,7 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest', tags: ['integration']
     expect(GovukError).to receive(:notify)
     @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
 
-    expect(0).to eq(@queue.message_count)
+    expect(@queue.message_count).to eq(0)
   end
 
   def client

--- a/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
+++ b/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest', tags: ['integratio
 
     get "/search"
 
-    expect(['mainstream answer', 'mainstream help']).to eq(parsed_response['results'].map { |r| r['title'] }.sort)
+    expect(parsed_response['results'].map { |r| r['title'] }.sort).to eq(['mainstream answer', 'mainstream help'])
   end
 
   it "can_enable_format_to_use_govuk_index" do
@@ -23,7 +23,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest', tags: ['integratio
 
     get "/search"
 
-    expect(['govuk help', 'mainstream answer']).to eq(parsed_response['results'].map { |r| r['title'] }.sort)
+    expect(parsed_response['results'].map { |r| r['title'] }.sort).to eq(['govuk help', 'mainstream answer'])
   end
 
   it "can_enable_multiple_formats_to_use_govuk_index" do
@@ -31,6 +31,6 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest', tags: ['integratio
 
     get "/search"
 
-    expect(['govuk answer', 'govuk help']).to eq(parsed_response['results'].map { |r| r['title'] }.sort)
+    expect(parsed_response['results'].map { |r| r['title'] }.sort).to eq(['govuk answer', 'govuk help'])
   end
 end

--- a/spec/integration/govuk_index/updating_popularity_data_spec.rb
+++ b/spec/integration/govuk_index/updating_popularity_data_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest', tags: ['integration'] d
     GovukIndex::PopularityUpdater.update('govuk_test')
 
     document = fetch_document_from_rummager(id: id, index: 'govuk_test')
-    expect(3).to eq(document['_version'])
+    expect(document['_version']).to eq(3)
   end
 
   it "skips_non_indexable_formats" do

--- a/spec/integration/govuk_index/versioning_spec.rb
+++ b/spec/integration/govuk_index/versioning_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(123).to eq(document["_version"])
+    expect(document["_version"]).to eq(123)
 
     version2 = version1.merge(title: "new title", payload_version: 124)
     process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(124).to eq(document["_version"])
-    expect("new title").to eq(document["_source"]["title"])
+    expect(document["_version"]).to eq(124)
+    expect(document["_source"]["title"]).to eq("new title")
   end
 
   it "should_discard_message_with_same_version_as_existing_document" do
@@ -40,13 +40,13 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(123).to eq(document["_version"])
+    expect(document["_version"]).to eq(123)
 
     version2 = version1.merge(title: "new title", payload_version: 123)
     process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(123).to eq(document["_version"])
+    expect(document["_version"]).to eq(123)
     expect(version1["title"]).to eq(document["_source"]["title"])
   end
 
@@ -62,13 +62,13 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(123).to eq(document["_version"])
+    expect(document["_version"]).to eq(123)
 
     version2 = version1.merge(title: "new title", payload_version: 122)
     process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(123).to eq(document["_version"])
+    expect(document["_version"]).to eq(123)
     expect(version1["title"]).to eq(document["_source"]["title"])
   end
 
@@ -84,7 +84,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(1).to eq(document["_version"])
+    expect(document["_version"]).to eq(1)
 
     version2 = generate_random_example(
       schema: 'gone',
@@ -105,7 +105,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version3)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(3).to eq(document["_version"])
+    expect(document["_version"]).to eq(3)
   end
 
   it "should_discard_unpublishing_message_with_earlier_version" do
@@ -119,7 +119,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version1)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(2).to eq(document["_version"])
+    expect(document["_version"]).to eq(2)
 
     version2 = generate_random_example(
       schema: 'gone',
@@ -133,7 +133,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version2, unpublishing: true)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(2).to eq(document["_version"])
+    expect(document["_version"]).to eq(2)
   end
 
   it "should_ignore_event_for_non_indexable_formats" do
@@ -149,7 +149,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
 
-    expect(123).to eq(document["_version"])
+    expect(document["_version"]).to eq(123)
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(false)
 
@@ -157,7 +157,7 @@ RSpec.describe 'GovukIndex::VersioningTest', tags: ['integration'] do
     process_message(version2)
 
     document = fetch_document_from_rummager(id: base_path, index: "govuk_test")
-    expect(123).to eq(document["_version"])
+    expect(document["_version"]).to eq(123)
     expect(version1["title"]).to eq(document["_source"]["title"])
   end
 

--- a/spec/integration/indexer/amendment_spec.rb
+++ b/spec/integration/indexer/amendment_spec.rb
@@ -41,6 +41,6 @@ RSpec.describe 'ElasticsearchAmendmentTest', tags: ['integration'] do
 
     post "/documents/%2Fan-example-answer", "title=A+new+title"
 
-    expect(202).to eq(last_response.status)
+    expect(last_response.status).to eq(202)
   end
 end

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'ElasticsearchDeletionTest', tags: ['integration'] do
 
     delete "/documents/%2Fan-example-page"
 
-    expect(202).to eq(last_response.status)
+    expect(last_response.status).to eq(202)
   end
 
   it "removes_document_with_url" do

--- a/spec/integration/indexer/index_group_spec.rb
+++ b/spec/integration/indexer/index_group_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'ElasticsearchIndexGroupTest', tags: ['integration'] do
     expect(@index_group.index_names).to be_empty
     index = @index_group.create_index
 
-    expect(1).to eq(@index_group.index_names.count)
+    expect(@index_group.index_names.count).to eq(1)
     expect(index.index_name).to eq(@index_group.index_names[0])
     expect(
       SearchConfig.instance.search_server.schema.elasticsearch_mappings("mainstream")
@@ -48,8 +48,8 @@ RSpec.describe 'ElasticsearchIndexGroupTest', tags: ['integration'] do
     @index_group.create_index
     @index_group.switch_to(@index_group.create_index)
 
-    expect(2).to eq(@index_group.index_names.count)
+    expect(@index_group.index_names.count).to eq(2)
     @index_group.clean
-    expect(1).to eq(@index_group.index_names.count)
+    expect(@index_group.index_names.count).to eq(1)
   end
 end

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'ElasticsearchIndexingTest', tags: ['integration'] do
   it "adding_a_document_to_the_search_index_with_queue" do
     post "/documents", SAMPLE_DOCUMENT.to_json
 
-    expect(202).to eq(last_response.status)
+    expect(last_response.status).to eq(202)
     expect_document_is_in_rummager(SAMPLE_DOCUMENT)
   end
 end

--- a/spec/integration/indexer/migration_spec.rb
+++ b/spec/integration/indexer/migration_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'ElasticsearchMigrationTest', tags: ['integration'] do
     # stemming settings
 
     get "/search?q=directive"
-    expect(2).to eq(parsed_response["results"].length)
+    expect(parsed_response["results"].length).to eq(2)
 
     @stemmer["rules"] = ["directive => directive"]
 
@@ -95,7 +95,7 @@ RSpec.describe 'ElasticsearchMigrationTest', tags: ['integration'] do
     commit_index
 
     get "/search?q=directive"
-    expect(2).to eq(parsed_response["results"].length)
+    expect(parsed_response["results"].length).to eq(2)
 
     @stemmer["rules"] = ["directive => directive"]
 
@@ -123,7 +123,7 @@ RSpec.describe 'ElasticsearchMigrationTest', tags: ['integration'] do
     allow_any_instance_of(SearchIndices::Index).to receive(:bulk_index).and_raise(SearchIndices::IndexLocked)
 
     get "/search?q=directive"
-    expect(2).to eq(parsed_response["results"].length)
+    expect(parsed_response["results"].length).to eq(2)
 
     @stemmer["rules"] = ["directive => directive"]
 
@@ -138,7 +138,7 @@ RSpec.describe 'ElasticsearchMigrationTest', tags: ['integration'] do
     expect(original_index_name).to eq(index_group.current_real.real_name)
 
     get "/search?q=directive"
-    expect(2).to eq(parsed_response["results"].length)
+    expect(parsed_response["results"].length).to eq(2)
   end
 
   it "reindex_with_no_existing_index" do

--- a/spec/integration/search/best_bets_spec.rb
+++ b/spec/integration/search/best_bets_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'BestBetsTest', tags: ['integration'] do
 
     links = get_links "/search?q=a+forced+best+bet"
 
-    expect(["/the-link-that-should-surface", "/an-organic-result"]).to eq(links)
+    expect(links).to eq(["/the-link-that-should-surface", "/an-organic-result"])
   end
 
   it "exact_worst_bet" do
@@ -56,7 +56,7 @@ RSpec.describe 'BestBetsTest', tags: ['integration'] do
 
     links = get_links "/search?q=best+bet+and+such"
 
-    expect(["/the-link-that-should-surface"]).to eq(links)
+    expect(links).to eq(["/the-link-that-should-surface"])
   end
 
   it "stemmed_best_bet_variant" do
@@ -74,7 +74,7 @@ RSpec.describe 'BestBetsTest', tags: ['integration'] do
     # note that we're searching for "bests bet", not "best bet" here.
     links = get_links "/search?q=bests+bet"
 
-    expect(["/the-link-that-should-surface"]).to eq(links)
+    expect(links).to eq(["/the-link-that-should-surface"])
   end
 
   it "stemmed_best_bet_words_not_in_phrase_order" do

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'BoosterTest', tags: ['integration'] do
 
     get "/search?q=agile"
 
-    expect(["Can we be agile?", "Agile is good", "Being agile is good"]).to eq(result_titles)
+    expect(result_titles).to eq(["Can we be agile?", "Agile is good", "Being agile is good"])
   end
 
   def result_titles

--- a/spec/integration/search/expands_values_from_schema_spec.rb
+++ b/spec/integration/search/expands_values_from_schema_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe 'ExpandsValuesFromSchemaTest', tags: ['integration'] do
     get "/search?filter_document_type=cma_case&fields=case_type,description,title"
     first_result = parsed_response["results"].first
 
-    expect([{ "label" => "Mergers", "value" => "mergers" }]).to eq(first_result["case_type"])
+    expect(first_result["case_type"]).to eq([{ "label" => "Mergers", "value" => "mergers" }])
   end
 end

--- a/spec/integration/search/legacy_search_spec.rb
+++ b/spec/integration/search/legacy_search_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest', tags: ['integration'] do
 
     expect(last_response).to be_ok
     expect_result_total 1
-    expect(["ministry-of-cheese"]).to eq(parsed_response["results"][0]["organisations"])
+    expect(parsed_response["results"][0]["organisations"]).to eq(["ministry-of-cheese"])
   end
 
   it "should_allow_ordering_by_properties" do
@@ -190,6 +190,6 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest', tags: ['integration'] do
   it "does_not_allow_page_to_be_super_high" do
     get "/#{@index_name}/advanced_search.json?per_page=4&page=500001&order[updated_at]=desc"
 
-    expect(422).to eq(last_response.status)
+    expect(last_response.status).to eq(422)
   end
 end

--- a/spec/integration/search/quoted_and_unquoted_searches_spec.rb
+++ b/spec/integration/search/quoted_and_unquoted_searches_spec.rb
@@ -12,57 +12,57 @@ RSpec.describe 'QuotedAndUnquotedSearchTest', tags: ['integration'] do
   it "new_weighting_three_matches_found_for_london" do
     commit_london_transport_docs
     get "/search?q=london&debug=new_weighting"
-    expect(200).to eq(last_response.status)
-    expect(3).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(3)
   end
 
   it "new_weighting_three_matches_found_for_transport" do
     commit_london_transport_docs
     get "/search?q=transport&debug=new_weighting"
-    expect(200).to eq(last_response.status)
-    expect(3).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(3)
   end
 
   it "new_weighting_three_matches_found_for_unquoted_london_transport" do
     commit_london_transport_docs
     get "/search?q=london+transport&debug=new_weighting"
-    expect(200).to eq(last_response.status)
-    expect(3).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(3)
   end
 
   it "new_weighting_one_match_found_for_quoted_london_transport" do
     commit_london_transport_docs
     get "/search?q=%22london+transport%22&debug=new_weighting"
-    expect(200).to eq(last_response.status)
-    expect(1).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(1)
   end
 
   it "new_weighting_synonyms_are_returned_with_unquoted_phrases" do
     commit_synonym_documents
     get "/search?q=driving+abroad&debug=new_weighting"
-    expect(200).to eq(last_response.status)
-    expect(2).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(2)
   end
 
   it "new_weighting_synonyms_are_not_returned_with_quoted_phrases" do
     commit_synonym_documents
     get "/search?q=%22driving+abroad%22&debug=new_weighting"
-    expect(200).to eq(last_response.status)
-    expect(1).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(1)
   end
 
   it "new_weighting_stemming_is_in_place_for_unquoted_phrases" do
     commit_stemming_documents
     get "/search?q=dog&debug=new_weighting"
-    expect(200).to eq(last_response.status)
-    expect(2).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(2)
   end
 
   it "new_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
     commit_stemming_documents
     get "/search?q=%22dog%22&debug=new_weighting"
-    expect(200).to eq(last_response.status)
-    expect(2).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(2)
   end
 
 
@@ -71,50 +71,50 @@ RSpec.describe 'QuotedAndUnquotedSearchTest', tags: ['integration'] do
   it "old_weighting_three_matches_found_for_london" do
     commit_london_transport_docs
     get "/search?q=london"
-    expect(200).to eq(last_response.status)
-    expect(3).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(3)
   end
 
   it "old_weighting_three_matches_found_for_transport" do
     commit_london_transport_docs
     get "/search?q=transport"
-    expect(200).to eq(last_response.status)
-    expect(3).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(3)
   end
 
   it "old_weighting_three_matches_found_for_unquoted_london_transport" do
     commit_london_transport_docs
     get "/search?q=london+transport"
-    expect(200).to eq(last_response.status)
-    expect(3).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(3)
   end
 
   it "old_weighting_one_match_found_for_quoted_london_transport" do
     commit_london_transport_docs
     get "/search?q=%22london+transport%22"
-    expect(200).to eq(last_response.status)
-    expect(1).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(1)
   end
 
   it "old_weighting_synonyms_are_returned_with_unquoted_phrases" do
     commit_synonym_documents
     get "/search?q=driving+abroad"
-    expect(200).to eq(last_response.status)
-    expect(2).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(2)
   end
 
   it "old_weighting_stemming_is_in_place_for_unquoted_phrases" do
     commit_stemming_documents
     get "/search?q=dog"
-    expect(200).to eq(last_response.status)
-    expect(2).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(2)
   end
 
   it "old_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
     commit_stemming_documents
     get "/search?q=%22dog%22"
-    expect(200).to eq(last_response.status)
-    expect(2).to eq(parsed_response["results"].size)
+    expect(last_response.status).to eq(200)
+    expect(parsed_response["results"].size).to eq(2)
   end
 
 

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
     get "/search?q=result&fields[]=title_with_highlighting"
 
     expect(first_search_result.key?('title')).to be_falsey
-    expect("I am the <mark>result</mark>").to eq(first_search_result['title_with_highlighting'])
+    expect(first_search_result['title_with_highlighting']).to eq("I am the <mark>result</mark>")
   end
 
   it "returns_highlighted_title_fallback" do
@@ -23,7 +23,7 @@ RSpec.describe 'ResultsWithHighlightingTest', tags: ['integration'] do
     get "/search?q=result&fields[]=title_with_highlighting"
 
     expect(first_search_result.key?('title')).to be_falsey
-    expect("Thing without").to eq(first_search_result['title_with_highlighting'])
+    expect(first_search_result['title_with_highlighting']).to eq("Thing without")
   end
 
   it "returns_highlighted_description" do

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=serch&suggest=spelling"
 
-    expect(['search']).to eq(parsed_response['suggested_queries'])
+    expect(parsed_response['suggested_queries']).to eq(['search'])
   end
 
   it "spell_checking_with_blacklisted_typo" do
@@ -48,7 +48,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=brexit&suggest=spelling"
 
-    expect([]).to eq(parsed_response['suggested_queries'])
+    expect(parsed_response['suggested_queries']).to eq([])
   end
 
   it "spell_checking_without_typo" do
@@ -56,7 +56,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=milliband"
 
-    expect([]).to eq(parsed_response['suggested_queries'])
+    expect(parsed_response['suggested_queries']).to eq([])
   end
 
   it "returns_docs_from_all_indexes" do
@@ -73,7 +73,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&order=public_timestamp"
 
-    expect(["/government-1", "/government-2"]).to eq(result_links.take(2))
+    expect(result_links.take(2)).to eq(["/government-1", "/government-2"])
   end
 
   it "sort_by_date_descending" do
@@ -83,7 +83,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     # The government links have dates, so appear before all the other links.
     # The other documents have no dates, so appear in an undefined order
-    expect(["/government-2", "/government-1"]).to eq(result_links.take(2))
+    expect(result_links.take(2)).to eq(["/government-2", "/government-1"])
   end
 
   it "sort_by_title_ascending" do
@@ -100,7 +100,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_mainstream_browse_pages=browse/page/1"
 
-    expect(["/government-1", "/mainstream-1"]).to eq(result_links.sort)
+    expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
   end
 
   it "reject_by_field" do
@@ -108,7 +108,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?reject_mainstream_browse_pages=browse/page/1"
 
-    expect(["/government-2", "/mainstream-2"]).to eq(result_links.sort)
+    expect(result_links.sort).to eq(["/government-2", "/mainstream-2"])
   end
 
   it "can_filter_for_missing_field" do
@@ -116,7 +116,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_specialist_sectors=_MISSING"
 
-    expect(["/government-1", "/mainstream-1"]).to eq(result_links.sort)
+    expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
   end
 
   it "can_filter_for_missing_or_specific_value_in_field" do
@@ -124,7 +124,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
 
-    expect(["/government-1", "/mainstream-1"]).to eq(result_links.sort)
+    expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
   end
 
   it "can_filter_and_reject" do
@@ -145,7 +145,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     results = parsed_response["results"]
     expect(results[0].keys).not_to include("specialist_sectors")
-    expect([{ "slug" => "farming" }]).to eq(results[1]["specialist_sectors"])
+    expect(results[1]["specialist_sectors"]).to eq([{ "slug" => "farming" }])
   end
 
   it "aggregate_counting" do
@@ -153,7 +153,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2"
 
-    expect(4).to eq(parsed_response["total"])
+    expect(parsed_response["total"]).to eq(4)
 
     aggregate = parsed_response["aggregates"]
 
@@ -178,7 +178,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&facet_mainstream_browse_pages=2"
 
-    expect(4).to eq(parsed_response["total"])
+    expect(parsed_response["total"]).to eq(4)
 
     facets = parsed_response["facets"]
 
@@ -204,16 +204,16 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2"
 
-    expect(4).to eq(parsed_response["total"])
+    expect(parsed_response["total"]).to eq(4)
     aggregates_without_filter = parsed_response["aggregates"]
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2&filter_mainstream_browse_pages=browse/page/1"
-    expect(2).to eq(parsed_response["total"])
+    expect(parsed_response["total"]).to eq(2)
 
     aggregates_with_filter = parsed_response["aggregates"]
 
     expect(aggregates_with_filter).to eq(aggregates_without_filter)
-    expect(2).to eq(aggregates_without_filter["mainstream_browse_pages"]["options"].size)
+    expect(aggregates_without_filter["mainstream_browse_pages"]["options"].size).to eq(2)
   end
 
   it "aggregate_counting_missing_options" do
@@ -221,7 +221,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=1"
 
-    expect(4).to eq(parsed_response["total"])
+    expect(parsed_response["total"]).to eq(4)
     aggregates = parsed_response["aggregates"]
     expect(
       "mainstream_browse_pages" => {
@@ -241,7 +241,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2,scope:all_filters&filter_mainstream_browse_pages=browse/page/1"
 
-    expect(2).to eq(parsed_response["total"])
+    expect(parsed_response["total"]).to eq(2)
     aggregates = parsed_response["aggregates"]
 
     expect(
@@ -369,7 +369,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?filter_document_type=cma_case"
 
     expect(last_response).to be_ok
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
     expect(
       hash_including(
         "document_type" => "cma_case",
@@ -387,7 +387,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
 
     expect(last_response).to be_ok
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
     expect(
       hash_including(
         "title" => cma_case_attributes.fetch("title"),
@@ -404,7 +404,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
 
     expect(last_response).to be_ok
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
     expect(
       hash_including(
         "title" => cma_case_attributes.fetch("title"),
@@ -421,7 +421,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
 
     expect(last_response).to be_ok
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
     expect(
       hash_including(
         "title" => cma_case_attributes.fetch("title"),
@@ -438,7 +438,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
 
     expect(last_response).to be_ok
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
     expect(
       hash_including(
         "title" => cma_case_attributes.fetch("title"),
@@ -452,7 +452,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
   it "cannot_provide_date_filter_key_multiple_times" do
     get "/search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
 
-    expect(422).to eq(last_response.status)
+    expect(last_response.status).to eq(422)
     expect(
       { "error" => %{Too many values (2) for parameter "opened_date" (must occur at most once)} }
     ).to eq(
@@ -463,7 +463,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
   it "cannot_provide_invalid_dates_for_date_filter" do
     get "/search?filter_document_type=cma_case&filter_opened_date=from:not-a-date"
 
-    expect(422).to eq(last_response.status)
+    expect(last_response.status).to eq(422)
     expect(
       { "error" => %{Invalid value "not-a-date" for parameter "opened_date" (expected ISO8601 date} }
     ).to eq(
@@ -652,7 +652,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     get "/search?q=test"
-    expect(0).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(0)
   end
 
   it "withdrawn_content_with_flag" do
@@ -664,7 +664,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     get "/search?q=test&debug=include_withdrawn&fields[]=is_withdrawn"
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
     expect(parsed_response.dig("results", 0, "is_withdrawn")).to be true
   end
 
@@ -678,7 +678,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     get "/search?q=test&debug=include_withdrawn&aggregate_mainstream_browse_pages=2"
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
   end
 
   it "show_the_query" do
@@ -699,7 +699,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
       get "/search?filter_document_type=dfid_research_output&#{filter_query}"
 
       expect(last_response).to be_ok
-      expect(1).to eq(parsed_response.fetch("total")), "Failure to search by #{filter_query}"
+      expect(parsed_response.fetch("total")).to eq(1), "Failure to search by #{filter_query}"
       expect(
         hash_including(
           "document_type" => "dfid_research_output",
@@ -721,10 +721,10 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     )
 
     get "/search?q=test&fields[]=taxons"
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
 
     taxons = parsed_response.dig("results", 0, "taxons")
-    expect(["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]).to eq(taxons)
+    expect(taxons).to eq(["eb2093ef-778c-4105-9f33-9aa03d14bc5c"])
   end
 
   it "taxonomy_can_be_filtered" do
@@ -738,7 +738,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?filter_taxons=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
 
     expect(last_response).to be_ok
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
     expect(
       hash_including(
         "title" => "I am the result",
@@ -761,19 +761,19 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search?filter_part_of_taxonomy_tree=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
 
     expect(last_response).to be_ok
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
 
     get "/search?filter_part_of_taxonomy_tree=aa2093ef-778c-4105-9f33-9aa03d14bc5c"
 
     expect(last_response).to be_ok
-    expect(1).to eq(parsed_response.fetch("total"))
+    expect(parsed_response.fetch("total")).to eq(1)
   end
 
   it "return_400_response_for_integers_out_of_range" do
     get '/search.json?count=50&start=7599999900'
 
     expect(last_response).to be_bad_request
-    expect('Integer value of 7599999900 exceeds maximum allowed').to eq(last_response.body)
+    expect(last_response.body).to eq('Integer value of 7599999900 exceeds maximum allowed')
   end
 
   it "return_400_response_for_query_term_length_too_long" do
@@ -781,7 +781,7 @@ RSpec.describe 'SearchTest', tags: ['integration'] do
     get "/search.json?q=#{terms}"
 
     expect(last_response).to be_bad_request
-    expect('Query must be less than 1024 words').to eq(last_response.body)
+    expect(last_response.body).to eq('Query must be less than 1024 words')
   end
 
 private

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
     )
     generator = SitemapGenerator.new(SearchConfig.instance)
     sitemap_xml = generator.sitemaps
-    expect(1).to eq(sitemap_xml.length)
+    expect(sitemap_xml.length).to eq(1)
 
     expect(sitemap_xml[0]).not_to include("/an-example-answer")
   end
@@ -69,8 +69,8 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
       .css("url")
       .select { |item| item.css("loc").text == "http://www.dev.gov.uk/" }
 
-    expect(1).to eq(pages.count)
-    expect("0.5").to eq(pages[0].css("priority").text)
+    expect(pages.count).to eq(1)
+    expect(pages[0].css("priority").text).to eq("0.5")
   end
 
   it "should_not_include_recommended_links" do
@@ -90,7 +90,7 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
 
     sitemap_xml = generator.sitemaps
 
-    expect(1).to eq(sitemap_xml.length)
+    expect(sitemap_xml.length).to eq(1)
 
     expect(sitemap_xml[0]).not_to include("/external-example-answer")
   end
@@ -111,7 +111,7 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
 
     sitemap_xml = generator.sitemaps
 
-    expect(1).to eq(sitemap_xml.length)
+    expect(sitemap_xml.length).to eq(1)
     expect(sitemap_xml[0]).not_to include("/government/some-content")
   end
 
@@ -137,8 +137,8 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
       .css("url")
       .select { |item| item.css("loc").text == "http://www.dev.gov.uk/an-example-answer" }
 
-    expect(1).to eq(pages.count)
-    expect("2017-07-01T12:41:34+00:00").to eq(pages[0].css("lastmod").text)
+    expect(pages.count).to eq(1)
+    expect(pages[0].css("lastmod").text).to eq("2017-07-01T12:41:34+00:00")
   end
 
   it "links_should_include_priorities" do
@@ -163,7 +163,7 @@ RSpec.describe 'SitemapGeneratorTest', tags: ['integration'] do
       .css("url")
       .select { |item| item.css("loc").text == "http://www.dev.gov.uk/an-example-answer" }
 
-    expect(1).to eq(pages.count)
+    expect(pages.count).to eq(1)
     expect(0..10).to include(pages[0].css("priority").text.to_i)
   end
 

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Document do
 
     document = described_class.from_hash(hash, sample_elasticsearch_types)
 
-    expect("TITLE").to eq(document.title)
-    expect("DESCRIPTION").to eq(document.description)
-    expect("answer").to eq(document.format)
-    expect("/an-example-answer").to eq(document.link)
-    expect("HERE IS SOME CONTENT").to eq(document.indexable_content)
+    expect(document.title).to eq("TITLE")
+    expect(document.description).to eq("DESCRIPTION")
+    expect(document.format).to eq("answer")
+    expect(document.link).to eq("/an-example-answer")
+    expect(document.indexable_content).to eq("HERE IS SOME CONTENT")
   end
 
   it "should_permit_nonedition_documents" do
@@ -29,14 +29,14 @@ RSpec.describe Document do
 
     document = described_class.from_hash(hash, sample_elasticsearch_types)
 
-    expect("jobs").to eq(document.to_hash["stemmed_query"])
-    expect("jobs").to eq(document.stemmed_query)
-    expect("jobs").to eq(document.elasticsearch_export["stemmed_query"])
+    expect(document.to_hash["stemmed_query"]).to eq("jobs")
+    expect(document.stemmed_query).to eq("jobs")
+    expect(document.elasticsearch_export["stemmed_query"]).to eq("jobs")
 
     expect(document.to_hash.has_key?("_type")).to be_falsey
     expect(document.to_hash.has_key?("_id")).to be_falsey
-    expect("jobs_exact").to eq(document.elasticsearch_export["_id"])
-    expect("best_bet").to eq(document.elasticsearch_export["_type"])
+    expect(document.elasticsearch_export["_id"]).to eq("jobs_exact")
+    expect(document.elasticsearch_export["_type"]).to eq("best_bet")
   end
 
   it "should_reject_document_with_no_type" do
@@ -88,7 +88,7 @@ RSpec.describe Document do
 
     document = described_class.from_hash(hash, sample_elasticsearch_types)
 
-    expect("TITLE").to eq(document.title)
+    expect(document.title).to eq("TITLE")
   end
 
   it "should_skip_metadata_fields_in_to_hash" do
@@ -107,7 +107,7 @@ RSpec.describe Document do
 
   it "should_skip_missing_fields_in_to_hash" do
     document = described_class.from_hash({ "_type" => "edition" }, sample_elasticsearch_types)
-    expect([]).to eq(document.to_hash.keys)
+    expect(document.to_hash.keys).to eq([])
   end
 
   it "should_skip_missing_fields_in_elasticsearch_export" do

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SearchIndices::Index do
         headers: { 'Content-Type' => 'application/json' },
       )
 
-    expect("real-name").to eq(@index.real_name)
+    expect(@index.real_name).to eq("real-name")
   end
 
   it "real_name_when_no_index" do
@@ -79,7 +79,7 @@ RSpec.describe SearchIndices::Index do
       @index.add(documents)
       flunk("No exception raised")
     rescue Indexer::BulkIndexFailure => e
-      expect("Indexer::BulkIndexFailure").to eq(e.message)
+      expect(e.message).to eq("Indexer::BulkIndexFailure")
     end
   end
 
@@ -212,9 +212,9 @@ RSpec.describe SearchIndices::Index do
       headers: { 'Content-Type' => 'application/json' },
     ).then.to_raise("should never happen")
     all_documents = @index.all_documents.to_a
-    expect(100).to eq(all_documents.size)
-    expect("/foo-1").to eq(all_documents.first.link)
-    expect("/foo-100").to eq(all_documents.last.link)
+    expect(all_documents.size).to eq(100)
+    expect(all_documents.first.link).to eq("/foo-1")
+    expect(all_documents.last.link).to eq("/foo-100")
   end
 
   it "changing_scroll_id" do
@@ -259,7 +259,7 @@ RSpec.describe SearchIndices::Index do
     ).then.to_raise("should never happen")
 
     all_documents = @index.all_documents.to_a
-    expect(["/foo-1", "/foo-2", "/foo-3"]).to eq(all_documents.map(&:link))
+    expect(all_documents.map(&:link)).to eq(["/foo-1", "/foo-2", "/foo-3"])
   end
 
 private

--- a/spec/unit/govuk_index/document_type_inferer_spec.rb
+++ b/spec/unit/govuk_index/document_type_inferer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GovukIndex::DocumentTypeInferer do
 
     document_type_inferer = described_class.new(payload)
 
-    expect("edition").to eq(document_type_inferer.type)
+    expect(document_type_inferer.type).to eq("edition")
   end
 
   it "should_raise_not_found_error" do

--- a/spec/unit/govuk_index/indexable_content_sanitiser_spec.rb
+++ b/spec/unit/govuk_index/indexable_content_sanitiser_spec.rb
@@ -9,25 +9,25 @@ RSpec.describe GovukIndex::IndexableContentSanitiser do
       ]
     ]
 
-    expect("hello marmaduke").to eq(subject.clean(payload))
+    expect(subject.clean(payload)).to eq("hello marmaduke")
   end
 
   it "passes_single_string_content_unchanged" do
     payload = ["hello marmaduke"]
 
-    expect("hello marmaduke").to eq(subject.clean(payload))
+    expect(subject.clean(payload)).to eq("hello marmaduke")
   end
 
   it "passes_multiple_string_items_unchanged" do
     payload = ["hello marmaduke", "hello marley"]
 
-    expect("hello marmaduke\n\n\nhello marley").to eq(subject.clean(payload))
+    expect(subject.clean(payload)).to eq("hello marmaduke\n\n\nhello marley")
   end
 
   it "strips_html_tags_from_string_content" do
     payload = ["<h1>hello marmaduke</h1>"]
 
-    expect("hello marmaduke").to eq(subject.clean(payload))
+    expect(subject.clean(payload)).to eq("hello marmaduke")
   end
 
   it "multiple_html_text_payload_items" do
@@ -43,7 +43,7 @@ RSpec.describe GovukIndex::IndexableContentSanitiser do
     ]
 
 
-    expect("hello\ngoodbye").to eq(subject.clean(payload))
+    expect(subject.clean(payload)).to eq("hello\ngoodbye")
   end
 
   it "notifies_if_no_text_html_content" do

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       ]
     }
 
-    expect("hello").to eq(details_presenter(details).indexable_content)
+    expect(details_presenter(details).indexable_content).to eq("hello")
   end
 
   it "details_with_parts" do
@@ -34,7 +34,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       ]
     }
 
-    expect("title 1\n\nhello\n\ntitle 2\n\ngoodbye").to eq(details_presenter(details).indexable_content)
+    expect(details_presenter(details).indexable_content).to eq("title 1\n\nhello\n\ntitle 2\n\ngoodbye")
   end
 
   it "mapped_licence_fields" do
@@ -67,7 +67,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       "start_button_text" => "Start now",
     }
 
-    expect("introductory paragraph\n\nmore information").to eq(details_presenter(details, %w(introductory_paragraph more_information)).indexable_content)
+    expect(details_presenter(details, %w(introductory_paragraph more_information)).indexable_content).to eq("introductory paragraph\n\nmore information")
   end
 
   def details_presenter(details, indexable_content_keys = %w(body parts))

--- a/spec/unit/health_check/basic_auth_credentials_spec.rb
+++ b/spec/unit/health_check/basic_auth_credentials_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 RSpec.describe HealthCheck::BasicAuthCredentials do
   it "be callable with a user:password string" do
     creds = HealthCheck::BasicAuthCredentials.call "bob:horseradish"
-    expect("bob").to eq(creds.user)
-    expect("horseradish").to eq(creds.password)
+    expect(creds.user).to eq("bob")
+    expect(creds.password).to eq("horseradish")
   end
 
   it "fail on a malformed string" do

--- a/spec/unit/health_check/check_file_parser_spec.rb
+++ b/spec/unit/health_check/check_file_parser_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe HealthCheck::CheckFileParser do
       HealthCheck::SearchCheck.new("a", "should", "/a", 1, 1, %w(test)),
       HealthCheck::SearchCheck.new("b", "should", "/b", 1, 1, %w(test))
     ]
-    expect(expected).to eq(checks(data))
+    expect(checks(data)).to eq(expected)
   end
 
   it "skip rows that don't have an integer for the top N number" do
@@ -27,7 +27,7 @@ RSpec.describe HealthCheck::CheckFileParser do
     END
 
     expected = []
-    expect(expected).to eq(checks(data))
+    expect(checks(data)).to eq(expected)
   end
 
   it "skip rows that don't have a URL" do
@@ -37,7 +37,7 @@ RSpec.describe HealthCheck::CheckFileParser do
     END
 
     expected = []
-    expect(expected).to eq(checks(data))
+    expect(checks(data)).to eq(expected)
   end
 
   it "skip rows that don't have a imperative" do
@@ -47,7 +47,7 @@ RSpec.describe HealthCheck::CheckFileParser do
     END
 
     expected = []
-    expect(expected).to eq(checks(data))
+    expect(checks(data)).to eq(expected)
   end
 
   it "skip rows that don't have a search term" do
@@ -57,6 +57,6 @@ RSpec.describe HealthCheck::CheckFileParser do
     END
 
     expected = []
-    expect(expected).to eq(checks(data))
+    expect(checks(data)).to eq(expected)
   end
 end

--- a/spec/unit/health_check/json_search_client_spec.rb
+++ b/spec/unit/health_check/json_search_client_spec.rb
@@ -28,7 +28,7 @@ B)
     expected = { results: ["/a", "/b"], suggested_queries: %w[A B] }
     base_url = URI.parse("http://www.gov.uk/api/search.json")
 
-    expect(expected).to eq(described_class.new(base_url: base_url).search("cheese"))
+    expect(described_class.new(base_url: base_url).search("cheese")).to eq(expected)
   end
 
   it "call the search API with a rate limit token if provided" do
@@ -39,6 +39,6 @@ B)
 
     response = described_class.new(base_url: base_url, rate_limit_token: "some_token").search("cheese")
 
-    expect(expected).to eq(response)
+    expect(response).to eq(expected)
   end
 end

--- a/spec/unit/health_check/search_check_result_spec.rb
+++ b/spec/unit/health_check/search_check_result_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe HealthCheck::SearchCheckResult do
 
         it "return a successful Result" do
           expect(true).to eq(subject.success)
-          expect("FOUND").to eq(subject.found_label)
-          expect("PASS").to eq(subject.success_label)
+          expect(subject.found_label).to eq("FOUND")
+          expect(subject.success_label).to eq("PASS")
         end
       end
 
@@ -22,8 +22,8 @@ RSpec.describe HealthCheck::SearchCheckResult do
 
         it "return a failure Result" do
           expect(subject.success).to be_falsey
-          expect("FOUND").to eq(subject.found_label)
-          expect("FAIL").to eq(subject.success_label)
+          expect(subject.found_label).to eq("FOUND")
+          expect(subject.success_label).to eq("FAIL")
         end
       end
 
@@ -33,8 +33,8 @@ RSpec.describe HealthCheck::SearchCheckResult do
 
         it "return a failure Result" do
           expect(subject.success).to be_falsey
-          expect("NOT FOUND").to eq(subject.found_label)
-          expect("FAIL").to eq(subject.success_label)
+          expect(subject.found_label).to eq("NOT FOUND")
+          expect(subject.success_label).to eq("FAIL")
         end
       end
     end
@@ -48,8 +48,8 @@ RSpec.describe HealthCheck::SearchCheckResult do
 
       it "fail" do
         expect(subject.success).to be_falsey
-        expect("FOUND").to eq(subject.found_label)
-        expect("FAIL").to eq(subject.success_label)
+        expect(subject.found_label).to eq("FOUND")
+        expect(subject.success_label).to eq("FAIL")
       end
     end
 
@@ -59,8 +59,8 @@ RSpec.describe HealthCheck::SearchCheckResult do
 
       it "pass" do
         expect(subject.success).to be_truthy
-        expect("FOUND").to eq(subject.found_label)
-        expect("PASS").to eq(subject.success_label)
+        expect(subject.found_label).to eq("FOUND")
+        expect(subject.success_label).to eq("PASS")
       end
     end
 
@@ -70,8 +70,8 @@ RSpec.describe HealthCheck::SearchCheckResult do
 
       it "pass" do
         expect(subject.success).to be_truthy
-        expect("NOT FOUND").to eq(subject.found_label)
-        expect("PASS").to eq(subject.success_label)
+        expect(subject.found_label).to eq("NOT FOUND")
+        expect(subject.success_label).to eq("PASS")
       end
     end
   end

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Helpers do
     expect(subject).to receive(:content_type).with(:json)
     # 200 is the default status: whether it gets called or not, we don't mind
     expect(subject).to receive(:status).with(200).once
-    expect('{"result":"OK"}').to eq(subject.simple_json_result(true))
+    expect(subject.simple_json_result(true)).to eq('{"result":"OK"}')
   end
 
   it "simple_json_result_error" do
     expect(subject).to receive(:content_type).with(:json)
     expect(subject).to receive(:status).with(500)
-    expect('{"result":"error"}').to eq(subject.simple_json_result(false))
+    expect(subject.simple_json_result(false)).to eq('{"result":"error"}')
   end
 
   it "parse_query_string" do
@@ -31,7 +31,7 @@ RSpec.describe Helpers do
       ["foo=baz&&q=more", { "foo" => ["baz"], "q" => ["more"] }],
       ["foo=baz&boo&q=more", { "foo" => ["baz"], "boo" => [], "q" => ["more"] }],
     ].each do |qs, expected|
-      expect(expected).to eq(subject.parse_query_string(qs))
+      expect(subject.parse_query_string(qs)).to eq(expected)
     end
   end
 end

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe SearchIndices::IndexGroup do
         body: {}.to_json
       )
 
-    expect([]).to eq(@server.index_group("test").index_names)
+    expect(@server.index_group("test").index_names).to eq([])
   end
 
   it "index_names_with_index" do
@@ -162,7 +162,7 @@ RSpec.describe SearchIndices::IndexGroup do
         }.to_json
       )
 
-    expect([index_name]).to eq(@server.index_group("test").index_names)
+    expect(@server.index_group("test").index_names).to eq([index_name])
   end
 
   it "index_names_with_other_groups" do
@@ -179,7 +179,7 @@ RSpec.describe SearchIndices::IndexGroup do
         }.to_json
       )
 
-    expect([this_name]).to eq(@server.index_group("test").index_names)
+    expect(@server.index_group("test").index_names).to eq([this_name])
   end
 
   it "clean_with_no_indices" do

--- a/spec/unit/indexer/bulk_loader_spec.rb
+++ b/spec/unit/indexer/bulk_loader_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Indexer::BulkLoader do
       batches << batch
     end
 
-    expect([%W(a\n b\n), %W(c\n d\n)]).to eq(batches)
+    expect(batches).to eq([%W(a\n b\n), %W(c\n d\n)])
   end
 
   it "line_pairs_are_not_split_if_batch_size_too_small_to_fit_first_pair_of_lines" do
@@ -20,7 +20,7 @@ RSpec.describe Indexer::BulkLoader do
       batches << batch
     end
 
-    expect([%W(a\n b\n), %W(c\n d\n)]).to eq(batches)
+    expect(batches).to eq([%W(a\n b\n), %W(c\n d\n)])
   end
 
   it "line_pairs_are_not_split_if_batch_boundary_falls_in_second_pair_of_lines" do
@@ -31,6 +31,6 @@ RSpec.describe Indexer::BulkLoader do
       batches << batch
     end
 
-    expect([%W(a\n b\n c\n d\n), %W(e\n f\n)]).to eq(batches)
+    expect(batches).to eq([%W(a\n b\n c\n d\n), %W(e\n f\n)])
   end
 end

--- a/spec/unit/indexer/document_preparer_spec.rb
+++ b/spec/unit/indexer/document_preparer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Indexer::DocumentPreparer do
         true
       )
 
-      expect("guidance").to eq(updated_doc_hash["navigation_document_supertype"])
+      expect(updated_doc_hash["navigation_document_supertype"]).to eq("guidance")
     end
   end
 end

--- a/spec/unit/legacy_client/multivalue_converter_spec.rb
+++ b/spec/unit/legacy_client/multivalue_converter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe LegacyClient::MultivalueConverter do
 
     converted_hash = described_class.new(fields, sample_field_definitions).converted_hash
 
-    expect("the title").to eq(converted_hash["title"])
+    expect(converted_hash["title"]).to eq("the title")
   end
 
   # This might not be necessary since the new ES.
@@ -32,6 +32,6 @@ RSpec.describe LegacyClient::MultivalueConverter do
 
     converted_hash = described_class.new(fields, sample_field_definitions).converted_hash
 
-    expect("the title").to eq(converted_hash["title"])
+    expect(converted_hash["title"]).to eq("the title")
   end
 end

--- a/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
+++ b/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
@@ -176,8 +176,8 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
   it "returns_the_total_and_the_hits" do
     stub_empty_search
     result_set = @wrapper.advanced_search(default_params)
-    expect(0).to eq(result_set.total)
-    expect([]).to eq(result_set.results)
+    expect(result_set.total).to eq(0)
+    expect(result_set.results).to eq([])
   end
 
   it "returns_the_hits_converted_into_documents" do
@@ -188,9 +188,9 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
         headers: { "Content-Type" => "application/json" }
       )
     result_set = @wrapper.advanced_search(default_params)
-    expect(10).to eq(result_set.total)
-    expect(1).to eq(result_set.results.size)
-    expect("some_content").to eq(result_set.results.first.get("indexable_content"))
+    expect(result_set.total).to eq(10)
+    expect(result_set.results.size).to eq(1)
+    expect(result_set.results.first.get("indexable_content")).to eq("some_content")
   end
 
   def default_params

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SearchParameterParser do
   it "return valid params given nothing" do
     p = described_class.new({}, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -77,7 +77,7 @@ RSpec.describe SearchParameterParser do
   it "complain about an unknown parameter" do
     p = described_class.new({ "p" => ["extra"] }, @schema)
 
-    expect("Unexpected parameters: p").to eq(p.error)
+    expect(p.error).to eq("Unexpected parameters: p")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -92,14 +92,14 @@ RSpec.describe SearchParameterParser do
   it "complain about multiple unknown parameters" do
     p = described_class.new({ "p" => ["extra"], "boo" => ["goose"] }, @schema)
 
-    expect("Unexpected parameters: p, boo").to eq(p.error)
+    expect(p.error).to eq("Unexpected parameters: p, boo")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
   it "understand the start parameter" do
     p = described_class.new({ "start" => ["5"] }, @schema)
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(start: 5)).to eq(p.parsed_params)
   end
@@ -107,7 +107,7 @@ RSpec.describe SearchParameterParser do
   it "complain about a non-integer start parameter" do
     p = described_class.new({ "start" => ["5.5"] }, @schema)
 
-    expect("Invalid value \"5.5\" for parameter \"start\" (expected positive integer)").to eq(p.error)
+    expect(p.error).to eq("Invalid value \"5.5\" for parameter \"start\" (expected positive integer)")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -115,7 +115,7 @@ RSpec.describe SearchParameterParser do
   it "complain about a negative start parameter" do
     p = described_class.new({ "start" => ["-1"] }, @schema)
 
-    expect("Invalid negative value \"-1\" for parameter \"start\" (expected positive integer)").to eq(p.error)
+    expect(p.error).to eq("Invalid negative value \"-1\" for parameter \"start\" (expected positive integer)")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -123,7 +123,7 @@ RSpec.describe SearchParameterParser do
   it "complain about a non-decimal start parameter" do
     p = described_class.new({ "start" => ["x"] }, @schema)
 
-    expect("Invalid value \"x\" for parameter \"start\" (expected positive integer)").to eq(p.error)
+    expect(p.error).to eq("Invalid value \"x\" for parameter \"start\" (expected positive integer)")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -139,7 +139,7 @@ RSpec.describe SearchParameterParser do
   it "understand the count parameter" do
     p = described_class.new({ "count" => ["5"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(count: 5)).to eq(p.parsed_params)
   end
@@ -147,7 +147,7 @@ RSpec.describe SearchParameterParser do
   it "complain about a non-integer count parameter" do
     p = described_class.new({ "count" => ["5.5"] }, @schema)
 
-    expect("Invalid value \"5.5\" for parameter \"count\" (expected positive integer)").to eq(p.error)
+    expect(p.error).to eq("Invalid value \"5.5\" for parameter \"count\" (expected positive integer)")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -155,7 +155,7 @@ RSpec.describe SearchParameterParser do
   it "complain about a negative count parameter" do
     p = described_class.new({ "count" => ["-1"] }, @schema)
 
-    expect("Invalid negative value \"-1\" for parameter \"count\" (expected positive integer)").to eq(p.error)
+    expect(p.error).to eq("Invalid negative value \"-1\" for parameter \"count\" (expected positive integer)")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -163,7 +163,7 @@ RSpec.describe SearchParameterParser do
   it "complain about a non-decimal count parameter" do
     p = described_class.new({ "count" => ["x"] }, @schema)
 
-    expect("Invalid value \"x\" for parameter \"count\" (expected positive integer)").to eq(p.error)
+    expect(p.error).to eq("Invalid value \"x\" for parameter \"count\" (expected positive integer)")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -187,7 +187,7 @@ RSpec.describe SearchParameterParser do
   it "understand the q parameter" do
     p = described_class.new({ "q" => ["search-term"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(query: "search-term")).to eq(p.parsed_params)
   end
@@ -203,7 +203,7 @@ RSpec.describe SearchParameterParser do
   it "strip whitespace from the query" do
     p = described_class.new({ "q" => ["cheese "] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(query: "cheese")).to eq(p.parsed_params)
   end
@@ -211,7 +211,7 @@ RSpec.describe SearchParameterParser do
   it "put the query in normalized form" do
     p = described_class.new({ "q" => ["cafe\u0300 "] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(query: "caf\u00e8")).to eq(p.parsed_params)
   end
@@ -219,7 +219,7 @@ RSpec.describe SearchParameterParser do
   it "complain about invalid unicode in the query" do
     p = described_class.new({ "q" => ["\xff"] }, @schema)
 
-    expect("Invalid unicode in query").to eq(p.error)
+    expect(p.error).to eq("Invalid unicode in query")
     expect(p).not_to be_valid
     expect(expected_params(query: nil)).to eq(p.parsed_params)
   end
@@ -227,7 +227,7 @@ RSpec.describe SearchParameterParser do
   it "understand the similar_to parameter" do
     p = described_class.new({ "similar_to" => ["/search-term"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(similar_to: "/search-term")).to eq(p.parsed_params)
   end
@@ -243,7 +243,7 @@ RSpec.describe SearchParameterParser do
   it "strip whitespace from similar_to parameter" do
     p = described_class.new({ "similar_to" => ["/cheese "] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(similar_to: "/cheese")).to eq(p.parsed_params)
   end
@@ -251,7 +251,7 @@ RSpec.describe SearchParameterParser do
   it "put the similar_to parameter in normalized form" do
     p = described_class.new({ "similar_to" => ["/cafe\u0300 "] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(similar_to: "/caf\u00e8")).to eq(p.parsed_params)
   end
@@ -259,7 +259,7 @@ RSpec.describe SearchParameterParser do
   it "complain about invalid unicode in the similar_to parameter" do
     p = described_class.new({ "similar_to" => ["\xff"] }, @schema)
 
-    expect("Invalid unicode in similar_to").to eq(p.error)
+    expect(p.error).to eq("Invalid unicode in similar_to")
     expect(p).not_to be_valid
     expect(expected_params(similar_to: nil)).to eq(p.parsed_params)
   end
@@ -267,7 +267,7 @@ RSpec.describe SearchParameterParser do
   it "complain when both q and similar_to parameters are provided" do
     p = described_class.new({ "q" => ["hello"], "similar_to" => ["/world"] }, @schema)
 
-    expect("Parameters 'q' and 'similar_to' cannot be used together").to eq(p.error)
+    expect(p.error).to eq("Parameters 'q' and 'similar_to' cannot be used together")
     expect(p).not_to be_valid
     expect(expected_params(query: "hello", similar_to: "/world")).to eq(p.parsed_params)
   end
@@ -275,7 +275,7 @@ RSpec.describe SearchParameterParser do
   it "set the order parameter to nil when the similar_to parameter is provided" do
     p = described_class.new({ "similar_to" => ["/hello"], "order" => ["title"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(similar_to: "/hello")).to eq(p.parsed_params)
   end
@@ -283,7 +283,7 @@ RSpec.describe SearchParameterParser do
   it "understand filter paramers" do
     p = described_class.new({ "filter_organisations" => ["hm-magic"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(
       hash_including(filters: [
@@ -297,7 +297,7 @@ RSpec.describe SearchParameterParser do
   it "understand reject paramers" do
     p = described_class.new({ "reject_organisations" => ["hm-magic"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(
       hash_including(filters: [
@@ -314,7 +314,7 @@ RSpec.describe SearchParameterParser do
       "filter_mainstream_browse_pages" => ["cheese"],
     }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(
       hash_including(filters: [
@@ -329,7 +329,7 @@ RSpec.describe SearchParameterParser do
   it "understand multiple filter paramers" do
     p = described_class.new({ "filter_organisations" => ["hm-magic", "hmrc"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(
       expected_params(
@@ -349,27 +349,27 @@ RSpec.describe SearchParameterParser do
   it "understand filter for missing field" do
     p = described_class.new({ "filter_organisations" => ["_MISSING"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
 
     filters = p.parsed_params[:filters]
-    expect(1).to eq(filters.size)
-    expect("organisations").to eq(filters[0].field_name)
+    expect(filters.size).to eq(1)
+    expect(filters[0].field_name).to eq("organisations")
     expect(true).to eq(filters[0].include_missing)
-    expect([]).to eq(filters[0].values)
+    expect(filters[0].values).to eq([])
   end
 
   it "understand filter for missing field or specific value" do
     p = described_class.new({ "filter_organisations" => %w(_MISSING hmrc) }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
 
     filters = p.parsed_params[:filters]
-    expect(1).to eq(filters.size)
-    expect("organisations").to eq(filters[0].field_name)
+    expect(filters.size).to eq(1)
+    expect(filters[0].field_name).to eq("organisations")
     expect(true).to eq(filters[0].include_missing)
-    expect(["hmrc"]).to eq(filters[0].values)
+    expect(filters[0].values).to eq(["hmrc"])
   end
 
   it "complain about disallowed filter fields" do
@@ -455,13 +455,13 @@ RSpec.describe SearchParameterParser do
         "filter_opened_date" => ["_MISSING", "from:2014-04-01 00:00,to:2014-04-02 00:00"],
       }, @schema)
 
-      expect("").to eq(parser.error)
+      expect(parser.error).to eq("")
       expect(parser).to be_valid
 
       opened_date_filter = parser.parsed_params.fetch(:filters)
         .find { |filter| filter.field_name == "opened_date" }
 
-      expect("opened_date").to eq(opened_date_filter.field_name)
+      expect(opened_date_filter.field_name).to eq("opened_date")
       expect(true).to eq(opened_date_filter.include_missing)
 
       expect(
@@ -497,7 +497,7 @@ RSpec.describe SearchParameterParser do
   it "understand an ascending sort" do
     p = described_class.new({ "order" => ["public_timestamp"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params({ order: %w(public_timestamp asc) })).to eq(p.parsed_params)
   end
@@ -505,7 +505,7 @@ RSpec.describe SearchParameterParser do
   it "understand a descending sort" do
     p = described_class.new({ "order" => ["-public_timestamp"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params({ order: %w(public_timestamp desc) })).to eq(p.parsed_params)
   end
@@ -537,7 +537,7 @@ RSpec.describe SearchParameterParser do
   it "understand a aggregate field" do
     p = described_class.new({ "aggregate_organisations" => ["10"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(
       expected_params(aggregates: { "organisations" => expected_aggregate_params(requested: 10) })
@@ -550,7 +550,7 @@ RSpec.describe SearchParameterParser do
       "aggregate_mainstream_browse_pages" => ["5"],
     }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(
       expected_params(
@@ -609,7 +609,7 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:global"],
     }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(
       aggregates: {
@@ -627,7 +627,7 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,order:filtered:value.link:-count"],
     }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(
       aggregates: {
@@ -654,7 +654,7 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,order:filtered,order:value.link:-count"],
     }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(
       aggregates: {
@@ -670,7 +670,7 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,scope:all_filters"],
     }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(
       aggregates: {
@@ -706,7 +706,7 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_fields:slug,example_fields:title:link,example_scope:global"],
     }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(
       aggregates: {
@@ -724,7 +724,7 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title"],
     }, @schema)
 
-    expect("example_scope parameter must be set to 'query' or 'global' when requesting examples").to eq(p.error)
+    expect(p.error).to eq("example_scope parameter must be set to 'query' or 'global' when requesting examples")
     expect(p).not_to be_valid
     expect(expected_params({ aggregates: {} })).to eq(p.parsed_params)
   end
@@ -751,7 +751,7 @@ RSpec.describe SearchParameterParser do
       "aggregate_organisations" => ["10,examples:5,example_scope:invalid"],
     }, @schema)
 
-    expect("example_scope parameter must be set to 'query' or 'global' when requesting examples").to eq(p.error)
+    expect(p.error).to eq("example_scope parameter must be set to 'query' or 'global' when requesting examples")
     expect(p).not_to be_valid
     expect(expected_params({})).to eq(p.parsed_params)
   end
@@ -808,7 +808,7 @@ RSpec.describe SearchParameterParser do
   it "understand the fields parameter" do
     p = described_class.new({ "fields" => %w(title description) }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(return_fields: %w(title description))).to eq(p.parsed_params)
   end
@@ -816,7 +816,7 @@ RSpec.describe SearchParameterParser do
   it "complain about invalid fields parameters" do
     p = described_class.new({ "fields" => %w(title waffle) }, @schema)
 
-    expect("Some requested fields are not valid return fields: [\"waffle\"]").to eq(p.error)
+    expect(p.error).to eq("Some requested fields are not valid return fields: [\"waffle\"]")
     expect(p).not_to be_valid
     expect(expected_params(return_fields: ["title"])).to eq(p.parsed_params)
   end
@@ -832,7 +832,7 @@ RSpec.describe SearchParameterParser do
   it "merge values from repeated debug parameters" do
     p = described_class.new({ "debug" => ["disable_best_bets,explain", "disable_popularity"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(debug: { disable_best_bets: true, explain: true, disable_popularity: true })).to eq(p.parsed_params)
   end
@@ -840,7 +840,7 @@ RSpec.describe SearchParameterParser do
   it "ignore empty options in the debug parameter" do
     p = described_class.new({ "debug" => [",,"] }, @schema)
 
-    expect("").to eq(p.error)
+    expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(debug: {})).to eq(p.parsed_params)
   end
@@ -877,6 +877,6 @@ RSpec.describe SearchParameterParser do
     p = described_class.new({ "ab_tests" => ["min_should_match_length"] }, @schema)
 
     expect(p).not_to be_valid
-    expect("Invalid ab_tests, missing type \"min_should_match_length\"").to eq(p.error)
+    expect(p.error).to eq("Invalid ab_tests, missing type \"min_should_match_length\"")
   end
 end

--- a/spec/unit/query_components/best_bets_spec.rb
+++ b/spec/unit/query_components/best_bets_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe QueryComponents::BestBets do
       result = builder.wrap('QUERY')
 
       expected = { bool: { should: ['QUERY', { function_score: { query: { ids: { values: ["/best-bet"] } }, boost_factor: 1000000 } }] } }
-      expect(expected).to eq(result)
+      expect(result).to eq(expected)
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe QueryComponents::BestBets do
         }
       }
 
-      expect(expected).to eq(result)
+      expect(result).to eq(expected)
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe QueryComponents::BestBets do
       result = builder.wrap('QUERY')
 
       expected = { bool: { should: ['QUERY', { function_score: { query: { ids: { values: ["/best-bet", "/other-best-bet"] } }, boost_factor: 1000000 } }] } }
-      expect(expected).to eq(result)
+      expect(result).to eq(expected)
     end
   end
 
@@ -66,7 +66,7 @@ RSpec.describe QueryComponents::BestBets do
       result = builder.wrap({})
 
       expected = { bool: { should: [{}], must_not: [{ ids: { values: ["/worst-bet", "/other-worst-bet"] } }] } }
-      expect(expected).to eq(result)
+      expect(result).to eq(expected)
     end
   end
 end

--- a/spec/unit/query_components/sort_spec_spec.rb
+++ b/spec/unit/query_components/sort_spec_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      expect([{ "public_timestamp" => { order: "asc", missing: "_last" } }]).to eq(result)
+      expect(result).to eq([{ "public_timestamp" => { order: "asc", missing: "_last" } }])
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      expect([{ "public_timestamp" => { order: "desc", missing: "_last" } }]).to eq(result)
+      expect(result).to eq([{ "public_timestamp" => { order: "desc", missing: "_last" } }])
     end
   end
 

--- a/spec/unit/result_set_presenter_spec.rb
+++ b/spec/unit/result_set_presenter_spec.rb
@@ -170,15 +170,15 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "present empty list of results" do
-      expect([]).to eq(@output[:results])
+      expect(@output[:results]).to eq([])
     end
 
     it "have total of 0" do
-      expect(0).to eq(@output[:total])
+      expect(@output[:total]).to eq(0)
     end
 
     it "have no aggregates" do
-      expect({}).to eq(@output[:aggregates])
+      expect(@output[:aggregates]).to eq({})
     end
   end
 
@@ -194,11 +194,11 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct total" do
-      expect(3).to eq(@output[:total])
+      expect(@output[:total]).to eq(3)
     end
 
     it "have correct number of results" do
-      expect(3).to eq(@output[:results].length)
+      expect(@output[:results].length).to eq(3)
     end
 
     it "have short index names" do
@@ -270,11 +270,11 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct total" do
-      expect(3).to eq(@output[:total])
+      expect(@output[:total]).to eq(3)
     end
 
     it "have correct number of results" do
-      expect(3).to eq(@output[:results].length)
+      expect(@output[:results].length).to eq(3)
     end
 
     it "have short index names" do
@@ -326,11 +326,11 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      expect(1).to eq(@output[:aggregates].length)
+      expect(@output[:aggregates].length).to eq(1)
     end
 
     it "have correct number of aggregate values" do
-      expect(1).to eq(@output[:aggregates]["organisations"][:options].length)
+      expect(@output[:aggregates]["organisations"][:options].length).to eq(1)
     end
 
     it "include requested aggregate scope" do
@@ -346,15 +346,15 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of documents with no value" do
-      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(@output[:aggregates]["organisations"][:documents_with_no_value]).to eq(8)
     end
 
     it "have correct total number of options" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
+      expect(@output[:aggregates]["organisations"][:total_options]).to eq(2)
     end
 
     it "have correct number of missing options" do
-      expect(1).to eq(@output[:aggregates]["organisations"][:missing_options])
+      expect(@output[:aggregates]["organisations"][:missing_options]).to eq(1)
     end
   end
 
@@ -376,11 +376,11 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      expect(1).to eq(@output[:aggregates].length)
+      expect(@output[:aggregates].length).to eq(1)
     end
 
     it "have correct number of aggregate values" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:options].length)
+      expect(@output[:aggregates]["organisations"][:options].length).to eq(2)
     end
 
     it "have selected aggregate first" do
@@ -398,15 +398,15 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of documents with no value" do
-      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(@output[:aggregates]["organisations"][:documents_with_no_value]).to eq(8)
     end
 
     it "have correct total number of options" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
+      expect(@output[:aggregates]["organisations"][:total_options]).to eq(2)
     end
 
     it "have correct number of missing options" do
-      expect(0).to eq(@output[:aggregates]["organisations"][:missing_options])
+      expect(@output[:aggregates]["organisations"][:missing_options]).to eq(0)
     end
   end
 
@@ -428,11 +428,11 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      expect(1).to eq(@output[:aggregates].length)
+      expect(@output[:aggregates].length).to eq(1)
     end
 
     it "have correct number of aggregate values" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:options].length)
+      expect(@output[:aggregates]["organisations"][:options].length).to eq(2)
     end
 
     it "have selected aggregate first" do
@@ -450,15 +450,15 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of documents with no value" do
-      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(@output[:aggregates]["organisations"][:documents_with_no_value]).to eq(8)
     end
 
     it "have correct total number of options" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
+      expect(@output[:aggregates]["organisations"][:total_options]).to eq(2)
     end
 
     it "have correct number of missing options" do
-      expect(1).to eq(@output[:aggregates]["organisations"][:missing_options])
+      expect(@output[:aggregates]["organisations"][:missing_options]).to eq(1)
     end
   end
 
@@ -475,23 +475,23 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      expect(1).to eq(@output[:aggregates].length)
+      expect(@output[:aggregates].length).to eq(1)
     end
 
     it "have no aggregate values" do
-      expect(0).to eq(@output[:aggregates]["organisations"][:options].length)
+      expect(@output[:aggregates]["organisations"][:options].length).to eq(0)
     end
 
     it "have correct number of documents with no value" do
-      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(@output[:aggregates]["organisations"][:documents_with_no_value]).to eq(8)
     end
 
     it "have correct total number of options" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
+      expect(@output[:aggregates]["organisations"][:total_options]).to eq(2)
     end
 
     it "have correct number of missing options" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:missing_options])
+      expect(@output[:aggregates]["organisations"][:missing_options]).to eq(2)
     end
   end
 
@@ -606,12 +606,12 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      expect(2).to eq(@output[:aggregates].length)
+      expect(@output[:aggregates].length).to eq(2)
     end
 
     it "have correct number of aggregate values" do
-      expect(1).to eq(@output[:aggregates]["organisations"][:options].length)
-      expect(1).to eq(@output[:aggregates]["policy_areas"][:options].length)
+      expect(@output[:aggregates]["organisations"][:options].length).to eq(1)
+      expect(@output[:aggregates]["policy_areas"][:options].length).to eq(1)
     end
 
     it "have org aggregate value expanded" do
@@ -633,18 +633,18 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of documents with no value" do
-      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
-      expect(3).to eq(@output[:aggregates]["policy_areas"][:documents_with_no_value])
+      expect(@output[:aggregates]["organisations"][:documents_with_no_value]).to eq(8)
+      expect(@output[:aggregates]["policy_areas"][:documents_with_no_value]).to eq(3)
     end
 
     it "have correct total number of options" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
-      expect(2).to eq(@output[:aggregates]["policy_areas"][:total_options])
+      expect(@output[:aggregates]["organisations"][:total_options]).to eq(2)
+      expect(@output[:aggregates]["policy_areas"][:total_options]).to eq(2)
     end
 
     it "have correct number of missing options" do
-      expect(1).to eq(@output[:aggregates]["organisations"][:missing_options])
-      expect(1).to eq(@output[:aggregates]["policy_areas"][:missing_options])
+      expect(@output[:aggregates]["organisations"][:missing_options]).to eq(1)
+      expect(@output[:aggregates]["policy_areas"][:missing_options]).to eq(1)
     end
   end
 
@@ -674,11 +674,11 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of aggregates" do
-      expect(1).to eq(@output[:aggregates].length)
+      expect(@output[:aggregates].length).to eq(1)
     end
 
     it "have correct number of aggregate values" do
-      expect(1).to eq(@output[:aggregates]["organisations"][:options].length)
+      expect(@output[:aggregates]["organisations"][:options].length).to eq(1)
     end
 
     it "have org aggregate value expanded, and include examples" do
@@ -699,15 +699,15 @@ RSpec.describe Search::ResultSetPresenter do
     end
 
     it "have correct number of documents with no value" do
-      expect(8).to eq(@output[:aggregates]["organisations"][:documents_with_no_value])
+      expect(@output[:aggregates]["organisations"][:documents_with_no_value]).to eq(8)
     end
 
     it "have correct total number of options" do
-      expect(2).to eq(@output[:aggregates]["organisations"][:total_options])
+      expect(@output[:aggregates]["organisations"][:total_options]).to eq(2)
     end
 
     it "have correct number of missing options" do
-      expect(1).to eq(@output[:aggregates]["organisations"][:missing_options])
+      expect(@output[:aggregates]["organisations"][:missing_options]).to eq(1)
     end
   end
 

--- a/spec/unit/schema/combined_index_schema_spec.rb
+++ b/spec/unit/schema/combined_index_schema_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe CombinedIndexSchema do
   it "basic_field_definitions" do
     # The title and public_timestamp fields are defined in the
     # base_elasticsearch_type, so are available in all documents holding content.
-    expect("searchable_sortable_text").to eq(@combined_schema.field_definitions["title"].type.name)
-    expect("searchable_text").to eq(@combined_schema.field_definitions["description"].type.name)
-    expect("date").to eq(@combined_schema.field_definitions["public_timestamp"].type.name)
+    expect(@combined_schema.field_definitions["title"].type.name).to eq("searchable_sortable_text")
+    expect(@combined_schema.field_definitions["description"].type.name).to eq("searchable_text")
+    expect(@combined_schema.field_definitions["public_timestamp"].type.name).to eq("date")
   end
 
   it "merged_field_definitions" do

--- a/spec/unit/schema/elasticsearch_types_parser_spec.rb
+++ b/spec/unit/schema/elasticsearch_types_parser_spec.rb
@@ -30,21 +30,21 @@ RSpec.describe ElasticsearchTypesParser do
     end
 
     it "recognise the `manual_section` type" do
-      expect("manual_section").to eq(@types["manual_section"].name)
+      expect(@types["manual_section"].name).to eq("manual_section")
     end
 
     it "know that the `manual_section` type has a `manual` field" do
       manual_field = @types["manual_section"].fields["manual"]
       expect(manual_field).not_to be_nil
-      expect("manual").to eq(manual_field.name)
+      expect(manual_field.name).to eq("manual")
     end
 
     it "know that the `manual_section` type inherits the `link` field from the base type" do
       link_field = @types["manual_section"].fields["link"]
       expect(link_field).not_to be_nil
-      expect("link").to eq(link_field.name)
+      expect(link_field.name).to eq("link")
       expect(false).to eq(link_field.type.multivalued)
-      expect("identifier").to eq(link_field.type.name)
+      expect(link_field.type.name).to eq("identifier")
     end
 
     it "produce appropriate elasticsearch configuration for the `manual_section` type" do

--- a/spec/unit/schema/field_definition_parser_spec.rb
+++ b/spec/unit/schema/field_definition_parser_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe FieldDefinitionParser do
     end
 
     it "recognise the `link` field definition" do
-      expect("link").to eq(@definitions["link"].name)
+      expect(@definitions["link"].name).to eq("link")
     end
 
     it "know that the `link` field has type `identifier`" do
-      expect("identifier").to eq(@definitions["link"].type.name)
+      expect(@definitions["link"].type.name).to eq("identifier")
     end
 
     it "know that the `link` field has a description" do
@@ -23,7 +23,7 @@ RSpec.describe FieldDefinitionParser do
     end
 
     it "know that the `attachments` field has a child of `title` of type searchable_text" do
-      expect("searchable_text").to eq(@definitions["attachments"].children["title"].type.name)
+      expect(@definitions["attachments"].children["title"].type.name).to eq("searchable_text")
     end
 
     it "be able to merge two field definitions" do
@@ -34,9 +34,9 @@ RSpec.describe FieldDefinitionParser do
       definition2 = FieldDefinition.new("foo", "string", {}, "", nil, [value2, value3])
       merged = definition2.merge(definition1)
 
-      expect("foo").to eq(merged.name)
-      expect("string").to eq(merged.type)
-      expect([value1, value2, value3]).to eq(merged.expanded_search_result_fields.sort_by { |item| item["value"] })
+      expect(merged.name).to eq("foo")
+      expect(merged.type).to eq("string")
+      expect(merged.expanded_search_result_fields.sort_by { |item| item["value"] }).to eq([value1, value2, value3])
     end
   end
 end

--- a/spec/unit/schema/field_types_spec.rb
+++ b/spec/unit/schema/field_types_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FieldTypes do
     end
 
     it "recognise the `identifier` type" do
-      expect("identifier").to eq(@types.get("identifier").name)
+      expect(@types.get("identifier").name).to eq("identifier")
     end
 
     it "know that the `identifier` type is single-valued" do
@@ -19,7 +19,7 @@ RSpec.describe FieldTypes do
     end
 
     it "know that the `identifiers` type has a `text` filter type" do
-      expect("text").to eq(@types.get("identifiers").filter_type)
+      expect(@types.get("identifiers").filter_type).to eq("text")
     end
 
     it "know that the `identifiers` type does not have children" do
@@ -27,11 +27,11 @@ RSpec.describe FieldTypes do
     end
 
     it "know that the `objects` type has named children" do
-      expect("named").to eq(@types.get("objects").children)
+      expect(@types.get("objects").children).to eq("named")
     end
 
     it "know that the `opaque_object` type has dynamic children" do
-      expect("dynamic").to eq(@types.get("opaque_object").children)
+      expect(@types.get("opaque_object").children).to eq("dynamic")
     end
 
     it "raise an error for unknown types" do

--- a/spec/unit/schema/index_schema_parser_spec.rb
+++ b/spec/unit/schema/index_schema_parser_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe IndexSchemaParser do
     end
 
     it "have a schema for the mainstream index" do
-      expect("mainstream").to eq(@index_schemas["mainstream"].name)
+      expect(@index_schemas["mainstream"].name).to eq("mainstream")
     end
 
     it "include configuration for the `manual_section` type in the `mainstream` index" do

--- a/spec/unit/search/aggregate_example_fetcher_spec.rb
+++ b/spec/unit/search/aggregate_example_fetcher_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Search::AggregateExampleFetcher do
     end
 
     it "get an empty hash of examples" do
-      expect({}).to eq(@fetcher.fetch)
+      expect(@fetcher.fetch).to eq({})
     end
   end
 
@@ -227,7 +227,7 @@ RSpec.describe Search::AggregateExampleFetcher do
     end
 
     it "request and return aggregate examples" do
-      expect({ "sector" => {} }).to eq(@fetcher.fetch)
+      expect(@fetcher.fetch).to eq({ "sector" => {} })
     end
   end
 

--- a/spec/unit/search/best_bets_checker_spec.rb
+++ b/spec/unit/search/best_bets_checker_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "not find any best bets" do
-      expect({}).to eq(@checker.best_bets)
+      expect(@checker.best_bets).to eq({})
     end
 
     it "not find any worst bets" do
-      expect([]).to eq(@checker.worst_bets)
+      expect(@checker.worst_bets).to eq([])
     end
   end
 
@@ -72,11 +72,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "find one best bet" do
-      expect({ 1 => ["/jobsearch"] }).to eq(@checker.best_bets)
+      expect(@checker.best_bets).to eq({ 1 => ["/jobsearch"] })
     end
 
     it "not find any worst bets" do
-      expect([]).to eq(@checker.worst_bets)
+      expect(@checker.worst_bets).to eq([])
     end
   end
 
@@ -88,11 +88,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "not find any best bets" do
-      expect({}).to eq(@checker.best_bets)
+      expect(@checker.best_bets).to eq({})
     end
 
     it "find one worst bet" do
-      expect(["/jobsearch"]).to eq(@checker.worst_bets)
+      expect(@checker.worst_bets).to eq(["/jobsearch"])
     end
   end
 
@@ -105,11 +105,11 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "find just the exact best bet" do
-      expect({ 1 => ["/jobsearch"] }).to eq(@checker.best_bets)
+      expect(@checker.best_bets).to eq({ 1 => ["/jobsearch"] })
     end
 
     it "not find any worst bets" do
-      expect([]).to eq(@checker.worst_bets)
+      expect(@checker.worst_bets).to eq([])
     end
   end
 
@@ -126,7 +126,7 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "not find any worst bets" do
-      expect([]).to eq(@checker.worst_bets)
+      expect(@checker.worst_bets).to eq([])
     end
   end
 
@@ -146,7 +146,7 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "not find any worst bets" do
-      expect([]).to eq(@checker.worst_bets)
+      expect(@checker.worst_bets).to eq([])
     end
   end
 
@@ -164,7 +164,7 @@ RSpec.describe Search::BestBetsChecker do
     end
 
     it "find worst bets only from the exact bet" do
-      expect(["/jobsearch"]).to eq(@checker.worst_bets)
+      expect(@checker.worst_bets).to eq(["/jobsearch"])
     end
   end
 end

--- a/spec/unit/search/elasticsearch_escaping_spec.rb
+++ b/spec/unit/search/elasticsearch_escaping_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Search::Escaping do
   end
 
   it "escapes_the_query_for_lucene_chars" do
-    expect("how\\?").to eq(subject.escape("how?"))
+    expect(subject.escape("how?")).to eq("how\\?")
   end
 
   it "escapes_the_query_for_lucene_booleans" do
-    expect('fish "AND" chips').to eq(subject.escape("fish AND chips"))
+    expect(subject.escape("fish AND chips")).to eq('fish "AND" chips')
   end
 end

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Search::FormatMigrator do
         no_match_filter: 'none'
       }
     }
-    expect(expected).to eq(described_class.new(base_query).call)
+    expect(described_class.new(base_query).call).to eq(expected)
   end
 
   it "when_base_query_with_migrated_formats" do
@@ -36,7 +36,7 @@ RSpec.describe Search::FormatMigrator do
         }
       }
     }
-    expect(expected).to eq(described_class.new(base_query).call)
+    expect(described_class.new(base_query).call).to eq(expected)
   end
 
   it "when_no_base_query_without_migrated_formats" do
@@ -48,7 +48,7 @@ RSpec.describe Search::FormatMigrator do
         no_match_filter: 'none'
       }
     }
-    expect(expected).to eq(described_class.new(nil).call)
+    expect(described_class.new(nil).call).to eq(expected)
   end
 
   it "when_no_base_query_with_migrated_formats" do
@@ -68,6 +68,6 @@ RSpec.describe Search::FormatMigrator do
         }
       }
     }
-    expect(expected).to eq(described_class.new(nil).call)
+    expect(described_class.new(nil).call).to eq(expected)
   end
 end

--- a/spec/unit/search/presenters/highlighted_description_spec.rb
+++ b/spec/unit/search/presenters/highlighted_description_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Search::HighlightedDescription do
 
     highlighted_description = described_class.new(raw_result).text
 
-    expect("I will be <mark>hightlighted</mark>.").to eq(highlighted_description)
+    expect(highlighted_description).to eq("I will be <mark>hightlighted</mark>.")
   end
 
   it "uses_default_description_if_hightlight_not_found" do
@@ -19,7 +19,7 @@ RSpec.describe Search::HighlightedDescription do
 
     highlighted_description = described_class.new(raw_result).text
 
-    expect("I will not be hightlighted &amp; escaped.").to eq(highlighted_description)
+    expect(highlighted_description).to eq("I will not be hightlighted &amp; escaped.")
   end
 
   it "truncates_default_description_if_hightlight_not_found" do
@@ -29,7 +29,7 @@ RSpec.describe Search::HighlightedDescription do
 
     highlighted_description = described_class.new(raw_result).text
 
-    expect(225).to eq(highlighted_description.size)
+    expect(highlighted_description.size).to eq(225)
     expect(highlighted_description.ends_with?('…')).to be_truthy
   end
 
@@ -40,6 +40,6 @@ RSpec.describe Search::HighlightedDescription do
 
     highlighted_description = described_class.new(raw_result).text
 
-    expect("").to eq(highlighted_description)
+    expect(highlighted_description).to eq("")
   end
 end

--- a/spec/unit/search/presenters/highlighted_title_spec.rb
+++ b/spec/unit/search/presenters/highlighted_title_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Search::HighlightedTitle do
       "highlight" => { "title" => ["A Highlighted Title"] }
     })
 
-    expect("A Highlighted Title").to eq(title.text)
+    expect(title.text).to eq("A Highlighted Title")
   end
 
   it "fallback_title_is_escaped" do
@@ -15,6 +15,6 @@ RSpec.describe Search::HighlightedTitle do
       "fields" => { "title" => "A & Title" },
     })
 
-    expect("A &amp; Title").to eq(title.text)
+    expect(title.text).to eq("A &amp; Title")
   end
 end

--- a/spec/unit/search/presenters/result_presenter_spec.rb
+++ b/spec/unit/search/presenters/result_presenter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::ResultPresenter do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[format])).present
 
-    expect("a-string").to eq(result["format"])
+    expect(result["format"]).to eq("a-string")
   end
 
   it "conversion_values_to_labelled_objects" do

--- a/spec/unit/search/presenters/temporary_link_fix_spec.rb
+++ b/spec/unit/search/presenters/temporary_link_fix_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
 
-    expect("/some/link").to eq(result["link"])
+    expect(result["link"]).to eq("/some/link")
   end
 
   it "keep_http_links_intact" do
@@ -22,7 +22,7 @@ RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
 
-    expect("http://example.org/some-link").to eq(result["link"])
+    expect(result["link"]).to eq("http://example.org/some-link")
   end
 
   it "keep_correct_links_intact" do
@@ -34,6 +34,6 @@ RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
 
     result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
 
-    expect("/some-link").to eq(result["link"])
+    expect(result["link"]).to eq("/some-link")
   end
 end

--- a/spec/unit/search/query_builder_spec.rb
+++ b/spec/unit/search/query_builder_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Search::QueryBuilder do
       builder = builder_with_params(start: 11, count: 34, return_fields: ['a_field'])
 
       result = builder.payload
-      expect(11).to eq(result[:from])
-      expect(34).to eq(result[:size])
+      expect(result[:from]).to eq(11)
+      expect(result[:size]).to eq(34)
       expect(result[:fields]).to include('a_field')
       expect(result.key?(:query)).to be_truthy
     end

--- a/spec/unit/search/result_set_spec.rb
+++ b/spec/unit/search/result_set_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Search::ResultSet do
     end
 
     it "report zero results" do
-      expect(0).to eq(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total)
+      expect(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total).to eq(0)
     end
 
     it "have an empty result set" do
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
-      expect(0).to eq(result_set.results.size)
+      expect(result_set.results.size).to eq(0)
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe Search::ResultSet do
     end
 
     it "report one result" do
-      expect(1).to eq(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total)
+      expect(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total).to eq(1)
     end
 
     it "pass the fields to Document.from_hash" do
@@ -47,14 +47,14 @@ RSpec.describe Search::ResultSet do
       expect(Document).to receive(:from_hash).with(expected_hash, sample_elasticsearch_types, anything).and_return(:doc)
 
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
-      expect([:doc]).to eq(result_set.results)
+      expect(result_set.results).to eq([:doc])
     end
 
     it "pass the result score to Document.from_hash" do
       expect(Document).to receive(:from_hash).with(an_instance_of(Hash), sample_elasticsearch_types, 12).and_return(:doc)
 
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
-      expect([:doc]).to eq(result_set.results)
+      expect(result_set.results).to eq([:doc])
     end
 
     it "populate the document id and type from the metafields" do
@@ -62,7 +62,7 @@ RSpec.describe Search::ResultSet do
       expect(Document).to receive(:from_hash).with(expected_hash, sample_elasticsearch_types, anything).and_return(:doc)
 
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
-      expect([:doc]).to eq(result_set.results)
+      expect(result_set.results).to eq([:doc])
     end
   end
 end

--- a/spec/unit/search/timed_cache_spec.rb
+++ b/spec/unit/search/timed_cache_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Search::TimedCache do
     expect(fetch).to receive(:call).and_return("foo").once
 
     cache = described_class.new(5) { fetch.call }
-    2.times { expect("foo").to eq(cache.get) }
+    2.times { expect(cache.get).to eq("foo") }
   end
 
   it "cache_does_not_expire_within_lifetime" do

--- a/spec/unit/search_server_spec.rb
+++ b/spec/unit/search_server_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe SearchIndices::SearchServer do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index("mainstream_test")
     expect(index).to be_a(SearchIndices::Index)
-    expect("mainstream_test").to eq(index.index_name)
+    expect(index.index_name).to eq("mainstream_test")
   end
 
   it "returns_an_index_for_govuk_index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index("govuk_test")
     expect(index).to be_a(SearchIndices::Index)
-    expect("govuk_test").to eq(index.index_name)
+    expect(index.index_name).to eq("govuk_test")
   end
 
   it "raises_an_error_for_unknown_index" do
@@ -33,7 +33,7 @@ RSpec.describe SearchIndices::SearchServer do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index_for_search(%w{mainstream_test page-traffic_test})
     expect(index).to be_a(LegacyClient::IndexForSearch)
-    expect(["mainstream_test", "page-traffic_test"]).to eq(index.index_names)
+    expect(index.index_names).to eq(["mainstream_test", "page-traffic_test"])
   end
 
   it "raises_an_error_for_unknown_index_in_multi_index" do

--- a/spec/unit/sitemap/property_boost_calculator_spec.rb
+++ b/spec/unit/sitemap/property_boost_calculator_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    expect(0).to eq(calculator.boost(build_document(format: "format1")))
+    expect(calculator.boost(build_document(format: "format1"))).to eq(0)
     expect(0.5).to eq(calculator.boost(build_document(format: "format2")))
     expect(0.75).to eq(calculator.boost(build_document(format: "format3")))
     expect(0.88).to eq(calculator.boost(build_document(format: "format4")))
-    expect(1).to eq(calculator.boost(build_document(format: "format5")))
+    expect(calculator.boost(build_document(format: "format5"))).to eq(1)
   end
 
   it "unboosted_format_has_default_boost" do
@@ -45,9 +45,9 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    expect(1).to eq(calculator.boost(build_document(format: "format1")))
-    expect(1).to eq(calculator.boost(build_document(format: "format2")))
-    expect(1).to eq(calculator.boost(build_document(format: "format3")))
+    expect(calculator.boost(build_document(format: "format1"))).to eq(1)
+    expect(calculator.boost(build_document(format: "format2"))).to eq(1)
+    expect(calculator.boost(build_document(format: "format3"))).to eq(1)
   end
 
   it "unconfigured_format_has_default_boost" do

--- a/spec/unit/sitemap/sitemap_generator_spec.rb
+++ b/spec/unit/sitemap/sitemap_generator_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe SitemapGenerator do
 
     doc = Nokogiri::XML(sitemap_xml)
     urls = doc.css('url > loc').map(&:inner_html)
-    expect("https://www.gov.uk/page").to eq(urls[0])
-    expect("http://www.dev.gov.uk/another-page").to eq(urls[1])
-    expect("http://www.dev.gov.uk/yet-another-page").to eq(urls[2])
+    expect(urls[0]).to eq("https://www.gov.uk/page")
+    expect(urls[1]).to eq("http://www.dev.gov.uk/another-page")
+    expect(urls[2]).to eq("http://www.dev.gov.uk/yet-another-page")
   end
 
   it "links_should_include_timestamps" do
@@ -26,7 +26,7 @@ RSpec.describe SitemapGenerator do
 
     pages = Nokogiri::XML(sitemap_xml).css("url")
 
-    expect("2014-01-28T14:41:50+00:00").to eq(pages[0].css("lastmod").text)
+    expect(pages[0].css("lastmod").text).to eq("2014-01-28T14:41:50+00:00")
   end
 
   it "missing_timestamps_are_ignored" do
@@ -51,7 +51,7 @@ RSpec.describe SitemapGenerator do
 
     pages = Nokogiri::XML(sitemap_xml).css("url")
 
-    expect("0.48").to eq(pages[0].css("priority").text)
+    expect(pages[0].css("priority").text).to eq("0.48")
   end
 
   def build_document(url, timestamp: nil, is_withdrawn: nil)

--- a/spec/unit/sitemap/sitemap_presenter_spec.rb
+++ b/spec/unit/sitemap/sitemap_presenter_spec.rb
@@ -12,19 +12,19 @@ RSpec.describe SitemapPresenter do
   it "url_is_document_link_if_link_is_http_url" do
     document = build_document(url: "http://some.url")
     presenter = described_class.new(document, @boost_calculator)
-    expect("http://some.url").to eq(presenter.url)
+    expect(presenter.url).to eq("http://some.url")
   end
 
   it "url_is_document_link_if_link_is_https_url" do
     document = build_document(url: "https://some.url")
     presenter = described_class.new(document, @boost_calculator)
-    expect("https://some.url").to eq(presenter.url)
+    expect(presenter.url).to eq("https://some.url")
   end
 
   it "url_appends_host_name_if_link_is_a_path" do
     document = build_document(url: "/some/path")
     presenter = described_class.new(document, @boost_calculator)
-    expect("https://website_root/some/path").to eq(presenter.url)
+    expect(presenter.url).to eq("https://website_root/some/path")
   end
 
   it "last_updated_is_timestamp_if_timestamp_is_date_time" do
@@ -33,7 +33,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "2014-01-28T14:41:50+00:00"
     )
     presenter = described_class.new(document, @boost_calculator)
-    expect("2014-01-28T14:41:50+00:00").to eq(presenter.last_updated)
+    expect(presenter.last_updated).to eq("2014-01-28T14:41:50+00:00")
   end
 
   it "last_updated_is_timestamp_if_timestamp_is_date" do
@@ -42,7 +42,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "2017-07-12"
     )
     presenter = described_class.new(document, @boost_calculator)
-    expect("2017-07-12").to eq(presenter.last_updated)
+    expect(presenter.last_updated).to eq("2017-07-12")
   end
 
   it "last_updated_is_limited_to_recent_date" do
@@ -51,7 +51,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "1995-06-01"
     )
     presenter = described_class.new(document, @boost_calculator)
-    expect("2012-10-17T00:00:00+00:00").to eq(presenter.last_updated)
+    expect(presenter.last_updated).to eq("2012-10-17T00:00:00+00:00")
   end
 
   it "last_updated_is_omitted_if_timestamp_is_missing" do
@@ -87,7 +87,7 @@ RSpec.describe SitemapPresenter do
       is_withdrawn: false
     )
     presenter = described_class.new(document, @boost_calculator)
-    expect(1).to eq(presenter.priority)
+    expect(presenter.priority).to eq(1)
   end
 
   it "withdrawn_page_has_lower_priority" do
@@ -104,7 +104,7 @@ RSpec.describe SitemapPresenter do
       url: "/some/path"
     )
     presenter = described_class.new(document, @boost_calculator)
-    expect(1).to eq(presenter.priority)
+    expect(presenter.priority).to eq(1)
   end
 
   it "page_with_boosted_format_has_adjusted_priority" do


### PR DESCRIPTION
These where migrated from assert_equal with A and B in the 
wrong positions.

This has been correct for the following criteria:

The assertion is on a single line.

* A starts with “ or `
* A is a number
* A starts with [ or {
* A = expected

And B does not start with the same value.

This will not fix the ordering on all tests, however it will 
cover a majority of case and result in reduced manual effort 
later.