### PR TITLE
Make Manual and Manual Sections indexable in govuk index

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -19,6 +19,8 @@ international_development_fund: international_development_fund # Specialist Publ
 licence: edition
 local_transaction: edition
 maib_report: maib_report # Specialist Publisher
+manual: manual
+manual_section: manual_section
 medical_safety_alert: medical_safety_alert # Specialist Publisher
 place: edition
 raib_report: raib_report # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -34,3 +34,5 @@ migrated:
 indexable:
 - hmrc_manual
 - hmrc_manual_section
+- manual
+- manual_section

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -19,11 +19,13 @@ module GovukIndex
     def latest_change_note
       return nil if details["change_notes"].nil? || details["change_notes"].empty?
 
-      note_info = details["change_notes"]
-        .sort_by { |note| DateTime.parse(note["published_at"]) }
-        .last
+      if format == "hmrc_manual"
+        note_info = details["change_notes"]
+          .sort_by { |note| DateTime.parse(note["published_at"]) }
+          .last
 
-      note_info["change_note"] + " in " + note_info["title"]
+        note_info["change_note"] + " in " + note_info["title"]
+      end
     end
 
     def parent_manual

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -62,7 +62,7 @@ module GovukIndex
         grant_type:                          specialist.grant_type,
         hidden_indexable_content:            specialist.hidden_indexable_content,
         hmrc_manual_section_id:              common_fields.section_id,
-        indexable_content:                   indexable.indexable_content,
+        indexable_content:                   indexable.indexable_content || common_fields.description,
         industries:                          specialist.industries,
         is_withdrawn:                        common_fields.is_withdrawn,
         issued_date:                         specialist.issued_date,

--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -14,7 +14,7 @@ module GovukIndex
     end
 
     def indexable_content
-      return nil if details.nil?
+      return nil if details.nil? || format == 'manual'
       sanitiser.clean(indexable)
     end
 

--- a/spec/integration/govuk_index/manuals_spec.rb
+++ b/spec/integration/govuk_index/manuals_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe "Manual publishing" do
+  before do
+    bunny_mock = BunnyMock.new
+    @channel = bunny_mock.start.channel
+
+    consumer = GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "manuals.test",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      rabbitmq_connection: bunny_mock
+    )
+
+    @queue = @channel.queue("manuals.test")
+    consumer.run
+  end
+
+  it "indexes a Manual" do
+    random_example = generate_random_example(
+      schema: "manual",
+      payload: {
+        document_type: "manual",
+        description: "Manual description"
+      },
+      details: {
+        change_notes: [
+          {
+            change_note: "Some description of change",
+            title: "Name of manual section",
+            published_at: "2017-06-21T10:48:34+00:00",
+            base_path: "/some/section/base/path",
+          }
+        ]
+      },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
+    )
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["manual"])
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = {
+       "link" => random_example["base_path"],
+       "indexable_content" => "Manual description",
+       "latest_change_note" => nil
+     }
+
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "manual")
+  end
+
+  it "indexes a manual section" do
+    random_example = generate_random_example(
+      schema: "manual_section",
+      payload: { document_type: "manual_section" },
+      details: {
+        manual: {
+          "base_path": "/parent/manual/path"
+        },
+      },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
+    )
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["manual_section"])
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = {
+       "link" => random_example["base_path"],
+       "title" => random_example["title"],
+       "manual" => "/parent/manual/path",
+     }
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "manual_section")
+  end
+end


### PR DESCRIPTION
Manuals do not seem to care about change notes or section ids in the way that HMRC manuals do.

Indexable content is also just the description.

https://trello.com/c/mYeuXqjv