### PR TITLE
Enable specialist publisher - AAIB report

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -10,7 +10,22 @@ migrated:
 - transaction
 - simple_smart_answer
 
-indexable: []
-# We have not migrated the specialist formats as we encountered too many issues
-# to resolve in the allotted time when we ran the comparer.
-# The next step if to resolve the difference identified by the comparer task.
+indexable:
+- aaib_report
+#- asylum_support_decision
+#- business_finance_support_scheme
+#- cma_case
+#- countryside_stewardship_grant
+#- dfid_research_output
+#- drug_safety_update
+#- employment_appeal_tribunal_decision
+#- employment_tribunal_decision
+#- european_structural_investment_fund
+#- international_development_fund
+#- maib_report
+#- medical_safety_alert
+#- raib_report
+#- service_standard_report
+#- tax_tribunal_decision
+#- utaac_decision
+#- vehicle_recalls_and_faults_alert

--- a/lib/govuk_index/method_builder.rb
+++ b/lib/govuk_index/method_builder.rb
@@ -1,8 +1,14 @@
 module GovukIndex
   module MethodBuilder
-    def delegate_to_payload(name, hash_key: name)
+    def delegate_to_payload(name, hash_key: name, convert_to_array: false)
       define_method name do
-        payload[hash_key.to_s]
+        value = payload[hash_key.to_s]
+        return nil if value.nil?
+        if convert_to_array
+          Array(value)
+        else
+          value
+        end
       end
     end
 

--- a/lib/govuk_index/method_builder.rb
+++ b/lib/govuk_index/method_builder.rb
@@ -3,7 +3,7 @@ module GovukIndex
     def delegate_to_payload(name, hash_key: name, convert_to_array: false)
       define_method name do
         value = payload[hash_key.to_s]
-        return nil if value.nil?
+        return nil if value.nil? || value == ''
         if convert_to_array
           Array(value)
         else

--- a/lib/govuk_index/migrated_formats.rb
+++ b/lib/govuk_index/migrated_formats.rb
@@ -11,7 +11,7 @@ module GovukIndex
     end
 
     def indexable_formats
-      @migrated_formats ||= YAML.load_file(File.join(__dir__, '../../config/govuk_index/migrated_formats.yaml')).values.flatten
+      @indexable_formats ||= YAML.load_file(File.join(__dir__, '../../config/govuk_index/migrated_formats.yaml')).values.flatten
     end
   end
 end

--- a/lib/govuk_index/popularity_updater.rb
+++ b/lib/govuk_index/popularity_updater.rb
@@ -23,7 +23,7 @@ module GovukIndex
 
         worker.wait_until_processed
 
-        if index_name =~ 'govuk'
+        if index_name =~ /govuk/
           # need to do this to ensure the new govuk index is in sync while we migrate data
           SyncUpdater.new(
             source_index: 'mainstream',

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -13,8 +13,8 @@ module GovukIndex
     delegate_to_payload :build_start_date
     delegate_to_payload :business_sizes
     delegate_to_payload :business_stages
-    delegate_to_payload :case_state
-    delegate_to_payload :case_type
+    delegate_to_payload :case_state, convert_to_array: true
+    delegate_to_payload :case_type, convert_to_array: true
     delegate_to_payload :closed_date
     delegate_to_payload :closing_date
     delegate_to_payload :continuation_link
@@ -34,17 +34,19 @@ module GovukIndex
     delegate_to_payload :fund_type
     delegate_to_payload :funding_amount
     delegate_to_payload :funding_source
-    delegate_to_payload :grant_type
+    delegate_to_payload :grant_type, convert_to_array: true
     delegate_to_payload :hidden_indexable_content
     delegate_to_payload :industries
     delegate_to_payload :issued_date
     delegate_to_payload :land_use
+    delegate_to_payload :location, convert_to_array: true
     delegate_to_payload :manufacturer
     delegate_to_payload :market_sector
     delegate_to_payload :medical_specialism
     delegate_to_payload :opened_date
     delegate_to_payload :outcome_type
     delegate_to_payload :railway_type
+    delegate_to_payload :report_type, convert_to_array: true
     delegate_to_payload :registration
     delegate_to_payload :serial_number
     delegate_to_payload :therapeutic_area
@@ -62,15 +64,6 @@ module GovukIndex
     delegate_to_payload :value_of_funding
     delegate_to_payload :vessel_type
     delegate_to_payload :will_continue_on
-
-
-    def report_type
-      Array(metadata['report_type']) if metadata['report_type']
-    end
-
-    def location
-      Array(metadata['location']) if metadata['location']
-    end
 
     def initialize(metadata:)
       @metadata = metadata || {}

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -7,7 +7,7 @@ module GovukIndex
     delegate_to_payload :aircraft_category
     delegate_to_payload :aircraft_type
     delegate_to_payload :alert_issue_date
-    delegate_to_payload :alert_type
+    delegate_to_payload :alert_type, convert_to_array: true
     delegate_to_payload :assessment_date
     delegate_to_payload :build_end_date
     delegate_to_payload :build_start_date
@@ -30,7 +30,7 @@ module GovukIndex
     delegate_to_payload :faulty_item_model
     delegate_to_payload :faulty_item_type
     delegate_to_payload :first_published_at
-    delegate_to_payload :fund_state
+    delegate_to_payload :fund_state, convert_to_array: true
     delegate_to_payload :fund_type
     delegate_to_payload :funding_amount
     delegate_to_payload :funding_source

--- a/lib/govuk_index/sync_updater.rb
+++ b/lib/govuk_index/sync_updater.rb
@@ -7,19 +7,36 @@ module GovukIndex
       ).run
     end
 
