### PR TITLE
Don't notify of missing basepath for contacts and world locations

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -123,8 +123,7 @@ module GovukIndex
     end
 
     def valid!
-      return if base_path
-      raise(ValidationError, "base_path missing from payload")
+      base_path || raise(MissingBasePath, "base_path missing from payload")
     end
 
   private

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
 
     expect {
       presenter.valid!
-    }.to raise_error(GovukIndex::ValidationError)
+    }.to raise_error(GovukIndex::MissingBasePath)
   end
 
   def elasticsearch_presenter(payload, type = "aaib_report")

--- a/spec/unit/govuk_index/publishing_event_worker_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_worker_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe GovukIndex::PublishingEventWorker do
 
     it "notify of a validation error for missing basepath" do
       expect(GovukError).to receive(:notify).with(
-        instance_of(GovukIndex::ValidationError),
+        instance_of(GovukIndex::MissingBasePath),
         extra: {
           message_body: {
             'document_type' => 'help_page',

--- a/spec/unit/govuk_index/publishing_event_worker_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_worker_spec.rb
@@ -121,18 +121,42 @@ RSpec.describe GovukIndex::PublishingEventWorker do
     }.to raise_error(GovukIndex::MultipleMessagesInElasticsearchResponse)
   end
 
-  it "notify_when_validation_error" do
-    invalid_payload = {
-      "document_type" => "help_page",
-      "title" => "We love cheese"
-    }
+  context "when document type requires a basepath" do
+    let(:payload) do
+      {
+        "document_type" => "help_page",
+        "title" => "We love cheese",
+      }
+    end
 
-    expect(GovukError).to receive(:notify).with(
-      instance_of(GovukIndex::ValidationError),
-      extra: { message_body: { 'document_type' => 'help_page', 'title' => 'We love cheese' } }
-    )
+    it "notify of a validation error for missing basepath" do
+      expect(GovukError).to receive(:notify).with(
+        instance_of(GovukIndex::ValidationError),
+        extra: {
+          message_body: {
+            'document_type' => 'help_page',
+            'title' => 'We love cheese',
+          }
+        }
+      )
 
-    subject.perform('routing.key', invalid_payload)
+      subject.perform('routing.key', payload)
+    end
+  end
+
+  context "when document type doesn't require a basepath" do
+    let(:payload) do
+      {
+        "document_type" => "contact",
+        "title" => "We love cheese",
+      }
+    end
+
+    it "don't notify of a validation error for missing basepath" do
+      expect(GovukError).not_to receive(:notify)
+
+      subject.perform('routing.key', payload)
+    end
   end
 
   def stub_document_type_inferer


### PR DESCRIPTION
This formats don't expect this field to be populated so these notifications
are just noise.