### PR TITLE
Process message batches

### DIFF
--- a/lib/govuk_index/publishing_event_processor.rb
+++ b/lib/govuk_index/publishing_event_processor.rb
@@ -1,9 +1,11 @@
 module GovukIndex
   class PublishingEventProcessor
-    def process(message)
+    def process(messages)
+      messages = Array(messages) # treat a single message as an array with one value
+
       Services.statsd_client.increment('govuk_index.rabbit-mq-consumed')
-      PublishingEventWorker.perform_async(message.delivery_info[:routing_key], message.payload)
-      message.ack
+      PublishingEventWorker.perform_async(messages.map { |msg| [msg.delivery_info[:routing_key], msg.payload] })
+      messages.each(&:ack)
     end
   end
 end

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -1,153 +1,188 @@
 require 'spec_helper'
 
 RSpec.describe 'GovukIndex::PublishingEventProcessorTest' do
-  before do
-    bunny_mock = BunnyMock.new
-    @channel = bunny_mock.start.channel
+  context "Testing via fake rabbit queue" do
+    before do
+      bunny_mock = BunnyMock.new
+      @channel = bunny_mock.start.channel
 
-    consumer = GovukMessageQueueConsumer::Consumer.new(
-      queue_name: "bigwig.test",
-      processor: GovukIndex::PublishingEventProcessor.new,
-      rabbitmq_connection: bunny_mock
-    )
+      consumer = GovukMessageQueueConsumer::Consumer.new(
+        queue_name: "bigwig.test",
+        processor: GovukIndex::PublishingEventProcessor.new,
+        rabbitmq_connection: bunny_mock
+      )
 
-    @queue = @channel.queue("bigwig.test")
-    consumer.run
+      @queue = @channel.queue("bigwig.test")
+      consumer.run
+    end
+
+    it "saves new documents to elasticsearch" do
+      allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
+      random_example = generate_random_example(
+        payload: { document_type: "help_page", payload_version: 123 },
+      )
+
+      @queue.publish(random_example.to_json, content_type: "application/json")
+      commit_index 'govuk_test'
+
+      document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
+
+      expect(random_example["base_path"]).to eq(document["_source"]["link"])
+      expect(random_example["base_path"]).to eq(document["_id"])
+      expect(document["_type"]).to eq("edition")
+
+      expect(@queue.message_count).to eq(0)
+      expect(@channel.acknowledged_state[:acked].count).to eq(1)
+    end
+
+    it "includes popularity data when available" do
+      allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
+      random_example = generate_random_example(
+        payload: { document_type: "help_page", payload_version: 123 },
+      )
+
+      document_count = 4
+      document_rank = 2
+      insert_document("page-traffic_test", { rank_14: document_rank, path_components: [random_example["base_path"]] }, id: random_example["base_path"], type: "page-traffic")
+      setup_page_traffic_data(document_count: document_count)
+
+      popularity = 1.0 / ([document_count, document_rank].min + SearchConfig.instance.popularity_rank_offset)
+
+      @queue.publish(random_example.to_json, content_type: "application/json")
+      commit_index 'govuk_test'
+
+      document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
+
+      expect(popularity).to eq(document["_source"]["popularity"])
+    end
+
+    it "discards messages that are invalid" do
+      invalid_payload = {
+        "title" => "Pitts S-2B, G-SKYD, 21 June 1996",
+        "document_type" => "help_page",
+      }
+
+      expect(GovukError).to receive(:notify)
+      @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
+
+      expect(@queue.message_count).to eq(0)
+    end
+
+    it "discards messages that are withdrawn and invalid" do
+      invalid_payload = {
+        "title" => "Pitts S-2B, G-SKYD, 21 June 1996",
+        "document_type" => "gone",
+      }
+
+      expect(GovukError).to receive(:notify)
+      @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
+
+      expect(@queue.message_count).to eq(0)
+    end
   end
 
-  it "should_save_new_document_to_elasticsearch" do
-    allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
-    random_example = generate_random_example(
-      payload: { document_type: "help_page", payload_version: 123 },
-    )
+  context "test queue handles" do
+    it "can save multiple documents in a batch" do
+      allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
+      random_example_a = generate_random_example(
+        payload: { document_type: "help_page", payload_version: 123 },
+      )
+      random_example_b = generate_random_example(
+        payload: { document_type: "help_page", payload_version: 123 },
+      )
 
