### PR TITLE
Publish Finder Frontend site search special route

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :test do
   gem 'bunny-mock', '~> 1.7'
   gem "ci_reporter", "~> 1.7.1"
   gem 'govuk_schemas', '~> 3.0.0'
+  gem 'govuk-content-schema-test-helpers', '~> 1.5.0'
   gem "rack-test", "~> 0.6.3"
   gem 'rspec'
   gem "simplecov", "~> 0.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
+    govuk-content-schema-test-helpers (1.5.0)
+      json-schema (~> 2.5.1)
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
@@ -207,6 +209,7 @@ DEPENDENCIES
   ci_reporter (~> 1.7.1)
   elasticsearch (~> 2)
   gds-api-adapters (~> 47.9)
+  govuk-content-schema-test-helpers (~> 1.5.0)
   govuk-lint (~> 1.2.1)
   govuk_app_config (~> 0.2.0)
   govuk_document_types (~> 0.1)

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -39,6 +39,7 @@ require 'document'
 require 'duplicate_deleter'
 require 'duplicate_links_finder'
 require 'govuk_document_types'
+require 'special_route_publisher'
 
 require 'indexer'
 require 'indexer/amender'

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -1,0 +1,64 @@
+require 'gds_api/publishing_api/special_route_publisher'
+
+class SpecialRoutePublisher
+  def initialize(publisher_options)
+    @publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(publisher_options)
+  end
+
+  def publish(route)
+    @publisher.publish(
+      route.merge(
+        publishing_app: "rummager",
+        format: "special_route",
+        public_updated_at: Time.now.iso8601,
+        update_type: "major",
+      )
+    )
+  end
+
+  def routes
+    [
+      {
+        rendering_app: "finder-frontend",
+        content_id: "84e0909c-f3e6-43ee-ba68-9e33213a3cdd",
+        base_path: "/search",
+        title: "GOV.UK search results",
+        description: "Sitewide search results are displayed here.",
+        document_type: "search",
+        type: "exact",
+      },
+      {
+        rendering_app: "finder-frontend",
+        content_id: "9f306cd5-1842-43e9-8408-2c13116f4717",
+        base_path: "/search.json",
+        title: "GOV.UK search results API",
+        description: "Sitewide search results are displayed in JSON format here.",
+        type: "exact",
+      },
+      {
+        rendering_app: "finder-frontend",
+        content_id: "ba750368-8001-4d01-bd57-cec589153fdd",
+        base_path: "/search/opensearch.xml",
+        title: "GOV.UK opensearch descriptor",
+        description: "Provides the location and format of our search URL to browsers etc.",
+        type: "exact",
+      },
+      {
+        rendering_app: "rummager",
+        base_path: "/sitemap.xml",
+        content_id: "fee32a90-397a-4761-9f98-b06e47d2b798",
+        title: "GOV.UK sitemap index",
+        description: "Provides the locations of the GOV.UK sitemaps.",
+        type: "exact",
+      },
+      {
+        rendering_app: "rummager",
+        base_path: "/sitemaps",
+        content_id: "c202c6a5-656c-40d1-ae55-36fab995709c",
+        title: "GOV.UK sitemaps prefix",
+        description: "The prefix URL under which our XML sitemaps are located.",
+        type: "prefix",
+      }
+    ]
+  end
+end

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -1,8 +1,23 @@
+require 'gds_api/publishing_api'
 require 'gds_api/publishing_api/special_route_publisher'
 
 class SpecialRoutePublisher
   def initialize(publisher_options)
     @publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(publisher_options)
+  end
+
+  def take_ownership_of_search_routes
+    publishing_api_v1 = GdsApi::PublishingApi.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+    %w(/search /search.json /search/opensearch.xml).each do |path|
+      publishing_api_v1.put_path(
+        path,
+        publishing_app: 'rummager',
+        override_existing: true
+      )
+    end
   end
 
   def publish(route)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -6,6 +6,14 @@ namespace :publishing_api do
       publishing_api: Services.publishing_api
     )
 
