### PR TITLE
Fix page traffic runner and exit with an error if called incorrectly

### DIFF
--- a/bin/page_traffic_load
+++ b/bin/page_traffic_load
@@ -23,10 +23,11 @@ Slop.parse(help: true) do
   DOC
 
   run do |_opts, args|
-    if args.size == 1
+    if args.empty?
       GovukIndex::PageTrafficLoader.new.load_from($stdin)
     else
       puts self
+      exit 1
     end
   end
 end


### PR DESCRIPTION
Previously this was passed an index name to process which meant it had a single
argument, we are no longer passing in the index name (it was redundant) and as
a result we should have changed the logic.