### PR TITLE
Map collections fields for govuk index

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -31,6 +31,7 @@ service_manual_service_standard: service_manual_guide
 service_manual_topic: service_manual_topic
 service_standard_report: service_standard_report # Specialist Publisher
 simple_smart_answer: edition
+topic: edition # Collections Publisher
 task_list: edition
 tax_tribunal_decision: tax_tribunal_decision # Specialist Publisher
 transaction: edition

--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -19,6 +19,7 @@ international_development_fund: international_development_fund # Specialist Publ
 licence: edition
 local_transaction: edition
 maib_report: maib_report # Specialist Publisher
+mainstream_browse_page: edition # Collections Publisher
 manual: manual
 manual_section: manual_section
 medical_safety_alert: medical_safety_alert # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -40,4 +40,8 @@ migrated:
 - task_list
 
 indexable:
+- mainstream_browse_page
+- service_manual_guide
+- service_manual_topic
+- topic
 - travel_advice

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -43,5 +43,5 @@ indexable:
 - mainstream_browse_page
 - service_manual_guide
 - service_manual_topic
-- topic
+- specialist_sector
 - travel_advice

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -41,7 +41,5 @@ migrated:
 
 indexable:
 - mainstream_browse_page
-- service_manual_guide
-- service_manual_topic
 - specialist_sector
 - travel_advice

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -4,6 +4,7 @@ module GovukIndex
       "esi_fund" => "european_structural_investment_fund",
       "service_manual_homepage" => "service_manual_guide",
       "service_manual_service_standard" => "service_manual_guide",
+      "topic" => "specialist_sector",
     }.freeze
     extend MethodBuilder
 

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -143,7 +143,7 @@ module GovukIndex
     end
 
     def slug
-      if format == "topic"
+      if format == "specialist_sector"
         base_path.gsub(%r{^/topic/}, '')
       elsif format == "mainstream_browse_page"
         base_path.gsub(%r{^/browse/}, '')

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -94,6 +94,7 @@ module GovukIndex
         report_type:                         specialist.report_type,
         search_user_need_document_supertype: common_fields.search_user_need_document_supertype,
         serial_number:                       specialist.serial_number,
+        slug:                                slug,
         specialist_sectors:                  expanded_links.specialist_sectors,
         taxons:                              expanded_links.taxons,
         therapeutic_area:                    specialist.therapeutic_area,
@@ -133,16 +134,24 @@ module GovukIndex
 
     attr_reader :payload
 
-    def common_fields
-      @_common_fields ||= CommonFieldsPresenter.new(payload)
-    end
-
     def indexable
       IndexableContentPresenter.new(
         format: common_fields.format,
         details: payload["details"],
         sanitiser: IndexableContentSanitiser.new,
       )
+    end
+
+    def slug
+      if format == "topic"
+        base_path.gsub(%r{^/topic/}, '')
+      elsif format == "mainstream_browse_page"
+        base_path.gsub(%r{^/browse/}, '')
+      end
+    end
+
+    def common_fields
+      @_common_fields ||= CommonFieldsPresenter.new(payload)
     end
 
     def details

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -62,7 +62,7 @@ module GovukIndex
         grant_type:                          specialist.grant_type,
         hidden_indexable_content:            specialist.hidden_indexable_content,
         hmrc_manual_section_id:              common_fields.section_id,
-        indexable_content:                   indexable.indexable_content || common_fields.indexable_description,
+        indexable_content:                   indexable_content,
         industries:                          specialist.industries,
         is_withdrawn:                        common_fields.is_withdrawn,
         issued_date:                         specialist.issued_date,
@@ -134,12 +134,22 @@ module GovukIndex
 
     attr_reader :payload
 
+    INDEX_DESCRIPTION_FIELD = %w(manual service_manual_topic).freeze
+
     def indexable
       IndexableContentPresenter.new(
         format: common_fields.format,
         details: payload["details"],
         sanitiser: IndexableContentSanitiser.new,
       )
+    end
+
+    def indexable_content
+      if INDEX_DESCRIPTION_FIELD.include?(format)
+        common_fields.indexable_description
+      else
+        indexable.indexable_content
+      end
     end
 
     def slug

