### PR TITLE
Check first 20 results in the health check

### DIFF
--- a/lib/health_check/search_checker.rb
+++ b/lib/health_check/search_checker.rb
@@ -2,6 +2,9 @@ module HealthCheck
   class SearchChecker
     attr_reader :search_client
 
+    # Default page size on GOV.UK search
+    RESULT_COUNT = 20
+
     def initialize(search_client:, test_data:, produce_report: true)
       @test_data_file = test_data
       @search_client = search_client
@@ -15,7 +18,7 @@ module HealthCheck
       Logging.logger[self].info("Connecting to #{@search_client}")
 
       checks.each do |check|
-        search_results = search_client.search(check.search_term)[:results]
+        search_results = search_client.search(check.search_term, count: RESULT_COUNT)[:results]
         check_result = check.result(search_results)
         check_result.write_to_log
         @file_output << check_result


### PR DESCRIPTION
Increase the search result count from the default (10) to 20 when running the healthcheck.

This will make it easier to judge the healthcheck results because users will see 20 results when the search on GOV.UK, so if a result is not found by the healthcheck then it will not be in the first page of results for a user.

https://trello.com/c/9VF3Rw5V/451-test-synonyms-with-healthcheck-and-search-performance-explorer