### PR TITLE
[REVIEW ONLY] Run all search integration tests with A and B variants

### DIFF
--- a/spec/integration/search/best_bets_spec.rb
+++ b/spec/integration/search/best_bets_spec.rb
@@ -3,12 +3,14 @@ require 'spec_helper'
 RSpec.describe 'BestBetsTest' do
   with_ab_variants do
     it "exact_best_bet" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => '/an-organic-result',
         "indexable_content" => 'I will turn up in searches for "a forced best bet"',
       )
 
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => '/the-link-that-should-surface',
         "indexable_content" => 'Empty.',
       )
@@ -26,7 +28,8 @@ RSpec.describe 'BestBetsTest' do
     end
 
     it "exact_worst_bet" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "indexable_content" => 'I should not be shown.',
         "link" => '/we-never-show-this',
       )
@@ -44,7 +47,8 @@ RSpec.describe 'BestBetsTest' do
     end
 
     it "stemmed_best_bet" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => '/the-link-that-should-surface',
       )
 
@@ -61,7 +65,8 @@ RSpec.describe 'BestBetsTest' do
     end
 
     it "stemmed_best_bet_variant" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => '/the-link-that-should-surface',
       )
 
@@ -79,7 +84,8 @@ RSpec.describe 'BestBetsTest' do
     end
 
     it "stemmed_best_bet_words_not_in_phrase_order" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => '/only-shown-for-exact-matches',
       )
 

--- a/spec/integration/search/best_bets_spec.rb
+++ b/spec/integration/search/best_bets_spec.rb
@@ -1,104 +1,106 @@
 require 'spec_helper'
 
 RSpec.describe 'BestBetsTest' do
-  it "exact_best_bet" do
-    commit_document("mainstream_test",
-      "link" => '/an-organic-result',
-      "indexable_content" => 'I will turn up in searches for "a forced best bet"',
-    )
+  with_ab_variants do
+    it "exact_best_bet" do
+      commit_document("mainstream_test",
+        "link" => '/an-organic-result',
+        "indexable_content" => 'I will turn up in searches for "a forced best bet"',
+      )
 
-    commit_document("mainstream_test",
-      "link" => '/the-link-that-should-surface',
-      "indexable_content" => 'Empty.',
-    )
+      commit_document("mainstream_test",
+        "link" => '/the-link-that-should-surface',
+        "indexable_content" => 'Empty.',
+      )
 
-    add_best_bet(
-      query: 'a forced best bet',
-      type: 'exact',
-      link: '/the-link-that-should-surface',
-      position: 1,
-    )
+      add_best_bet(
+        query: 'a forced best bet',
+        type: 'exact',
+        link: '/the-link-that-should-surface',
+        position: 1,
+      )
 
-    links = get_links "/search?q=a+forced+best+bet"
+      links = get_links "/search?q=a+forced+best+bet"
 
-    expect(links).to eq(["/the-link-that-should-surface", "/an-organic-result"])
-  end
+      expect(links).to eq(["/the-link-that-should-surface", "/an-organic-result"])
+    end
 
-  it "exact_worst_bet" do
-    commit_document("mainstream_test",
-      "indexable_content" => 'I should not be shown.',
-      "link" => '/we-never-show-this',
-    )
+    it "exact_worst_bet" do
+      commit_document("mainstream_test",
+        "indexable_content" => 'I should not be shown.',
+        "link" => '/we-never-show-this',
+      )
 
-    add_worst_bet(
-      query: 'shown',
-      type: 'exact',
-      link: '/we-never-show-this',
-      position: 1,
-    )
+      add_worst_bet(
+        query: 'shown',
+        type: 'exact',
+        link: '/we-never-show-this',
+        position: 1,
+      )
 
-    links = get_links "/search?q=shown"
+      links = get_links "/search?q=shown"
 
-    expect(links).not_to include("/we-never-show-this")
-  end
+      expect(links).not_to include("/we-never-show-this")
+    end
 
-  it "stemmed_best_bet" do
-    commit_document("mainstream_test",
-      "link" => '/the-link-that-should-surface',
-    )
+    it "stemmed_best_bet" do
+      commit_document("mainstream_test",
+        "link" => '/the-link-that-should-surface',
+      )
 
-    add_best_bet(
-      query: 'best bet',
-      type: 'stemmed',
-      link: '/the-link-that-should-surface',
-      position: 1,
-    )
+      add_best_bet(
+        query: 'best bet',
+        type: 'stemmed',
+        link: '/the-link-that-should-surface',
+        position: 1,
+      )
 
-    links = get_links "/search?q=best+bet+and+such"
+      links = get_links "/search?q=best+bet+and+such"
 
-    expect(links).to eq(["/the-link-that-should-surface"])
-  end
+      expect(links).to eq(["/the-link-that-should-surface"])
+    end
 
-  it "stemmed_best_bet_variant" do
-    commit_document("mainstream_test",
-      "link" => '/the-link-that-should-surface',
-    )
+    it "stemmed_best_bet_variant" do
+      commit_document("mainstream_test",
+        "link" => '/the-link-that-should-surface',
+      )
 
-    add_best_bet(
-      query: 'best bet',
-      type: 'stemmed',
-      link: '/the-link-that-should-surface',
-      position: 1,
-    )
+      add_best_bet(
+        query: 'best bet',
+        type: 'stemmed',
+        link: '/the-link-that-should-surface',
+        position: 1,
+      )
 
-    # note that we're searching for "bests bet", not "best bet" here.
-    links = get_links "/search?q=bests+bet"
+      # note that we're searching for "bests bet", not "best bet" here.
+      links = get_links "/search?q=bests+bet"
 
-    expect(links).to eq(["/the-link-that-should-surface"])
-  end
+      expect(links).to eq(["/the-link-that-should-surface"])
+    end
 
-  it "stemmed_best_bet_words_not_in_phrase_order" do
-    commit_document("mainstream_test",
-      "link" => '/only-shown-for-exact-matches',
-    )
+    it "stemmed_best_bet_words_not_in_phrase_order" do
+      commit_document("mainstream_test",
+        "link" => '/only-shown-for-exact-matches',
+      )
 
-    add_best_bet(
-      query: 'best bet',
-      type: 'stemmed',
-      link: '/only-shown-for-exact-matches',
-      position: 1,
-    )
+      add_best_bet(
+        query: 'best bet',
+        type: 'stemmed',
+        link: '/only-shown-for-exact-matches',
+        position: 1,
+      )
 
-    # note that we're searching for "bet best", not "best bet" here.
-    links = get_links "/search?q=bet+best"
+      # note that we're searching for "bet best", not "best bet" here.
+      links = get_links "/search?q=bet+best"
 
-    expect(links).not_to include("/only-shown-for-exact-matches")
+      expect(links).not_to include("/only-shown-for-exact-matches")
+    end
   end
 
 private
 
   def get_links(path)
-    get(path)
+    get_with_variant(path)
     parsed_response["results"].map { |result| result["link"] }
   end
 

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -1,27 +1,29 @@
 require 'spec_helper'
 
 RSpec.describe 'BoosterTest' do
-  it "service_manual_formats_are_weighted_down" do
-    commit_document("mainstream_test",
-      "title" => "Agile is good",
-      "link" => "/agile-is-good",
-      "format" => "service_manual_guide",
-    )
+  with_ab_variants do
+    it "service_manual_formats_are_weighted_down" do
+      commit_document("mainstream_test",
+        "title" => "Agile is good",
+        "link" => "/agile-is-good",
+        "format" => "service_manual_guide",
+      )
 
-    commit_document("mainstream_test",
-      "title" => "Being agile is good",
-      "link" => "/being-agile-is-good",
-      "format" => "service_manual_topic",
-    )
+      commit_document("mainstream_test",
+        "title" => "Being agile is good",
+        "link" => "/being-agile-is-good",
+        "format" => "service_manual_topic",
+      )
 
-    commit_document("mainstream_test",
-      "title" => "Can we be agile?",
-      "link" => "/can-we-be-agile",
-    )
+      commit_document("mainstream_test",
+        "title" => "Can we be agile?",
+        "link" => "/can-we-be-agile",
+      )
 
-    get "/search?q=agile"
+      get_with_variant "/search?q=agile"
 
-    expect(result_titles).to eq(["Can we be agile?", "Agile is good", "Being agile is good"])
+      expect(result_titles).to eq(["Can we be agile?", "Agile is good", "Being agile is good"])
+    end
   end
 
   def result_titles

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -3,19 +3,22 @@ require 'spec_helper'
 RSpec.describe 'BoosterTest' do
   with_ab_variants do
     it "service_manual_formats_are_weighted_down" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "Agile is good",
         "link" => "/agile-is-good",
         "format" => "service_manual_guide",
       )
 
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "Being agile is good",
         "link" => "/being-agile-is-good",
         "format" => "service_manual_topic",
       )
 
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "Can we be agile?",
         "link" => "/can-we-be-agile",
       )

