### PR TITLE
Add a comment explaining that default is magic

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -2,6 +2,9 @@ index:
   settings:
     analysis:
       analyzer:
+        # At index time, elasticsearch will use an analyzer named default in the index settings
+        # if no analyzer is specified in the field mapping:
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/analyzer.html
         default:
           type: custom
           tokenizer: standard


### PR DESCRIPTION
Adding this comment because this isn't obvious or easy to find in the elasticsearch documentation.

Elasticsearch comes with a default analyzer called `standard`. But you override this by defining one called `default`. 🤔 