### PR TITLE
Add a task for debugging synonyms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 group :development do
   # (Intelligent) reloading server in development
   gem "mr-sparkle", "0.3.0"
+  gem "rainbow"
 end
 
 gem "pry-byebug", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,7 @@ DEPENDENCIES
   rack (~> 2.0)
   rack-logstasher (~> 1.0.0)
   rack-test (~> 0.6.3)
+  rainbow
   rake (~> 10.5)
   redis-namespace (~> 1.5.2)
   rspec

--- a/lib/debug/synonyms.rb
+++ b/lib/debug/synonyms.rb
@@ -9,25 +9,26 @@ module Debug
         @index = index
       end
 
-      def search(query)
+      def search(query, pre_tags:, post_tags:)
         search_query = {
           query: {
             multi_match: {
               "query" => query,
-              "fields" => %w(title^1000 description)
+              "fields" => %w(title^1000 description),
+              "analyzer" => 'query_with_old_synonyms',
             }
           },
           highlight: {
             "fields" => { "title" => {}, "description" => {} },
-            "pre_tags" => ["\e[32m"],
-            "post_tags" => ["\e[0m"]
+            "pre_tags" => pre_tags,
+            "post_tags" => post_tags
           }
         }
 
-        client.search(index: index, analyzer: 'query_with_old_synonyms', body: search_query)
+        client.search(index: index, body: search_query)
       end
 
-      def analyze(query)
+      def analyze_query(query)
         client.indices.analyze text: query, analyzer: 'query_with_old_synonyms', index: index
       end
     end
@@ -41,7 +42,7 @@ module Debug
         @index = index
       end
 
