### PR TITLE
Make smart answers indexable

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -47,4 +47,5 @@ migrated:
 - travel_advice
 - travel_advice_index
 
-indexable: []
+indexable:
+- smart-answer # transaction document type from the smart-answers publishing app

--- a/lib/govuk_index/indexable_content_sanitiser.rb
+++ b/lib/govuk_index/indexable_content_sanitiser.rb
@@ -1,9 +1,10 @@
 module GovukIndex
   class IndexableContentSanitiser
     def clean(items)
-      cleaned_content = items.map { |item|
-        strip_html_tags(indexable_content(item))
-      }.compact
+      cleaned_content = items.
+        flat_map { |item| indexable_content(item) }.
+        map { |item| strip_html_tags(item) }.
+        compact
 
       return nil if cleaned_content.empty?
       cleaned_content.join("\n").strip
@@ -12,7 +13,9 @@ module GovukIndex
   private
 
     def indexable_content(item)
-      item.instance_of?(String) ? item : html_content(item)
+      return [item] if item.instance_of?(String)
+      return item if item.all? { |row| row.instance_of?(String) }
+      [html_content(item)]
     end
 
     def html_content(item)

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -53,6 +53,9 @@ module GovukIndex
     end
 
     def format
+      # TODO: remove the special case for smart answers once it is fully migrated to
+      #   govuk as it's fallback `transaction` has the same implementation.
+      return 'smart-answer' if payload['publishing_app'] == 'smartanswers'
       document_type = payload['document_type']
       CUSTOM_FORMAT_MAP[document_type] || document_type
     end

--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -4,7 +4,7 @@ module GovukIndex
     BY_FORMAT = {
       'contact'       => %w(title description),
       'licence'       => %w(licence_short_description licence_overview),
-      'smart-answer'  => %w(introductory_paragraph),
+      'smart-answer'  => %w(introductory_paragraph more_information),
       'transaction'   => %w(introductory_paragraph more_information),
       'travel_advice' => %w(summary),
     }.freeze

--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -1,9 +1,10 @@
 module GovukIndex
   class IndexableContentPresenter
-    DEFAULTS = %w(body parts).freeze
+    DEFAULTS = %w(body parts hidden_search_terms).freeze
     BY_FORMAT = {
       'contact'       => %w(title description),
       'licence'       => %w(licence_short_description licence_overview),
+      'smart-answer'  => %w(introductory_paragraph),
       'transaction'   => %w(introductory_paragraph more_information),
       'travel_advice' => %w(summary),
     }.freeze

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -50,7 +50,7 @@ module GovukIndex
       if presenter.unpublishing_type?
         logger.info("#{routing_key} -> DELETE #{presenter.base_path} #{presenter.type}")
         actions.delete(presenter)
-      elsif MigratedFormats.indexable?(presenter.format) && payload['publishing_app'] != 'smartanswers'
+      elsif MigratedFormats.indexable?(presenter.format)
         logger.info("#{routing_key} -> INDEX #{presenter.base_path} #{presenter.type}")
         actions.save(presenter)
       else

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -35,19 +35,18 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest' do
     expect(@channel.acknowledged_state[:acked].count).to eq(1)
   end
 
-  it "not_indexing_when_publishing_app_is_smart_answers" do
+  it "indexed with a format of smart answers when publishing app is smart answers" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
     random_example = generate_random_example(
-      schema: 'special_route',
+      schema: 'transaction',
       payload: { document_type: "transaction", payload_version: 123, publishing_app: "smartanswers" },
     )
 
     @queue.publish(random_example.to_json, content_type: "application/json")
     commit_index 'govuk_test'
 
-    expect {
-      fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test", type: 'edition')
-    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test", type: 'edition')
+    expect(document["_source"]["format"]).to eq("smart-answer")
   end
 
   it "should_include_popularity_when_available" do

--- a/spec/unit/govuk_index/indexable_content_sanitiser_spec.rb
+++ b/spec/unit/govuk_index/indexable_content_sanitiser_spec.rb
@@ -19,6 +19,30 @@ RSpec.describe GovukIndex::IndexableContentSanitiser do
     expect(subject.clean(payload)).to eq("hello marmaduke")
   end
 
+  context "when an array of strings is passed in" do
+    it "treats each element of the array as a valid element" do
+      payload = [
+        [
+          "line 1",
+          "line 2"
+        ]
+      ]
+
+      expect(subject.clean(payload)).to eq("line 1\n\n\nline 2")
+    end
+
+    it "strips html tags from each element in the array" do
+      payload = [
+        [
+          "<p>line 1<\p>",
+          "<div>line<\div> 2"
+        ]
+      ]
+
+      expect(subject.clean(payload)).to eq("line 1\n\n\n\nline\n 2")
+    end
+  end
+
   context "when html test payloads exists" do
     it "strips out html tags from to the html content" do
       payload = [

--- a/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
@@ -97,4 +97,37 @@ RSpec.describe GovukIndex::IndexableContentPresenter do
       expect(subject.indexable_content).to eq("Title\n\n\nDescription\n\n\nTitle 1\n\n\nTitle 2")
     end
   end
+
+  context "smart-answers" do
+    let(:format) { 'smart-answer' }
+    let(:details) do
+      {
+        "introductory_paragraph" =>  [
+          {
+            "content" =>  "intro\n",
+            "content_type" =>  "text/govspeak"
+          },
+          {
+            "content_type" =>  "text/html",
+            "content" =>  "<p>intro</p>\n"
+          }
+        ],
+        "more_information" =>  [
+          {
+            "content" =>  "more<\n",
+            "content_type" =>  "text/govspeak"
+          },
+          {
+            "content_type" =>  "text/html",
+            "content" =>  "<p>more</p>\n"
+          }
+        ],
+        "hidden_search_terms" =>  ["hidden 1", "hidden 2"]
+      }
+    end
+
+    it 'hidden_search_terms is correctly indexed' do
+      expect(subject.indexable_content).to eq("hidden 1\n\n\nhidden 2\n\n\nintro\n\n\n\nmore")
+    end
+  end
 end


### PR DESCRIPTION
Smart answers pass in `hidden_search_terms` which is an array of strings.

I have updated the indexable_content_presenter to handle this new format
which required a little reworking of the code.

https://trello.com/c/tSPsLjz3/489-make-smartanswers-indexable