-    @queue.publish(random_example.to_json, content_type: "application/json")
-    commit_index 'govuk_test'
+      message_a = double(:msg1, payload: random_example_a, delivery_info: { routing_key: 'big.test' })
+      message_b = double(:msg2, payload: random_example_b, delivery_info: { routing_key: 'big.test' })
 
-    document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
+      expect(message_a).to receive(:ack)
+      expect(message_b).to receive(:ack)
 
-    expect(random_example["base_path"]).to eq(document["_source"]["link"])
-    expect(random_example["base_path"]).to eq(document["_id"])
-    expect(document["_type"]).to eq("edition")
+      GovukIndex::PublishingEventProcessor.new.process([message_a, message_b])
 
-    expect(@queue.message_count).to eq(0)
-    expect(@channel.acknowledged_state[:acked].count).to eq(1)
-  end
+      commit_index 'govuk_test'
 
-  it "should_include_popularity_when_available" do
-    allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
-    random_example = generate_random_example(
-      payload: { document_type: "help_page", payload_version: 123 },
-    )
+      document_a = fetch_document_from_rummager(id: random_example_a["base_path"], index: "govuk_test")
+      document_b = fetch_document_from_rummager(id: random_example_b["base_path"], index: "govuk_test")
 
-    document_count = 4
-    document_rank = 2
-    insert_document("page-traffic_test", { rank_14: document_rank, path_components: [random_example["base_path"]] }, id: random_example["base_path"], type: "page-traffic")
-    setup_page_traffic_data(document_count: document_count)
+      expect(document_a["_source"]["link"]).to eq(random_example_a["base_path"])
+      expect(document_a["_id"]).to eq(random_example_a["base_path"])
+      expect(document_a["_type"]).to eq("edition")
 
-    popularity = 1.0 / ([document_count, document_rank].min + SearchConfig.instance.popularity_rank_offset)
+      expect(document_b["_source"]["link"]).to eq(random_example_b["base_path"])
+      expect(document_b["_id"]).to eq(random_example_b["base_path"])
+      expect(document_b["_type"]).to eq("edition")
+    end
 
-    @queue.publish(random_example.to_json, content_type: "application/json")
-    commit_index 'govuk_test'
+    it "skips blacklisted formats" do
+      logger = double(info: true, debug: true)
+      worker = GovukIndex::PublishingEventWorker.new
+      allow(worker).to receive(:logger).and_return(logger)
 
-    document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
+      random_example = generate_random_example(
+        schema: 'generic_with_external_related_links',
+        payload: { document_type: "smart_answer", payload_version: 123 },
+      )
 
-    expect(popularity).to eq(document["_source"]["popularity"])
-  end
+      expect(logger).to receive(:info).with("test.route -> BLACKLISTED #{random_example['base_path']} 'unmapped type'")
+      worker.perform([['test.route', random_example]])
+      commit_index 'govuk_test'
 
-  it "should_discard_message_when_invalid" do
-    invalid_payload = {
-      "title" => "Pitts S-2B, G-SKYD, 21 June 1996",
-      "document_type" => "help_page",
-    }
+      expect {
+        fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
+      }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
 
-    expect(GovukError).to receive(:notify)
-    @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
+    it "alerts on unknown formats - neither white or black listed" do
+      allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(false)
+      allow(GovukIndex::MigratedFormats).to receive(:non_indexable?).and_return(false)
 
-    expect(@queue.message_count).to eq(0)
-  end
+      logger = double(info: true, debug: true)
+      worker = GovukIndex::PublishingEventWorker.new
+      allow(worker).to receive(:logger).and_return(logger)
 
-  it "should_discard_message_when_withdrawn_and_invalid" do
-    invalid_payload = {
-      "title" => "Pitts S-2B, G-SKYD, 21 June 1996",
-      "document_type" => "gone",
-    }
+      random_example = generate_random_example(
+        payload: { document_type: "help_page", payload_version: 123 },
+      )
 
