### PR TITLE
Support date-times in date filters

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -270,7 +270,7 @@ private
     def parse_date(string)
       Date.parse(string)
     rescue
-      @errors << %{Invalid value "#{string}" for parameter "#{field_name}" (expected ISO8601 date}
+      @errors << %{Invalid value "#{string}" for parameter "#{field_name}" (expected ISO8601 date)}
       null_date
     end
 

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -257,6 +257,7 @@ private
       values.map { |combined_from_and_to|
         dates_hash = combined_from_and_to.split(",").reduce({}) { |dates, param|
           key, date = param.split(":")
+          validate_date_key(key)
           dates.merge(key => parse_date(date))
         }
 
@@ -265,6 +266,12 @@ private
           dates_hash.fetch("to", null_date),
         )
       }
+    end
+
+    def validate_date_key(key)
+      if !%w(from to).include?(key)
+        @errors << %{Invalid date filter parameter "#{key}:" (expected "from:" or "to:")}
+      end
     end
 
     def parse_date(string)

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -485,7 +485,7 @@ RSpec.describe 'SearchTest' do
 
     expect(last_response.status).to eq(422)
     expect(
-      { "error" => %{Invalid value "not-a-date" for parameter "opened_date" (expected ISO8601 date} }
+      { "error" => %{Invalid value "not-a-date" for parameter "opened_date" (expected ISO8601 date)} }
     ).to eq(
       parsed_response,
     )

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe SearchParameterParser do
     it "include the type in return value of #parsed_params" do
       params = {
         "filter_document_type" => ["cma_case"],
-        "filter_opened_date" => "from:2014-04-01 00:00,to:2014-04-02 00:00",
+        "filter_opened_date" => "from:2014-04-01 05:08,to:2014-04-02 17:43:12",
       }
 
       parser = described_class.new(params, @schema)
@@ -437,9 +437,9 @@ RSpec.describe SearchParameterParser do
         .find { |filter| filter.field_name == "opened_date" }
 
       expect(opened_date_filter.values.first.from)
-        .to eq(Date.parse("2014-04-01 00:00"))
+        .to eq(DateTime.new(2014, 4, 1, 5, 8))
       expect(opened_date_filter.values.first.to)
-        .to eq(Date.parse("2014-04-02 00:00"))
+        .to eq(DateTime.new(2014, 4, 2, 17, 43, 12))
     end
 
     it "understand date filter for missing field or specific value" do
@@ -458,9 +458,28 @@ RSpec.describe SearchParameterParser do
       expect(true).to eq(opened_date_filter.include_missing)
 
       expect(opened_date_filter.values.first.from)
-        .to eq(Date.parse("2014-04-01 00:00"))
+        .to eq(Date.new(2014, 4, 1))
       expect(opened_date_filter.values.first.to)
-        .to eq(Date.parse("2014-04-02 00:00"))
+        .to eq(Date.new(2014, 4, 2))
+    end
+
+    it "includes the whole day if time is omitted" do
+      params = {
+        "filter_document_type" => ["cma_case"],
+        "filter_public_timestamp" => "from:2017-06-05,to:2017-06-08",
+      }
+
+      parser = described_class.new(params, @schema)
+
+      expect(parser).to be_valid, "Parameters should be valid: #{parser.errors}"
+
+      opened_date_filter = parser.parsed_params.fetch(:filters)
+        .find { |filter| filter.field_name == "public_timestamp" }
+
+      expect(opened_date_filter.values.first.from)
+        .to eq(DateTime.new(2017, 6, 5, 0, 0, 0))
+      expect(opened_date_filter.values.first.to)
+        .to eq(DateTime.new(2017, 6, 8, 23, 59, 59))
     end
   end
 

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -436,17 +436,10 @@ RSpec.describe SearchParameterParser do
       opened_date_filter = parser.parsed_params.fetch(:filters)
         .find { |filter| filter.field_name == "opened_date" }
 
-      expect(
-        Date.parse("2014-04-01 00:00")
-      ).to eq(
-        opened_date_filter.values.first.from,
-      )
-
-      expect(
-        Date.parse("2014-04-02 00:00")
-      ).to eq(
-        opened_date_filter.values.first.to,
-      )
+      expect(opened_date_filter.values.first.from)
+        .to eq(Date.parse("2014-04-01 00:00"))
+      expect(opened_date_filter.values.first.to)
+        .to eq(Date.parse("2014-04-02 00:00"))
     end
 
     it "understand date filter for missing field or specific value" do
@@ -464,17 +457,10 @@ RSpec.describe SearchParameterParser do
       expect(opened_date_filter.field_name).to eq("opened_date")
       expect(true).to eq(opened_date_filter.include_missing)
 
-      expect(
-        Date.parse("2014-04-01 00:00")
-      ).to eq(
-        opened_date_filter.values.first.from,
-      )
-
-      expect(
-        Date.parse("2014-04-02 00:00")
-      ).to eq(
-        opened_date_filter.values.first.to,
-      )
+      expect(opened_date_filter.values.first.from)
+        .to eq(Date.parse("2014-04-01 00:00"))
+      expect(opened_date_filter.values.first.to)
+        .to eq(Date.parse("2014-04-02 00:00"))
     end
   end
 

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -464,11 +464,25 @@ RSpec.describe SearchParameterParser do
     end
   end
 
-  context "filtering a date field with an invalid date" do
-    it "does not filter on date" do
+  context "filtering a date field with invalid parameters" do
+    it "does not filter on date if date is invalid" do
       params = {
         "filter_document_type" => ["cma_case"],
         "filter_opened_date" => "from:2014-bananas-01 00:00,to:2014-04-02 00:00",
+      }
+
+      parser = described_class.new(params, @schema)
+
+      opened_date_filter = parser.parsed_params.fetch(:filters)
+        .find { |filter| filter.field_name == "opened_date" }
+
+      expect(opened_date_filter).to be_nil
+    end
+
+    it "does not filter on date if the filter parameter name is invalid" do
+      params = {
+        "filter_document_type" => ["cma_case"],
+        "filter_opened_date" => "some_invalid_parameter:2014-04-01",
       }
 
       parser = described_class.new(params, @schema)

--- a/spec/unit/query_components/filter_spec.rb
+++ b/spec/unit/query_components/filter_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      expect(result).to eq("range" => { "field_with_date" => { "from" => "2014-04-01", "to" => "2014-04-02" } })
+      expect(result).to eq("range" => { "field_with_date" => { "from" => "2014-04-01T00:00:00+00:00", "to" => "2014-04-02T00:00:00+00:00" } })
     end
   end
 


### PR DESCRIPTION
Allow documents to be filtered by dates and times, as well as just by date. The time in a filter parameter used to just be ignored.

Examples:
 - `from:2014-04-01`
 - `to:2015-12-31 14:05`
 - `from:2017-09-01 00:00:00,to:2017-09-15 23:59:59`

As well as making search filtering more flexible, this fixes a timezone bug in finders like Announcements (https://www.gov.uk/government/announcements) which allow users to specify publishing dates. Before, if you entered a 'to' date which falls during BST, the results would include anything publishing between midnight and 1am on the following day.

https://trello.com/c/lSbGhlav/349-make-rummager-handle-times-as-well-as-dates

Probably easiest to review each commit because there are few which just add some test cases or validation. The main change is in the final commit.