### PR TITLE
Move schedule config back into repo

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,1 +1,10 @@
-# This file is overwritten on deploy
+set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
+bundler_prefix = ENV.fetch('BUNDLER_PREFIX', '/usr/local/bin/govuk_setenv rummager')
+job_type :rake, "cd :path && #{bundler_prefix} bundle exec rake :task :output"
+
+# Sitemap filenames are generated based on the current day and hour. Putting
+# this at 10 past gets around any problems that might arise from running just
+# before the hour.
+every 1.day, :at => ENV.fetch('SITEMAP_GENERATION_TIME', '1.10am') do
+  rake 'sitemap:generate_and_replace'
+end


### PR DESCRIPTION
This allows the schedule.rb to be configured via environment variables and
helps move us forward towards bringing alphagov-deployment to an end.

I'm not quite sure how best to test this script out aside from a deploy
to integration.

Related Puppet PR: https://github.com/alphagov/govuk-puppet/pull/6670