### PR TITLE
Add A/B test of specialist sector (aka topic) boosting

### DIFF
--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -21,7 +21,16 @@ module QueryComponents
   private
 
     def boost_filters
-      property_boosts + [time_boost]
+      boosts = property_boosts + [time_boost]
+      boosts << specialist_sector_boost if @search_params.format_weighting_b_variant?
+      boosts
+    end
+
+    def specialist_sector_boost
+      {
+        filter: { term: { format: "specialist_sector" } },
+        boost_factor: 2.5
+      }
     end
 
     def property_boosts

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -52,6 +52,10 @@ module Search
       query && suggest.include?('spelling')
     end
 
+    def format_weighting_b_variant?
+      ab_tests[:format_weighting] == 'B'
+    end
+
   private
 
     def determine_if_quoted_phrase

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -24,6 +24,38 @@ RSpec.describe 'BoosterTest' do
     expect(result_titles).to eq(["Can we be agile?", "Agile is good", "Being agile is good"])
   end
 
+  context "Topic (aka Specialist Sectors) A/B test" do
+    it "adds format weighting for A bucket requests" do
+      commit_document("mainstream_test",
+        "format" => "specialist_sector",
+        "title" => "Keeping pet micropigs"
+      )
+      commit_document("mainstream_test",
+        "format" => "speech",
+        "title" => "Micropigs and the future of micropigs"
+      )
+
+      get "/search?q=micropig&ab_tests=format_weighting:A"
+
+      expect(result_titles).to eq(["Micropigs and the future of micropigs", "Keeping pet micropigs"])
+    end
+
+    it "adds format weighting for B bucket requests" do
+      commit_document("mainstream_test",
+        "format" => "specialist_sector",
+        "title" => "Keeping pet micropigs"
+      )
+      commit_document("mainstream_test",
+        "format" => "speech",
+        "title" => "Micropigs and the future of micropigs"
+      )
+
+      get "/search?q=micropig&ab_tests=format_weighting:B"
+
+      expect(result_titles).to eq(["Keeping pet micropigs", "Micropigs and the future of micropigs"])
+    end
+  end
+
   def result_titles
     parsed_response['results'].map do |result|
       result['title']


### PR DESCRIPTION
We have previously run A/B tests which showed that boosting mainstream
content above specialist content helped more users to find the
information they were looking for. This new A/B test iterates on that by
boosting topics in search results, which we belive are useful navigation
pages for users to find in search.

The boost value of 1.5 is just an initial value, chosen to be similar to other mainstream boosts. We'll refine this based on how it performs in the healthcheck.

https://trello.com/c/cmxfgx1H/391-configure-format-weighting-a-b-test-in-rummager

Mobbed with @JonathanHallam and @suzannehamilton 