### PR TITLE
Make policies indexable

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -25,6 +25,7 @@ manual: manual
 manual_section: manual_section
 medical_safety_alert: medical_safety_alert # Specialist Publisher
 place: edition
+policy: policy # Policy Publisher
 raib_report: raib_report # Specialist Publisher
 service_manual_guide: service_manual_guide
 service_manual_homepage: service_manual_guide

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -46,4 +46,5 @@ migrated:
 - travel_advice
 - travel_advice_index
 
-indexable: []
+indexable:
+- policy

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -11,7 +11,6 @@ module GovukIndex
     delegate_to_payload :content_id
     delegate_to_payload :content_purpose_document_supertype
     delegate_to_payload :content_store_document_type, hash_key: "document_type"
-    delegate_to_payload :description
     delegate_to_payload :email_document_supertype
     delegate_to_payload :government_document_supertype
     delegate_to_payload :link, hash_key: "base_path"
@@ -24,6 +23,16 @@ module GovukIndex
 
     def initialize(payload)
       @payload = payload
+    end
+
+    def description
+      if format == "policy"
+        summary = [] << payload["details"]["summary"]
+        sanitiser = GovukIndex::IndexableContentSanitiser.new
+        sanitiser.clean(summary)
+      else
+        payload["description"]
+      end
     end
 
     def title

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -78,6 +78,8 @@ module GovukIndex
         organisations:                       expanded_links.organisations,
         outcome_type:                        specialist.outcome_type,
         part_of_taxonomy_tree:               expanded_links.part_of_taxonomy_tree,
+        people:                              expanded_links.people,
+        policy_groups:                       expanded_links.policy_groups,
         popularity:                          common_fields.popularity,
         primary_publishing_organisation:     expanded_links.primary_publishing_organisation,
         public_timestamp:                    common_fields.public_timestamp,
@@ -150,6 +152,8 @@ module GovukIndex
         base_path.gsub(%r{^/topic/}, '')
       elsif format == "mainstream_browse_page"
         base_path.gsub(%r{^/browse/}, '')
+      elsif format == "policy"
+        base_path.gsub(%r{^/government/policies/}, '')
       end
     end
 

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -16,6 +16,14 @@ module GovukIndex
       content_ids("organisations")
     end
 
+    def people
+      slugs("people", "/government/people/")
+    end
+
+    def policy_groups
+      slugs("working_groups", "/government/groups/")
+    end
+
     def primary_publishing_organisation
       organisation_slugs("primary_publishing_organisation")
     end
@@ -29,15 +37,11 @@ module GovukIndex
     end
 
     def specialist_sectors
-      expanded_links_item("topics").map do |content_item|
-        content_item["base_path"].sub("/topic/", "")
-      end
+      slugs("topics", "/topic/")
     end
 
     def mainstream_browse_pages
-      expanded_links_item("mainstream_browse_pages").map do |content_item|
-        content_item["base_path"].sub("/browse/", "")
-      end
+      slugs("mainstream_browse_pages", "/browse/")
     end
 
     def part_of_taxonomy_tree
@@ -60,6 +64,12 @@ module GovukIndex
 
     def content_ids(collection)
       values_from_collection(expanded_links_item(collection), "content_id")
+    end
+
+    def slugs(type, path_prefix)
+      expanded_links_item(type).map do |content_item|
+        content_item["base_path"].gsub(%r{^#{path_prefix}}, "")
+      end
     end
 
     def organisation_slugs(type)

--- a/spec/integration/govuk_index/policy_spec.rb
+++ b/spec/integration/govuk_index/policy_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+RSpec.describe "Policy publishing" do
+  before do
+    bunny_mock = BunnyMock.new
+    @channel = bunny_mock.start.channel
+
+    consumer = GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "policies.test",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      rabbitmq_connection: bunny_mock
+    )
+
+    @queue = @channel.queue("policies.test")
+    consumer.run
+  end
+
+  let(:people) do
+    [
+      {
+        "content_id" => SecureRandom.uuid,
+        "title" => "Person 1",
+        "base_path" => "/government/people/person-1",
+        "locale" => "en",
+      },
+      {
+        "content_id" => SecureRandom.uuid,
+        "title" => "Person 2",
+        "base_path" => "/government/people/person-2",
+        "locale" => "en",
+      },
+    ]
+  end
+
+  let(:working_groups) do
+    [
+      {
+        "content_id" => SecureRandom.uuid,
+        "title" => "Working group 1",
+        "base_path" => "/government/groups/working-group-1",
+        "locale" => "en",
+      },
+      {
+        "content_id" => SecureRandom.uuid,
+        "title" => "Working group 2",
+        "base_path" => "/government/groups/working-group-2",
+        "locale" => "en",
+      },
+    ]
+  end
+
+  it "indexes a policy" do
+    random_example = generate_random_example(
+      schema: "policy",
+      payload: {
+        document_type: "policy",
+        base_path: "/government/policies/hs2-high-speed-rail",
+        expanded_links: {
+          working_groups: working_groups,
+          people: people
+        }
+      },
+      details: { summary: "<p>Description about policy.</p>\n" },
+      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
+    )
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["policy"])
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = {
+       "link" => random_example["base_path"],
+       "people" => ["person-1", "person-2"],
+       "policy_groups" => ["working-group-1", "working-group-2"],
+       "description" => "Description about policy.",
+       "slug" => "hs2-high-speed-rail",
+     }
+
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "policy")
+  end
+end

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     @directly_mapped_fields = %w(
       content_id
-      description
       email_document_supertype
       government_document_supertype
       navigation_document_supertype

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -131,6 +131,40 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.topic_content_ids).to eq(expected_topic_content_ids)
   end
 
+  it "people" do
+    expanded_links = {
+      "people" => [
+          {
+            "base_path" => "/government/people/badger-of-deploy",
+            "content_id" => "dbce902f-36d1-471e-a79a-8934aee7c34c",
+            "locale" => "en",
+            "title" => "Badger of Deploy"
+          }
+      ]
+    }
+
+    presenter = expanded_links_presenter(expanded_links)
+
+    expect(presenter.people).to eq(["badger-of-deploy"])
+  end
+
+  it "policy groups" do
+    expanded_links = {
+      "working_groups" => [
+          {
+            "base_path" => "/government/groups/micropig-advisory-group",
+            "content_id" => "33848853-6411-4e36-b72b-afe50aff1b93",
+            "locale" => "en",
+            "title" => "Micropig advisory group"
+          }
+      ]
+    }
+
+    presenter = expanded_links_presenter(expanded_links)
+
+    expect(presenter.policy_groups).to eq(["micropig-advisory-group"])
+  end
+
   def expanded_links_presenter(expanded_links)
     described_class.new(expanded_links)
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/IXXgzDpD/497-make-policies-indexable)
- Maps `policy_groups`, `people`, `description` and `slug` fields.
- This is to set up the policy format to be migrated to the govuk search index.