### PR TITLE
Add task_list document type

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -21,6 +21,7 @@ place: edition
 raib_report: raib_report # Specialist Publisher
 service_standard_report: service_standard_report # Specialist Publisher
 simple_smart_answer: edition
+task_list: edition
 tax_tribunal_decision: tax_tribunal_decision # Specialist Publisher
 transaction: edition
 utaac_decision: utaac_decision # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -5,6 +5,7 @@ migrated:
 - licence
 - local_transaction
 - place
+- task_list
 - transaction
 - simple_smart_answer
 


### PR DESCRIPTION
This has been added to [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/pull/652/commits/c2addd9bd75bf9745c41e5a4232b49454ddb7c32) already.

There is no published content for this yet.

https://trello.com/c/uBQLh8h5/209-prepare-rummager-for-indexing-task-list-pages