### PR TITLE
[PROOF OF CONCEPT] Handle batched data

### DIFF
--- a/lib/batcher.rb
+++ b/lib/batcher.rb
@@ -1,28 +1,73 @@
 class Batcher
   QUEUES_NAME = 'batcher_queues_name'
+  MAX_QUEUE_LENGTH = 100
 
   def initialize(processor)
     @processor = processor
+    @uuid = SecureRandom.uuid
   end
 
   def process(message)
+    @process.process(message, worker: self)
+  end
+
+  def perform_async(*args)
     # store message on queue A
     queue_name = current_queue_name
-    if redis.llen(queue_name) >
-    redis.rpush("#{QUEUES_NAME}-#{processor.class}", "#{QUEUES_NAME}-#{processor.class}-#{SecureRandom.uuid}")
+    redis.rpush(current_queue_name, args.to_json)
 
     # check if count of message on the queue is greater than X
+    if redis.llen(queue_name) >= MAX_QUEUE_LENGTH || after_timeout?(queue_name)
+      process_queue(queue_name)
+    end
+  end
 
-    # update the storage queue to Queue B if we are the winner
+  def process_queue(queue_name)
+    processed = false
+    entrants_list = "#{queue_name}-entrant"
 
-    # process message on queue A in bulk to the processor
+    # remove it from the queue_name list
+    redis.lrem(queue_name_list, 0, queue_name)
+    # add myself as an entrant
+    redis.rpush(entrants_list, @uuid)
+
+    # check if I am the winner
+    if redis.lindex(entrants_list, 0) == @uuid
+      # process message on queue A in bulk to the processor
+      batched_data = redis.lrange(queue_name).map { |d| JSON.parse(d) }
+
+      @processor.process(batch: batched_data)
+      processed = true
+
+      # delete the queue so that it isn't left on redis
+      redis.del(queue_name)
+    end
+
+    # remove self from the entrants - assuming the winner will be the last to be removed
+    redis.lrem(entrants_list, 0, @uuid)
+    # remove the entrants list
+    redis.del(entrants_list) if redis.llen(entrants_list) == 0
+  rescue Exception
+    # push the queue_name back onto the list of queue names so we can try and process it again
+    # in the event of any errors
+    redis.lpush(queue_name_list, queue_name) unless processed
+    raise
   end
 
   def current_queue_name
-    queue_name = redis.lget("#{QUEUES_NAME}-#{processor.class}", 0)
+    queue_name = redis.lget(queue_name_list, 0)
     return queue_name if queue_name
-    redis.rpush("#{QUEUES_NAME}-#{processor.class}", "#{QUEUES_NAME}-#{processor.class}-#{SecureRandom.uuid}")
-    redis.lget("#{QUEUES_NAME}-#{processor.class}", 0)
+    redis.rpush(queue_name_list, "#{QUEUES_NAME}-#{processor.class}-#{SecureRandom.uuid}")
+    redis.lindex(queue_name_list, 0)
+  end
+
+  def queue_name_list
+    "#{QUEUES_NAME}-#{processor.class}"
+  end
+
+  def after_timeout?(queue_name)
+    expiry = rdis.get("#{queue_name}-expiry")
+    if expiry && Time.at(expiry)
   end
 
   def redis

--- a/lib/batcher.rb
+++ b/lib/batcher.rb
@@ -1,0 +1,31 @@
+class Batcher
+  QUEUES_NAME = 'batcher_queues_name'
+
+  def initialize(processor)
+    @processor = processor
+  end
+
+  def process(message)
+    # store message on queue A
+    queue_name = current_queue_name
+    if redis.llen(queue_name) >
+    redis.rpush("#{QUEUES_NAME}-#{processor.class}", "#{QUEUES_NAME}-#{processor.class}-#{SecureRandom.uuid}")
+
+    # check if count of message on the queue is greater than X
+
+    # update the storage queue to Queue B if we are the winner
+
+    # process message on queue A in bulk to the processor
+  end
+
+  def current_queue_name
+    queue_name = redis.lget("#{QUEUES_NAME}-#{processor.class}", 0)
+    return queue_name if queue_name
+    redis.rpush("#{QUEUES_NAME}-#{processor.class}", "#{QUEUES_NAME}-#{processor.class}-#{SecureRandom.uuid}")
+    redis.lget("#{QUEUES_NAME}-#{processor.class}", 0)
+  end
+
+  def redis
+    Sidekiq.redis
+  end
+end

