### PR TITLE
Make Finder format description indexable

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -134,7 +134,7 @@ module GovukIndex
 
     attr_reader :payload
 
-    INDEX_DESCRIPTION_FIELD = %w(manual service_manual_topic travel_advice_index).freeze
+    INDEX_DESCRIPTION_FIELD = %w(finder manual service_manual_topic travel_advice_index).freeze
 
     def indexable
       IndexableContentPresenter.new(


### PR DESCRIPTION
The indexable content field for the Finder format is being [removed](https://github.com/alphagov/whitehall/pull/3575) when publishing occurs. It was felt that the extra keywords added nothing to the ability for these pages to be found on internal search and looking at the most common search terms which end up with visits to those pages confirms this. Therefore we are using the contents of the description field as these Finder's indexable content in Elasticsearch.


news | /government/announcements | 819 | 41%
-- | -- | -- | --
announcements | /government/announcements | 284 | 76%
press release | /government/announcements | 56 | 27%
press releases | /government/announcements | 28 | 11%
press notices | /government/announcements | 11 | 33%
announce,mets | /government/announcements | 6 | 100%
news released | /government/announcements | 6 | 100%
white paper | /government/announcements | 6 | 1%
speech trafficking | /government/announcements | 6 | 100%
improving lives white paper | /government/announcements | 6 | 100%
minister | /government/ministers | 128 | 47%
fco ministers | /government/ministers | 33 | 59%
minister for education | /government/ministers | 11 | 50%
the minister | /government/ministers | 11 | 183%
what does a cabinet minister do | /government/ministers | 6 | 55%
business minister | /government/ministers | 6 | 35%
dclg ministers | /government/ministers | 6 | 100%
cabinet office ministers | /government/ministers | 6 | 55%
statistics | /government/statistics | 535 | 44%
statistic | /government/statistics | 45 | 54%
diabetes statistics | /government/statistics | 39 | 21%
national statistics | /government/statistics | 17 | 16%
malnutrition statistics | /government/statistics | 6 | 100%
prison release statistics | /government/statistics | 6 | 100%
statistical releases | /government/statistics | 6 | 100%

https://trello.com/c/ut9cWxrT