### PR TITLE
Blacklisting functionality

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -33,6 +33,7 @@ service_manual_service_standard: service_manual_guide
 service_manual_topic: service_manual_topic
 service_standard_report: service_standard_report # Specialist Publisher
 simple_smart_answer: edition
+special_route: edition
 topic: edition # Collections Publisher
 task_list: edition
 tax_tribunal_decision: tax_tribunal_decision # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -48,4 +48,89 @@ migrated:
 - travel_advice
 - travel_advice_index
 
-indexable: []
+indexable:
+- special_route:
+  - '/help'
+  - '/find-local-council'
+
+non_indexable:
+- smart_answer # this is the format for the `/<path>/y` flow landing page for smart answers
+- special_route:
+  - '/homepage'
+  - '/tour'
+  - '/help/ab-testing'
+  - '/help.json'
+  - '/random'
+# detailed formats
+- detailed_guide
+# whitehall formats
+- about
+- about_our_services
+- access_and_opening
+- authored_article
+- case_study
+- complaints_procedure
+- consultation
+#- contact # migrated
+- corporate_report
+- correspondence
+- decision
+- document_collection
+- equality_and_diversity
+- fatality_notice
+- field_of_operation
+#- finder # migrated
+- foi_release
+- form
+- government_response
+- guidance
+- html_publication
+- impact_assessment
+- imported
+- independent_report
+- international_treaty
+- map
+- media_enquiries
+- membership
+- ministerial_role
+- national_statistics
+- national_statistics_announcement
+- news_story
+- notice
+- official_statistics
+- official_statistics_announcement
+- oral_statement
+- organisation
+- our_energy_use
+- our_governance
+- person
+- personal_information_charter
+- petitions_and_campaigns
+- policy_area
+- policy_paper
+- press_release
+- procurement
+- promotional
+- publication
+- publication_scheme
+- recruitment
+- regulation
+- research
+- services_and_information
+- social_media_use
+- speech
+- staff_update
+- statistical_data_set
+- statistics
+- statutory_guidance
+- take_part
+- terms_of_reference
+- topical_event
+- topical_event_about_page
+- transparency
+- welsh_language_scheme
+- working_group
+- world_location
+- world_news_story
+- worldwide_organisation
+- written_statement

--- a/lib/govuk_index/document_type_inferer.rb
+++ b/lib/govuk_index/document_type_inferer.rb
@@ -11,7 +11,6 @@ module GovukIndex
         raise NotFoundError if existing_document.nil?
         existing_document['_type']
       else
-        raise UnknownDocumentTypeError if elasticsearch_document_type.nil?
         elasticsearch_document_type
       end
     end

--- a/lib/govuk_index/migrated_formats.rb
+++ b/lib/govuk_index/migrated_formats.rb
@@ -2,16 +2,42 @@ module GovukIndex
   module MigratedFormats
     extend self
 
-    def indexable?(format)
-      indexable_formats.include?(format)
+    def non_indexable?(format, path)
+      non_indexable_formats[format] &&
+        (non_indexable_formats[format] == :all || non_indexable_formats[format].include?(path))
     end
 
-    def migrated_formats
-      @migrated_formats ||= YAML.load_file(File.join(__dir__, '../../config/govuk_index/migrated_formats.yaml'))['migrated']
+    def non_indexable_formats
+      @blacklist_formats ||= convert_to_allowed_hash(data_file['non_indexable'])
+    end
+
+    def indexable?(format, path)
+      indexable_formats[format] && (indexable_formats[format] == :all || indexable_formats[format].include?(path))
     end
 
     def indexable_formats
-      @indexable_formats ||= YAML.load_file(File.join(__dir__, '../../config/govuk_index/migrated_formats.yaml')).values.flatten
+      @indexable_formats ||= convert_to_allowed_hash(data_file['migrated'] + data_file['indexable'])
+    end
+
+    def migrated_formats
+      @migrated_formats ||= convert_to_allowed_hash(data_file['migrated'])
+    end
+
+  private
+
+    def data_file
+      @data_file ||= YAML.load_file(File.join(__dir__, '../../config/govuk_index/migrated_formats.yaml'))
+    end
+
+    def convert_to_allowed_hash(formats)
+      formats.inject({}) do |hash, format|
+        if format.is_a?(Hash)
+          hash.merge(format)
+        else
+          hash[format] = :all
+          hash
+        end
+      end
     end
   end
 end

