### PR TITLE
Prepend HMRC Manual Section ID to title

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -16,11 +16,14 @@ module GovukIndex
     delegate_to_payload :publishing_app
     delegate_to_payload :rendering_app
     delegate_to_payload :search_user_need_document_supertype
-    delegate_to_payload :title
     delegate_to_payload :user_journey_document_supertype
 
     def initialize(payload)
       @payload = payload
+    end
+
+    def title
+      [section_id, payload["title"]].compact.join(" - ")
     end
 
     def is_withdrawn
@@ -35,6 +38,10 @@ module GovukIndex
     def format
       document_type = payload['document_type']
       CUSTOM_FORMAT_MAP[document_type] || document_type
+    end
+
+    def section_id
+      @_section_id ||= payload.dig("details", "section_id") if format == "hmrc_manual_section"
     end
 
   private

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -6,7 +6,6 @@ module GovukIndex
 
     delegate_to_payload :licence_identifier
     delegate_to_payload :licence_short_description
-    delegate_to_payload :section_id
 
     def initialize(details:, format:)
       @details = details

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -61,7 +61,7 @@ module GovukIndex
         government_document_supertype:       common_fields.government_document_supertype,
         grant_type:                          specialist.grant_type,
         hidden_indexable_content:            specialist.hidden_indexable_content,
-        hmrc_manual_section_id:              details.section_id,
+        hmrc_manual_section_id:              common_fields.section_id,
         indexable_content:                   indexable.indexable_content,
         industries:                          specialist.industries,
         is_withdrawn:                        common_fields.is_withdrawn,

--- a/spec/integration/govuk_index/hmrc_manuals_spec.rb
+++ b/spec/integration/govuk_index/hmrc_manuals_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "HMRC manual publishing" do
 
     expected_document = {
        "link" => random_example["base_path"],
+       "title" => "some_section_id - #{random_example['title']}",
        "hmrc_manual_section_id" => "some_section_id",
        "manual" => "/parent/manual/path",
      }


### PR DESCRIPTION
Manual section titles need to be prepended by their section ids when being added to the elasticsearch index.

Doing this is in the common fields presenter is not ideal. As we migrate more formats we are finding more and more instances of format specific foibles in our payload part approach to presenters.

https://trello.com/c/64Nv2XP8