-      def search(query)
+      def search(query, pre_tags:, post_tags:)
         search_query = {
           query: {
             multi_match: {
@@ -51,18 +52,20 @@ module Debug
           },
           highlight: {
             "fields" => { "title.synonym" => {}, "description.synonym" => {} },
-            "pre_tags" => ["\e[32m"],
-            "post_tags" => ["\e[0m"]
+            "pre_tags" => pre_tags,
+            "post_tags" => post_tags
           }
         }
 
         client.search(index: index, analyzer: 'with_search_synonyms', body: search_query)
       end
 
-      def analyze(query)
-        index_tokens = client.indices.analyze text: query, analyzer: 'with_index_synonyms', index: index
-        search_tokens = client.indices.analyze text: query, analyzer: 'with_search_synonyms', index: index
-        [index_tokens, search_tokens]
+      def analyze_query(query)
+        client.indices.analyze text: query, analyzer: 'with_search_synonyms', index: index
+      end
+
+      def analyze_index(query)
+        client.indices.analyze text: query, analyzer: 'with_index_synonyms', index: index
       end
     end
   end

--- a/lib/debug/synonyms.rb
+++ b/lib/debug/synonyms.rb
@@ -1,0 +1,69 @@
+module Debug
+  module Synonyms
+    class OldModel
+      attr_reader :client
+      attr_reader :index
+
+      def initialize(index: "govuk", client: Services.elasticsearch)
+        @client = client
+        @index = index
+      end
+
+      def search(query)
+        search_query = {
+          query: {
+            multi_match: {
+              "query" => query,
+              "fields" => %w(title^1000 description)
+            }
+          },
+          highlight: {
+            "fields" => { "title" => {}, "description" => {} },
+            "pre_tags" => ["\e[32m"],
+            "post_tags" => ["\e[0m"]
+          }
+        }
+
+        client.search(index: index, analyzer: 'query_with_old_synonyms', body: search_query)
+      end
+
+      def analyze(query)
+        client.indices.analyze text: query, analyzer: 'query_with_old_synonyms', index: index
+      end
+    end
+
+    class NewModel
+      attr_reader :client
+      attr_reader :index
+
+      def initialize(index: "govuk", client: Services.elasticsearch)
+        @client = client
+        @index = index
+      end
+
+      def search(query)
+        search_query = {
+          query: {
+            multi_match: {
+              "query" => query,
+              "fields" => %w(title.synonym^1000 description.synonym)
+            }
+          },
+          highlight: {
+            "fields" => { "title.synonym" => {}, "description.synonym" => {} },
+            "pre_tags" => ["\e[32m"],
+            "post_tags" => ["\e[0m"]
+          }
+        }
+
+        client.search(index: index, analyzer: 'with_search_synonyms', body: search_query)
+      end
+
+      def analyze(query)
+        index_tokens = client.indices.analyze text: query, analyzer: 'with_index_synonyms', index: index
+        search_tokens = client.indices.analyze text: query, analyzer: 'with_search_synonyms', index: index
+        [index_tokens, search_tokens]
+      end
+    end
+  end
+end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -1,5 +1,7 @@
 require 'rummager'
 require 'pp'
+require 'rainbow'
+require 'debug/synonyms'
 
 namespace :debug do
   desc "Pretty print a document in the old content indexes"
@@ -14,5 +16,62 @@ namespace :debug do
     index = SearchConfig.instance.new_content_index
     docs = index.get_document_by_link(args.link)
     pp docs
+  end
+
+  desc "New synonyms test"
+  task :show_new_synonyms, [:query] do |_, args|
+    model = Debug::Synonyms::NewModel.new
+
+    index_tokens, search_tokens = model.analyze(args.query)
+    search_results = model.search(args.query)
+
+    puts Rainbow("Query interpretation for '#{args.query}':").yellow
+    puts search_tokens["tokens"]
+    puts ""
+
+    puts Rainbow("Document with this exact text is indexed as:").yellow
+    puts index_tokens["tokens"]
+    puts ""
+
+    puts Rainbow("Sample matches (basic query with synonyms):").yellow
+
+    hits = search_results["hits"]["hits"]
+    if hits.empty?
+      puts Rainbow("No results found").red
+    else
+      hits.each do |hit|
+        title = hit.dig("highlight", "title.synonym") || hit.dig("_source", "title")
+        description = hit.dig("highlight", "description.synonym") || hit.dig("_source", "description")
+        puts title
+        puts description if description
+        puts ""
+      end
+    end
+  end
+
+  desc "Old synonyms test"
+  task :show_old_synonyms, [:query] do |_, args|
+    model = Debug::Synonyms::OldModel.new
+    search_tokens = model.analyze(args.query)
+    search_results = model.search(args.query)
+
+    puts Rainbow("Query interpretation for '#{args.query}':").yellow
+    puts search_tokens["tokens"]
+    puts ""
+
+    puts Rainbow("Sample matches (basic query with synonyms):").yellow
+
+    hits = search_results["hits"]["hits"]
+    if hits.empty?
+      puts Rainbow("No results found").red
+    else
+      hits.each do |hit|
+        title = hit.dig("highlight", "title") || hit.dig("_source", "title")
+        description = hit.dig("highlight", "description") || hit.dig("_source", "description")
+        puts title
+        puts description if description
+        puts ""
+      end
+    end
   end
 end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -3,6 +3,9 @@ require 'pp'
 require 'rainbow'
 require 'debug/synonyms'
 
+ANSI_GREEN = "\e[32m".freeze
+ANSI_RESET = "\e[0m".freeze
+
 namespace :debug do
   desc "Pretty print a document in the old content indexes"
   task :show_old_index_link, [:link] do |_, args|
@@ -22,8 +25,9 @@ namespace :debug do
   task :show_new_synonyms, [:query] do |_, args|
     model = Debug::Synonyms::NewModel.new
 
-    index_tokens, search_tokens = model.analyze(args.query)
-    search_results = model.search(args.query)
+    search_tokens = model.analyze_query(args.query)
+    index_tokens = model.analyze_index(args.query)
+    search_results = model.search(args.query, pre_tags: [ANSI_GREEN], post_tags: [ANSI_RESET])
 
     puts Rainbow("Query interpretation for '#{args.query}':").yellow
     puts search_tokens["tokens"]
@@ -52,8 +56,8 @@ namespace :debug do
   desc "Old synonyms test"
   task :show_old_synonyms, [:query] do |_, args|
     model = Debug::Synonyms::OldModel.new
-    search_tokens = model.analyze(args.query)
-    search_results = model.search(args.query)
+    search_tokens = model.analyze_query(args.query)
+    search_results = model.search(args.query, pre_tags: [ANSI_GREEN], post_tags: [ANSI_RESET])
 
     puts Rainbow("Query interpretation for '#{args.query}':").yellow
     puts search_tokens["tokens"]


### PR DESCRIPTION
This prints out how text is being analyzed, and shows example content that
matches the query with the synonym rules applied (ignoring all other factors
that cause results to be boosted).

I've been using this to figure out what our synonyms are doing.

If this proves useful I'll probably move it into search admin.

Example output:

## Old synonyms
<img width="896" alt="screen shot 2017-11-09 at 17 38 50" src="https://user-images.githubusercontent.com/87579/32620214-115a148e-c575-11e7-9d26-d5d8a8fd014e.png">

## New synonyms
<img width="915" alt="screen shot 2017-11-09 at 17 39 18" src="https://user-images.githubusercontent.com/87579/32620185-f299fd02-c574-11e7-8596-11a71a84695f.png">