-    expect(GovukError).to receive(:notify)
-    @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
+      expect(logger).to receive(:info).with("test.route -> UNKNOWN #{random_example['base_path']} edition")
+      worker.perform([['test.route', random_example]])
+    end
 
-    expect(@queue.message_count).to eq(0)
-  end
+    it "will consider a format that is both white and black listed to be blacklisted" do
+      allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
+      allow(GovukIndex::MigratedFormats).to receive(:non_indexable?).and_return(true)
 
-  it "skips blacklisted formats" do
-    logger = double(info: true, debug: true)
-    worker = GovukIndex::PublishingEventWorker.new
-    allow(worker).to receive(:logger).and_return(logger)
+      logger = double(info: true, debug: true)
+      worker = GovukIndex::PublishingEventWorker.new
+      allow(worker).to receive(:logger).and_return(logger)
 
-    random_example = generate_random_example(
-      schema: 'generic_with_external_related_links',
-      payload: { document_type: "smart_answer", payload_version: 123 },
-    )
+      random_example = generate_random_example(
+        payload: { document_type: "help_page", payload_version: 123 },
+      )
 
-    expect(logger).to receive(:info).with("test.route -> BLACKLISTED #{random_example['base_path']} 'unmapped type'")
-    worker.perform('test.route', random_example)
-    commit_index 'govuk_test'
+      expect(logger).to receive(:info).with("test.route -> BLACKLISTED #{random_example['base_path']} edition")
+      worker.perform([['test.route', random_example]])
+    end
 
