### PR TITLE
remove pry binding

### DIFF
--- a/lib/indexer/govuk_index_field_comparer.rb
+++ b/lib/indexer/govuk_index_field_comparer.rb
@@ -23,8 +23,6 @@ module Indexer
       return compare_content(id, old, new) if key == 'indexable_content'
       return true if old.nil? && new == ''
       return true if key == 'rendering_app' && old == 'specialist-frontend' && new == 'government-frontend'
-      require 'pry'
-      # binding.pry if key == 'alert_type' && old != new
       old == new
     end
 


### PR DESCRIPTION
- Caused a rake task to fail on staging

```
LoadError: cannot load such file -- pry
/data/vhost/rummager.staging.publishing.service.gov.uk/releases/20171103121737/lib/indexer/govuk_index_field_comparer.rb:26:in `require'
```