+    begin
+      publisher.take_ownership_of_search_routes
+    rescue GdsApi::TimedOutException
+      puts "WARNING: publishing-api timed out when trying to publish route #{payload.inspect}"
+    rescue GdsApi::HTTPServerError => e
+      puts "WARNING: publishing-api errored out when trying to publish route #{payload.inspect}\n\nError: #{e.inspect}"
+    end
+
     publisher.routes.each do |route|
       begin
         publisher.publish(route)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,46 +1,14 @@
 namespace :publishing_api do
   desc "Publish special routes such as sitemaps"
   task :publish_special_routes do
-    require 'gds_api/publishing_api/special_route_publisher'
-
-    publishing_api = GdsApi::PublishingApiV2.new(
-      Plek.new.find('publishing-api'),
-      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
-    )
-
-    publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
+    publisher = SpecialRoutePublisher.new(
       logger: Logger.new(STDOUT),
-      publishing_api: publishing_api
+      publishing_api: Services.publishing_api
     )
 
-    routes = [
-      {
-        base_path: "/sitemap.xml",
-        content_id: "fee32a90-397a-4761-9f98-b06e47d2b798",
-        title: "GOV.UK sitemap index",
-        description: "Provides the locations of the GOV.UK sitemaps.",
-        type: "exact",
-      },
-      {
-        base_path: "/sitemaps",
-        content_id: "c202c6a5-656c-40d1-ae55-36fab995709c",
-        title: "GOV.UK sitemaps prefix",
-        description: "The prefix URL under which our XML sitemaps are located.",
-        type: "prefix",
-      },
-    ]
-
-    routes.each do |route|
+    publisher.routes.each do |route|
       begin
-        payload = route.merge(
-          format: "special_route",
-          publishing_app: "rummager",
-          rendering_app: "rummager",
-          public_updated_at: Time.now.iso8601,
-          update_type: "major",
-        )
-
-        publisher.publish(payload)
+        publisher.publish(route)
       rescue GdsApi::TimedOutException
         puts "WARNING: publishing-api timed out when trying to publish route #{payload.inspect}"
       rescue GdsApi::HTTPServerError => e

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,8 @@ require 'sidekiq/testing'
 require "sidekiq/testing/inline" # Make all queued jobs run immediately
 require 'bunny-mock'
 require 'govuk_schemas'
+require 'govuk-content-schema-test-helpers'
+require 'govuk-content-schema-test-helpers/validator'
 
 # Silence log output
 Logging.logger.root.appenders = nil

--- a/spec/unit/special_route_publisher_spec.rb
+++ b/spec/unit/special_route_publisher_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe SpecialRoutePublisher do
+  before do
+    GovukContentSchemaTestHelpers.configure do |config|
+      config.schema_type = 'publisher_v2'
+      config.project_root = File.expand_path('../../../', __FILE__)
+    end
+
+    @publishing_api = double
+
+    logger = Logger.new(STDOUT)
+    logger.level = Logger::WARN
+
+    @publisher = described_class.new(
+      publishing_api: @publishing_api,
+      logger: logger
+    )
+  end
+
+  it "should publish a valid content item for special routes" do
+    @publisher.routes.each do |route|
+      expect(@publishing_api).to receive(:put_content) do |_, payload|
+        assert_valid_content_item(payload)
+      end
+      expect(@publishing_api).to receive(:publish)
+
+      @publisher.publish(route)
+    end
+  end
+
+  def assert_valid_content_item(payload)
+    validator = GovukContentSchemaTestHelpers::Validator.new(
+      "special_route",
+      "schema",
+      payload
+    )
+
+    expect(validator.valid?).to be true
+  end
+end


### PR DESCRIPTION
We are adding site search to Finder Frontend. As Rummager already talks to the publishing API it seemed like a reasonable place to be registering the routes as opposed to making another frontend app talk to the publishing API.

https://trello.com/c/lxKbO5Xw

dependent on https://github.com/alphagov/frontend/pull/1294