### PR TITLE
Create all indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,17 @@ rebuild the index nightly to incorporate the latest analytics.
 
 ### Setup
 
-To create indices, or to update them to the latest index settings, run:
+To create an empty index:
 
-    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_index
+    bundle exec rake rummager:create_index[<index_name>]
 
-If you have indices from a Rummager instance before aliased indices, run:
+To create an empty index for all rummager indices:
 
-    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_from_unaliased_index
+    RUMMAGER_INDEX=all bundle exec rake rummager:create_all_indices
 
-If you don't know which of these you need to run, try running the first one; it
-will fail safely with an error if you have an unmigrated index.
+To update an index to the latest index settings, run:
+
+    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_schema
 
 ### Running the application
 

--- a/lib/govuk_index/popularity_updater.rb
+++ b/lib/govuk_index/popularity_updater.rb
@@ -21,14 +21,17 @@ module GovukIndex
           destination_index: new_index.real_name,
         ).run
 
-        # need to do this to ensure the new index is fully populated
-        SyncUpdater.new(
-          source_index: 'mainstream',
-          destination_index: new_index.real_name,
-        ).run
-
         worker.wait_until_processed
-        SyncWorker.wait_until_processed
+
+        if index_name =~ 'govuk'
+          # need to do this to ensure the new govuk index is in sync while we migrate data
+          SyncUpdater.new(
+            source_index: 'mainstream',
+            destination_index: new_index.real_name,
+          ).run
+
+          SyncWorker.wait_until_processed
+        end
 
         index_group.switch_to(new_index)
       end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -101,21 +101,6 @@ You should run this task if the index schema has changed.
     end
   end
 
-  desc "Migrates an index group to a new index.
-
-Seamlessly creates a new index in the same index_group using the latest
-schema, copies over all data and switches over the index_groups alias to point
-to the new index on success. For safety it verifies that the new index
-contains exactly the same number of documents as the original index.
-
-You should run this task if the index schema has changed.
-"
-  task :migrate_index do
-    index_names.each do |index_name|
-      Indexer::BulkLoader.new(search_config, index_name).load_from_current_index
-    end
-  end
-
   desc "Switches an index group to a new index WITHOUT transferring the data"
   task :switch_to_empty_index do
     # Note that this task will effectively clear out the index, so shouldn't be
@@ -141,15 +126,6 @@ You should run this task if the index schema has changed.
         index_group = search_server.index_group(index_name)
         index_group.switch_to(index_group.index_for_name(new_index_name))
       end
-    end
-  end
-
-  desc "Migrates from an index with the actual index name to an alias"
-  task :migrate_from_unaliased_index do
-    # WARNING: this is potentially dangerous, and will leave the search
-    # unavailable for a very short (sub-second) period of time
-    index_names.each do |index_name|
-      Indexer::BulkLoader.new(search_config, index_name).load_from_current_unaliased_index
     end
   end
 

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -41,6 +41,15 @@ namespace :rummager do
     ).run
   end
 
+  desc "Create a brand new indices and assign an alias if no alias currently exists"
+  task :create_all_indices do
+    index_names.each do |index_name|
+      index_group = search_config.search_server.index_group(index_name)
+      index = index_group.create_index
+      index_group.switch_to(index) unless index_group.current_real
+    end
+  end
+
   desc "Create a brand new index and assign an alias if no alias currently exists"
   task :create_index, :index_name do |_, args|
     index_group = search_config.search_server.index_group(args[:index_name])


### PR DESCRIPTION
This fixes a bug introduced into the "publishing e2e tests" by the removal of the Indexer::BulkLoader
class. As they only required the creation of empty indices this seems like the best approach.