--- a/spec/integration/search/quoted_and_unquoted_searches_spec.rb
+++ b/spec/integration/search/quoted_and_unquoted_searches_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'QuotedAndUnquotedSearchTest' do
     Rummager.class_variable_set(:'@@registries', nil)
   end
 
-    with_ab_variants do
+  with_ab_variants do
     # NEW WEIGHTING TESTS
     #
     it "new_weighting_three_matches_found_for_london" do

--- a/spec/integration/search/quoted_and_unquoted_searches_spec.rb
+++ b/spec/integration/search/quoted_and_unquoted_searches_spec.rb
@@ -7,114 +7,116 @@ RSpec.describe 'QuotedAndUnquotedSearchTest' do
     Rummager.class_variable_set(:'@@registries', nil)
   end
 
-  # NEW WEIGHTING TESTS
-  #
-  it "new_weighting_three_matches_found_for_london" do
-    commit_london_transport_docs
-    get "/search?q=london&debug=new_weighting"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(3)
-  end
+    with_ab_variants do
+    # NEW WEIGHTING TESTS
+    #
+    it "new_weighting_three_matches_found_for_london" do
+      commit_london_transport_docs
+      get_with_variant "/search?q=london&debug=new_weighting"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(3)
+    end
 
-  it "new_weighting_three_matches_found_for_transport" do
-    commit_london_transport_docs
-    get "/search?q=transport&debug=new_weighting"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(3)
-  end
+    it "new_weighting_three_matches_found_for_transport" do
+      commit_london_transport_docs
+      get_with_variant "/search?q=transport&debug=new_weighting"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(3)
+    end
 
-  it "new_weighting_three_matches_found_for_unquoted_london_transport" do
-    commit_london_transport_docs
-    get "/search?q=london+transport&debug=new_weighting"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(3)
-  end
+    it "new_weighting_three_matches_found_for_unquoted_london_transport" do
+      commit_london_transport_docs
+      get_with_variant "/search?q=london+transport&debug=new_weighting"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(3)
+    end
 
-  it "new_weighting_one_match_found_for_quoted_london_transport" do
-    commit_london_transport_docs
-    get "/search?q=%22london+transport%22&debug=new_weighting"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(1)
-  end
+    it "new_weighting_one_match_found_for_quoted_london_transport" do
+      commit_london_transport_docs
+      get_with_variant "/search?q=%22london+transport%22&debug=new_weighting"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(1)
+    end
 
-  it "new_weighting_synonyms_are_returned_with_unquoted_phrases" do
-    commit_synonym_documents
-    get "/search?q=driving+abroad&debug=new_weighting"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(2)
-  end
+    it "new_weighting_synonyms_are_returned_with_unquoted_phrases" do
+      commit_synonym_documents
+      get_with_variant "/search?q=driving+abroad&debug=new_weighting"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(2)
+    end
 
-  it "new_weighting_synonyms_are_not_returned_with_quoted_phrases" do
-    commit_synonym_documents
-    get "/search?q=%22driving+abroad%22&debug=new_weighting"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(1)
-  end
+    it "new_weighting_synonyms_are_not_returned_with_quoted_phrases" do
+      commit_synonym_documents
+      get_with_variant "/search?q=%22driving+abroad%22&debug=new_weighting"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(1)
+    end
 
-  it "new_weighting_stemming_is_in_place_for_unquoted_phrases" do
-    commit_stemming_documents
-    get "/search?q=dog&debug=new_weighting"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(2)
-  end
+    it "new_weighting_stemming_is_in_place_for_unquoted_phrases" do
+      commit_stemming_documents
+      get_with_variant "/search?q=dog&debug=new_weighting"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(2)
+    end
 
-  it "new_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
-    commit_stemming_documents
-    get "/search?q=%22dog%22&debug=new_weighting"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(2)
-  end
+    it "new_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
+      commit_stemming_documents
+      get_with_variant "/search?q=%22dog%22&debug=new_weighting"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(2)
+    end
 
 
-  # OLD WEIGHTING TESTS
-  #
-  it "old_weighting_three_matches_found_for_london" do
-    commit_london_transport_docs
-    get "/search?q=london"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(3)
-  end
+    # OLD WEIGHTING TESTS
+    #
+    it "old_weighting_three_matches_found_for_london" do
+      commit_london_transport_docs
+      get_with_variant "/search?q=london"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(3)
+    end
 
-  it "old_weighting_three_matches_found_for_transport" do
-    commit_london_transport_docs
-    get "/search?q=transport"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(3)
-  end
+    it "old_weighting_three_matches_found_for_transport" do
+      commit_london_transport_docs
+      get_with_variant "/search?q=transport"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(3)
+    end
 
-  it "old_weighting_three_matches_found_for_unquoted_london_transport" do
-    commit_london_transport_docs
-    get "/search?q=london+transport"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(3)
-  end
+    it "old_weighting_three_matches_found_for_unquoted_london_transport" do
+      commit_london_transport_docs
+      get_with_variant "/search?q=london+transport"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(3)
+    end
 
-  it "old_weighting_one_match_found_for_quoted_london_transport" do
-    commit_london_transport_docs
-    get "/search?q=%22london+transport%22"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(1)
-  end
+    it "old_weighting_one_match_found_for_quoted_london_transport" do
+      commit_london_transport_docs
+      get_with_variant "/search?q=%22london+transport%22"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(1)
+    end
 
-  it "old_weighting_synonyms_are_returned_with_unquoted_phrases" do
-    commit_synonym_documents
-    get "/search?q=driving+abroad"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(2)
-  end
+    it "old_weighting_synonyms_are_returned_with_unquoted_phrases" do
+      commit_synonym_documents
+      get_with_variant "/search?q=driving+abroad"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(2)
+    end
 
-  it "old_weighting_stemming_is_in_place_for_unquoted_phrases" do
-    commit_stemming_documents
-    get "/search?q=dog"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(2)
-  end
+    it "old_weighting_stemming_is_in_place_for_unquoted_phrases" do
+      commit_stemming_documents
+      get_with_variant "/search?q=dog"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(2)
+    end
 
