### PR TITLE
Switch to B version of A/B test of topic and core mainstream formats

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -21,10 +21,14 @@ base:
     topical_event: 1.5
     # Hide mainstream browse pages
     mainstream_browse_page: 0
+    # Topics
+    specialist_sector: 2.5
   content_store_document_type:
     foi_release: 0.2
   navigation_document_supertype:
     guidance: 2.5
+  search_user_need_document_supertype:
+    core: 1.5
   organisation_state:
     closed: 0.2
     devolved: 0.3

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -21,26 +21,7 @@ module QueryComponents
   private
 
     def boost_filters
-      boosts = property_boosts + [time_boost]
-      if @search_params.format_weighting_b_variant?
-        boosts << specialist_sector_boost
-        boosts << search_user_need_document_supertype_boost
-      end
-      boosts
-    end
-
-    def specialist_sector_boost
-      {
-        filter: { term: { format: "specialist_sector" } },
-        boost_factor: 2.5
-      }
-    end
-
-    def search_user_need_document_supertype_boost
-      {
-        filter: { term: { search_user_need_document_supertype: "core" } },
-        boost_factor: 1.5
-      }
+      property_boosts + [time_boost]
     end
 
     def property_boosts

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -52,10 +52,6 @@ module Search
       query && suggest.include?('spelling')
     end
 
-    def format_weighting_b_variant?
-      ab_tests[:format_weighting] == 'B'
-    end
-
   private
 
     def determine_if_quoted_phrase

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -24,54 +24,6 @@ RSpec.describe 'BoosterTest' do
     expect(result_titles).to eq(["Can we be agile?", "Agile is good", "Being agile is good"])
   end
 
-  context "Topic (aka Specialist Sectors) A/B test" do
-    before do
-      commit_document("mainstream_test",
-        "format" => "specialist_sector",
-        "title" => "Keeping pet micropigs"
-      )
-      commit_document("mainstream_test",
-        "format" => "speech",
-        "title" => "Micropigs and the future of micropigs"
-      )
-    end
-
-    it "does not add specialist sector weighting for A bucket requests" do
-      get "/search?q=micropig&ab_tests=format_weighting:A"
-      expect(result_titles).to eq(["Micropigs and the future of micropigs", "Keeping pet micropigs"])
-    end
-
-    it "adds specialist sector weighting for B bucket requests" do
-      get "/search?q=micropig&ab_tests=format_weighting:B"
-      expect(result_titles).to eq(["Keeping pet micropigs", "Micropigs and the future of micropigs"])
-    end
-  end
-
-  context "Search user need supertype A/B test" do
-    before do
-      commit_document("govuk_test",
-        "format" => "transaction",
-        "search_user_need_document_supertype" => "core",
-        "title" => "Keeping pet axolotls"
-      )
-      commit_document("govuk_test",
-        "format" => "help_page",
-        "search_user_need_document_supertype" => "government",
-        "title" => "Axolotls, axolotls and more axolotls"
-      )
-    end
-
-    it "does not add user need supertype weighting for A bucket requests" do
-      get "/search?q=axolotls&ab_tests=format_weighting:A"
-      expect(result_titles).to eq(["Axolotls, axolotls and more axolotls", "Keeping pet axolotls"])
-    end
-
-    it "adds user need supertype weighting for B bucket requests" do
-      get "/search?q=axolotls&ab_tests=format_weighting:B"
-      expect(result_titles).to eq(["Keeping pet axolotls", "Axolotls, axolotls and more axolotls"])
-    end
-  end
-
   def result_titles
     parsed_response['results'].map do |result|
       result['title']


### PR DESCRIPTION
Remove the A/B test and always apply the boosts for topics (aka specialist sectors) and core mainstream formats.

https://trello.com/c/8xLTxEUQ/452-deploy-format-weighting-b-version

Marked as "do not merge" until alphagov/cdn-configs#26 has been deployed.