### PR TITLE
Remove non breaking spaces from markdown files

### DIFF
--- a/doc/public-api/faceted-search.md
+++ b/doc/public-api/faceted-search.md
@@ -2,7 +2,7 @@
 
 You can build [faceted search interfaces](https://alistapart.com/article/design-patterns-faceted-navigation) using the search API's `filter`/`reject` and `aggregate` parameters.
 
-## Example
+## Example
 
 Pass the `aggregate_organisations` parameter to the search API to get a list of organisations, and the number of documents published by each of them.
 

--- a/doc/schemas.md
+++ b/doc/schemas.md
@@ -147,7 +147,7 @@ means "a search for 'foo' should return documents with 'bar' or 'baz' in them"
 is the same as `foo, bar, baz => foo, bar, baz` and means "a search for
 foo, bar or baz should return documents with any of them".
 
-## Additional configuration
+## Additional configuration
 
 Additional configuration is defined in the `elasticsearch_schema.yml` and
 `stems.yml` files.  This configuration is merged with the JSON configuration,


### PR DESCRIPTION
These break markdown tooling, e.g. the highlighting in Emacs and the
processing done by the govuk-developer-docs.