### PR TITLE
Add primary_publishing_organisation field to aggregation whitelist

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -56,6 +56,7 @@ class BaseParameterParser
     people
     policies
     policy_areas
+    primary_publishing_organisation
     publishing_app
     rendering_app
     search_format_types


### PR DESCRIPTION
To surface tagging progress in content-tagger, we use the aggregation params in
Search API to count (1) the number of documents that belong to a given primary
publishing organisation and (2) the number of these documents that have been
tagged (i.e. they have at least one taxon).

Currently, the aggregation field whitelist does not contain the
primary_publishing_organisation field we are relying on. This commit adds the
field into the whitelist which seems to satisfy our requirements.

---

Related [PR in content-tagger](https://github.com/alphagov/content-tagger/pull/501) and [Trello card](https://trello.com/c/m0kfPG5I/38-show-tagging-progress-made-by-an-organisation)