### PR TITLE
Remove incorrect deprecation warning from rake task

### DIFF
--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -94,7 +94,7 @@ This does not update the schema.
     end
   end
 
-  desc "(deprecated) Migrate the data to a new schema definition
+  desc "Migrate the data to a new schema definition
 
 Lock the current index, migrate all the data to a new index,
 wait for the process to complete, switch to the new index and


### PR DESCRIPTION
Remove deprecation warning from the `indices:migrate_schema` rake task. It was accidentally copied from the old `migrate_index` task which was deprecated and then deleted.

cc @dwhenry 