### PR TITLE
Add service manual custom format type

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -2,6 +2,8 @@ module GovukIndex
   class CommonFieldsPresenter
     CUSTOM_FORMAT_MAP = {
       "esi_fund" => "european_structural_investment_fund",
+      "service_manual_homepage" => "service_manual_guide",
+      "service_manual_service_standard" => "service_manual_guide",
     }.freeze
     extend MethodBuilder
 


### PR DESCRIPTION
Both the service manual homepage and the service standard use `service_manual_guide` as their custom format type in elasticsearch.

https://trello.com/c/gJlxVo4x