### PR TITLE
Move drug-safety-notices back to indexable

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -15,7 +15,6 @@ migrated:
 - asylum_support_decision
 - business_finance_support_scheme
 - countryside_stewardship_grant
-- drug_safety_update
 - employment_appeal_tribunal_decision
 - international_development_fund
 - medical_safety_alert
@@ -25,7 +24,8 @@ migrated:
 # Other
 - task_list
 
-indexable: []
+indexable:
+- drug_safety_update
 #- cma_case
 #- dfid_research_output
 #- employment_tribunal_decision


### PR DESCRIPTION
These got incorrect marked as migrated as a result
of merging conflict.

https://trello.com/c/GGtlwDF2/389-specialist-publisher-drugsafetyupdate