--- a/lib/govuk_index/popularity_updater.rb
+++ b/lib/govuk_index/popularity_updater.rb
@@ -30,7 +30,7 @@ module GovukIndex
       {
         query: {
           terms: {
-            format: MigratedFormats.indexable_formats
+            format: MigratedFormats.indexable_formats.keys
           }
         }
       }

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -55,7 +55,7 @@ module GovukIndex
     def format
       # TODO: remove the special case for smart answers once it is fully migrated to
       #   govuk as it's fallback `transaction` has the same implementation.
-      return 'smart-answer' if payload['publishing_app'] == 'smartanswers'
+      return 'smart-answer' if payload['publishing_app'] == 'smartanswers' && payload['document_type'] == 'transaction'
       document_type = payload['document_type']
       CUSTOM_FORMAT_MAP[document_type] || document_type
     end

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -11,9 +11,14 @@ module GovukIndex
       @type ||= @infered_type.type
     end
 
+    def _type
+      # raise the error at the last possible moment to avoid requiring declaration for unused value
+      type || raise(UnknownDocumentTypeError)
+    end
+
     def identifier
       {
-        _type: type,
+        _type: _type,
         _id: base_path,
         version: payload["payload_version"],
         version_type: "external",
@@ -129,7 +134,13 @@ module GovukIndex
 
     attr_reader :payload
 
-    INDEX_DESCRIPTION_FIELD = %w(finder manual service_manual_topic travel_advice_index).freeze
+    INDEX_DESCRIPTION_FIELD = %w(
+      finder
+      manual
+      service_manual_topic
+      special_route
+      travel_advice_index
+    ).freeze
 
     def indexable
       IndexableContentPresenter.new(

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -47,14 +47,17 @@ module GovukIndex
       )
       presenter.valid!
 
+      identifier = "#{presenter.base_path} #{presenter.type || "'unmapped type'"}"
       if presenter.unpublishing_type?
-        logger.info("#{routing_key} -> DELETE #{presenter.base_path} #{presenter.type}")
+        logger.info("#{routing_key} -> DELETE #{identifier}")
         actions.delete(presenter)
-      elsif MigratedFormats.indexable?(presenter.format)
-        logger.info("#{routing_key} -> INDEX #{presenter.base_path} #{presenter.type}")
+      elsif MigratedFormats.non_indexable?(presenter.format, presenter.base_path)
+        logger.info("#{routing_key} -> BLACKLISTED #{identifier}")
+      elsif MigratedFormats.indexable?(presenter.format, presenter.base_path)
+        logger.info("#{routing_key} -> INDEX #{identifier}")
         actions.save(presenter)
       else
-        logger.info("#{routing_key} -> SKIPPED #{presenter.base_path} #{presenter.type}")
+        logger.info("#{routing_key} -> UNKNOWN #{identifier}")
       end
     end
 

--- a/lib/govuk_index/sync_updater.rb
+++ b/lib/govuk_index/sync_updater.rb
@@ -36,7 +36,7 @@ module GovukIndex
           bool: {
             clause => {
               terms: {
-                format: Array(@format_override || MigratedFormats.indexable_formats)
+                format: Array(@format_override || MigratedFormats.indexable_formats.keys)
               }
             }
           }

--- a/lib/search/format_migrator.rb
+++ b/lib/search/format_migrator.rb
@@ -15,7 +15,7 @@ module Search
     end
 
     def migrated_formats
-      GovukIndex::MigratedFormats.migrated_formats
+      GovukIndex::MigratedFormats.migrated_formats.keys
     end
 
   private

--- a/spec/integration/analytics_data_spec.rb
+++ b/spec/integration/analytics_data_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'AnalyticsDataTest' do
   before do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return([])
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
     @analytics_data_fetcher = AnalyticsData.new(SearchConfig.instance.base_uri, %w(mainstream_test govuk_test))
   end
 
@@ -42,7 +42,7 @@ RSpec.describe 'AnalyticsDataTest' do
   end
 
   it "only includes migrated formats from the govuk index" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(["answers"])
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("answers" => :all)
 
     document = {
       "content_id" => "587b0635-2911-49e6-af68-3f0ea1b07cc5",

--- a/spec/integration/govuk_index/collections_spec.rb
+++ b/spec/integration/govuk_index/collections_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Collections publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["mainstream_browse_page"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("mainstream_browse_page" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 
@@ -50,7 +50,7 @@ RSpec.describe "Collections publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["specialist_sector"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("specialist_sector" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 

--- a/spec/integration/govuk_index/hmrc_manuals_spec.rb
+++ b/spec/integration/govuk_index/hmrc_manuals_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "HMRC manual publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["hmrc_manual"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("hmrc_manual" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 
@@ -57,7 +57,7 @@ RSpec.describe "HMRC manual publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["hmrc_manual_section"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("hmrc_manual_section" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 

--- a/spec/integration/govuk_index/manuals_spec.rb
+++ b/spec/integration/govuk_index/manuals_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Manual publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["manual"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("manual" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 
@@ -60,7 +60,7 @@ RSpec.describe "Manual publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["manual_section"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("manual_section" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 

--- a/spec/integration/govuk_index/policy_spec.rb
+++ b/spec/integration/govuk_index/policy_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Policy publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["policy"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("policy" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 

--- a/spec/integration/govuk_index/service_manual_topic_spec.rb
+++ b/spec/integration/govuk_index/service_manual_topic_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Service Manual Topic publishing" do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["service_manual_topic"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("service_manual_topic" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 

--- a/spec/integration/govuk_index/specialist_formats_spec.rb
+++ b/spec/integration/govuk_index/specialist_formats_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'SpecialistFormatTest' do
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(["finder"])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("finder" => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 
@@ -57,7 +57,7 @@ RSpec.describe 'SpecialistFormatTest' do
         payload: { document_type: specialist_document_type },
         regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
       )
-      allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return([specialist_document_type])
+      allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(specialist_document_type => :all)
 
       @queue.publish(random_example.to_json, content_type: "application/json")
 
@@ -74,7 +74,7 @@ RSpec.describe 'SpecialistFormatTest' do
       payload: { document_type: publisher_document_type },
       regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return([search_document_type])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(search_document_type => :all)
 
     @queue.publish(random_example.to_json, content_type: "application/json")
 

--- a/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
+++ b/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest' do
   end
 
   it "defaults_to_excluding_govuk_index_records" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return([])
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
 
     get "/search"
 
@@ -19,7 +19,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest' do
   end
 
   it "can_enable_format_to_use_govuk_index" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(['help_page'])
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
 
     get "/search"
 
@@ -27,7 +27,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest' do
   end
 
   it "can_enable_multiple_formats_to_use_govuk_index" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(%w(help_page answer))
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("help_page" => :all, "answer" => :all)
 
     get "/search"
 

--- a/spec/integration/govuk_index/sync_data_spec.rb
+++ b/spec/integration/govuk_index/sync_data_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'GovukIndex::SyncDataTest' do
   before do
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(['help_page'])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return('help_page' => :all)
   end
 
   it "syncs_records_for_non_indexable_formats" do

--- a/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
+++ b/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'GovukIndex::UnpublishingMessageProcessing' do
   it "unpublish_message_will_remove_record_from_elasticsearch" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(%w(answer))
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("answer" => :all)
 
     message = unpublishing_event_message(
       "gone",
@@ -29,7 +29,7 @@ RSpec.describe 'GovukIndex::UnpublishingMessageProcessing' do
   end
 
   it "unpublish_withdrawn_messages_will_set_is_withdrawn_flag" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(%w(help_page))
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("help_page" => :all)
 
     message = unpublishing_event_message(
       "help_page",

--- a/spec/integration/govuk_index/updating_popularity_data_spec.rb
+++ b/spec/integration/govuk_index/updating_popularity_data_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
   before do
-    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(['help_page'])
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return('help_page' => :all)
   end
 
   it "updates_the_popularity_when_it_exists" do

--- a/spec/integration/search/aggregates_spec.rb
+++ b/spec/integration/search/aggregates_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'search queries' do
     end
 
     it "returns examples before migration" do
-      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return([])
+      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
 
       add_sample_documents('mainstream_test', 2)
       add_sample_documents('govuk_test', 2)
@@ -111,7 +111,7 @@ RSpec.describe 'search queries' do
     end
 
     it "returns examples after migration" do
-      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(['answers'])
+      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('answers' => :all)
 
       add_sample_documents('mainstream_test', 2)
       add_sample_documents('govuk_test', 2)
@@ -125,7 +125,7 @@ RSpec.describe 'search queries' do
     end
 
     it "returns examples before migration within query scope" do
-      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return([])
+      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
 
       add_sample_documents('mainstream_test', 2)
       add_sample_documents('govuk_test', 2)
@@ -139,7 +139,7 @@ RSpec.describe 'search queries' do
     end
 
     it "returns examples after migration within query scope" do
-      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(['answers'])
+      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('answers' => :all)
 
       add_sample_documents('mainstream_test', 2)
       add_sample_documents('govuk_test', 2)

--- a/spec/unit/govuk_index/document_type_inferer_spec.rb
+++ b/spec/unit/govuk_index/document_type_inferer_spec.rb
@@ -22,16 +22,6 @@ RSpec.describe GovukIndex::DocumentTypeInferer do
     }.to raise_error(GovukIndex::NotFoundError)
   end
 
-  it "should_raise_unknown_document_type_error" do
-    payload = { "document_type" => "unknown" }
-
-    allow_any_instance_of(described_class).to receive(:elasticsearch_document_type).and_return(nil)
-
-    expect {
-      described_class.new(payload).type
-    }.to raise_error(GovukIndex::UnknownDocumentTypeError)
-  end
-
   it "infer_existing_document_type" do
     payload = {
       "base_path" => "/cheese",

--- a/spec/unit/govuk_index/migrated_formats_spec.rb
+++ b/spec/unit/govuk_index/migrated_formats_spec.rb
@@ -1,0 +1,26 @@
+require 'rspec'
+
+RSpec.describe GovukIndex::MigratedFormats do
+  it 'does not contain formats with value of :all in both the indexable and non_indexable lists' do
+    indexable = described_class.indexable_formats
+    non_indexable = described_class.non_indexable_formats
+
+    duplicate_keys = indexable.keys & non_indexable.keys
+
+    duplicate_keys.each do |duplicate_key|
+      expect(indexable[duplicate_key]).not_to eq(:all)
+      expect(non_indexable[duplicate_key]).not_to eq(:all)
+    end
+  end
+
+  it 'does not contain formats with paths in both the indexable and non_indexable lists' do
+    indexable = described_class.indexable_formats
+    non_indexable = described_class.non_indexable_formats
+
+    duplicate_keys = indexable.keys & non_indexable.keys
+
+    duplicate_keys.each do |duplicate_key|
+      expect(indexable[duplicate_key] & non_indexable[duplicate_key]).to be_empty
+    end
+  end
+end

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     expect(expected_identifier).to eq(presenter.identifier)
   end
 
+  it "raise UnknownDocumentTypeError if the document type does not have a valid mapping" do
+    payload = generate_random_example(payload: { payload_version: 1 })
+    presenter = elasticsearch_presenter(payload, nil)
+
+    expect {
+      presenter.identifier
+    }.to raise_error(GovukIndex::UnknownDocumentTypeError)
+  end
+
+
   it "raise_validation_error" do
     payload = {}
 

--- a/spec/unit/govuk_index/publishing_event_worker_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_worker_spec.rb
@@ -162,6 +162,6 @@ RSpec.describe GovukIndex::PublishingEventWorker do
   def stub_document_type_inferer
     allow_any_instance_of(GovukIndex::DocumentTypeInferer).to receive(:unpublishing_type?).and_return(true)
     allow_any_instance_of(GovukIndex::DocumentTypeInferer).to receive(:type).and_return('real_document_type')
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(%w(real_document_type))
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("real_document_type" => :all)
   end
 end

--- a/spec/unit/search/aggregate_example_fetcher_spec.rb
+++ b/spec/unit/search/aggregate_example_fetcher_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Search::AggregateExampleFetcher do
 
   context "one aggregate with global scope" do
     before do
-      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return([])
+      allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
       @index = stub_index("content index")
       @example_fields = %w{link title other_field}
       main_query_response = { "aggregations" => {

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Search::FormatMigrator do
   it "when_base_query_without_migrated_formats" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return([])
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
     base_query = { filter: 'component' }
     expected = {
       indices: {
@@ -17,7 +17,7 @@ RSpec.describe Search::FormatMigrator do
   end
 
   it "when_base_query_with_migrated_formats" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(['help_page'])
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
     base_query = { filter: 'component' }
     expected = {
       indices: {
@@ -40,7 +40,7 @@ RSpec.describe Search::FormatMigrator do
   end
 
   it "when_no_base_query_without_migrated_formats" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return([])
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
     expected = {
       indices: {
         indices: %w(mainstream_test government_test),
@@ -52,7 +52,7 @@ RSpec.describe Search::FormatMigrator do
   end
 
   it "when_no_base_query_with_migrated_formats" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return(['help_page'])
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
     expected = {
       indices: {
         indices: %w(mainstream_test government_test),


### PR DESCRIPTION
Add the ability to blacklist as well as whitelist formats. This also adds the ability to blacklist just some paths from a format which is required for `specialist_routes`.

https://trello.com/c/TZ6zhjUj/527-index-special-routes-to-govuk
https://trello.com/c/cBRbdmq1/521-blacklist-formats