### PR TITLE
Adjust format weighting A/B test boost amount

### DIFF
--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -39,7 +39,7 @@ module QueryComponents
     def search_user_need_document_supertype_boost
       {
         filter: { term: { search_user_need_document_supertype: "core" } },
-        boost_factor: 2.5
+        boost_factor: 1.5
       }
     end
 


### PR DESCRIPTION
Having compared the benchmark results we have decided on boosting the core formats by 1.5 as this has the potential of a very reasonable improvement in search results for core content with minimal impact on specialist users.

https://trello.com/c/JhlOtxit