### PR TITLE
[WIP] Extend synonyms A/B test to other subqueries

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -24,7 +24,7 @@
 - both: apply, applying, application, claim, claiming => apply
 - both: bank holiday, bank holidays, public holiday, public holidays => bank_holiday
 - both: bankrupt => bankruptcy
-- both: car => vehicle
+- index: car => vehicle, car
 - index: car tax bands => car tax bands, vehicle tax rates
 - both: copyright, intellectual property => copyright
 - both: death => bereavement
@@ -61,8 +61,6 @@
 - both: firing, dismiss, dismissing => firing, dismiss, dismissing, dismissal
 - index: heating allowance => heating allowance, winter fuel payment
 - index: winter fuel payment => winter fuel payment, heating allowance, winter fuel allowance, winter allowance, winter payment, winter payments
-- index: disclosure and barring service => disclosure and barring service, independent safeguarding authority, crb, criminal records bureau, dbs
-- index: independent safeguarding authority => independent safeguarding authority, disclosure and barring service
 - index: inland revenue, hmrc, hm revenue customs
 - index: nextstep, careers, national careers service => careers
 - index: old age pension, state pension
@@ -146,7 +144,12 @@
 - index: sanctionsconlist, sanctionsconlist.csv, sanctionsconlist.txt, sanctionslist, financial sanctions consolidated list
 # Acronyms
 - index: aspp, additional paternity pay
-- index: crb, criminal records bureau, dbs => crb, criminal records bureau, dbs, disclosure and barring service
+
+# DBS replaced CRB and ISA
+# so searches for the old organisations should return content from the new one
+- index: crb, criminal records bureau
+- index: dbs, disclosure and barring service => crb, dbs, disclosure and barring service, independent safeguarding authority, criminal records bureau
+
 - index: csco, carbon saving community obligation
 - index: cwp => cwp, cold weather
 - index: dada, dance and drama awards
@@ -166,44 +169,50 @@
 - index: fco, foreign commonwealth office
 - index: fcoc, future character of conflict
 - index: foi, freedom of information
-- index: gae => government authorised exchange
+- index: gae, government authorised exchange
 - index: gdhif, green deal home improvement fund
-- index: gsc => government security classifications
+- index: gsc, government security classifications
 - index: hmcs, hmcts, hm courts tribunals service
 - index: idi, immigration directorate instructions
-- index: iib => industrial injuries disablement benefit
-- index: ilr => indefinite leave, settle, individualised learner record
+- index: iib, industrial injuries disablement benefit
+- search: ilr => indefinite leave, settle, individualised learner record
 - index: jsa, jobseeker’s allowance
 - index: lha, local housing allowance
 - index: lpa, lasting power of attorney
-- index: nasm => noise amelioration scheme military
+- index: nasm, noise amelioration scheme military
 - index: nea, new enterprise allowance
-- index: ni => national insurance
-- index: nin, nino => national insurance number
-- index: nppg => national planning practice guidance
-- index: ntl, no time limit
+- both: el nino => el_nino
+- both: ni, nin, nino, national insurance, national insurance number => national_insurance_number
+- index: nppg, national planning practice guidance
+- both: ntl, no time limit => ntl
 - index: ogn, operational guidance note
 - index: ospp, ordinary statutory paternity pay
 - index: pcdl, professional and career development loan
 - index: pilon, payment in lieu of notice, pay in lieu of notice
-- index: ppg => pollution prevention guidance
-- index: psw => post study work
+- index: ppg, pollution prevention guidance
+- index: psw, post study work
 - index: rlmt, resident labour market test
 - index: rnps, register of number plate suppliers
 - index: rti, real time information
-- index: s2p => state second pension
+- index: s2p, state second pension
 - index: sap, statutory adoption pay
 - index: sar, subject access request
-- index: sf => student finance
-- index: sfe => student finance england
+- search: sf => student finance
+- index: sfe, student finance england
 - index: slc, student loans company
-- index: sms => sponsorship management system
-- index: spol => state pension online
+- index: sms, sponsorship management system => sponsorship management system, sponsor login, sms
+
+- index: spol, state pension online
 - index: spp, statutory paternity pay
-- index: twov => transit without visa
-- index: uj, ujm => universal jobmatch
+- index: twov, transit without visa
+
+# TODO: Suzanne is working on this
+#- index: uj, ujm, universal jobmatch
+
 - index: ukba, border agency, uk ba => ukba, border agency, ukvi, uk visas and immigration