+    def self.update_immediately(source_index: 'mainstream', destination_index: 'govuk', format_override:)
+      new(
+        source_index: source_index,
+        destination_index: destination_index,
+        format_override: format_override,
+      ).run(async: false)
+    end
+
     def self.worker
       SyncWorker
+    end
+
+    def initialize(source_index:, destination_index:, format_override: nil)
+      super(
+        source_index: source_index,
+        destination_index: destination_index,
+      )
+      @format_override = format_override
     end
 
   private
 
     def search_body
+      cause = @format_override ? :must : :must_not
       {
         query: {
           bool: {
-            must_not: {
+            cause => {
               terms: {
-                format: MigratedFormats.indexable_formats
+                format: Array(@format_override || MigratedFormats.indexable_formats)
               }
             }
           }

--- a/lib/govuk_index/sync_updater.rb
+++ b/lib/govuk_index/sync_updater.rb
@@ -30,11 +30,11 @@ module GovukIndex
   private
 
     def search_body
-      cause = @format_override ? :must : :must_not
+      clause = @format_override ? :must : :must_not
       {
         query: {
           bool: {
-            cause => {
+            clause => {
               terms: {
                 format: Array(@format_override || MigratedFormats.indexable_formats)
               }

--- a/lib/govuk_index/updater.rb
+++ b/lib/govuk_index/updater.rb
@@ -44,7 +44,7 @@ module GovukIndex
       ) do |record|
         {
           'identifier' => record.slice(*%w{_id _type _version}),
-          'document'=> record.fetch('_source'),
+          'document' => record.fetch('_source'),
         }
       end
     end

--- a/lib/govuk_index/updater.rb
+++ b/lib/govuk_index/updater.rb
@@ -1,7 +1,7 @@
 module GovukIndex
   class Updater
     SCROLL_BATCH_SIZE = 500
-    PROCESSOR_BATCH_SIZE = 25
+    PROCESSOR_BATCH_SIZE = 100
     TIMEOUT_SECONDS = 30
 
     class ImplementationRequired < StandardError; end
@@ -11,9 +11,13 @@ module GovukIndex
       @destination_index = destination_index
     end
 
-    def run
+    def run(async: true)
       scroll_enumerator.each_slice(PROCESSOR_BATCH_SIZE) do |documents|
-        worker.perform_async(documents, @destination_index)
+        if async
+          worker.perform_async(documents, @destination_index)
+        else
+          worker.new.perform(documents, @destination_index)
+        end
       end
     end
 
@@ -39,8 +43,8 @@ module GovukIndex
         batch_size: SCROLL_BATCH_SIZE
       ) do |record|
         {
-          identifier: record.slice(*%w{_id _type _version}),
-          document: record.fetch('_source'),
+          'identifier' => record.slice(*%w{_id _type _version}),
+          'document'=> record.fetch('_source'),
         }
       end
     end

--- a/lib/indexer/compare_enumerator.rb
+++ b/lib/indexer/compare_enumerator.rb
@@ -1,7 +1,7 @@
 module Indexer
   class CompareEnumerator < Enumerator
     NO_VALUE = :__no_value_found__
-    BATCH_SIZE = 50
+    BATCH_SIZE = 250
     DEFAULT_QUERY = { match_all: {} }.freeze
     # the `_uid` is a combination of the id and type (format: 'type#id') and is used
     # as sorting on the _id field does not return ordered results

--- a/lib/indexer/comparer.rb
+++ b/lib/indexer/comparer.rb
@@ -9,7 +9,7 @@ module Indexer
       @new_index_name = new_index_name
       @filtered_format = filtered_format
       @field_to_ignore = ignore
-      @field_comparer = field_comparer || ->(_key, old, new) { old == new }
+      @field_comparer = field_comparer || ->(_id, key, old, new) { key =~ /^_root/ || old == new }
       @io = io
     end
 
@@ -48,7 +48,7 @@ module Indexer
       return [] if reject_fields(old_item) == reject_fields(new_item)
 
       keys = (old_item.keys | new_item.keys) - @field_to_ignore
-      keys.reject { |key| @field_comparer.call(key, old_item[key], new_item[key]) }.sort
+      keys.reject { |key| @field_comparer.call(old_item["_root_id"], key, old_item[key], new_item[key]) }.sort
     end
 
     def reject_fields(hash)

--- a/lib/indexer/comparer.rb
+++ b/lib/indexer/comparer.rb
@@ -4,13 +4,14 @@ module Indexer
 
     DEFAULT_FIELDS_TO_IGNORE = ["popularity"].freeze
 
-    def initialize(old_index_name, new_index_name, filtered_format: nil, ignore: DEFAULT_FIELDS_TO_IGNORE, io: STDOUT, field_comparer: nil)
+    def initialize(old_index_name, new_index_name, filtered_format: nil, ignore: DEFAULT_FIELDS_TO_IGNORE, io: STDOUT, field_comparer: nil, enum_options: {})
       @old_index_name = old_index_name
       @new_index_name = new_index_name
       @filtered_format = filtered_format
       @field_to_ignore = ignore
       @field_comparer = field_comparer || ->(_id, key, old, new) { key =~ /^_root/ || old == new }
       @io = io
+      @enum_options = enum_options
     end
 
     def run
@@ -21,7 +22,7 @@ module Indexer
       search_body = {}
       search_body[:filter] = { term: { format: @filtered_format } } if @filtered_format
 
-      CompareEnumerator.new(@old_index_name, @new_index_name, search_body).each do |old_item, new_item|
+      CompareEnumerator.new(@old_index_name, @new_index_name, search_body, @enum_options).each do |old_item, new_item|
         if old_item == CompareEnumerator::NO_VALUE
           outcomes[:added_items] += 1
         elsif new_item == CompareEnumerator::NO_VALUE

--- a/lib/indexer/govuk_index_field_comparer.rb
+++ b/lib/indexer/govuk_index_field_comparer.rb
@@ -8,6 +8,9 @@ module Indexer
     def call(key, old, new)
       return compare_time(old, new) if key == 'public_timestamp'
       return compare_content(old, new) if key == 'indexable_content'
+      return true if %w(content_id publishing_app rendering_app content_store_document_type).include?(key) && old.nil?
+      return true if old.nil? && new == ''
+      return true if key == 'rendering_app' && old == 'specialist-frontend' && new == 'government-frontend'
       old == new
     end
 
@@ -18,42 +21,47 @@ module Indexer
     end
 
     def compare_content(old, new)
-      clean_old = clean_content(old)
+      clean_old = clean_content(remove_links(old))
       clean_new = clean_content(new)
       if clean_old == clean_new
         true
       else
-        old_words = clean_old.split(' ')
-        new_words = clean_new.split(' ')
+        old_words = clean_old.split(' ').compact
+        new_words = clean_new.split(' ').compact
 
         extra_old = old_words - new_words
-        diff = extra_old + (new_words - old_words)
-        diff_per = (200.0 * diff.count / (old_words.count + new_words.count))
+        extra_old.reject! { |w| new_words.any? { |new| new.include?(w) } } # ignore words that have been trimmed
+        extra_old.reject! { |w| w =~ /^\d+$/ } # ignore numbers
+
+        diff_per = (200.0 * extra_old.count / (old_words.count + new_words.count))
         if extra_old.count == 0
           # we don't need to worry too much about additional words being added
           return true
-        elsif clean_old =~ /https assets.digital.cabinet office.gov.uk/
-          # This is an issue with the link in the markdown, we should regex this out as a better solution
-          puts "link: #{old}"
-          return false
-        elsif diff_per < 5
+        elsif diff_per < 2
           # if the page has less than X % difference then we are just going to say it is close enough
           # This should be reviewed with the Product Manager
           return true
         else
           # These are the real difference as are printed to the screen so they can be review on an individual basis
-          puts "Mismatch content: #{diff_per.round(2)} : #{diff.length}\n`#{clean_old}`\n!=\n`#{clean_new}`\n\n"
+          puts "Mismatch content: #{diff_per.round(2)} : #{extra_old.length} : #{extra_old.join(', ')}\n`#{clean_old}`\n!=\n`#{clean_new}`\n\n"
           false
         end
       end
     end
 
+    def remove_links(str)
+      str.gsub(/\[([^\]]*)\]\([^\)]*\)/, ' \1 ')
+        .gsub(/#+\s*/, ' ')
+        .gsub(/\[InlineAttachment:([^\[\]]*(?:\[[^\]]*\][^\[\]]*|)*)\]/, '\1')
+    end
+
     def clean_content(str)
       (str || '')
-        .gsub(/\[InlineAttachment:([^\]]*)\.[^\.]*\]/) { $1.tr('_', ' ') } # remove inline attachment text
         .downcase # normalise case
-        .gsub(/\.[a-z]{3}( |$)/, '\1') # hash as sometimes the link will have the extension
-        .gsub(/[\s,\-_:\/]+/, ' ') # remove all special characters
+        .gsub(/\.[a-z]{3}(\)| |$)/, '\1') # hash as sometimes the link will have the extension
+        .gsub(/[\s,\-_:\/–\[\]\(\)\.\*]+/, ' ') # remove all special characters
+        .gsub(/&amp;/, '&')
+        .gsub(/[’'‘]/, "'")
     end
   end
 end

--- a/lib/indexer/govuk_index_field_comparer.rb
+++ b/lib/indexer/govuk_index_field_comparer.rb
@@ -48,7 +48,7 @@ module Indexer
         extra_old = old_words - new_words
         extra_old.uniq!
         extra_old.reject! { |w| w =~ /^\d+$/ } # ignore numbers
-        extra_old.reject! { |w| new_words.any? { |new| new =~ /^#{w}/ } } # ignore words that have been trimmed
+        extra_old.reject! { |old_word| new_words.any? { |new_word| new_word =~ /^#{old_word}/ } } # ignore words that have been truncated
         diff_per = (200.0 * extra_old.count / (old_words.count + new_words.count))
         if extra_old.count == 0
           # we don't need to worry too much about additional words being added

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -95,8 +95,10 @@ namespace :delete do
       if delete_commands.empty?
         puts "No #{format} documents to delete"
       else
-        puts "Deleting #{delete_commands.count} #{format} documents from #{index} index"
-        client.bulk(body: delete_commands)
+        puts "Deleting #{delete_commands.count} #{format} documents from #{index} index (in batches of 1000)"
+        delete_commands.each_slice(1000) do |slice|
+          client.bulk(body: slice)
+        end
 
         client.indices.refresh(index: index)
       end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -35,12 +35,10 @@ namespace :rummager do
     puts Indexer::Comparer.new(
       'mainstream',
       'govuk',
-      {
-        field_comparer: comparer,
-        ignore: %w(popularity is_withdrawn),
-        filtered_format: filtered_format,
-      },
-      include_version: true
+      field_comparer: comparer,
+      ignore: %w(popularity is_withdrawn),
+      filtered_format: filtered_format,
+      enum_options: { include_version: true },
     ).run
     puts comparer.stats
   end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -31,14 +31,15 @@ namespace :rummager do
   task :compare_govuk, :format do |_, args|
     filtered_format = args[:format]
     filtered_format = nil if filtered_format == 'all'
-
+    comparer = Indexer::GovukIndexFieldComparer.new
     puts Indexer::Comparer.new(
       'mainstream',
       'govuk',
-      field_comparer: Indexer::GovukIndexFieldComparer.new,
+      field_comparer: comparer,
       ignore: %w(popularity is_withdrawn),
       filtered_format: filtered_format
     ).run
+    puts comparer.stats
   end
 
   desc "Create a brand new indices and assign an alias if no alias currently exists"

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -35,9 +35,12 @@ namespace :rummager do
     puts Indexer::Comparer.new(
       'mainstream',
       'govuk',
-      field_comparer: comparer,
-      ignore: %w(popularity is_withdrawn),
-      filtered_format: filtered_format
+      {
+        field_comparer: comparer,
+        ignore: %w(popularity is_withdrawn),
+        filtered_format: filtered_format,
+      },
+      include_version: true
     ).run
     puts comparer.stats
   end

--- a/spec/unit/govuk_index/specialist_formats_spec.rb
+++ b/spec/unit/govuk_index/specialist_formats_spec.rb
@@ -64,8 +64,12 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "market_sector" => ["energy"],
       "outcome_type" => "ca98-no-grounds-for-action-non-infringement",
     }
+    special_formated_output = {
+      "case_type" => ["ca98-and-civil-cartels"],
+      "case_state" => ["closed"],
+    }
     document = build_example_with_metadata(custom_metadata)
-    expect_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
   it "countryside_stewardship_grant" do
@@ -75,8 +79,11 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "tiers_or_standalone_items" => ["higher-tier"],
       "funding_amount" => ["201-to-300"],
     }
+    special_formated_output = {
+      "grant_type" => ["option"],
+    }
     document = build_example_with_metadata(custom_metadata)
-    expect_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
   it "dfid_research_output" do
@@ -132,8 +139,11 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "location" => ["south-west"],
       "funding_source" => ["european-regional-development-fund"],
     }
+    special_formated_output = {
+      "fund_state" => ["open"],
+    }
     document = build_example_with_metadata(custom_metadata)
-    expect_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
   it "international_development_fund" do
@@ -144,8 +154,11 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "location" => ["south-west"],
       "funding_source" => ["european-regional-development-fund"],
     }
+    special_formated_output = {
+      "fund_state" => ["open"],
+    }
     document = build_example_with_metadata(custom_metadata)
-    expect_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
   it "maib_report" do
@@ -167,8 +180,11 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "issued_date" => "2016-02-01",
       "medical_specialism" => %w(anaesthetics cardiology),
     }
+    special_formated_output = {
+      "alert_type" => ["company-led-drugs"],
+    }
     document = build_example_with_metadata(custom_metadata)
-    expect_document_include_hash(document, custom_metadata)
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
   it "raib_report" do

--- a/spec/unit/indexer/comparer_spec.rb
+++ b/spec/unit/indexer/comparer_spec.rb
@@ -81,6 +81,7 @@ private
       'index_a',
       'index_b',
       {},
+      {},
     ).and_return([[left, right]].to_enum)
   end
 end


### PR DESCRIPTION
We have decided that trying to put all specialist publisher formats live in one go is too hard and we should look to tackle them one by one.

This is the first format to become indexable: AAIB Report's

The latest comparison stats are:

* unchanged=>10210, 
* changes: indexable_content=>2
* changes: description=>1
* changes: location=>1

* AddedValue: description=>9257
* AddedValue: content_id=>1742
* AddedValue: content_store_document_type=>1742
* AddedValue: publishing_app=>1742
* AddedValue: rendering_app=>1742
* AddedValue: registration=>43
* AddedValue: aircraft_category=>17
* AddedValue: aircraft_type=>16
* RemovedValue: location=>1

https://trello.com/c/KDfyOeS1/257-specialist-publisher-implementation