-  it "old_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
-    commit_stemming_documents
-    get "/search?q=%22dog%22"
-    expect(last_response.status).to eq(200)
-    expect(parsed_response["results"].size).to eq(2)
+    it "old_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
+      commit_stemming_documents
+      get_with_variant "/search?q=%22dog%22"
+      expect(last_response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(2)
+    end
   end
 
 

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -1,99 +1,101 @@
 require 'spec_helper'
 
 RSpec.describe 'ResultsWithHighlightingTest' do
-  it "returns_highlighted_title" do
-    commit_document("mainstream_test",
-      "title" => "I am the result",
-      "link" => "/some-nice-link",
-    )
+  with_ab_variants do
+    it "returns_highlighted_title" do
+      commit_document("mainstream_test",
+        "title" => "I am the result",
+        "link" => "/some-nice-link",
+      )
 
-    get "/search?q=result&fields[]=title_with_highlighting"
+      get_with_variant "/search?q=result&fields[]=title_with_highlighting"
 
-    expect(first_search_result.key?('title')).to be_falsey
-    expect(first_search_result['title_with_highlighting']).to eq("I am the <mark>result</mark>")
-  end
+      expect(first_search_result.key?('title')).to be_falsey
+      expect(first_search_result['title_with_highlighting']).to eq("I am the <mark>result</mark>")
+    end
 
-  it "returns_highlighted_title_fallback" do
-    commit_document("mainstream_test",
-      "title" => "Thing without",
-      "description" => "I am the result",
-      "link" => "/some-nice-link",
-    )
+    it "returns_highlighted_title_fallback" do
+      commit_document("mainstream_test",
+        "title" => "Thing without",
+        "description" => "I am the result",
+        "link" => "/some-nice-link",
+      )
 
-    get "/search?q=result&fields[]=title_with_highlighting"
+      get_with_variant "/search?q=result&fields[]=title_with_highlighting"
 
-    expect(first_search_result.key?('title')).to be_falsey
-    expect(first_search_result['title_with_highlighting']).to eq("Thing without")
-  end
+      expect(first_search_result.key?('title')).to be_falsey
+      expect(first_search_result['title_with_highlighting']).to eq("Thing without")
+    end
 
-  it "returns_highlighted_description" do
-    commit_document("mainstream_test",
-      "link" => "/some-nice-link",
-      "description" => "This is a test search result of many results."
-    )
+    it "returns_highlighted_description" do
+      commit_document("mainstream_test",
+        "link" => "/some-nice-link",
+        "description" => "This is a test search result of many results."
+      )
 
-    get "/search?q=result&fields[]=description_with_highlighting"
+      get_with_variant "/search?q=result&fields[]=description_with_highlighting"
 
-    expect(first_search_result.key?('description')).to be_falsey
-    expect("This is a test search <mark>result</mark> of many <mark>results</mark>.").to eq(
-      first_search_result['description_with_highlighting']
-    )
-  end
+      expect(first_search_result.key?('description')).to be_falsey
+      expect("This is a test search <mark>result</mark> of many <mark>results</mark>.").to eq(
+        first_search_result['description_with_highlighting']
+      )
+    end
 
-  it "returns_documents_html_escaped" do
-    commit_document("mainstream_test",
-      "title" => "Escape & highlight my title",
-      "link" => "/some-nice-link",
-      "description" => "Escape & highlight the description as well."
-    )
+    it "returns_documents_html_escaped" do
+      commit_document("mainstream_test",
+        "title" => "Escape & highlight my title",
+        "link" => "/some-nice-link",
+        "description" => "Escape & highlight the description as well."
+      )
 
-    get "/search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
+      get_with_variant "/search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
 
-    expect("Escape &amp; <mark>highlight</mark> the description as well.").to eq(
-      first_search_result['description_with_highlighting']
-    )
-    expect("Escape &amp; <mark>highlight</mark> my title").to eq(
-      first_search_result['title_with_highlighting']
-    )
-  end
+      expect("Escape &amp; <mark>highlight</mark> the description as well.").to eq(
+        first_search_result['description_with_highlighting']
+      )
+      expect("Escape &amp; <mark>highlight</mark> my title").to eq(
+        first_search_result['title_with_highlighting']
+      )
+    end
 
-  it "returns_truncated_correctly_where_result_at_start_of_description" do
-    commit_document("mainstream_test",
-      "link" => "/some-nice-link",
-      "description" => "word " + ("something " * 200)
-    )
+    it "returns_truncated_correctly_where_result_at_start_of_description" do
+      commit_document("mainstream_test",
+        "link" => "/some-nice-link",
+        "description" => "word " + ("something " * 200)
+      )
 
-    get "/search?q=word&fields[]=description_with_highlighting"
-    description = first_search_result['description_with_highlighting']
+      get_with_variant "/search?q=word&fields[]=description_with_highlighting"
+      description = first_search_result['description_with_highlighting']
 
-    expect(description.starts_with?("<mark>word</mark>")).to be_truthy
-    expect(description.ends_with?("…")).to be_truthy
-  end
+      expect(description.starts_with?("<mark>word</mark>")).to be_truthy
+      expect(description.ends_with?("…")).to be_truthy
+    end
 
-  it "returns_truncated_correctly_where_result_at_end_of_description" do
-    commit_document("mainstream_test",
-      "link" => "/some-nice-link",
-      "description" => ("something " * 200) + " word"
-    )
+    it "returns_truncated_correctly_where_result_at_end_of_description" do
+      commit_document("mainstream_test",
+        "link" => "/some-nice-link",
+        "description" => ("something " * 200) + " word"
+      )
 
-    get "/search?q=word&fields[]=description_with_highlighting"
-    description = first_search_result['description_with_highlighting']
+      get_with_variant "/search?q=word&fields[]=description_with_highlighting"
+      description = first_search_result['description_with_highlighting']
 
-    expect(description.starts_with?("…")).to be_truthy
-    expect(description.size < 350).to be_truthy
-  end
+      expect(description.starts_with?("…")).to be_truthy
+      expect(description.size < 350).to be_truthy
+    end
 
-  it "returns_truncated_correctly_where_result_in_middle_of_description" do
-    commit_document("mainstream_test",
-      "link" => "/some-nice-link",
-      "description" => ("something " * 200) + " word " + ("something " * 200)
-    )
+    it "returns_truncated_correctly_where_result_in_middle_of_description" do
+      commit_document("mainstream_test",
+        "link" => "/some-nice-link",
+        "description" => ("something " * 200) + " word " + ("something " * 200)
+      )
 
-    get "/search?q=word&fields[]=description_with_highlighting"
-    description = first_search_result['description_with_highlighting']
+      get_with_variant "/search?q=word&fields[]=description_with_highlighting"
+      description = first_search_result['description_with_highlighting']
 
-    expect(description.ends_with?("…")).to be_truthy
-    expect(description.starts_with?("…")).to be_truthy
+      expect(description.ends_with?("…")).to be_truthy
+      expect(description.starts_with?("…")).to be_truthy
+    end
   end
 
 private

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 RSpec.describe 'ResultsWithHighlightingTest' do
   with_ab_variants do
     it "returns_highlighted_title" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "I am the result",
         "link" => "/some-nice-link",
       )
@@ -15,7 +16,8 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     end
 
     it "returns_highlighted_title_fallback" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "Thing without",
         "description" => "I am the result",
         "link" => "/some-nice-link",
@@ -28,9 +30,10 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     end
 
     it "returns_highlighted_description" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => "/some-nice-link",
-        "description" => "This is a test search result of many results."
+        "description" => "This is a test search result of many results.",
       )
 
       get_with_variant "/search?q=result&fields[]=description_with_highlighting"
@@ -42,10 +45,11 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     end
 
     it "returns_documents_html_escaped" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "Escape & highlight my title",
         "link" => "/some-nice-link",
-        "description" => "Escape & highlight the description as well."
+        "description" => "Escape & highlight the description as well.",
       )
 
       get_with_variant "/search?q=highlight&fields[]=title_with_highlighting,description_with_highlighting"
@@ -59,9 +63,10 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     end
 
     it "returns_truncated_correctly_where_result_at_start_of_description" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => "/some-nice-link",
-        "description" => "word " + ("something " * 200)
+        "description" => "word " + ("something " * 200),
       )
 
       get_with_variant "/search?q=word&fields[]=description_with_highlighting"
@@ -72,9 +77,10 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     end
 
     it "returns_truncated_correctly_where_result_at_end_of_description" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => "/some-nice-link",
-        "description" => ("something " * 200) + " word"
+        "description" => ("something " * 200) + " word",
       )
 
       get_with_variant "/search?q=word&fields[]=description_with_highlighting"
@@ -85,9 +91,10 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     end
 
     it "returns_truncated_correctly_where_result_in_middle_of_description" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "link" => "/some-nice-link",
-        "description" => ("something " * 200) + " word " + ("something " * 200)
+        "description" => ("something " * 200) + " word " + ("something " * 200),
       )
 
       get_with_variant "/search?q=word&fields[]=description_with_highlighting"

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -1,673 +1,675 @@
 require 'spec_helper'
 
 RSpec.describe 'SearchTest' do
-  it "returns_success" do
-    get "/search?q=important"
+  with_ab_variants do
+    it "returns_success" do
+      get_with_variant "/search?q=important"
 
-    expect(last_response).to be_ok
-  end
+      expect(last_response).to be_ok
+    end
 
-  it "id_code_with_space" do
-    # when debug mode includes "use_id_codes" and it searches for
-    # "P 60" instead of "P60" a P60 document should be found!
+    it "id_code_with_space" do
+      # when debug mode includes "use_id_codes" and it searches for
+      # "P 60" instead of "P60" a P60 document should be found!
 