--- a/lib/govuk_index/publishing_event_processor.rb
+++ b/lib/govuk_index/publishing_event_processor.rb
@@ -1,8 +1,8 @@
 module GovukIndex
   class PublishingEventProcessor
-    def process(message)
+    def process(message, worker: PublishingEventWorker)
       Services.statsd_client.increment('govuk_index.rabbit-mq-consumed')
-      PublishingEventWorker.perform_async(message.delivery_info[:routing_key], message.payload)
+      worker.perform_async(message.delivery_info[:routing_key], message.payload)
       message.ack
     end
   end

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -15,7 +15,7 @@ module GovukIndex
       actions = ElasticsearchProcessor.new
       process_action(actions, routing_key, payload)
       response = actions.commit
-      process_response(response) if response
+      process_responses(routing_key, response, payload)
     # Rescuing as we don't want to retry this class of error
     rescue MissingBasePath => e
       return if DOCUMENT_TYPES_WITHOUT_BASE_PATH.include?(payload["document_type"])
@@ -36,6 +36,16 @@ module GovukIndex
     end
 
   private
+
+    def process_actions(actions, routing_key, payload)
+      if payload.is_a?(Hash) && payload['multiple']
+        payload['batch'].each do |single_payload|
+          process_action(actions, routing_key, single_payload)
+        end
+      else
+        process_action(routing_key, actions, routing_key, payload)
+      end
+    end
 
     def process_action(actions, routing_key, payload)
       logger.debug("Processing #{routing_key}: #{payload}")
@@ -58,15 +68,33 @@ module GovukIndex
       end
     end
 
-    def process_response(response)
-      # we are only expecting to process a single message at a time
-      if response['items'].count > 1
-        Services.statsd_client.increment('govuk_index.elasticsearch.multiple_responses')
-        raise MultipleMessagesInElasticsearchResponse
+    def process_responses(routing_key, responses, payload)
+      requests_with_error = []
+
+      requests = payload['batch'] || [payload]
+      responses['items'].zip(requests).each do |response, request|
+        requests_with_error << request unless process_response(response)
       end
 
-      item = response['items'].first
-      action_type, details = *item.first # item is a hash with a single key, value pair
+      if requests_with_error.any?
+        if requests_with_error.count == requests.count
+          # automatically retry
+          raise(
+            ElasticsearchError,
+            reason: "All requests failed",
+            requests: requests.count,
+            first_request: requests.first,
+            first_error_details: responses['items'].first.first.last
+          )
+        else
+          PublishingEventWorker.perform_async(routing_key, batch: requests_with_error)
+        end
+      end
+    end
+
+
+    def valid_response?(response)
+      action_type, details = *responce.first # item is a hash with a single key, value pair
       status = details['status']
 
       if (200..399).cover?(status)
@@ -83,8 +111,15 @@ module GovukIndex
       else
         logger.error("#{action_type} not processed: status #{status}")
         Services.statsd_client.increment("govuk_index.elasticsearch.#{action_type}_error")
-        raise ElasticsearchError, action_type: action_type, details: details
+        # log something here
+        GovukError.notify(ElasticsearchError.new,
+          action_type: action_type,
+          details: details,
+        )
+        return false
       end
+
+      true
     end
   end
 end

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -19,7 +19,7 @@ namespace :message_queue do
   task :insert_data_into_govuk do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "rummager_govuk_index",
-      processor: Batcher.new(GovukIndex::PublishingEventProcessor.new),
+      processor: Batcher.new(processor: GovukIndex::PublishingEventProcessor.new, worker: PublishingEventWorker),
       statsd_client: Services.statsd_client,
     ).run
   end

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -19,7 +19,7 @@ namespace :message_queue do
   task :insert_data_into_govuk do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "rummager_govuk_index",
-      processor: GovukIndex::PublishingEventProcessor.new,
+      processor: Batcher.new(GovukIndex::PublishingEventProcessor.new),
       statsd_client: Services.statsd_client,
     ).run
   end


### PR DESCRIPTION
we currently process data off rabbitMQ a document at a time, this means that when we do large republishing (i.e. topic update) this can result in large volumes of records coming through and requiring processing.

Ideally we would use put multiple documents off the rabbit queue and put them on the sidekiq queue, however this is not possible so instead I am using redis as a tempory store to batch up data.

This does mean we could lose data is redis goes down.

This code adds some complexity as it makes the downstream processes handle both a single record and a batch of records.