### PR TITLE
Add a debug option to disable boosting

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -337,6 +337,8 @@ private
         options[:disable_popularity] = true
       when "disable_synonyms"
         options[:disable_synonyms] = true
+      when "disable_boosting"
+        options[:disable_boosting] = true
       when "new_weighting"
         options[:new_weighting] = true
       when "explain"

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -4,6 +4,8 @@ module QueryComponents
     DEFAULT_BOOST = 1
 
     def wrap(core_query)
+      return core_query if search_params.disable_boosting?
+
       {
         function_score: {
           boost_mode: :multiply,

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -40,6 +40,10 @@ module Search
       debug[:disable_best_bets]
     end
 
+    def disable_boosting?
+      debug[:disable_boosting]
+    end
+
     def enable_id_codes?
       debug[:use_id_codes]
     end


### PR DESCRIPTION
With this option, we can disable all format boosting, and date boosting.
You can already disable popularity boosting and best bets, and by
disabling all of those you can isolate the main text matching part of
the query, i.e. the text analysis pipeline, TF-IDF, and the boolean
queries that combine various kinds of matching.

This is very useful at the moment, because this stuff is really broken,
and it's the foundation our search query is based on - by working on
this, we can tackle some of the really weird search behaviour, where
rummager returns documents that don't look anything like the query.