### PR TITLE
Improve reindexing checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'lib/tasks/*.rake'
+    - 'spec/**/*'
 
 # Don't care about single/double quotes inside interpolation
 Style/StringLiteralsInInterpolation:

--- a/lib/schema_migrator.rb
+++ b/lib/schema_migrator.rb
@@ -1,6 +1,7 @@
 class SchemaMigrator
-  def initialize(index_name, wait_between_task_list_check: 5)
+  def initialize(index_name, config, wait_between_task_list_check: 5)
     @index_name = index_name
+    @config = config
     @wait_between_task_list_check = wait_between_task_list_check
 
     index_group.current.with_lock do
@@ -53,7 +54,7 @@ private
   end
 
   def index_group
-    @index_group ||= search_config.search_server.index_group(@index_name)
+    @index_group ||= @config.search_server.index_group(@index_name)
   end
 
   def index

--- a/lib/schema_migrator.rb
+++ b/lib/schema_migrator.rb
@@ -20,7 +20,8 @@ class SchemaMigrator
           index: index.real_name,
           version_type: "external",
         }
-      }
+      },
+      refresh: true
     )
 
     task_id = response.fetch('task')

--- a/lib/schema_migrator.rb
+++ b/lib/schema_migrator.rb
@@ -31,7 +31,9 @@ class SchemaMigrator
   end
 
   def changed?
-    comparison[:changed] != 0
+    comparison[:changed] != 0 ||
+      comparison[:removed_items] != 0 ||
+      comparison[:added_items] != 0
   end
 
   def switch_to_new_index

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -110,7 +110,7 @@ You should run this task if the index schema has changed.
     failed_indices = []
 
     index_names.each do |index_name|
-      SchemaMigrator.new(index_name) do |migrator|
+      SchemaMigrator.new(index_name, search_config) do |migrator|
         migrator.reindex
 
         if migrator.changed?

--- a/spec/integration/schema_migrator_spec.rb
+++ b/spec/integration/schema_migrator_spec.rb
@@ -67,8 +67,7 @@ RSpec.describe SchemaMigrator do
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
-        client.delete(index: "govuk_test", id: "/a-page-to-be-reindexed", type: "edition" )
-        commit_index("govuk_test")
+        client.delete(index: "govuk_test", id: "/a-page-to-be-reindexed", type: "edition", refresh: true)
 
         expect(migrator).to be_changed
       end

--- a/spec/integration/schema_migrator_spec.rb
+++ b/spec/integration/schema_migrator_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe SchemaMigrator do
+  it "switches the alias to a new index" do
+    index_group = search_server.index_group("govuk_test")
+    original_index = index_group.current_real
+
+    SchemaMigrator.new("govuk_test", search_config) do |migrator|
+      migrator.reindex
+      migrator.switch_to_new_index
+    end
+
+    expect(index_group.current_real.real_name).not_to eq(original_index.real_name)
+  end
+
+  it "copies data to the new index" do
+    index_group = search_server.index_group("govuk_test")
+    original_index = index_group.current_real
+
+    document = {
+      "link" => "/a-page-to-be-reindexed",
+      "title" => "A page to be reindexed"
+    }
+    commit_document("govuk_test", document)
+
+    SchemaMigrator.new("govuk_test", search_config) do |migrator|
+      migrator.reindex
+      migrator.switch_to_new_index
+    end
+
+    expect_document_is_in_rummager(document, index: "govuk_test", id: "/a-page-to-be-reindexed")
+    expect_document_is_in_rummager(document, index: original_index.real_name, id: "/a-page-to-be-reindexed")
+  end
+
+  # TODO: Test missing content
+end

--- a/spec/integration/schema_migrator_spec.rb
+++ b/spec/integration/schema_migrator_spec.rb
@@ -1,11 +1,15 @@
 require 'spec_helper'
 
 RSpec.describe SchemaMigrator do
+  before(:each) do
+    clean_index_content("govuk_test")
+  end
+
   it "switches the alias to a new index" do
     index_group = search_server.index_group("govuk_test")
     original_index = index_group.current_real
 
-    SchemaMigrator.new("govuk_test", search_config) do |migrator|
+    SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
       migrator.reindex
       migrator.switch_to_new_index
     end
@@ -23,7 +27,7 @@ RSpec.describe SchemaMigrator do
     }
     commit_document("govuk_test", document)
 
-    SchemaMigrator.new("govuk_test", search_config) do |migrator|
+    SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
       migrator.reindex
       migrator.switch_to_new_index
     end
@@ -36,7 +40,7 @@ RSpec.describe SchemaMigrator do
     it "identifies when content has not changed" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" })
 
-      SchemaMigrator.new("govuk_test", search_config) do |migrator|
+      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
         migrator.reindex
 
         expect(migrator).not_to be_changed
@@ -46,7 +50,7 @@ RSpec.describe SchemaMigrator do
     it "finds added content" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" })
 
-      SchemaMigrator.new("govuk_test", search_config) do |migrator|
+      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
@@ -59,7 +63,7 @@ RSpec.describe SchemaMigrator do
     it "finds removed content" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" }, type: "edition")
 
-      SchemaMigrator.new("govuk_test", search_config) do |migrator|
+      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
@@ -76,7 +80,7 @@ RSpec.describe SchemaMigrator do
         { "link" => "/some-page", "title" => "Original title" }
       )
 
-      SchemaMigrator.new("govuk_test", search_config) do |migrator|
+      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -111,6 +111,11 @@ module IntegrationSpecHelper
     return_id
   end
 
+  def update_document(index_name, attributes, id: attributes["link"], type: "edition")
+    client.update(index: index_name, id: id, type: type, body: { doc: attributes })
+    commit_index(index_name)
+  end
+
   def commit_index(index_name = "mainstream_test")
     client.indices.refresh(index: index_name)
   end

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -46,7 +46,9 @@ module IntegrationSpecHelper
     allowed_paths << '[a-z_-]+[_-]test.*'
     allowed_paths << '_aliases'
     allowed_paths << '_bulk'
+    allowed_paths << '_reindex'
     allowed_paths << '_search/scroll'
+    allowed_paths << '_tasks'
 
     allow_urls = %r{http://localhost:9200/(#{allowed_paths.join('|')})}
     WebMock.disable_net_connect!(allow: allow_urls)


### PR DESCRIPTION
Add extra checks to reindexing to make sure that no documents have been added or removed by the reindexing process. The existing checks just looked for changes within a document.

Also add some integration tests of reindexing.