### PR TITLE
Fix error reporting when publishing special routes

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -8,19 +8,19 @@ namespace :publishing_api do
 
     begin
       publisher.take_ownership_of_search_routes
-    rescue GdsApi::TimedOutException
-      puts "WARNING: publishing-api timed out when trying to publish route #{payload.inspect}"
+    rescue GdsApi::TimedOutException => e
+      puts "WARNING: publishing-api timed out when trying to take ownership of a search route"
     rescue GdsApi::HTTPServerError => e
-      puts "WARNING: publishing-api errored out when trying to publish route #{payload.inspect}\n\nError: #{e.inspect}"
+      puts "WARNING: publishing-api errored out when trying to take ownership of a search route \n\nError: #{e.inspect}"
     end
 
     publisher.routes.each do |route|
       begin
         publisher.publish(route)
       rescue GdsApi::TimedOutException
-        puts "WARNING: publishing-api timed out when trying to publish route #{payload.inspect}"
+        puts "WARNING: publishing-api timed out when trying to publish route #{route[:base_path]}"
       rescue GdsApi::HTTPServerError => e
-        puts "WARNING: publishing-api errored out when trying to publish route #{payload.inspect}\n\nError: #{e.inspect}"
+        puts "WARNING: publishing-api errored out when trying to publish route #{route[:base_path]}\n\nError: #{e.inspect}"
       end
     end
   end


### PR DESCRIPTION
Fix `NameError`s which occur when logging errors caused by failed special route publishing.

It's generally safe to just log a warning because the special routes
published by rummager are updated so rarely:
- https://github.com/alphagov/rummager/pull/658
- cfcf6f9a1c6b6b9413a07f1484b98a72d71a21ce