### PR TITLE
Add stopwords filter to synonyms analyzers

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -22,7 +22,7 @@ index:
         with_index_synonyms:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, index_synonym, synonym_protwords, stemmer_override, stemmer_english]
+          filter: [standard, asciifolding, lowercase, index_synonym, synonym_protwords, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
         # Analyzer used at search time for the .synonym variants of searchable
@@ -30,7 +30,7 @@ index:
         with_search_synonyms:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, search_synonym, synonym_protwords, stemmer_override, stemmer_english]
+          filter: [standard, asciifolding, lowercase, search_synonym, synonym_protwords, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
         # Analyzer used to search across pairs of adjacent words.


### PR DESCRIPTION
We are planning to A/B test the current synonyms approach against a new approach which uses the `with_index_synonyms` analyzer for indexing and the `with_search_synonyms` for queries. To make this a fair test, the old and new analyzers should be the same apart from the synonym handling.

This commit adds the `stop` filter to make the new analyzer consistent with the existing analyzers (`default` for indexing and `query_with_old_synonyms` for querying). This means that stopwords like "the" will not be indexed in the fields used for searches with the new synonym config, and will be stripped from users' search queries.

The `stop` filter has been added after synonyms have been applied because synonyms may include stopwords, so we don't want to filter them out too soon.

https://trello.com/c/w9Pv2oeU/441-make-indexing-analyzers-consistent

Marked as "do not merge" while I do some local testing.

cc @Rosa-Fox @MatMoore 