-    commit_document(
-      "mainstream_test",
-      "title" => "Get P45, P60 and other forms for your employees",
-      "description" => "Get PAYE forms from HMRC including P45, P60, starter checklist (which replaced the P46), P11D(b)",
-      "link" => "/get-paye-forms-p45-p60"
+      commit_document(
+        "mainstream_test",
+        "title" => "Get P45, P60 and other forms for your employees",
+        "description" => "Get PAYE forms from HMRC including P45, P60, starter checklist (which replaced the P46), P11D(b)",
+        "link" => "/get-paye-forms-p45-p60"
 
-    )
-
-    get "/search?q=p+60&debug=use_id_codes"
-
-    expect(parsed_response['results'].size).to eq(1)
-    expect(parsed_response["results"][0]["link"]).to eq("/get-paye-forms-p45-p60")
-
-    get "/search?q=p+60"
-    expect(parsed_response['results'].size).to eq(0)
-  end
-
-  it "spell_checking_with_typo" do
-    commit_document("mainstream_test",
-      "title" => "I am the result",
-      "description" => "This is a test search result",
-      "link" => "/some-nice-link"
-    )
-
-    get "/search?q=serch&suggest=spelling"
-
-    expect(parsed_response['suggested_queries']).to eq(['search'])
-  end
-
-  it "spell_checking_with_blacklisted_typo" do
-    commit_document("mainstream_test",
-      "title" => "Brexitt",
-      "description" => "Brexitt",
-      "link" => "/brexitt")
-
-    get "/search?q=brexit&suggest=spelling"
-
-    expect(parsed_response['suggested_queries']).to eq([])
-  end
-
-  it "spell_checking_without_typo" do
-    build_sample_documents_on_content_indices(documents_per_index: 1)
-
-    get "/search?q=milliband"
-
-    expect(parsed_response['suggested_queries']).to eq([])
-  end
-
-  it "returns_docs_from_all_indexes" do
-    build_sample_documents_on_content_indices(documents_per_index: 1)
-
-    get "/search?q=important"
-
-    expect(result_links).to include "/government-1"
-    expect(result_links).to include "/mainstream-1"
-  end
-
-  it "sort_by_date_ascending" do
-    build_sample_documents_on_content_indices(documents_per_index: 2)
-
-    get "/search?q=important&order=public_timestamp"
-
-    expect(result_links.take(2)).to eq(["/government-1", "/government-2"])
-  end
-
-  it "sort_by_date_descending" do
-    build_sample_documents_on_content_indices(documents_per_index: 2)
-
-    get "/search?q=important&order=-public_timestamp"
-
-    # The government links have dates, so appear before all the other links.
-    # The other documents have no dates, so appear in an undefined order
-    expect(result_links.take(2)).to eq(["/government-2", "/government-1"])
-  end
-
-  it "sort_by_title_ascending" do
-    build_sample_documents_on_content_indices(documents_per_index: 1)
-
-    get "/search?order=title"
-    lowercase_titles = result_titles.map(&:downcase)
-
-    expect(lowercase_titles).to eq(lowercase_titles.sort)
-  end
-
-  it "filter_by_field" do
-    build_sample_documents_on_content_indices(documents_per_index: 1)
-
-    get "/search?filter_mainstream_browse_pages=browse/page/1"
-
-    expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
-  end
-
-  it "reject_by_field" do
-    build_sample_documents_on_content_indices(documents_per_index: 2)
-
-    get "/search?reject_mainstream_browse_pages=browse/page/1"
-
-    expect(result_links.sort).to eq(["/government-2", "/mainstream-2"])
-  end
-
-  it "can_filter_for_missing_field" do
-    build_sample_documents_on_content_indices(documents_per_index: 1)
-
-    get "/search?filter_specialist_sectors=_MISSING"
-
-    expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
-  end
-
-  it "can_filter_for_missing_or_specific_value_in_field" do
-    build_sample_documents_on_content_indices(documents_per_index: 1)
-
-    get "/search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
-
-    expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
-  end
-
-  it "can_filter_and_reject" do
-    build_sample_documents_on_content_indices(documents_per_index: 2)
-
-    get "/search?reject_mainstream_browse_pages=1&filter_specialist_sectors[]=farming"
-
-    expect([
-      "/government-2",
-      "/mainstream-2",
-    ]).to eq(result_links.sort)
-  end
-
-  it "only_contains_fields_which_are_present" do
-    build_sample_documents_on_content_indices(documents_per_index: 2)
-
-    get "/search?q=important&order=public_timestamp"
-
-    results = parsed_response["results"]
-    expect(results[0].keys).not_to include("specialist_sectors")
-    expect(results[1]["specialist_sectors"]).to eq([{ "slug" => "farming" }])
-  end
-
-  it "validates_integer_params" do
-    get "/search?start=a"
-
-    expect(last_response.status).to eq(422)
-    expect(parsed_response).to eq({ "error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)" })
-  end
-
-  it "allows_integer_params_leading_zeros" do
-    get "/search?start=09"
-
-    expect(last_response).to be_ok
-  end
-
-  it "validates_unknown_params" do
-    get "/search?foo&bar=1"
-
-    expect(last_response.status).to eq(422)
-    expect(parsed_response).to eq("error" => "Unexpected parameters: foo, bar")
-  end
-
-  it "debug_explain_returns_explanations" do
-    build_sample_documents_on_content_indices(documents_per_index: 1)
-
-    get "/search?debug=explain"
-
-    first_hit_explain = parsed_response["results"].first["_explanation"]
-    expect(first_hit_explain).not_to be_nil
-    expect(first_hit_explain.keys).to include("value")
-    expect(first_hit_explain.keys).to include("description")
-    expect(first_hit_explain.keys).to include("details")
-  end
-
-  it "can_scope_by_elasticsearch_type" do
-    commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
-
-    get "/search?filter_document_type=cma_case"
-
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
-    expect(
-      hash_including(
-        "document_type" => "cma_case",
-        "title" => cma_case_attributes.fetch("title"),
-        "link" => cma_case_attributes.fetch("link"),
       )
-    ).to eq(
-      parsed_response.fetch("results").fetch(0),
-    )
-  end
 
-  it "can_filter_between_dates" do
-    commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
+      get_with_variant "/search?q=p+60&debug=use_id_codes"
 
-    get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
+      expect(parsed_response['results'].size).to eq(1)
+      expect(parsed_response["results"][0]["link"]).to eq("/get-paye-forms-p45-p60")
 
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
-    expect(
-      hash_including(
-        "title" => cma_case_attributes.fetch("title"),
-        "link" => cma_case_attributes.fetch("link"),
-      )
-    ).to eq(
-      parsed_response.fetch("results").fetch(0),
-    )
-  end
+      get_with_variant "/search?q=p+60"
+      expect(parsed_response['results'].size).to eq(0)
+    end
 
-  it "can_filter_between_dates_with_reversed_parameter_order" do
-    commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
-
-    get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
-
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
-    expect(
-      hash_including(
-        "title" => cma_case_attributes.fetch("title"),
-        "link" => cma_case_attributes.fetch("link"),
-      )
-    ).to eq(
-      parsed_response.fetch("results").fetch(0),
-    )
-  end
-
-  it "can filter from date" do
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-03-30", "link" => "/old-cma-with-date"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-03-30T23:00:00.000+00:00", "link" => "/old-cma-with-datetime"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-03-31", "link" => "/matching-cma-with-date"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-03-31T00:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
-      type: "cma_case")
-
-    get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
-
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("results")).to contain_exactly(
-      hash_including("link" => "/matching-cma-with-date"),
-      hash_including("link" => "/matching-cma-with-datetime"),
-    )
-  end
-
-  it "can filter from time" do
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-03-31", "link" => "/old-cma-with-date"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-03-31T13:59:59.000+00:00", "link" => "/old-cma-with-datetime"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-01", "link" => "/matching-cma-with-date"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-03-31T14:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
-      type: "cma_case")
-
-    get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31 14:00:00"
-
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("results")).to contain_exactly(
-      hash_including("link" => "/matching-cma-with-date"),
-      hash_including("link" => "/matching-cma-with-datetime"),
-    )
-  end
-
-  it "can filter to date" do
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-02", "link" => "/matching-cma-with-date"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-02T05:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-03", "link" => "/future-cma-with-date"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-03T00:00:00.000+00:00", "link" => "/future-cma-with-datetime"),
-      type: "cma_case")
-
-    get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
-
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("results")).to contain_exactly(
-      hash_including("link" => "/matching-cma-with-date"),
-      hash_including("link" => "/matching-cma-with-datetime"),
-    )
-  end
-
-  it "can filter to time" do
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-02", "link" => "/matching-cma-with-date"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-02T11:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-03", "link" => "/future-cma-with-date"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2014-04-02T11:00:01.000+00:00", "link" => "/future-cma-with-datetime"),
-      type: "cma_case")
-
-    get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02 11:00:00"
-
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("results")).to contain_exactly(
-      hash_including("link" => "/matching-cma-with-date"),
-      hash_including("link" => "/matching-cma-with-datetime"),
-    )
-  end
-
-  it "can filter times in different time zones" do
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2017-07-01T11:20:00.000-03:00", "link" => "/cma-1"),
-      type: "cma_case")
-    commit_document(
-      "mainstream_test",
-      cma_case_attributes("opened_date" => "2017-07-02T00:15:00.000+01:00", "link" => "/cma-2"),
-      type: "cma_case")
-
-    get "/search?filter_document_type=cma_case&filter_opened_date=from:2017-07-01 12:00,to:2017-07-01 23:30:00"
-
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("results")).to contain_exactly(
-      hash_including("link" => "/cma-1"),
-      hash_including("link" => "/cma-2"),
-    )
-  end
-
-  it "cannot_provide_date_filter_key_multiple_times" do
-    get "/search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
-
-    expect(last_response.status).to eq(422)
-    expect(
-      { "error" => %{Too many values (2) for parameter "opened_date" (must occur at most once)} }
-    ).to eq(
-      parsed_response,
-    )
-  end
-
-  it "cannot_provide_invalid_dates_for_date_filter" do
-    get "/search?filter_document_type=cma_case&filter_opened_date=from:not-a-date"
-
-    expect(last_response.status).to eq(422)
-    expect(
-      { "error" => %{Invalid "from" value "not-a-date" for parameter "opened_date" (expected ISO8601 date)} }
-    ).to eq(
-      parsed_response,
-    )
-  end
-
-  it "expandinging_of_organisations" do
-    commit_document("mainstream_test",
-      "title" => 'Advice on Treatment of Dragons',
-      "link" => '/dragon-guide',
-      "organisations" => ['/ministry-of-magic']
-    )
-
-    commit_document("government_test",
-      "slug" => '/ministry-of-magic',
-      "title" => 'Ministry of Magic',
-      "link" => '/ministry-of-magic-site',
-      "format" => 'organisation'
-    )
-
-    get "/search.json?q=dragons"
-
-    expect(first_result['organisations']).to eq(
-      [{ "slug" => "/ministry-of-magic",
-         "link" => "/ministry-of-magic-site",
-         "title" => "Ministry of Magic" }]
-    )
-  end
-
-  it "expandinging_of_organisations_via_content_id" do
-    commit_document(
-      "mainstream_test",
-      "title" => 'Advice on Treatment of Dragons',
-      "link" => '/dragon-guide',
-      "organisation_content_ids" => ['organisation-content-id']
-    )
-
-    commit_document(
-      "government_test",
-      "content_id" => 'organisation-content-id',
-      "slug" => '/ministry-of-magic',
-      "title" => 'Ministry of Magic',
-      "link" => '/ministry-of-magic-site',
-      "format" => 'organisation'
-    )
-
-    get "/search.json?q=dragons"
-
-    # Adds a new key with the expanded organisations
-    expect(
-      first_result['expanded_organisations']
-    ).to eq(
-      [
-        {
-          "content_id" => 'organisation-content-id',
-          "slug" => '/ministry-of-magic',
-          "link" => '/ministry-of-magic-site',
-          "title" => 'Ministry of Magic',
-        }
-      ]
-    )
-
-    # Keeps the organisation content ids
-    expect(
-      first_result['organisation_content_ids']
-    ).to eq(
-      ['organisation-content-id']
-    )
-  end
-
-  it "search_for_expanded_organisations_works" do
-    commit_document(
-      "mainstream_test",
-      "title" => 'Advice on Treatment of Dragons',
-      "link" => '/dragon-guide',
-      "organisation_content_ids" => ['organisation-content-id']
-    )
-
-    commit_document(
-      "government_test",
-      "content_id" => 'organisation-content-id',
-      "slug" => '/ministry-of-magic',
-      "title" => 'Ministry of Magic',
-      "link" => '/ministry-of-magic-site',
-      "format" => 'organisation'
-    )
-
-    get "/search.json?q=dragons&fields[]=expanded_organisations"
-
-    expect(first_result['expanded_organisations']).to be_truthy
-  end
-
-  it "filter_by_organisation_content_ids_works" do
-    commit_document(
-      "mainstream_test",
-      "title" => 'Advice on Treatment of Dragons',
-      "link" => '/dragon-guide',
-      "organisation_content_ids" => ['organisation-content-id']
-    )
-
-    commit_document(
-      "government_test",
-      "content_id" => 'organisation-content-id',
-      "slug" => '/ministry-of-magic',
-      "title" => 'Ministry of Magic',
-      "link" => '/ministry-of-magic-site',
-      "format" => 'organisation'
-    )
-
-    get "/search.json?filter_organisation_content_ids[]=organisation-content-id"
-
-    expect(first_result['expanded_organisations']).to be_truthy
-  end
-
-  it "expandinging_of_topics" do
-    commit_document("mainstream_test",
-      "title" => 'Advice on Treatment of Dragons',
-      "link" => '/dragon-guide',
-      "topic_content_ids" => ['topic-content-id']
-    )
-
-    commit_document("government_test",
-      "content_id" => 'topic-content-id',
-      "slug" => 'topic-magic',
-      "title" => 'Magic topic',
-      "link" => '/magic-topic-site',
-      # TODO: we should rename this format to `topic` and update all apps
-      "format" => 'specialist_sector'
-    )
-
-    get "/search.json?q=dragons"
-
-    # Adds a new key with the expanded topics
-    expect(
-      first_result['expanded_topics']
-    ).to eq(
-      [
-        {
-          "content_id" => 'topic-content-id',
-          "slug" => "topic-magic",
-          "link" => "/magic-topic-site",
-          "title" => "Magic topic"
-        }
-      ]
-    )
-
-    # Keeps the topic content ids
-    expect(first_result['topic_content_ids']).to eq(['topic-content-id'])
-  end
-
-  it "filter_by_topic_content_ids_works" do
-    commit_document("mainstream_test",
-      "title" => 'Advice on Treatment of Dragons',
-      "link" => '/dragon-guide',
-      "topic_content_ids" => ['topic-content-id']
-    )
-
-    commit_document("government_test",
-      "content_id" => 'topic-content-id',
-      "slug" => 'topic-magic',
-      "title" => 'Magic topic',
-      "link" => '/magic-topic-site',
-      # TODO: we should rename this format to `topic` and update all apps
-      "format" => 'specialist_sector'
-    )
-    get "/search.json?filter_topic_content_ids[]=topic-content-id"
-
-    expect(first_result['expanded_topics']).to be_truthy
-  end
-
-  it "id_search" do
-    build_sample_documents_on_content_indices(documents_per_index: 1)
-
-    get "/search?q=id1&debug=new_weighting"
-
-    expect(result_links).to include "/mainstream-1"
-  end
-
-  it "withdrawn_content" do
-    commit_document("mainstream_test",
-      "title" => "I am the result",
-      "description" => "This is a test search result",
-      "link" => "/some-nice-link",
-      "is_withdrawn" => true
-    )
-
-    get "/search?q=test"
-    expect(parsed_response.fetch("total")).to eq(0)
-  end
-
-  it "withdrawn_content_with_flag" do
-    commit_document("mainstream_test",
-      "title" => "I am the result",
-      "description" => "This is a test search result",
-      "link" => "/some-nice-link",
-      "is_withdrawn" => true
-    )
-
-    get "/search?q=test&debug=include_withdrawn&fields[]=is_withdrawn"
-    expect(parsed_response.fetch("total")).to eq(1)
-    expect(parsed_response.dig("results", 0, "is_withdrawn")).to be true
-  end
-
-  it "withdrawn_content_with_flag_with_aggregations" do
-    commit_document("mainstream_test",
-      "title" => "I am the result",
-      "organisation" => "Test Org",
-      "description" => "This is a test search result",
-      "link" => "/some-nice-link",
-      "is_withdrawn" => true
-    )
-
-    get "/search?q=test&debug=include_withdrawn&aggregate_mainstream_browse_pages=2"
-    expect(parsed_response.fetch("total")).to eq(1)
-  end
-
-  it "show_the_query" do
-    get "/search?q=test&debug=show_query"
-
-    expect(parsed_response.fetch("elasticsearch_query")).to be_truthy
-  end
-
-  it "taxonomy_can_be_returned" do
-    commit_document("mainstream_test",
-      "title" => "I am the result",
-      "description" => "This is a test search result",
-      "link" => "/some-nice-link",
-      "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
-    )
-
-    get "/search?q=test&fields[]=taxons"
-    expect(parsed_response.fetch("total")).to eq(1)
-
-    taxons = parsed_response.dig("results", 0, "taxons")
-    expect(taxons).to eq(["eb2093ef-778c-4105-9f33-9aa03d14bc5c"])
-  end
-
-  it "taxonomy_can_be_filtered" do
-    commit_document("mainstream_test",
-      "title" => "I am the result",
-      "description" => "This is a test search result",
-      "link" => "/some-nice-link",
-      "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
-    )
-
-    get "/search?filter_taxons=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
-
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
-    expect(
-      hash_including(
+    it "spell_checking_with_typo" do
+      commit_document("mainstream_test",
         "title" => "I am the result",
-        "link" => "/some-nice-link",
+        "description" => "This is a test search result",
+        "link" => "/some-nice-link"
       )
-    ).to eq(
-      parsed_response.fetch("results").fetch(0),
-    )
-  end
 
-  it "taxonomy_can_be_filtered_by_part" do
-    commit_document("mainstream_test",
-      "title" => "I am the result",
-      "description" => "This is a test search result",
-      "link" => "/some-nice-link",
-      "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"],
-      "part_of_taxonomy_tree" => %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
-    )
+      get_with_variant "/search?q=serch&suggest=spelling"
 
