### PR TITLE
Add missing service manual document types

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -25,6 +25,8 @@ medical_safety_alert: medical_safety_alert # Specialist Publisher
 place: edition
 raib_report: raib_report # Specialist Publisher
 service_manual_guide: service_manual_guide
+service_manual_homepage: service_manual_guide
+service_manual_service_standard: service_manual_guide
 service_manual_topic: service_manual_topic
 service_standard_report: service_standard_report # Specialist Publisher
 simple_smart_answer: edition


### PR DESCRIPTION
There is one service manual document each for both of these types which are mapped to `service_manual_guide` format in Rummager and elasticsearch.

https://trello.com/c/gJlxVo4x