### PR TITLE
Fix a curly quote in the synonyms definitions

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -172,7 +172,7 @@
 - search: idi, immigration directorate instructions
 - search: iib => industrial injuries disablement benefit
 - search: ilr => indefinite leave, settle, individualised learner record
-- search: jsa, jobseeker’s allowance
+- search: jsa, jobseeker's allowance
 - search: lha, local housing allowance
 - search: lpa, lasting power of attorney
 - search: nasm => noise amelioration scheme military


### PR DESCRIPTION
Replace a curly quote `’` with an apostrophe `'` in the new synonym config. Curly quotes have caused problems in the past because they are not stripped by the Elasticsearch filters in the same way as apostrophes.

Spotted by eagle-eyed @tarastockford. This is the only instance in this file. I'm guessing it was introduced when we were working with the data in a Google doc.

https://trello.com/c/9VF3Rw5V/451-test-synonyms-with-healthcheck-and-search-performance-explorer