-- index: utr, unique taxpayer reference =>
+- search: uk ba => ukba
+- index: utr, unique taxpayer reference
+
 # Acronyms with spaces or punctuation
 - search: c v => cv
 - search: d l a => dla
@@ -212,6 +221,7 @@
 - search: m o t => mot
 - search: n i => ni
 - search: p i p => pip
+
 # Adding terms to return relevant content that doesn't mention the original search term
 - index: document legalised => apostille, document legalised
 - index: cold weather => cold weather, bad weather, winter weather, cwp
@@ -237,7 +247,6 @@
 # "snow, snow code => snow, ice, grit, winter, weather, closures",
 - index: spouse visa => spouse visa, soc code, soc codes, spousal visa
 - index: benefits => social security, benefits
-- index: sponsorship management system => sponsorship management system, sponsor login, sms
 - index: under occupancy => under occupancy, under occupancy, underoccupancy
 - index: uk visa => visa4uk, uk visa
 # Adding terms to raise the best results

--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -1060,5 +1060,4 @@
 - search: form an, an form => form_an_naturalisation
 - index: naturalisation guide => naturalisation guide, naturalisation_guide
 - search: guide an, an guide => naturalisation_guide
-- index: will => wills_keyword
-- search: will, wills => wills_keyword
+- search: will, wills

--- a/lib/debug/explainotron.rb
+++ b/lib/debug/explainotron.rb
@@ -18,7 +18,7 @@ module Debug
         metasearch_index: SearchConfig.instance.metasearch_index
       )
       search_query = query_builder.payload
