### PR TITLE
Fix flaky unpublishing test

### DIFF
--- a/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
+++ b/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
@@ -57,11 +57,12 @@ RSpec.describe 'GovukIndex::UnpublishingMessageProcessing' do
   end
 
   def unpublishing_event_message(schema_name, user_defined: {}, excluded_fields: [])
-    payload = GovukSchemas::RandomExample.for_schema(notification_schema: schema_name) do |hash|
-      hash.merge!(user_defined.stringify_keys)
-      hash.delete_if { |k, _| excluded_fields.include?(k) }
-      hash
-    end
+    payload = generate_random_example(
+      schema: schema_name,
+      payload: user_defined,
+      excluded_fields: excluded_fields,
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
+    )
     stub_message_payload(payload, unpublishing: true)
   end
 end


### PR DESCRIPTION
Ensure unpublishing test does not generate examples with the publishing app `smartanswers`, since these are currently excluded from the govuk index.

This workaround is already used elsewhere in the tests, and will be removed when we migrate smart answers to the govuk index.