### PR TITLE
Enable indexing for simple to migrate format

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -15,21 +15,21 @@ migrated:
 # Other
 - task_list
 
-indexable: []
-#- asylum_support_decision
-#- business_finance_support_scheme
+indexable:
+- asylum_support_decision
+- business_finance_support_scheme
+- countryside_stewardship_grant
+- employment_appeal_tribunal_decision
+- international_development_fund
+- medical_safety_alert
+- raib_report
+- service_standard_report
+- utaac_decision
 #- cma_case
-#- countryside_stewardship_grant
 #- dfid_research_output
 #- drug_safety_update
-#- employment_appeal_tribunal_decision
 #- employment_tribunal_decision
 #- european_structural_investment_fund
-#- international_development_fund
 #- maib_report
-#- medical_safety_alert
-#- raib_report
-#- service_standard_report
 #- tax_tribunal_decision
-#- utaac_decision
 #- vehicle_recalls_and_faults_alert


### PR DESCRIPTION
Key differences:
* employment_appeal_tribunal_decision has addiiton hidden_indexable_content
* service_standard_report has "Alpha accessment" added to the title field
which brings it inline with the content.

https://trello.com/c/91EaLyiX/386-simple-specialist-formats