### PR TITLE
Ignore differences in apostrophes when comparing content

### DIFF
--- a/lib/indexer/govuk_index_field_comparer.rb
+++ b/lib/indexer/govuk_index_field_comparer.rb
@@ -23,7 +23,8 @@ module Indexer
       return compare_content(id, old, new) if key == 'indexable_content'
       return true if old.nil? && new == ''
       return true if key == 'rendering_app' && old == 'specialist-frontend' && new == 'government-frontend'
-      old == new
+      return compare_arrays(old, new) if old.is_a?(Array) && new.is_a?(Array)
+      clean_field(old) == clean_field(new)
     end
 
     def compare_time(key, old, new)
@@ -66,10 +67,18 @@ module Indexer
       end
     end
 
+    def compare_arrays(old, new)
+      old.map { |i| clean_field(i) } == new.map { |i| clean_field(i) }
+    end
+
     def remove_links(str)
       str.gsub(/\[([^\]]*(?:\[[^\]]*\][^\]]*)?)\]\([^\)]*\)/, ' \1 ') # [name](link) => name
         .gsub(/#+\s*/, ' ')
         .gsub(/\[InlineAttachment:(?:.*\/)?([^\[\]\/]*(?:\[[^\]\/]*\][^\[\]\/]*|)*)\]/, '\1')
+    end
+
+    def clean_field(str)
+      str.gsub(/[’'‘]/, "'")
     end
 
     def clean_content(str)

--- a/spec/unit/indexer/field_comparer_spec.rb
+++ b/spec/unit/indexer/field_comparer_spec.rb
@@ -59,4 +59,14 @@ RSpec.describe Indexer::GovukIndexFieldComparer do
     is_same = described_class.new.call("/some/id", "title", nil, "some text")
     expect(is_same).to be true
   end
+
+  it "ignores differences in apostrophes" do
+    is_same = described_class.new.call(
+      "/some/id",
+      "title",
+      "What the government's doing about pigs' and micropigs' welfare",
+      "What the government‘s doing about pigs' and micropigs’ welfare"
+    )
+    expect(is_same).to be true
+  end
 end

--- a/spec/unit/indexer/field_comparer_spec.rb
+++ b/spec/unit/indexer/field_comparer_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe Indexer::GovukIndexFieldComparer do
+  it "identifies unchanged content" do
+    is_same = described_class.new.call("/some/id", "title", "some text", "some text")
+    expect(is_same).to be true
+  end
+
+  it "identifies unchanged arrays of content" do
+    is_same = described_class.new.call(
+      "/some/id",
+      "title",
+      %w(value1 value2 value3),
+      %w(value1 value2 value3)
+    )
+    expect(is_same).to be true
+  end
+
+  it "identifies changed content" do
+    is_same = described_class.new.call("/some/id", "title", "some text", "other text")
+    expect(is_same).to be false
+  end
+
+  it "identifies changes in arrays" do
+    is_same = described_class.new.call(
+      "/some/id",
+      "title",
+      %w(value1 value2 value3),
+      %w(value1 other_value2 value3)
+    )
+    expect(is_same).to be false
+  end
+
+  it "identifies items added to arrays as changed" do
+    is_same = described_class.new.call(
+      "/some/id",
+      "title",
+      %w(value1 value2),
+      %w(value1 value2 value3)
+    )
+    expect(is_same).to be false
+  end
+
+  it "identifies items removed from arrays as changed" do
+    is_same = described_class.new.call(
+      "/some/id",
+      "title",
+      %w(value1 value2 value3),
+      %w(value1 value2)
+    )
+    expect(is_same).to be false
+  end
+
+  it "identifies removed content" do
+    is_same = described_class.new.call("/some/id", "title", "some text", nil)
+    expect(is_same).to be false
+  end
+
+  # We don't mind if the new search index includes additional fields
+  it "ignores added content" do
+    is_same = described_class.new.call("/some/id", "title", nil, "some text")
+    expect(is_same).to be true
+  end
+end


### PR DESCRIPTION
I spotted this issue when migrating policies, which has a few curly quotes in new content which the comparer should ignore. We already ignored differences in apostrophes in `indexable_content` - this just extends the comparison to other fields.

This change also adds some basic tests of the `GovukIndexFieldComparer`. It doesn't attempt to cover all the cases because the code is temporary and some of the checks are very specific to formats that we've already migrated.

https://trello.com/c/IXXgzDpD/497-make-policies-indexable