### PR TITLE
Mark the policy format as migrated

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -38,6 +38,7 @@ migrated:
 - hmrc_manual_section
 - manual
 - manual_section
+- policy
 - service_manual_guide
 - service_manual_homepage
 - service_manual_service_standard
@@ -46,5 +47,4 @@ migrated:
 - travel_advice
 - travel_advice_index
 
-indexable:
-- policy
+indexable: []


### PR DESCRIPTION
There are no significant differences between policies in the mainstream and govuk indices, so this format can be fully migrated to the govuk index.

https://trello.com/c/rnrR9LGl/515-makes-policies-fully-migrated

Marked as "do not merge" until we've run the comparer on production.