### PR TITLE
Reinstate flag for disabling synonyms

### DIFF
--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -3,6 +3,7 @@ require "search/query_helpers"
 module QueryComponents
   class CoreQuery < BaseComponent
     DEFAULT_QUERY_ANALYZER = "query_with_old_synonyms".freeze
+    DEFAULT_QUERY_ANALYZER_WITHOUT_SYNONYMS = "default".freeze
 
     # If the search query is a single quoted phrase, we run a different query,
     # which uses phrase matching across various fields.
@@ -85,7 +86,7 @@ module QueryComponents
         match: {
           field_name => {
             query: escape(search_term),
-            analyzer: DEFAULT_QUERY_ANALYZER,
+            analyzer: query_analyzer,
             minimum_should_match: MINIMUM_SHOULD_MATCH,
           }
         }
@@ -97,7 +98,7 @@ module QueryComponents
         match_phrase: {
           field_name => {
             query: escape(search_term),
-            analyzer: DEFAULT_QUERY_ANALYZER,
+            analyzer: query_analyzer,
           }
         }
       }
@@ -109,7 +110,7 @@ module QueryComponents
           query: escape(search_term),
           operator: "and",
           fields: fields,
-          analyzer: DEFAULT_QUERY_ANALYZER
+          analyzer: query_analyzer
         }
       }
     end
@@ -126,6 +127,14 @@ module QueryComponents
     end
 
   private
+
+    def query_analyzer
+      if search_params.disable_synonyms?
+        DEFAULT_QUERY_ANALYZER_WITHOUT_SYNONYMS
+      else
+        DEFAULT_QUERY_ANALYZER
+      end
+    end
 
     # FIXME: this method is basically the same as #minimum_should_match, but
     # doesn't override the analyzer.

--- a/spec/unit/query_components/core_query_spec.rb
+++ b/spec/unit/query_components/core_query_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe QueryComponents::CoreQuery do
       query = builder.minimum_should_match_with_synonyms
 
       expect(query.to_s).to match(/all_searchable_text\.synonym/)
+      expect(query.to_s).not_to match(/query_with_old_synonyms/)
     end
   end
 
@@ -25,6 +26,17 @@ RSpec.describe QueryComponents::CoreQuery do
 
       query = builder.minimum_should_match("_all")
       expect(query.to_s).to match(/"2<2 3<3 7<50%"/)
+    end
+  end
+
+  context "the search query with synonyms disabled" do
+    it "uses the default analyzer" do
+      builder = described_class.new(search_query_params(debug: { disable_synonyms: true }))
+
+      query = builder.minimum_should_match("_all")
+
+      expect(query.to_s).to match(/default/)
+      expect(query.to_s).not_to match(/query_with_old_synonyms/)
     end
   end
 end


### PR DESCRIPTION
The ability to debug search by disabling synonyms was removed in c611aff (PR #1010) because we thought it was part of an old synonym variation. This commit re-adds it so we can keep using it for debugging.

https://trello.com/c/PqwdCw1d/447-configure-synonym-a-b-query-in-rummager