### PR TITLE
 Highlight synonym version of description fields

### DIFF
--- a/lib/search/presenters/highlighted_description.rb
+++ b/lib/search/presenters/highlighted_description.rb
@@ -22,7 +22,7 @@ module Search
       # `highlight` will be missing if none of the search terms match what's in
       # the title, eg. when displaying best bets.
       raw_result['highlight'] &&
-        raw_result['highlight']['description'].to_a.first
+        (raw_result['highlight']['description'].to_a.first || raw_result['highlight']['description.synonym'].to_a.first)
     end
 
     # The highlighting will return a truncated version of the description. It
@@ -57,7 +57,7 @@ module Search
 
     def original_description
       # `fields.description` is nil if the document doesn't have a description set.
-      raw_result['fields']['description'] || ""
+      raw_result['fields']['description'] || raw_result['fields']['description.synonym'] || ""
     end
   end
 end

--- a/lib/search/query_components/highlight.rb
+++ b/lib/search/query_components/highlight.rb
@@ -11,7 +11,14 @@ module QueryComponents
           title: {
             number_of_fragments: 0,
           },
+          "title.synonym".to_sym => {
+            number_of_fragments: 0,
+          },
           description: {
+            number_of_fragments: 1,
+            fragment_size: 285,
+          },
+          "description.synonym".to_sym => {
             number_of_fragments: 1,
             fragment_size: 285,
           },

--- a/spec/unit/query_components/highlight_spec.rb
+++ b/spec/unit/query_components/highlight_spec.rb
@@ -10,12 +10,28 @@ RSpec.describe QueryComponents::Highlight do
       expect(payload[:fields].keys).to include(:title)
     end
 
+    it 'enables highlighting on title with synonyms' do
+      parameters = Search::QueryParameters.new(return_fields: %w[title_with_highlighting])
+
+      payload = QueryComponents::Highlight.new(parameters).payload
+
+      expect(payload[:fields].keys).to include(:"title.synonym")
+    end
+
     it 'enables highlighting on description' do
       parameters = Search::QueryParameters.new(return_fields: %w[description_with_highlighting])
 
       payload = QueryComponents::Highlight.new(parameters).payload
 
       expect(payload[:fields].keys).to include(:description)
+    end
+
+    it 'enables highlighting on description with synonyms' do
+      parameters = Search::QueryParameters.new(return_fields: %w[description_with_highlighting])
+
+      payload = QueryComponents::Highlight.new(parameters).payload
+
+      expect(payload[:fields].keys).to include(:"description.synonym")
     end
 
     it 'does not enable highlighting when not requested' do

--- a/spec/unit/search/presenters/highlighted_description_spec.rb
+++ b/spec/unit/search/presenters/highlighted_description_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
 RSpec.describe Search::HighlightedDescription do
-  it "adds_highlighting_if_present" do
+  it "adds highlighting if present" do
     raw_result = {
-      "fields" => { "description" => "I will be hightlighted." },
-      "highlight" => { "description" => ["I will be <mark>hightlighted</mark>."] }
+      "fields" => { "description" => "I will be highlighted." },
+      "highlight" => { "description" => ["I will be <mark>highlighted</mark>."] }
     }
 
     highlighted_description = described_class.new(raw_result).text
 
-    expect(highlighted_description).to eq("I will be <mark>hightlighted</mark>.")
+    expect(highlighted_description).to eq("I will be <mark>highlighted</mark>.")
   end
 
-  it "uses_default_description_if_hightlight_not_found" do
+  it "uses default description if highlight not found" do
     raw_result = {
-      "fields" => { "description" => "I will not be hightlighted & escaped." }
+      "fields" => { "description" => "I will not be highlighted & escaped." }
     }
 
     highlighted_description = described_class.new(raw_result).text
 
-    expect(highlighted_description).to eq("I will not be hightlighted &amp; escaped.")
+    expect(highlighted_description).to eq("I will not be highlighted &amp; escaped.")
   end
 
-  it "truncates_default_description_if_hightlight_not_found" do
+  it "truncates default description if highlight not found" do
     raw_result = {
       "fields" => { "description" => ("This is a sentence that is too long." * 10) }
     }
@@ -33,7 +33,7 @@ RSpec.describe Search::HighlightedDescription do
     expect(highlighted_description.ends_with?('…')).to be_truthy
   end
 
-  it "returns_empty_string_if_theres_no_description" do
+  it "returns empty string if theres no description" do
     raw_result = {
       "fields" => { "description" => nil }
     }

--- a/spec/unit/search/presenters/highlighted_description_spec.rb
+++ b/spec/unit/search/presenters/highlighted_description_spec.rb
@@ -12,9 +12,30 @@ RSpec.describe Search::HighlightedDescription do
     expect(highlighted_description).to eq("I will be <mark>highlighted</mark>.")
   end
 
+  it "highlights description with synonyms if present" do
+    raw_result = {
+      "fields" => { "description.synonym" => "I will be highlighted." },
+      "highlight" => { "description.synonym" => ["I will be <mark>highlighted</mark>."] }
+    }
+
+    highlighted_description = described_class.new(raw_result).text
+
+    expect(highlighted_description).to eq("I will be <mark>highlighted</mark>.")
+  end
+
   it "uses default description if highlight not found" do
     raw_result = {
       "fields" => { "description" => "I will not be highlighted & escaped." }
+    }
+
+    highlighted_description = described_class.new(raw_result).text
+
+    expect(highlighted_description).to eq("I will not be highlighted &amp; escaped.")
+  end
+
+  it "uses description with synonyms if highlight not found" do
+    raw_result = {
+      "fields" => { "description.synonym" => "I will not be highlighted & escaped." }
     }
 
     highlighted_description = described_class.new(raw_result).text


### PR DESCRIPTION
The description fields should have highlighting applied so that a user can see which of their search terms appear in the content. This was not working in the B version of the synonyms A/B test because the `description.synonym` fields did not have highlighting applied.

https://trello.com/c/yHuPBjBM/505-fix-term-highlighting-in-synonyms-b-version

We should fix title highlighting too for consistency, but it's not used in the search frontend so it's less critical than description highlighting which I'd like to deploy by the end of the day.