### PR TITLE
Include Govuk data in Analytics export

### DIFF
--- a/lib/analytics_data.rb
+++ b/lib/analytics_data.rb
@@ -12,9 +12,10 @@ class AnalyticsData
     client = Elasticsearch::Client.new(host: @elasticsearch_url)
 
     query = {
-      "query": {
-        "match_all": {}
-      }
+      query: {
+        match_all: {}
+      },
+      filter: Search::FormatMigrator.new.call
     }
 
     ScrollEnumerator.new(client: client, index_names: @indices, search_body: query) do |hit|

--- a/lib/tasks/analytics.rake
+++ b/lib/tasks/analytics.rake
@@ -2,6 +2,8 @@ require "analytics_data"
 require "csv"
 
 namespace :analytics do
+  ALL_CONTENT_SEARCH_INDICES = %w(mainstream detailed government govuk).freeze
+
   desc "
   Export all indexed pages to a CSV suitable for importing into Google Analytics.
 
@@ -11,7 +13,7 @@ namespace :analytics do
   task :create_data_import_csv do
     elasticsearch_config = SearchConfig.new.elasticsearch
 
-    analytics_data = AnalyticsData.new(elasticsearch_config["base_uri"], CONTENT_SEARCH_INDICES)
+    analytics_data = AnalyticsData.new(elasticsearch_config["base_uri"], ALL_CONTENT_SEARCH_INDICES)
 
     path = ENV['EXPORT_PATH'] || 'data'
     FileUtils.mkdir_p(path)


### PR DESCRIPTION
This ensures that data for migrated formats is taken
From govuk and not mainstream.

https://trello.com/c/2Yqifiud/347-google-analytics-update-data-does-not-include-govuk