### PR TITLE
Ignore file options without any values

### DIFF
--- a/lib/legacy_search/advanced_search_query_builder.rb
+++ b/lib/legacy_search/advanced_search_query_builder.rb
@@ -154,7 +154,7 @@ module LegacySearch
           date_property_filter(property, filter_value)
         elsif boolean_properties.include?(property)
           boolean_property_filter(property, filter_value)
-        else
+        elsif Array(filter_value).compact.any? # skip when only nil values are present
           standard_property_filter(property, filter_value)
         end
       end

--- a/spec/unit/legacy_search/advanced_search_query_builder_spec.rb
+++ b/spec/unit/legacy_search/advanced_search_query_builder_spec.rb
@@ -47,4 +47,19 @@ RSpec.describe LegacySearch::AdvancedSearchQueryBuilder do
       }
     )
   end
+
+  it "ignores empty filters" do
+    builder = build_builder("how to drive", { "format" => "organisation", "specialist_sectors" => "driving", "people" => nil })
+    query_hash = builder.filter_query_hash
+
+    expect(query_hash).to eq(
+      "filter" => {
+        "and" => [
+          { "term" => { "format" => "organisation" } },
+          { "term" => { "specialist_sectors" => "driving" } },
+          { "not" => { "term" => { "is_withdrawn" => true } } }
+        ]
+      }
+    )
+  end
 end


### PR DESCRIPTION
Otehrwise this causes an ES error when search for a null value for a term.