### PR TITLE
Remove id check for contact format in duplicate deleter

### DIFF
--- a/lib/duplicate_deleter.rb
+++ b/lib/duplicate_deleter.rb
@@ -28,7 +28,7 @@ class DuplicateDeleter
       end
 
       ids = results[:results].map { |a| a[:_id] }
-      if ids.uniq.count != 1 && !results_contain_duplicate_contacts(results[:results], type_to_delete)
+      if ids.uniq.count != 1
         io.puts "Skipping #{id_type} #{id} as multiple _id's detected #{ids.uniq.join(', ')}"
         next
       end
@@ -66,13 +66,4 @@ private
 
   attr_reader :search_config
 
-  def results_contain_duplicate_contacts(results, type_to_delete)
-    contact_results = results.select { |a| a[:elasticsearch_type] == "contact" }
-
-    # The _id field for most content is the same as the link (including the leading `/`), but contacts have an _id
-    # without a leading slash. It's possible for duplicate contacts to be created *with* a leading slash, so the
-    # _id's do not match exactly.
-    contact_results.size == 1 &&
-      results.any? { |a| a[:elasticsearch_type] == type_to_delete && a[:_id] == "/" + contact_results.first[:_id] }
-  end
 end

--- a/spec/integration/duplicate_deleter_spec.rb
+++ b/spec/integration/duplicate_deleter_spec.rb
@@ -93,33 +93,6 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
   end
 
-  it "can_delete_duplicate_content_ids_when_contact_id_is_wrong" do
-    commit_document(
-      "mainstream_test",
-      {
-        "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
-        "link" => "/contact-page",
-      },
-      id: "contact-page",
-      type: "contact",
-    )
-    commit_document(
-      "mainstream_test",
-      {
-        "content_id" => "e3eaa461-3a85-4881-b412-9c58e7ea4ebd",
-        "link" => "/contact-page",
-      },
-      id: "/contact-page",
-      type: "edition",
-    )
-
-    DuplicateDeleter.new('edition', io, search_config: SearchConfig.instance).call(["e3eaa461-3a85-4881-b412-9c58e7ea4ebd"])
-
-    expect_log_message(msg: "Deleted duplicate for content_id")
-    expect_document_present_in_rummager(id: "contact-page", type: "contact")
-    expect_document_missing_in_rummager(id: "/contact-page", type: "edition")
-  end
-
   it "can_delete_duplicate_documents_on_different_types_using_link" do
     commit_document(
       "mainstream_test",


### PR DESCRIPTION
The contact format has been moved to the govuk index and republished with the correct `_id` which includes the preceeding `/`. We no longer need to check for this in the duplicate deleter.

https://trello.com/c/kt6kFrjO