### PR TITLE
Fix "UTR" synonym and add extra validation

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -203,7 +203,7 @@
 - index: twov => transit without visa
 - index: uj, ujm => universal jobmatch
 - index: ukba, border agency, uk ba => ukba, border agency, ukvi, uk visas and immigration
-- index: utr, unique taxpayer reference =>
+- index: utr, unique taxpayer reference
 # Acronyms with spaces or punctuation
 - search: c v => cv
 - search: d l a => dla

--- a/lib/schema/synonyms.rb
+++ b/lib/schema/synonyms.rb
@@ -60,16 +60,7 @@ private
     end
 
     def <<(synonym)
-      synonym_terms = synonym
-        .split("=>")
-        .first
-        .split(",")
-        .map(&:strip)
-
-      synonym_terms.each do |term|
-        validate_term!(term)
-        unique_terms << term
-      end
+      validate_synonym!(synonym)
 
       synonyms << synonym
     end
@@ -88,9 +79,29 @@ private
 
     attr_reader :synonyms, :synonym_type, :unique_terms
 
-    def validate_term!(term)
-      if unique_terms.include?(term)
-        raise InvalidSynonymConfig.new("Synonym '#{term}' already defined for '#{synonym_type}'")
+    def validate_synonym!(synonym)
+      if synonym.include?("=>")
+        terms, values = synonym.split("=>")
+        validate_terms!(terms)
+        validate_values!(synonym, values)
+      else
+        validate_terms!(synonym)
+      end
+    end
+
+    def validate_values!(synonym, values)
+      if values.nil? || values.strip.empty?
+        raise InvalidSynonymConfig.new("Synonym '#{synonym}' has no definition")
+      end
+    end
+
+    def validate_terms!(terms)
+      terms.split(",").map(&:strip).each do |term|
+        if unique_terms.include?(term)
+          raise InvalidSynonymConfig.new("Synonym '#{term}' already defined for '#{synonym_type}'")
+        end
+
+        unique_terms << term
       end
     end
   end

--- a/spec/unit/schema/synonyms_spec.rb
+++ b/spec/unit/schema/synonyms_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe SynonymParser do
     }.to raise_error(SynonymParser::InvalidSynonymConfig)
   end
 
+  it "rejects missing synonym definitions" do
+    config = [
+      { "search" => "micropig =>" }
+    ]
+
+    expect {
+      described_class.new.parse(config)
+    }.to raise_error(SynonymParser::InvalidSynonymConfig)
+  end
+
   context "duplicate validation" do
     it "rejects duplicate terms with the 'search' key" do
       config = [


### PR DESCRIPTION
Fix a missing synonym definition and add validation to catch cases like this.

cc @MatMoore 