-    get "/search?filter_part_of_taxonomy_tree=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
+      expect(parsed_response['suggested_queries']).to eq(['search'])
+    end
 
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
+    it "spell_checking_with_blacklisted_typo" do
+      commit_document("mainstream_test",
+        "title" => "Brexitt",
+        "description" => "Brexitt",
+        "link" => "/brexitt")
 
-    get "/search?filter_part_of_taxonomy_tree=aa2093ef-778c-4105-9f33-9aa03d14bc5c"
+      get_with_variant "/search?q=brexit&suggest=spelling"
 
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
-  end
+      expect(parsed_response['suggested_queries']).to eq([])
+    end
 
-  it "return_400_response_for_integers_out_of_range" do
-    get '/search.json?count=50&start=7599999900'
+    it "spell_checking_without_typo" do
+      build_sample_documents_on_content_indices(documents_per_index: 1)
 
-    expect(last_response).to be_bad_request
-    expect(last_response.body).to eq('Integer value of 7599999900 exceeds maximum allowed')
-  end
+      get_with_variant "/search?q=milliband"
 
-  it "return_400_response_for_query_term_length_too_long" do
-    terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
-    get "/search.json?q=#{terms}"
+      expect(parsed_response['suggested_queries']).to eq([])
+    end
 
-    expect(last_response).to be_bad_request
-    expect(last_response.body).to eq('Query must be less than 1024 words')
-  end
+    it "returns_docs_from_all_indexes" do
+      build_sample_documents_on_content_indices(documents_per_index: 1)
+
+      get_with_variant "/search?q=important"
+
+      expect(result_links).to include "/government-1"
+      expect(result_links).to include "/mainstream-1"
+    end
+
+    it "sort_by_date_ascending" do
+      build_sample_documents_on_content_indices(documents_per_index: 2)
+
+      get_with_variant "/search?q=important&order=public_timestamp"
+
+      expect(result_links.take(2)).to eq(["/government-1", "/government-2"])
+    end
+
+    it "sort_by_date_descending" do
+      build_sample_documents_on_content_indices(documents_per_index: 2)
+
+      get_with_variant "/search?q=important&order=-public_timestamp"
+
+      # The government links have dates, so appear before all the other links.
+      # The other documents have no dates, so appear in an undefined order
+      expect(result_links.take(2)).to eq(["/government-2", "/government-1"])
+    end
+
+    it "sort_by_title_ascending" do
+      build_sample_documents_on_content_indices(documents_per_index: 1)
+
+      get_with_variant "/search?order=title"
+      lowercase_titles = result_titles.map(&:downcase)
+
+      expect(lowercase_titles).to eq(lowercase_titles.sort)
+    end
+
+    it "filter_by_field" do
+      build_sample_documents_on_content_indices(documents_per_index: 1)
+
+      get_with_variant "/search?filter_mainstream_browse_pages=browse/page/1"
+
+      expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
+    end
+
+    it "reject_by_field" do
+      build_sample_documents_on_content_indices(documents_per_index: 2)
+
+      get_with_variant "/search?reject_mainstream_browse_pages=browse/page/1"
+
+      expect(result_links.sort).to eq(["/government-2", "/mainstream-2"])
+    end
+
+    it "can_filter_for_missing_field" do
+      build_sample_documents_on_content_indices(documents_per_index: 1)
+
+      get_with_variant "/search?filter_specialist_sectors=_MISSING"
+
+      expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
+    end
+
+    it "can_filter_for_missing_or_specific_value_in_field" do
+      build_sample_documents_on_content_indices(documents_per_index: 1)
+
+      get_with_variant "/search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
+
+      expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
+    end
+
+    it "can_filter_and_reject" do
+      build_sample_documents_on_content_indices(documents_per_index: 2)
+
+      get_with_variant "/search?reject_mainstream_browse_pages=1&filter_specialist_sectors[]=farming"
+
+      expect([
+        "/government-2",
+        "/mainstream-2",
+      ]).to eq(result_links.sort)
+    end
+
+    it "only_contains_fields_which_are_present" do
+      build_sample_documents_on_content_indices(documents_per_index: 2)
+
+      get_with_variant "/search?q=important&order=public_timestamp"
+
+      results = parsed_response["results"]
+      expect(results[0].keys).not_to include("specialist_sectors")
+      expect(results[1]["specialist_sectors"]).to eq([{ "slug" => "farming" }])
+    end
+
+    it "validates_integer_params" do
+      get_with_variant "/search?start=a"
+
+      expect(last_response.status).to eq(422)
+      expect(parsed_response).to eq({ "error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)" })
+    end
+
+    it "allows_integer_params_leading_zeros" do
+      get_with_variant "/search?start=09"
+
+      expect(last_response).to be_ok
+    end
+
+    it "validates_unknown_params" do
+      get_with_variant "/search?foo&bar=1"
+
+      expect(last_response.status).to eq(422)
+      expect(parsed_response).to eq("error" => "Unexpected parameters: foo, bar")
+    end
+
+    it "debug_explain_returns_explanations" do
+      build_sample_documents_on_content_indices(documents_per_index: 1)
+
+      get_with_variant "/search?debug=explain"
+
+      first_hit_explain = parsed_response["results"].first["_explanation"]
+      expect(first_hit_explain).not_to be_nil
+      expect(first_hit_explain.keys).to include("value")
+      expect(first_hit_explain.keys).to include("description")
+      expect(first_hit_explain.keys).to include("details")
+    end
+
+    it "can_scope_by_elasticsearch_type" do
+      commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
+
+      get_with_variant "/search?filter_document_type=cma_case"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("total")).to eq(1)
+      expect(
+        hash_including(
+          "document_type" => "cma_case",
+          "title" => cma_case_attributes.fetch("title"),
+          "link" => cma_case_attributes.fetch("link"),
+        )
+      ).to eq(
+        parsed_response.fetch("results").fetch(0),
+      )
+    end
+
+    it "can_filter_between_dates" do
+      commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
+
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("total")).to eq(1)
+      expect(
+        hash_including(
+          "title" => cma_case_attributes.fetch("title"),
+          "link" => cma_case_attributes.fetch("link"),
+        )
+      ).to eq(
+        parsed_response.fetch("results").fetch(0),
+      )
+    end
+
+    it "can_filter_between_dates_with_reversed_parameter_order" do
+      commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
+
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("total")).to eq(1)
+      expect(
+        hash_including(
+          "title" => cma_case_attributes.fetch("title"),
+          "link" => cma_case_attributes.fetch("link"),
+        )
+      ).to eq(
+        parsed_response.fetch("results").fetch(0),
+      )
+    end
+
+    it "can filter from date" do
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-03-30", "link" => "/old-cma-with-date"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-03-30T23:00:00.000+00:00", "link" => "/old-cma-with-datetime"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-03-31", "link" => "/matching-cma-with-date"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-03-31T00:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
+        type: "cma_case")
+
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("results")).to contain_exactly(
+        hash_including("link" => "/matching-cma-with-date"),
+        hash_including("link" => "/matching-cma-with-datetime"),
+      )
+    end
+
+    it "can filter from time" do
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-03-31", "link" => "/old-cma-with-date"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-03-31T13:59:59.000+00:00", "link" => "/old-cma-with-datetime"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-01", "link" => "/matching-cma-with-date"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-03-31T14:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
+        type: "cma_case")
+
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31 14:00:00"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("results")).to contain_exactly(
+        hash_including("link" => "/matching-cma-with-date"),
+        hash_including("link" => "/matching-cma-with-datetime"),
+      )
+    end
+
+    it "can filter to date" do
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-02", "link" => "/matching-cma-with-date"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-02T05:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-03", "link" => "/future-cma-with-date"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-03T00:00:00.000+00:00", "link" => "/future-cma-with-datetime"),
+        type: "cma_case")
+
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("results")).to contain_exactly(
+        hash_including("link" => "/matching-cma-with-date"),
+        hash_including("link" => "/matching-cma-with-datetime"),
+      )
+    end
+
+    it "can filter to time" do
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-02", "link" => "/matching-cma-with-date"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-02T11:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-03", "link" => "/future-cma-with-date"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2014-04-02T11:00:01.000+00:00", "link" => "/future-cma-with-datetime"),
+        type: "cma_case")
+
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02 11:00:00"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("results")).to contain_exactly(
+        hash_including("link" => "/matching-cma-with-date"),
+        hash_including("link" => "/matching-cma-with-datetime"),
+      )
+    end
+
+    it "can filter times in different time zones" do
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2017-07-01T11:20:00.000-03:00", "link" => "/cma-1"),
+        type: "cma_case")
+      commit_document(
+        "mainstream_test",
+        cma_case_attributes("opened_date" => "2017-07-02T00:15:00.000+01:00", "link" => "/cma-2"),
+        type: "cma_case")
+
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=from:2017-07-01 12:00,to:2017-07-01 23:30:00"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("results")).to contain_exactly(
+        hash_including("link" => "/cma-1"),
+        hash_including("link" => "/cma-2"),
+      )
+    end
+
+    it "cannot_provide_date_filter_key_multiple_times" do
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
+
+      expect(last_response.status).to eq(422)
+      expect(
+        { "error" => %{Too many values (2) for parameter "opened_date" (must occur at most once)} }
+      ).to eq(
+        parsed_response,
+      )
+    end
+
+    it "cannot_provide_invalid_dates_for_date_filter" do
+      get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=from:not-a-date"
+
+      expect(last_response.status).to eq(422)
+      expect(
+        { "error" => %{Invalid "from" value "not-a-date" for parameter "opened_date" (expected ISO8601 date)} }
+      ).to eq(
+        parsed_response,
+      )
+    end
+
+    it "expandinging_of_organisations" do
+      commit_document("mainstream_test",
+        "title" => 'Advice on Treatment of Dragons',
+        "link" => '/dragon-guide',
+        "organisations" => ['/ministry-of-magic']
+      )
+
+      commit_document("government_test",
+        "slug" => '/ministry-of-magic',
+        "title" => 'Ministry of Magic',
+        "link" => '/ministry-of-magic-site',
+        "format" => 'organisation'
+      )
+
+      get_with_variant "/search.json?q=dragons"
+
+      expect(first_result['organisations']).to eq(
+        [{ "slug" => "/ministry-of-magic",
+           "link" => "/ministry-of-magic-site",
+           "title" => "Ministry of Magic" }]
+      )
+    end
+
+    it "expandinging_of_organisations_via_content_id" do
+      commit_document(
+        "mainstream_test",
+        "title" => 'Advice on Treatment of Dragons',
+        "link" => '/dragon-guide',
+        "organisation_content_ids" => ['organisation-content-id']
+      )
+
+      commit_document(
+        "government_test",
+        "content_id" => 'organisation-content-id',
+        "slug" => '/ministry-of-magic',
+        "title" => 'Ministry of Magic',
+        "link" => '/ministry-of-magic-site',
+        "format" => 'organisation'
+      )
+
+      get_with_variant "/search.json?q=dragons"
+
+      # Adds a new key with the expanded organisations
+      expect(
+        first_result['expanded_organisations']
+      ).to eq(
+        [
+          {
+            "content_id" => 'organisation-content-id',
+            "slug" => '/ministry-of-magic',
+            "link" => '/ministry-of-magic-site',
+            "title" => 'Ministry of Magic',
+          }
+        ]
+      )
+
+      # Keeps the organisation content ids
+      expect(
+        first_result['organisation_content_ids']
+      ).to eq(
+        ['organisation-content-id']
+      )
+    end
+
+    it "search_for_expanded_organisations_works" do
+      commit_document(
+        "mainstream_test",
+        "title" => 'Advice on Treatment of Dragons',
+        "link" => '/dragon-guide',
+        "organisation_content_ids" => ['organisation-content-id']
+      )
+
+      commit_document(
+        "government_test",
+        "content_id" => 'organisation-content-id',
+        "slug" => '/ministry-of-magic',
+        "title" => 'Ministry of Magic',
+        "link" => '/ministry-of-magic-site',
+        "format" => 'organisation'
+      )
+
+      get_with_variant "/search.json?q=dragons&fields[]=expanded_organisations"
+
+      expect(first_result['expanded_organisations']).to be_truthy
+    end
+
+    it "filter_by_organisation_content_ids_works" do
+      commit_document(
+        "mainstream_test",
+        "title" => 'Advice on Treatment of Dragons',
+        "link" => '/dragon-guide',
+        "organisation_content_ids" => ['organisation-content-id']
+      )
+
+      commit_document(
+        "government_test",
+        "content_id" => 'organisation-content-id',
+        "slug" => '/ministry-of-magic',
+        "title" => 'Ministry of Magic',
+        "link" => '/ministry-of-magic-site',
+        "format" => 'organisation'
+      )
+
+      get_with_variant "/search.json?filter_organisation_content_ids[]=organisation-content-id"
+
+      expect(first_result['expanded_organisations']).to be_truthy
+    end
+
+    it "expandinging_of_topics" do
+      commit_document("mainstream_test",
+        "title" => 'Advice on Treatment of Dragons',
+        "link" => '/dragon-guide',
+        "topic_content_ids" => ['topic-content-id']
+      )
+
+      commit_document("government_test",
+        "content_id" => 'topic-content-id',
+        "slug" => 'topic-magic',
+        "title" => 'Magic topic',
+        "link" => '/magic-topic-site',
+        # TODO: we should rename this format to `topic` and update all apps
+        "format" => 'specialist_sector'
+      )
+
+      get_with_variant "/search.json?q=dragons"
+
+      # Adds a new key with the expanded topics
+      expect(
+        first_result['expanded_topics']
+      ).to eq(
+        [
+          {
+            "content_id" => 'topic-content-id',
+            "slug" => "topic-magic",
+            "link" => "/magic-topic-site",
+            "title" => "Magic topic"
+          }
+        ]
+      )
+
+      # Keeps the topic content ids
+      expect(first_result['topic_content_ids']).to eq(['topic-content-id'])
+    end
+
+    it "filter_by_topic_content_ids_works" do
+      commit_document("mainstream_test",
+        "title" => 'Advice on Treatment of Dragons',
+        "link" => '/dragon-guide',
+        "topic_content_ids" => ['topic-content-id']
+      )
+
+      commit_document("government_test",
+        "content_id" => 'topic-content-id',
+        "slug" => 'topic-magic',
+        "title" => 'Magic topic',
+        "link" => '/magic-topic-site',
+        # TODO: we should rename this format to `topic` and update all apps
+        "format" => 'specialist_sector'
+      )
+      get_with_variant "/search.json?filter_topic_content_ids[]=topic-content-id"
+
+      expect(first_result['expanded_topics']).to be_truthy
+    end
+
+    it "id_search" do
+      build_sample_documents_on_content_indices(documents_per_index: 1)
+
+      get_with_variant "/search?q=id1&debug=new_weighting"
+
+      expect(result_links).to include "/mainstream-1"
+    end
+
+    it "withdrawn_content" do
+      commit_document("mainstream_test",
+        "title" => "I am the result",
+        "description" => "This is a test search result",
+        "link" => "/some-nice-link",
+        "is_withdrawn" => true
+      )
+
+      get_with_variant "/search?q=test"
+      expect(parsed_response.fetch("total")).to eq(0)
+    end
+
+    it "withdrawn_content_with_flag" do
+      commit_document("mainstream_test",
+        "title" => "I am the result",
+        "description" => "This is a test search result",
+        "link" => "/some-nice-link",
+        "is_withdrawn" => true
+      )
+
+      get_with_variant "/search?q=test&debug=include_withdrawn&fields[]=is_withdrawn"
+      expect(parsed_response.fetch("total")).to eq(1)
+      expect(parsed_response.dig("results", 0, "is_withdrawn")).to be true
+    end
+
+    it "withdrawn_content_with_flag_with_aggregations" do
+      commit_document("mainstream_test",
+        "title" => "I am the result",
+        "organisation" => "Test Org",
+        "description" => "This is a test search result",
+        "link" => "/some-nice-link",
+        "is_withdrawn" => true
+      )
+
+      get_with_variant "/search?q=test&debug=include_withdrawn&aggregate_mainstream_browse_pages=2"
+      expect(parsed_response.fetch("total")).to eq(1)
+    end
+
+    it "show_the_query" do
+      get_with_variant "/search?q=test&debug=show_query"
+
+      expect(parsed_response.fetch("elasticsearch_query")).to be_truthy
+    end
+
+    it "taxonomy_can_be_returned" do
+      commit_document("mainstream_test",
+        "title" => "I am the result",
+        "description" => "This is a test search result",
+        "link" => "/some-nice-link",
+        "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
+      )
+
+      get_with_variant "/search?q=test&fields[]=taxons"
+      expect(parsed_response.fetch("total")).to eq(1)
+
+      taxons = parsed_response.dig("results", 0, "taxons")
+      expect(taxons).to eq(["eb2093ef-778c-4105-9f33-9aa03d14bc5c"])
+    end
+
+    it "taxonomy_can_be_filtered" do
+      commit_document("mainstream_test",
+        "title" => "I am the result",
+        "description" => "This is a test search result",
+        "link" => "/some-nice-link",
+        "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"]
+      )
+
+      get_with_variant "/search?filter_taxons=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("total")).to eq(1)
+      expect(
+        hash_including(
+          "title" => "I am the result",
+          "link" => "/some-nice-link",
+        )
+      ).to eq(
+        parsed_response.fetch("results").fetch(0),
+      )
+    end
+
+    it "taxonomy_can_be_filtered_by_part" do
+      commit_document("mainstream_test",
+        "title" => "I am the result",
+        "description" => "This is a test search result",
+        "link" => "/some-nice-link",
+        "taxons" => ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"],
+        "part_of_taxonomy_tree" => %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
+      )
+
+      get_with_variant "/search?filter_part_of_taxonomy_tree=eb2093ef-778c-4105-9f33-9aa03d14bc5c"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("total")).to eq(1)
+
+      get_with_variant "/search?filter_part_of_taxonomy_tree=aa2093ef-778c-4105-9f33-9aa03d14bc5c"
+
+      expect(last_response).to be_ok
+      expect(parsed_response.fetch("total")).to eq(1)
+    end
+
+    it "return_400_response_for_integers_out_of_range" do
+      get '/search.json?count=50&start=7599999900'
+
+      expect(last_response).to be_bad_request
+      expect(last_response.body).to eq('Integer value of 7599999900 exceeds maximum allowed')
+    end
+
+    it "return_400_response_for_query_term_length_too_long" do
+      terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
+      get_with_variant "/search.json?q=#{terms}"
+
+      expect(last_response).to be_bad_request
+      expect(last_response.body).to eq('Query must be less than 1024 words')
+    end
+end
 
 private
 

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'SearchTest' do
         "title" => "Get P45, P60 and other forms for your employees",
         "description" => "Get PAYE forms from HMRC including P45, P60, starter checklist (which replaced the P46), P11D(b)",
         "link" => "/get-paye-forms-p45-p60"