--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -7,7 +7,6 @@ module GovukIndex
       'transaction'   => %w(introductory_paragraph more_information),
       'travel_advice' => %w(summary),
     }.freeze
-    INDEX_DESCRIPTION_FIELD = %w(manual service_manual_topic).freeze
 
     def initialize(format:, details:, sanitiser:)
       @format    = format
@@ -16,7 +15,7 @@ module GovukIndex
     end
 
     def indexable_content
-      return nil if details.nil? || INDEX_DESCRIPTION_FIELD.include?(format)
+      return nil if details.nil?
       sanitiser.clean(indexable)
     end
 

--- a/spec/integration/govuk_index/collections_spec.rb
+++ b/spec/integration/govuk_index/collections_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Collections publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["topic"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["specialist_sector"])
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 

--- a/spec/integration/govuk_index/collections_spec.rb
+++ b/spec/integration/govuk_index/collections_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Collections publishing" do
 
     expected_document = {
        "link" => random_example["base_path"],
-       "indexable_content" => "Mainstream browse page description",
+       "indexable_content" => nil,
        "slug" => "benefits",
      }
 
@@ -56,7 +56,7 @@ RSpec.describe "Collections publishing" do
 
     expected_document = {
        "link" => random_example["base_path"],
-       "indexable_content" => "Specialist sector page description",
+       "indexable_content" => nil,
        "slug" => "benefits-credits",
      }
     expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")

--- a/spec/integration/govuk_index/collections_spec.rb
+++ b/spec/integration/govuk_index/collections_spec.rb
@@ -37,4 +37,27 @@ RSpec.describe "Collections publishing" do
 
     expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
   end
+
+  it "indexes a specialist_sector page" do
+    random_example = generate_random_example(
+      schema: "topic",
+      payload: {
+        document_type: "topic",
+        description: "Specialist sector page description"
+      },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
+    )
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["topic"])
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = {
+       "link" => random_example["base_path"],
+       "indexable_content" => "Specialist sector page description",
+       "slug" => "benefits-credits",
+     }
+
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
+  end
 end

--- a/spec/integration/govuk_index/collections_spec.rb
+++ b/spec/integration/govuk_index/collections_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe "Collections publishing" do
       schema: "mainstream_browse_page",
       payload: {
         document_type: "mainstream_browse_page",
-        description: "Mainstream browse page description"
+        description: "Mainstream browse page description",
+        base_path: "/browse/benefits",
       },
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
@@ -43,7 +44,8 @@ RSpec.describe "Collections publishing" do
       schema: "topic",
       payload: {
         document_type: "topic",
-        description: "Specialist sector page description"
+        description: "Specialist sector page description",
+        base_path: "/topic/benefits-credits",
       },
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
@@ -57,7 +59,6 @@ RSpec.describe "Collections publishing" do
        "indexable_content" => "Specialist sector page description",
        "slug" => "benefits-credits",
      }
-
     expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
   end
 end

--- a/spec/integration/govuk_index/collections_spec.rb
+++ b/spec/integration/govuk_index/collections_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe "Collections publishing" do
+  before do
+    bunny_mock = BunnyMock.new
+    @channel = bunny_mock.start.channel
+
+    consumer = GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "collections.test",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      rabbitmq_connection: bunny_mock
+    )
+
+    @queue = @channel.queue("collections.test")
+    consumer.run
+  end
+
+  it "indexes a mainstream browse page" do
+    random_example = generate_random_example(
+      schema: "mainstream_browse_page",
+      payload: {
+        document_type: "mainstream_browse_page",
+        description: "Mainstream browse page description"
+      },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
+    )
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["mainstream_browse_page"])
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = {
+       "link" => random_example["base_path"],
+       "indexable_content" => "Mainstream browse page description",
+       "slug" => "benefits",
+     }
+
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/8oQDr7ca/458-configure-rummager-for-moving-collections-to-govuk-index)

- sets up the ability to migrate the collections formats (`mainstream_browse_page` and `specialist_sector`) to `govuk` index.
-  Similar to mainstream but `slug` is generated from the `base_path`.