-    expect {
-      fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
-    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
-  end
+    it "can black/white list specific base_paths within a format" do
+      logger = double(info: true, debug: true)
+      worker = GovukIndex::PublishingEventWorker.new
+      allow(worker).to receive(:logger).and_return(logger)
 
-  it "alerts on unknown formats - neither white or black listed" do
-    allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(false)
-    allow(GovukIndex::MigratedFormats).to receive(:non_indexable?).and_return(false)
+      homepage_example = generate_random_example(
+        schema: 'special_route',
+        payload: { document_type: "special_route", base_path: '/homepage', payload_version: 123 },
+      )
+      help_example = generate_random_example(
+        schema: 'special_route',
+        payload: { document_type: "special_route", base_path: '/help', payload_version: 123 },
+      )
 
-    logger = double(info: true, debug: true)
-    worker = GovukIndex::PublishingEventWorker.new
-    allow(worker).to receive(:logger).and_return(logger)
-
-    random_example = generate_random_example(
-      payload: { document_type: "help_page", payload_version: 123 },
-    )
-
-    expect(logger).to receive(:info).with("test.route -> UNKNOWN #{random_example['base_path']} edition")
-    worker.perform('test.route', random_example)
-  end
-
-  it "will consider a format that is both white and black listed to be blacklisted" do
-    allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
-    allow(GovukIndex::MigratedFormats).to receive(:non_indexable?).and_return(true)
-
-    logger = double(info: true, debug: true)
-    worker = GovukIndex::PublishingEventWorker.new
-    allow(worker).to receive(:logger).and_return(logger)
-
-    random_example = generate_random_example(
-      payload: { document_type: "help_page", payload_version: 123 },
-    )
-
-    expect(logger).to receive(:info).with("test.route -> BLACKLISTED #{random_example['base_path']} edition")
-    worker.perform('test.route', random_example)
-  end
-
-  it "can black/white list specific base_paths within a format" do
-    logger = double(info: true, debug: true)
-    worker = GovukIndex::PublishingEventWorker.new
-    allow(worker).to receive(:logger).and_return(logger)
-
-    homepage_example = generate_random_example(
-      schema: 'special_route',
-      payload: { document_type: "special_route", base_path: '/homepage', payload_version: 123 },
-    )
-    help_example = generate_random_example(
-      schema: 'special_route',
-      payload: { document_type: "special_route", base_path: '/help', payload_version: 123 },
-    )
-
-    expect(logger).to receive(:info).with("test.route -> BLACKLISTED #{homepage_example['base_path']} edition")
-    expect(logger).to receive(:info).with("test.route -> INDEX #{help_example['base_path']} edition")
-    worker.perform('test.route', homepage_example)
-    worker.perform('test.route', help_example)
+      expect(logger).to receive(:info).with("test.route -> BLACKLISTED #{homepage_example['base_path']} edition")
+      expect(logger).to receive(:info).with("test.route -> INDEX #{help_example['base_path']} edition")
+      worker.perform([['test.route', homepage_example]])
+      worker.perform([['test.route', help_example]])
+    end
   end
 
   def client

--- a/spec/unit/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_processor_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GovukIndex::PublishingEventProcessor do
-  it "should_process_and_acknowledge_a_message" do
+  it "will process and ack a single message" do
     message = double(
       payload: {
         "base_path" => "/cheese",
@@ -13,9 +13,40 @@ RSpec.describe GovukIndex::PublishingEventProcessor do
       }
     )
 
-    expect(GovukIndex::PublishingEventWorker).to receive(:perform_async).with('routing.key', message.payload)
+    expect(GovukIndex::PublishingEventWorker).to receive(:perform_async).with([['routing.key', message.payload]])
     expect(message).to receive(:ack)
 
     subject.process(message)
+  end
+
+  it "will process and ack an array of messages" do
+    message1 = double(
+      payload: {
+        "base_path" => "/cheese",
+        "document_type" => "help_page",
+        "title" => "We love cheese"
+      },
+      delivery_info: {
+        routing_key: 'routing.key'
+      }
+    )
+    message2 = double(
+      payload: {
+        "base_path" => "/crackers",
+        "document_type" => "help_page",
+        "title" => "We love crackers"
+      },
+      delivery_info: {
+        routing_key: 'routing.key'
+      }
+    )
+
+    expect(GovukIndex::PublishingEventWorker).to receive(:perform_async).with(
+      [['routing.key', message1.payload], ['routing.key', message2.payload]]
+    )
+    expect(message1).to receive(:ack)
+    expect(message2).to receive(:ack)
+
+    subject.process([message1, message2])
   end
 end

--- a/spec/unit/govuk_index/publishing_event_worker_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_worker_spec.rb
@@ -1,166 +1,275 @@
 require 'spec_helper'
 
 RSpec.describe GovukIndex::PublishingEventWorker do
-  it "save_valid_message" do
-    payload = {
-      "base_path" => "/cheese",
-      "document_type" => "help_page",
-      "title" => "We love cheese"
-    }
-
-    actions = double('actions')
-    expect(GovukIndex::ElasticsearchProcessor).to receive(:new).and_return(actions)
-    expect(actions).to receive(:save)
-    expect(actions).to receive(:commit).and_return('items' => [{ 'index' => { 'status' => 200 } }])
-
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
-    subject.perform('routing.key', payload)
+  before do
+    allow(GovukIndex::ElasticsearchProcessor).to receive(:new).and_return(actions)
   end
+  let(:actions) { double('actions') }
 
-  it "delete_record_when_unpublishing_message_received" do
-    payload = {
-      "base_path" => "/cheese",
-      "document_type" => "redirect",
-      "title" => "We love cheese"
-    }
-    stub_document_type_inferer
+  context 'when a single message is received' do
 
-    actions = double('actions')
-
-    expect(GovukIndex::ElasticsearchProcessor).to receive(:new).and_return(actions)
-    expect(actions).to receive(:delete)
-    expect(actions).to receive(:commit).and_return('items' => [{ 'delete' => { 'status' => 200 } }])
-
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete')
-    subject.perform('routing.unpublish', payload)
-  end
-
-  it "should_not_delete_withdrawn" do
-    payload = {
-      "base_path" => "/cheese",
-      "document_type" => "help_page",
-      "title" => "We love cheese",
-      "withdrawn_notice" => {
-        "explanation" => "<div class=\"govspeak\"><p>test 2</p>\n</div>",
-        "withdrawn_at" => "2017-08-03T14:02:18Z"
-      }
-    }
-
-    actions = double('actions')
-    expect(GovukIndex::ElasticsearchProcessor).to receive(:new).and_return(actions)
-    expect(actions).to receive(:save)
-    expect(actions).to receive(:commit).and_return('items' => [{ 'index' => { 'status' => 200 } }])
-
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
-
-    subject.perform('routing.unpublish', payload)
-  end
-
-  it "raise_error_when_elasticsearch_update_error" do
-    payload = {
-      "base_path" => "/cheese",
-      "document_type" => "gone",
-      "title" => "We love cheese"
-    }
-    stub_document_type_inferer
-
-    actions = double('actions')
-    expect(GovukIndex::ElasticsearchProcessor).to receive(:new).and_return(actions)
-    expect(actions).to receive(:delete)
-    expect(actions).to receive(:commit).and_return('items' => [{ 'delete' => { 'status' => 500 } }])
-
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete_error')
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
-
-    expect {
-      subject.perform('routing.unpublish', payload)
-    }.to raise_error(GovukIndex::ElasticsearchError)
-  end
-
-  it "does_not_raise_error_when_document_not_found_while_attempting_to_delete" do
-    payload = {
-      "base_path" => "/cheese",
-      "document_type" => "substitute",
-      "title" => "We love cheese"
-    }
-    stub_document_type_inferer
-
-    actions = double('actions')
-    expect(GovukIndex::ElasticsearchProcessor).to receive(:new).and_return(actions)
-    expect(actions).to receive(:delete)
-    expect(actions).to receive(:commit).and_return('items' => [{ 'delete' => { 'status' => 404 } }])
-
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.already_deleted')
-    subject.perform('routing.unpublish', payload)
-  end
-
-  it "raise_error_if_elasticsearch_returns_multiple_responses" do
-    payload = {
-      "base_path" => "/cheese",
-      "document_type" => "vanish",
-      "title" => "We love cheese"
-    }
-    stub_document_type_inferer
-
-    actions = double('actions')
-    expect(GovukIndex::ElasticsearchProcessor).to receive(:new).and_return(actions)
-    expect(actions).to receive(:delete)
-    expect(actions).to receive(:commit).and_return('items' => [{ 'index' => { 'status' => 200 } }, { 'delete' => { 'status' => 200 } }])
-
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.multiple_responses')
-    expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
-
-    expect {
-      subject.perform('routing.unpublish', payload)
-    }.to raise_error(GovukIndex::MultipleMessagesInElasticsearchResponse)
-  end
-
-  context "when document type requires a basepath" do
-    let(:payload) do
-      {
+    it "will save a valid document" do
+      payload = {
+        "base_path" => "/cheese",
         "document_type" => "help_page",
-        "title" => "We love cheese",
+        "title" => "We love cheese"
       }
+
+      expect(actions).to receive(:save)
+      expect(actions).to receive(:commit).and_return('items' => [{ 'index' => { 'status' => 200 } }])
+
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
+      subject.perform([['routing.key', payload]])
     end
 
-    it "notify of a validation error for missing basepath" do
-      expect(GovukError).to receive(:notify).with(
-        instance_of(GovukIndex::MissingBasePath),
-        extra: {
-          message_body: {
-            'document_type' => 'help_page',
-            'title' => 'We love cheese',
+    context "when a message to unpublish the document is received" do
+      it "will delete the document" do
+        payload = {
+          "base_path" => "/cheese",
+          "document_type" => "redirect",
+          "title" => "We love cheese"
+        }
+        stub_document_type_inferer
+
+        expect(actions).to receive(:delete)
+        expect(actions).to receive(:commit).and_return('items' => [{ 'delete' => { 'status' => 200 } }])
+
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete')
+        subject.perform([['routing.unpublish', payload]])
+      end
+
+      it "will not delete withdrawn documents" do
+        payload = {
+          "base_path" => "/cheese",
+          "document_type" => "help_page",
+          "title" => "We love cheese",
+          "withdrawn_notice" => {
+            "explanation" => "<div class=\"govspeak\"><p>test 2</p>\n</div>",
+            "withdrawn_at" => "2017-08-03T14:02:18Z"
           }
         }
-      )
 
-      subject.perform('routing.key', payload)
+        expect(actions).to receive(:save)
+        expect(actions).to receive(:commit).and_return('items' => [{ 'index' => { 'status' => 200 } }])
+
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
+
+        subject.perform([['routing.unpublish', payload]])
+      end
+
+      it "will raise an error when elasticsearch returns a 500 status" do
+        payload = {
+          "base_path" => "/cheese",
+          "document_type" => "gone",
+          "title" => "We love cheese"
+        }
+        stub_document_type_inferer
+
+        expect(actions).to receive(:delete)
+        expect(actions).to receive(:commit).and_return('items' => [{ 'delete' => { 'status' => 500 } }])
+
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete_error')
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
+
+        expect {
+          subject.perform([['routing.unpublish', payload]])
+        }.to raise_error(GovukIndex::ElasticsearchRetryError)
+      end
+
+      it "will not raise an error when elasticsearch returns a 404 - not found" do
+        payload = {
+          "base_path" => "/cheese",
+          "document_type" => "substitute",
+          "title" => "We love cheese"
+        }
+        stub_document_type_inferer
+
+        expect(actions).to receive(:delete)
+        expect(actions).to receive(:commit).and_return('items' => [{ 'delete' => { 'status' => 404 } }])
+
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.already_deleted')
+        subject.perform([['routing.unpublish', payload]])
+      end
+    end
+
+    context "when document type requires a basepath" do
+      let(:actions) { GovukIndex::ElasticsearchProcessor.new }
+      let(:payload) do
+        {
+          "document_type" => "help_page",
+          "title" => "We love cheese",
+        }
+      end
+
+      it "notify of a validation error for missing basepath" do
+        expect(GovukError).to receive(:notify).with(
+          instance_of(GovukIndex::MissingBasePath),
+          extra: {
+            message_body: {
+              'document_type' => 'help_page',
+              'title' => 'We love cheese',
+            }
+          }
+        )
+
+        subject.perform([['routing.key', payload]])
+      end
+    end
+
+    context "when document type doesn't require a basepath" do
+      let(:actions) { GovukIndex::ElasticsearchProcessor.new }
+      let(:payload) do
+        {
+          "document_type" => "contact",
+          "title" => "We love cheese",
+        }
+      end
+
+      it "don't notify of a validation error for missing basepath" do
+        expect(GovukError).not_to receive(:notify)
+
+        subject.perform([['routing.key', payload]])
+      end
     end
   end
 
-  context "when document type doesn't require a basepath" do
-    let(:payload) do
+  context 'when multiple messages are received' do
+    let(:payload1) do
       {
-        "document_type" => "contact",
-        "title" => "We love cheese",
+        "base_path" => "/cheese",
+        "document_type" => "help_page",
+        "title" => "We love cheese"
+      }
+    end
+    let(:payload2) do
+      {
+        "base_path" => "/cheese",
+        "document_type" => "help_page",
+        "title" => "We love cheese"
+      }
+    end
+    let(:payload_delete) do
+      {
+        "base_path" => "/cheese",
+        "document_type" => "gone",
+        "title" => "We love cheese"
+      }
+    end
+    let(:payload_withdrawal) do
+      {
+        "base_path" => "/cheese",
+        "document_type" => "help_page",
+        "title" => "We love cheese"
       }
     end
 
-    it "don't notify of a validation error for missing basepath" do
-      expect(GovukError).not_to receive(:notify)
+    it 'can save multiple documents' do
+      expect(actions).to receive(:save).twice
+      expect(actions).to receive(:commit).and_return(
+        'items' => [{ 'index' => { 'status' => 200 } }, { 'index' => { 'status' => 200 } }]
+      )
 
-      subject.perform('routing.key', payload)
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.multiple_responses')
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index').twice
+      subject.perform([['routing.key', payload1], ['routing.key', payload2]])
+    end
+
+    it 'can save and delete documents in the same batch' do
+      stub_document_type_inferer
+
+      expect(actions).to receive(:save)
+      expect(actions).to receive(:delete)
+      expect(actions).to receive(:commit).and_return(
+        'items' => [{ 'index' => { 'status' => 200 } }, { 'delete' => { 'status' => 200 } }]
+      )
+
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.multiple_responses')
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
+      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete')
+      subject.perform([['routing.key', payload1], ['routing.key', payload_delete]])
+    end
+
+    context 'when all messages fail' do
+      before do
+        allow(actions).to receive(:save).twice
+        allow(actions).to receive(:commit).and_return(
+          'items' => [{ 'index' => { 'status' => 500 } }, { 'index' => { 'status' => 500 } }]
+        )
+        allow(Services.statsd_client).to receive(:increment)
+      end
+
+      it 'will reprocess the entire batch using ES retry mechanism' do
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
+
+        expect {
+          subject.perform([['routing.key', payload1], ['routing.key', payload2]])
+        }.to raise_error(GovukIndex::ElasticsearchRetryError)
+      end
+
+      it 'will notify for each message that fails' do
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index_error').twice
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
+
+        expect {
+          subject.perform([['routing.key', payload1], ['routing.key', payload2]])
+        }.to raise_error(GovukIndex::ElasticsearchRetryError)
+      end
+
+      it 'will notify that the batch failed' do
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
+
+        expect {
+          subject.perform([['routing.key', payload1], ['routing.key', payload2]])
+        }.to raise_error(GovukIndex::ElasticsearchRetryError)
+      end
+    end
+
+    context 'elasticsearch fails during processing for some messages' do
+      before do
+        allow(actions).to receive(:save).twice
+        allow(actions).to receive(:commit).and_return(
+          'items' => [{ 'index' => { 'status' => 200 } }, { 'index' => { 'status' => 500 } }]
+        )
+        allow(Services.statsd_client).to receive(:increment)
+        # allow(GovukIndex::PublishingEventWorker).to receive(:perform_async)
+      end
+
+      it 'will raise an error so that sidekiq retries the entire batch' do
+        expect {
+          subject.perform([['routing.key', payload1], ['routing.key', payload2]])
+        }.to raise_error(GovukIndex::ElasticsearchRetryError)
+      end
+
+      it 'will notify for each message that fails' do
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index_error')
+        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
+        expect {
+          subject.perform([['routing.key', payload1], ['routing.key', payload2]])
+        }.to raise_error(GovukIndex::ElasticsearchRetryError)
+      end
+    end
+
+    it "raises an error is the number of response item does not match the number of actions requested" do
+      allow(actions).to receive(:save).twice
+      allow(actions).to receive(:commit).and_return(
+        'items' => [{ 'index' => { 'status' => 200 } }]
+      )
+      allow(Services.statsd_client).to receive(:increment)
+
+      expect {
+        subject.perform([['routing.key', payload1], ['routing.key', payload2]])
+      }.to raise_error(GovukIndex::ElasticsearchInvalidResponseItemCount, "received 1 expected 2")
     end
   end
 
   def stub_document_type_inferer
-    allow_any_instance_of(GovukIndex::DocumentTypeInferer).to receive(:unpublishing_type?).and_return(true)
     allow_any_instance_of(GovukIndex::DocumentTypeInferer).to receive(:type).and_return('real_document_type')
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("real_document_type" => :all)
   end

--- a/spec/unit/search/base_registry_spec.rb
+++ b/spec/unit/search/base_registry_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Search::BaseRegistry do
   it "uses_time_as_default_clock" do
     # This is to make sure the cache expiry is expressed in seconds; DateTime,
     # for example, treats number addition as a number of days.
-    expect(Search::TimedCache).to receive(:new).with(an_instance_of(Fixnum), Time)
+    expect(Search::TimedCache).to receive(:new).with(an_instance_of(Integer), Time)
     described_class.new(@index, sample_field_definitions, "example-format")
   end
 


### PR DESCRIPTION
This is the first step to enabling the processing of batches from rabbit mq.
The idea is that this should increase the throughput speed when large volumes
of data are republished.

The code works by checking which of the events sent across succeed, and
manually resending any that failed. Unfortunately this means the sidekiq retry
count is reset whenever more than one item in the batch is successful, however
this is considered an acceptable compromise at this stage.

**UPDATE:**
This code now resends all messages in a batch if any fail. This allows us to reuse 
the sidekiq retry functionality at the expense of ES performance when an error occurs.
We plan to monitor this process once it is live to determine the number of errors that
occur.

This code is designed to work in coordination with: alphagov/govuk_message_queue_consumer#47

https://trello.com/c/OBhgB1Lw/531-code-tidy-up