### PR TITLE
Add a new debug command to inspect explain plans

### DIFF
--- a/lib/debug/explainotron.rb
+++ b/lib/debug/explainotron.rb
@@ -1,13 +1,12 @@
-require 'pry'
+require 'rainbow'
 
 module Debug
   class Explainotron
-    def self.explain!(query, ab_tests: {})
+    def self.explain!(query)
       client = Services.elasticsearch
 
       parsed_params = {
         query: query,
-        ab_tests: ab_tests,
         debug: { explain: true, disable_best_bets: true, disable_popularity: true, disable_boosting: true }
  }
       search_params = Search::QueryParameters.new(parsed_params)
@@ -18,16 +17,35 @@ module Debug
         metasearch_index: SearchConfig.instance.metasearch_index
       )
       search_query = query_builder.payload
-      pp search_query[:query]
 
-      results = client.search(
+      client.search(
         index: "govuk,mainstream,detailed,government",
         analyzer: 'with_search_synonyms',
-        body: search_query
+        body: search_query.merge(size: 3)
       )["hits"]["hits"]
+    end
 
-      # rubocop:disable Lint/Debugger
-      binding.pry
+    def self.print(explain_output, query, indent: 0)
+      details = explain_output["details"]
+      value = explain_output["value"]
+      description = explain_output["description"]
+
+      description.gsub!(/[0-9.]+/) do |match|
+        Rainbow(match).cyan
+      end
+
+      description.gsub!(/(?<=:)(.*)(?= in)/) do |match|
+        Rainbow(match).green
+      end
+
+      spaces = ' ' * indent
+      puts spaces.to_s + Rainbow("[#{value}] ").magenta + description
+
+      if details
+        details.each do |detail|
+          print(detail, query, indent: indent + 2)
+        end
+      end
     end
   end
 end

--- a/lib/debug/explainotron.rb
+++ b/lib/debug/explainotron.rb
@@ -18,7 +18,7 @@ module Debug
         metasearch_index: SearchConfig.instance.metasearch_index
       )
       search_query = query_builder.payload
-      puts search_query.inspect
+      pp search_query[:query]
 
       results = client.search(
         index: "govuk,mainstream,detailed,government",

--- a/lib/debug/explainotron.rb
+++ b/lib/debug/explainotron.rb
@@ -1,0 +1,33 @@
+require 'pry'
+
+module Debug
+  class Explainotron
+    def self.explain!(query, ab_tests: {})
+      client = Services.elasticsearch
+
+      parsed_params = {
+        query: query,
+        ab_tests: ab_tests,
+        debug: { explain: true, disable_best_bets: true, disable_popularity: true, disable_boosting: true }
+ }
+      search_params = Search::QueryParameters.new(parsed_params)
+
+      query_builder = Search::QueryBuilder.new(
+        search_params: search_params,
+        content_index_names: SearchConfig.instance.content_index_names,
+        metasearch_index: SearchConfig.instance.metasearch_index
+      )
+      search_query = query_builder.payload
+      puts search_query.inspect
+
+      results = client.search(
+        index: "govuk,mainstream,detailed,government",
+        analyzer: 'with_search_synonyms',
+        body: search_query
+      )["hits"]["hits"]
+
+      # rubocop:disable Lint/Debugger
+      binding.pry
+    end
+  end
+end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -82,6 +82,6 @@ namespace :debug do
 
   desc "Run the core of the search query with explain plans enabled and special boosting disabled"
   task :explain, [:query] do |_, args|
-    Debug::Explainotron.explain!(args.query)
+    Debug::Explainotron.explain!(args.query, ab_tests: { synonyms: 'A' })
   end
 end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -2,6 +2,7 @@ require 'rummager'
 require 'pp'
 require 'rainbow'
 require 'debug/synonyms'
+require 'debug/explainotron'
 
 ANSI_GREEN = "\e[32m".freeze
 ANSI_RESET = "\e[0m".freeze
@@ -77,5 +78,10 @@ namespace :debug do
         puts ""
       end
     end
+  end
+
+  desc "Run the core of the search query with explain plans enabled and special boosting disabled"
+  task :explain, [:query] do |_, args|
+    Debug::Explainotron.explain!(args.query)
   end
 end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -82,6 +82,15 @@ namespace :debug do
 
   desc "Run the core of the search query with explain plans enabled and special boosting disabled"
   task :explain, [:query] do |_, args|
-    Debug::Explainotron.explain!(args.query, ab_tests: { synonyms: 'A' })
+    results = Debug::Explainotron.explain!(args.query)
+
+    results.each do |result|
+      title = result.dig("fields", "title").first
+      description = result.dig("fields", "description").first
+      puts Rainbow(title).yellow + " - #{description}"
+      puts ""
+      Debug::Explainotron.print(result["_explanation"], args.query)
+      puts ""
+    end
   end
 end


### PR DESCRIPTION
When investigating why a document scored higher/lower than anticipated, or why
a result matched at all, the boosting is fairly easy to understand, but it's
hard to see what the core of the query is doing. The explain plan sheds some
light on this, but it's very long and confusing when the whole query is used.

This is a minimal rake task that disables all boosting and best bets, enables
the explain plan, runs the query and then opens a repl with pry. This could
be extended to highlight the interesting parts of the explain output or diff
across A/B tests.

https://github.com/alphagov/rummager/pull/1039 should be merged first.