-
       )
 
       get_with_variant "/search?q=p+60&debug=use_id_codes"
@@ -30,7 +29,8 @@ RSpec.describe 'SearchTest' do
     end
 
     it "spell_checking_with_typo" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "I am the result",
         "description" => "This is a test search result",
         "link" => "/some-nice-link"
@@ -42,10 +42,12 @@ RSpec.describe 'SearchTest' do
     end
 
     it "spell_checking_with_blacklisted_typo" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "Brexitt",
         "description" => "Brexitt",
-        "link" => "/brexitt")
+        "link" => "/brexitt"
+      )
 
       get_with_variant "/search?q=brexit&suggest=spelling"
 
@@ -237,19 +239,23 @@ RSpec.describe 'SearchTest' do
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-03-30", "link" => "/old-cma-with-date"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-03-30T23:00:00.000+00:00", "link" => "/old-cma-with-datetime"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-03-31", "link" => "/matching-cma-with-date"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-03-31T00:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
-        type: "cma_case")
+        type: "cma_case"
+      )
 
       get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31"
 
@@ -264,19 +270,23 @@ RSpec.describe 'SearchTest' do
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-03-31", "link" => "/old-cma-with-date"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-03-31T13:59:59.000+00:00", "link" => "/old-cma-with-datetime"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-01", "link" => "/matching-cma-with-date"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-03-31T14:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
-        type: "cma_case")
+        type: "cma_case"
+      )
 
       get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31 14:00:00"
 
