### PR TITLE
Add task to check state of Rummager document taxons

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ Performance/TimesMap:
 AllCops:
   TargetRubyVersion: 2.3
 
+Metrics/BlockLength:
+  Exclude:
+    - 'lib/tasks/*.rake'
+
 # Don't care about single/double quotes inside interpolation
 Style/StringLiteralsInInterpolation:
   Enabled: false
@@ -27,3 +31,8 @@ Style/ClassVars:
   Exclude:
     - 'app.rb'
     - 'lib/search/suggestion_blacklist.rb'
+
+# Cannot use %i arrays as rake task arguments
+Style/SymbolArray:
+  Exclude:
+    - 'lib/tasks/*.rake'


### PR DESCRIPTION
This is not entirely necessary but since I hacked this together to save me time I thought I'd raise it just in case in anyone else finds it useful.

It is just to check whether the taxons associated with a particular format were in draft state or not. There is a bug whereby documents in the mainstream index have taxons associated to them but
they are in draft state. As a result when republishing to the govuk index they are not present in the notification payload. This task just saves time checking them by hand.