-      puts search_query.inspect
+      pp search_query[:query]
 
       results = client.search(
         index: "govuk,mainstream,detailed,government",

--- a/lib/debug/explainotron.rb
+++ b/lib/debug/explainotron.rb
@@ -1,0 +1,33 @@
+require 'pry'
+
+module Debug
+  class Explainotron
+    def self.explain!(query, ab_tests: {})
+      client = Services.elasticsearch
+
+      parsed_params = {
+        query: query,
+        ab_tests: ab_tests,
+        debug: { explain: true, disable_best_bets: true, disable_popularity: true, disable_boosting: true }
+ }
+      search_params = Search::QueryParameters.new(parsed_params)
+
+      query_builder = Search::QueryBuilder.new(
+        search_params: search_params,
+        content_index_names: SearchConfig.instance.content_index_names,
+        metasearch_index: SearchConfig.instance.metasearch_index
+      )
+      search_query = query_builder.payload
+      puts search_query.inspect
+
+      results = client.search(
+        index: "govuk,mainstream,detailed,government",
+        analyzer: 'with_search_synonyms',
+        body: search_query
+      )["hits"]["hits"]
+
+      # rubocop:disable Lint/Debugger
+      binding.pry
+    end
+  end
+end

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -337,6 +337,8 @@ private
         options[:disable_popularity] = true
       when "disable_synonyms"
         options[:disable_synonyms] = true
+      when "disable_boosting"
+        options[:disable_boosting] = true
       when "new_weighting"
         options[:new_weighting] = true
       when "explain"

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -70,7 +70,7 @@ module Search
                     end,
 
                     if search_params.synonym_b_variant?
-                      core_query.minimum_should_match_with_synonyms
+                      core_query.minimum_should_match("all_searchable_text")
                     else
                       core_query.minimum_should_match("_all")
                     end
@@ -129,11 +129,7 @@ module Search
     end
 
     def main_text_fields
-      if search_params.synonym_b_variant?
-        %w(title.synonym acronym.synonym description.synonym indexable_content.synonym)
-      else
-        %w(title acronym description indexable_content)
-      end
+      %w(title acronym description indexable_content)
     end
 
     # More like this is a separate function for returning similar documents,

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -4,6 +4,8 @@ module QueryComponents
     DEFAULT_BOOST = 1
 
     def wrap(core_query)
+      return core_query if search_params.disable_boosting?
+
       {
         function_score: {
           boost_mode: :multiply,

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -126,6 +126,16 @@ module QueryComponents
       }
     end
 
+    def match_any_terms(fields)
+      {
+        multi_match: {
+          query: escape(search_term),
+          operator: "or",
+          fields: fields,
+        }
+      }
+    end
+
   private
 
     def query_analyzer

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -5,6 +5,11 @@ module QueryComponents
     DEFAULT_QUERY_ANALYZER = "query_with_old_synonyms".freeze
     DEFAULT_QUERY_ANALYZER_WITHOUT_SYNONYMS = "default".freeze
 
+    # Used with foo.synonym fields. Passing this is not necessary because
+    # it's the default for these fields. We're only passing it at query time
+    # to make the various possible queries more consistant with each other.
+    QUERY_TIME_SYNONYMS_ANALYZER = "with_search_synonyms".freeze
+
     # If the search query is a single quoted phrase, we run a different query,
     # which uses phrase matching across various fields.
     # Boost title the most, but ensure that organisations rank brilliantly
@@ -70,21 +75,10 @@ module QueryComponents
       ]
     end
 
-    def minimum_should_match_with_synonyms
-      {
-        match: {
-          "all_searchable_text.synonym" => {
-            query: escape(search_term),
-            minimum_should_match: MINIMUM_SHOULD_MATCH,
-          }
-        }
-      }
-    end
-
     def minimum_should_match(field_name)
       {
         match: {
-          field_name => {
+          synonym_field(field_name) => {
             query: escape(search_term),
             analyzer: query_analyzer,
             minimum_should_match: MINIMUM_SHOULD_MATCH,
@@ -96,7 +90,7 @@ module QueryComponents
     def match_phrase(field_name)
       {
         match_phrase: {
-          field_name => {
+          synonym_field(field_name) => {
             query: escape(search_term),
             analyzer: query_analyzer,
           }
@@ -105,6 +99,8 @@ module QueryComponents
     end
 
     def match_all_terms(fields)
+      fields = fields.map { |f| synonym_field(f) }
+
       {
         multi_match: {
           query: escape(search_term),
@@ -116,6 +112,8 @@ module QueryComponents
     end
 
     def match_bigrams(fields)
+      fields = fields.map { |f| synonym_field(f) }
+
       {
         multi_match: {
           query: escape(search_term),
@@ -127,21 +125,38 @@ module QueryComponents
     end
 
     def match_any_terms(fields)
+      fields = fields.map { |f| synonym_field(f) }
+
       {
         multi_match: {
           query: escape(search_term),
           operator: "or",
           fields: fields,
+          analyzer: query_analyzer
         }
       }
+    end
+
+    # Use the synonym variant of the field unless we're disabling synonyms
+    def synonym_field(field_name)
+      return field_name if search_params.disable_synonyms?
+      return field_name if !search_params.synonym_b_variant?
+      raise ValueError if field_name.include?(".")
+
+      field_name + ".synonym"
     end
 
   private
 
     def query_analyzer
       if search_params.disable_synonyms?
+        # this is the default defined in the mapping for regular fields
         DEFAULT_QUERY_ANALYZER_WITHOUT_SYNONYMS
+      elsif search_params.synonym_b_variant?
+        # this is the default defined in the mapping for *.synonym fields
+        QUERY_TIME_SYNONYMS_ANALYZER
       else
+        # this excludes the synonym filter
         DEFAULT_QUERY_ANALYZER
       end
     end

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -40,6 +40,10 @@ module Search
       debug[:disable_best_bets]
     end
 
+    def disable_boosting?
+      debug[:disable_boosting]
+    end
+
     def enable_id_codes?
       debug[:use_id_codes]
     end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -82,6 +82,6 @@ namespace :debug do
 
   desc "Run the core of the search query with explain plans enabled and special boosting disabled"
   task :explain, [:query] do |_, args|
-    Debug::Explainotron.explain!(args.query)
+    Debug::Explainotron.explain!(args.query, ab_tests: { synonyms: 'A' })
   end
 end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -2,6 +2,7 @@ require 'rummager'
 require 'pp'
 require 'rainbow'
 require 'debug/synonyms'
+require 'debug/explainotron'
 
 ANSI_GREEN = "\e[32m".freeze
 ANSI_RESET = "\e[0m".freeze
@@ -77,5 +78,10 @@ namespace :debug do
         puts ""
       end
     end
+  end
+
+  desc "Run the core of the search query with explain plans enabled and special boosting disabled"
+  task :explain, [:query] do |_, args|
+    Debug::Explainotron.explain!(args.query)
   end
 end


### PR DESCRIPTION
This is a change to the synonym A/B test after debugging some queries.

I've also checked in some debug code I used, which I think could be useful in the future. I plan to use it to compare how the A and B versions treat specific documents.

See individual commit messages for more details.

This is still a WIP:
- I need to rerun the healthcheck with these changes
- I'm not convinced the `core_query.minimum_should_match_with_synonyms` part is working as expected, because we've debugged a couple of queries where matches on `all_searchable_text` don't show up in the query output, whereas with the A version we **can** see matches on the `_all` field.

Trello: https://trello.com/c/9VF3Rw5V/451-test-synonyms-with-healthcheck-and-search-performance-explorer