@@ -291,19 +301,23 @@ RSpec.describe 'SearchTest' do
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-02", "link" => "/matching-cma-with-date"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-02T05:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-03", "link" => "/future-cma-with-date"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-03T00:00:00.000+00:00", "link" => "/future-cma-with-datetime"),
-        type: "cma_case")
+        type: "cma_case"
+      )
 
       get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02"
 
@@ -318,19 +332,23 @@ RSpec.describe 'SearchTest' do
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-02", "link" => "/matching-cma-with-date"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-02T11:00:00.000+00:00", "link" => "/matching-cma-with-datetime"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-03", "link" => "/future-cma-with-date"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2014-04-02T11:00:01.000+00:00", "link" => "/future-cma-with-datetime"),
-        type: "cma_case")
+        type: "cma_case"
+      )
 
       get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02 11:00:00"
 
@@ -345,11 +363,13 @@ RSpec.describe 'SearchTest' do
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2017-07-01T11:20:00.000-03:00", "link" => "/cma-1"),
-        type: "cma_case")
+        type: "cma_case"
+      )
       commit_document(
         "mainstream_test",
         cma_case_attributes("opened_date" => "2017-07-02T00:15:00.000+01:00", "link" => "/cma-2"),
-        type: "cma_case")
+        type: "cma_case"
+      )
 
       get_with_variant "/search?filter_document_type=cma_case&filter_opened_date=from:2017-07-01 12:00,to:2017-07-01 23:30:00"
 
