### PR TITLE
Fix tests after content schema changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ end
 group :test do
   gem 'bunny-mock', '~> 1.7'
   gem "ci_reporter", "~> 1.7.1"
-  gem 'govuk_schemas', '~> 2.2.0'
+  gem 'govuk_schemas', '~> 3.0.0'
   gem "rack-test", "~> 0.6.3"
   gem 'rspec'
   gem "simplecov", "~> 0.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     govuk_document_types (0.1.8)
     govuk_message_queue_consumer (3.0.2)
       bunny (~> 2.2.0)
-    govuk_schemas (2.2.0)
+    govuk_schemas (3.0.0)
       json-schema (~> 2.5.0)
     hashdiff (0.3.0)
     http-cookie (1.0.3)
@@ -211,7 +211,7 @@ DEPENDENCIES
   govuk_app_config (~> 0.2.0)
   govuk_document_types (~> 0.1)
   govuk_message_queue_consumer (~> 3.0.2)
-  govuk_schemas (~> 2.2.0)
+  govuk_schemas (~> 3.0.0)
   logging (~> 2.1.0)
   loofah
   mr-sparkle (= 0.3.0)

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -72,7 +72,7 @@ module GovukIndex
       parents = [taxon_hash["content_id"]]
 
       direct_parents = taxon_hash.dig("links", "parent_taxons")
-      while !direct_parents.empty?
+      while direct_parents && !direct_parents.empty?
         # There should not be more than one parent for a taxon. If there is,
         # make an arbitrary choice.
         direct_parent = direct_parents.first

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest' do
   it "not_indexing_when_publishing_app_is_smart_answers" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
     random_example = generate_random_example(
+      schema: 'special_route',
       payload: { document_type: "transaction", payload_version: 123, publishing_app: "smartanswers" },
     )
 

--- a/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
+++ b/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
@@ -57,9 +57,11 @@ RSpec.describe 'GovukIndex::UnpublishingMessageProcessing' do
   end
 
   def unpublishing_event_message(schema_name, user_defined: {}, excluded_fields: [])
-    payload = GovukSchemas::RandomExample
-      .for_schema(notification_schema: schema_name)
-      .customise_and_validate(user_defined, excluded_fields)
+    payload = GovukSchemas::RandomExample.for_schema(notification_schema: schema_name) do |hash|
+      hash.merge!(user_defined.stringify_keys)
+      hash.delete_if { |k, _| excluded_fields.include?(k) }
+      hash
+    end
     stub_message_payload(payload, unpublishing: true)
   end
 end

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -42,9 +42,11 @@ module SpecHelpers
 
     payload[:document_type] ||= schema
     retry_attempts.times do
-      random_example = GovukSchemas::RandomExample
-        .for_schema(notification_schema: schema)
-        .merge_and_validate(payload, excluded_fields)
+      random_example = GovukSchemas::RandomExample.for_schema(notification_schema: schema) do |hash|
+        hash.merge!(payload.stringify_keys)
+        hash.delete_if { |k, _| excluded_fields.include?(k) }
+        hash
+      end
 
       return random_example unless regenerate_if.call(random_example)
     end

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
   it "non_directly_mapped_fields" do
     defined_fields = {
       base_path: "/some/path",
-      details: { body: "We love cheese" },
       expanded_links: {},
     }
 

--- a/spec/unit/govuk_index/specialist_formats_spec.rb
+++ b/spec/unit/govuk_index/specialist_formats_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
 
     document = build_example_with_metadata(custom_metadata)
     expect_document_include_hash(document, custom_metadata)
-    expect(document[:indexable_content]).to eq("Test body\n\n\nsome hidden content")
+    expect(document[:indexable_content]).to eq("some hidden content")
   end
 
   it "business_finance_support_scheme" do
@@ -109,7 +109,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     }
     document = build_example_with_metadata(custom_metadata)
     expect_document_include_hash(document, custom_metadata)
-    expect(document[:indexable_content]).to eq("Test body\n\n\nhidden content")
+    expect(document[:indexable_content]).to eq("hidden content")
   end
 
   it "employment_tribunal_decision" do
@@ -121,7 +121,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     }
     document = build_example_with_metadata(custom_metadata)
     expect_document_include_hash(document, custom_metadata)
-    expect(document[:indexable_content]).to eq("Test body\n\n\nhidden etd content")
+    expect(document[:indexable_content]).to eq("hidden etd content")
   end
 
   it "european_structural_investment_fund" do
@@ -201,7 +201,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     }
     document = build_example_with_metadata(custom_metadata)
     expect_document_include_hash(document, custom_metadata)
-    expect(document[:indexable_content]).to eq("Test body\n\n\nhidden ttd content")
+    expect(document[:indexable_content]).to eq("hidden ttd content")
   end
 
   it "utaac_decision" do
@@ -214,7 +214,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     }
     document = build_example_with_metadata(custom_metadata)
     expect_document_include_hash(document, custom_metadata)
-    expect(document[:indexable_content]).to eq("Test body\n\n\nhidden utaac content")
+    expect(document[:indexable_content]).to eq("hidden utaac content")
   end
 
   it "vehicle_recalls_and_faults_alert" do
@@ -235,15 +235,11 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
 private
 
   def build_example_with_metadata(metadata)
-    example = GovukSchemas::RandomExample
-                .for_schema(notification_schema: 'specialist_document')
-                .customise_and_validate(
-                  'details' => {
-                    'body' => 'Test body',
-                    'change_history' => [],
-                    'metadata' => metadata,
-                  }
-                )
+    example = GovukSchemas::RandomExample.for_schema(notification_schema: 'specialist_document') do |payload|
+      payload['details']['metadata'] = metadata
+      payload
+    end
+
     described_class.new(payload: example).document
   end
 


### PR DESCRIPTION
This does not work as currently whitehall format schemas do not allow `withdrawn_notice` as a property. This means our withdrawn tests fail.


This moves to the new block based example builder
and address a number of problems that result from 
trying to generate invalid random data now that the
schemes are more prescriptive.

https://trello.com/c/qx627h9B/396-fix-master-build