### PR TITLE
Fix failing tests caused by "" != nil

### DIFF
--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     payload = generate_random_example(
       payload: { expanded_links: {} },
       excluded_fields: ["withdrawn_notice"],
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
+      regenerate_if: ->(example) {
+        example["publishing_app"] == "smartanswers" ||
+          @directly_mapped_fields.any? { |field| example[field] == '' }
+      },
     )
 
     presenter = common_fields_presenter(payload)


### PR DESCRIPTION
This is due to a change we made that replaces empty strings
with nil in the ES data.