### PR TITLE
Ignore new empty arrays in the index comparer

### DIFF
--- a/lib/indexer/govuk_index_field_comparer.rb
+++ b/lib/indexer/govuk_index_field_comparer.rb
@@ -11,6 +11,7 @@ module Indexer
 
     def call(id, key, old, new)
       return true if key =~ /^_root/
+      return true if old.nil? && new == []
       if old.nil? && !new.nil?
         stats["AddedValue: #{key}"] += 1
         return true

--- a/spec/unit/indexer/field_comparer_spec.rb
+++ b/spec/unit/indexer/field_comparer_spec.rb
@@ -69,4 +69,13 @@ RSpec.describe Indexer::GovukIndexFieldComparer do
     )
     expect(is_same).to be true
   end
+
+  it "treats new empty arrays like missing values in old content" do
+    comparer = described_class.new
+
+    is_same = comparer.call("/some/id", "organisations", nil, [])
+
+    expect(is_same).to be true
+    expect(comparer.stats["AddedValue: organisations"]).to eq 0
+  end
 end


### PR DESCRIPTION
There are cases where the publishing app wouldn't send an empty field to rummager, but the new publishing process saves an empty array. This is valid, and the comparer shouldn't treat it like a new field.

https://trello.com/c/IXXgzDpD/497-make-policies-indexable

cc @dwhenry and @brenetic: Would this have been valid for the other formats you've migrated?