### PR TITLE
Update docs with correct rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can start the message queue consumer process in development by running:
 
 After changing the schema, you'll need to migrate the index.
 
-    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_index
+    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_schema
 
 #### Internal only APIs
 

--- a/doc/adding-new-fields.md
+++ b/doc/adding-new-fields.md
@@ -33,4 +33,4 @@ For the new elasticsearch configuration to take effect, you need to rebuild the 
 
 On production, this is done automatically every night by the [`search_fetch_analytics`](https://github.com/alphagov/search-analytics) jenkins job.
 
-For other environments, you can run `RUMMAGER_INDEX=all SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 rummager:migrate_index`.
+For other environments, you can run `RUMMAGER_INDEX=all SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 rummager:migrate_schema`.

--- a/doc/popularity.md
+++ b/doc/popularity.md
@@ -22,4 +22,4 @@ is run after populating the page-traffic index. As part of the migration, the
 popularity for each document will be computed from the page-traffic index and
 merged into the documents. To do this, run:
 
-    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_index
+    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_schema


### PR DESCRIPTION
`migrate_index` is now `migrate_schema`