@@ -382,14 +402,16 @@ RSpec.describe 'SearchTest' do
       )
     end
 
-    it "expandinging_of_organisations" do
-      commit_document("mainstream_test",
+    it "expanding_of_organisations" do
+      commit_document(
+        "mainstream_test",
         "title" => 'Advice on Treatment of Dragons',
         "link" => '/dragon-guide',
         "organisations" => ['/ministry-of-magic']
       )
 
-      commit_document("government_test",
+      commit_document(
+        "government_test",
         "slug" => '/ministry-of-magic',
         "title" => 'Ministry of Magic',
         "link" => '/ministry-of-magic-site',
@@ -405,7 +427,7 @@ RSpec.describe 'SearchTest' do
       )
     end
 
-    it "expandinging_of_organisations_via_content_id" do
+    it "expanding_of_organisations_via_content_id" do
       commit_document(
         "mainstream_test",
         "title" => 'Advice on Treatment of Dragons',
@@ -491,13 +513,15 @@ RSpec.describe 'SearchTest' do
     end
 
     it "expandinging_of_topics" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => 'Advice on Treatment of Dragons',
         "link" => '/dragon-guide',
         "topic_content_ids" => ['topic-content-id']
       )
 
-      commit_document("government_test",
+      commit_document(
+        "government_test",
         "content_id" => 'topic-content-id',
         "slug" => 'topic-magic',
         "title" => 'Magic topic',
@@ -527,13 +551,15 @@ RSpec.describe 'SearchTest' do
     end
 
     it "filter_by_topic_content_ids_works" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => 'Advice on Treatment of Dragons',
         "link" => '/dragon-guide',
         "topic_content_ids" => ['topic-content-id']
       )
 
-      commit_document("government_test",
+      commit_document(
+        "government_test",
         "content_id" => 'topic-content-id',
         "slug" => 'topic-magic',
         "title" => 'Magic topic',
@@ -555,7 +581,8 @@ RSpec.describe 'SearchTest' do
     end
 
     it "withdrawn_content" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "I am the result",
         "description" => "This is a test search result",
         "link" => "/some-nice-link",
@@ -567,7 +594,8 @@ RSpec.describe 'SearchTest' do
     end
 
     it "withdrawn_content_with_flag" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "I am the result",
         "description" => "This is a test search result",
         "link" => "/some-nice-link",
@@ -580,7 +608,8 @@ RSpec.describe 'SearchTest' do
     end
 
     it "withdrawn_content_with_flag_with_aggregations" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "I am the result",
         "organisation" => "Test Org",
         "description" => "This is a test search result",
@@ -599,7 +628,8 @@ RSpec.describe 'SearchTest' do
     end
 
     it "taxonomy_can_be_returned" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "I am the result",
         "description" => "This is a test search result",
         "link" => "/some-nice-link",
@@ -614,7 +644,8 @@ RSpec.describe 'SearchTest' do
     end
 
     it "taxonomy_can_be_filtered" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "I am the result",
         "description" => "This is a test search result",
         "link" => "/some-nice-link",
@@ -636,7 +667,8 @@ RSpec.describe 'SearchTest' do
     end
 
     it "taxonomy_can_be_filtered_by_part" do
-      commit_document("mainstream_test",
+      commit_document(
+        "mainstream_test",
         "title" => "I am the result",
         "description" => "This is a test search result",
         "link" => "/some-nice-link",
@@ -669,7 +701,7 @@ RSpec.describe 'SearchTest' do
       expect(last_response).to be_bad_request
       expect(last_response.body).to eq('Query must be less than 1024 words')
     end
-end
+  end
 
 private
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,7 @@ Sidekiq::Logging.logger = nil
 
 require 'webmock/rspec'
 
+require "#{__dir__}/support/ab_spec_helper"
 require "#{__dir__}/support/default_mappings"
 require "#{__dir__}/support/spec_helpers"
 require "#{__dir__}/support/hash_including_helpers"

--- a/spec/support/ab_spec_helper.rb
+++ b/spec/support/ab_spec_helper.rb
@@ -1,0 +1,16 @@
+module ABVariants
+  def with_ab_variants(&block)
+    %w(A B).each do |variant|
+      context "with '#{variant}' variant" do
+        let(:ab_variant) { variant }
+        module_eval(&block)
+      end
+    end
+  end
+
+  def get_with_variant path
+    get path + "&ab_tests=synonyms:#{ab_variant}"
+  end
+
+  RSpec.configure { |c| c.extend self }
+end

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -1,6 +1,8 @@
 require 'spec/support/index_helpers'
 
 module IntegrationSpecHelper
+  include ABVariants
+
   SAMPLE_DOCUMENT_ATTRIBUTES = {
     "title" => "TITLE1",
     "description" => "DESCRIPTION",


### PR DESCRIPTION
This is just an idea. Feedback welcome on whether it's a _good_ idea, and also on how to make it easier to configure in RSpec.

Most of our A/B tests only affect a small part of the search functionality. For example, changing format weighting or synonyms shouldn't affect best bets or quoted search terms.

This means that most of the existing integration tests are applicable to both the A and the B variant, but we normally don't run them against B. Being able to run them for both would give us more confidence that we haven't caused any regressions in B. We worried about this we configured the synonyms A/B test because changing the analyzers is quite fiddly.

This change runs the integration tests which hit the `/search` endpoint twice: once for each variant. It does it by wrapping the test definitions in a block, which makes it easy to define separate tests which really do apply to just A or B.

Things that don't work so well (but might be fixable with some RSpec magic):
- The diff is enormous because the change indents all the tests. This would happen each time you set up or remove an A/B test.
- You have to change `get` to `get_with_variant` in each test, otherwise all the tests will silently use the A variant.

https://trello.com/c/PqwdCw1d/447-configure-synonym-a-b-query-in-rummager

Paired with @Rosa-Fox on the initial idea.