### PR TITLE
Delete smartanswers workaround

### DIFF
--- a/spec/integration/govuk_index/collections_spec.rb
+++ b/spec/integration/govuk_index/collections_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe "Collections publishing" do
         description: "Mainstream browse page description",
         base_path: "/browse/benefits",
       },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("mainstream_browse_page" => :all)
@@ -47,7 +46,6 @@ RSpec.describe "Collections publishing" do
         description: "Specialist sector page description",
         base_path: "/topic/benefits-credits",
       },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("specialist_sector" => :all)

--- a/spec/integration/govuk_index/hmrc_manuals_spec.rb
+++ b/spec/integration/govuk_index/hmrc_manuals_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe "HMRC manual publishing" do
           }
         ]
       },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("hmrc_manual" => :all)
@@ -54,7 +53,6 @@ RSpec.describe "HMRC manual publishing" do
           "base_path": "/parent/manual/path"
         },
       },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("hmrc_manual_section" => :all)

--- a/spec/integration/govuk_index/manuals_spec.rb
+++ b/spec/integration/govuk_index/manuals_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe "Manual publishing" do
           }
         ]
       },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("manual" => :all)
@@ -57,7 +56,6 @@ RSpec.describe "Manual publishing" do
           "base_path": "/parent/manual/path"
         },
       },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("manual_section" => :all)

--- a/spec/integration/govuk_index/policy_spec.rb
+++ b/spec/integration/govuk_index/policy_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe "Policy publishing" do
         }
       },
       details: { summary: "<p>Description about policy.</p>\n" },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("policy" => :all)

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest' do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
     random_example = generate_random_example(
       payload: { document_type: "help_page", payload_version: 123 },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     @queue.publish(random_example.to_json, content_type: "application/json")
@@ -39,7 +38,6 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest' do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
     random_example = generate_random_example(
       payload: { document_type: "help_page", payload_version: 123 },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     document_count = 4

--- a/spec/integration/govuk_index/service_manual_topic_spec.rb
+++ b/spec/integration/govuk_index/service_manual_topic_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe "Service Manual Topic publishing" do
         title: "Service Manual title",
         description: "Service Manual description"
       },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("service_manual_topic" => :all)

--- a/spec/integration/govuk_index/specialist_formats_spec.rb
+++ b/spec/integration/govuk_index/specialist_formats_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe 'SpecialistFormatTest' do
     random_example = generate_random_example(
       schema: "finder",
       payload: { document_type: "finder" },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("finder" => :all)
@@ -55,7 +54,6 @@ RSpec.describe 'SpecialistFormatTest' do
       random_example = generate_random_example(
         schema: "specialist_document",
         payload: { document_type: specialist_document_type },
-        regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
       )
       allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(specialist_document_type => :all)
 
@@ -72,7 +70,6 @@ RSpec.describe 'SpecialistFormatTest' do
     random_example = generate_random_example(
       schema: "specialist_document",
       payload: { document_type: publisher_document_type },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return(search_document_type => :all)
 
@@ -89,7 +86,6 @@ RSpec.describe 'SpecialistFormatTest' do
     random_example = generate_random_example(
       schema: "finder_email_signup",
       payload: { document_type: "finder_email_signup" },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     @queue.publish(random_example.to_json, content_type: "application/json")

--- a/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
+++ b/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe 'GovukIndex::UnpublishingMessageProcessing' do
       schema: schema_name,
       payload: user_defined,
       excluded_fields: excluded_fields,
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
     stub_message_payload(payload, unpublishing: true)
   end

--- a/spec/integration/govuk_index/versioning_spec.rb
+++ b/spec/integration/govuk_index/versioning_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'GovukIndex::VersioningTest' do
 
     version1 = generate_random_example(
       payload: { payload_version: 123 },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
 
     base_path = version1["base_path"]
@@ -31,10 +30,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
 
   it "should_discard_message_with_same_version_as_existing_document" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
-    version1 = generate_random_example(
-      payload: { payload_version: 123 },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
-    )
+    version1 = generate_random_example(payload: { payload_version: 123 })
 
     base_path = version1["base_path"]
     process_message(version1)
@@ -53,10 +49,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
   it "should_discard_message_with_earlier_version_than_existing_document" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
 
-    version1 = generate_random_example(
-      payload: { payload_version: 123 },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
-    )
+    version1 = generate_random_example(payload: { payload_version: 123 })
 
     base_path = version1["base_path"]
     process_message(version1)
@@ -77,7 +70,6 @@ RSpec.describe 'GovukIndex::VersioningTest' do
     version1 = generate_random_example(
       payload: { payload_version: 1 },
       excluded_fields: ["withdrawn_notice"],
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
 
     base_path = version1["base_path"]
@@ -93,7 +85,6 @@ RSpec.describe 'GovukIndex::VersioningTest' do
         payload_version: 2
       },
       excluded_fields: ["withdrawn_notice"],
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
     process_message(version2, unpublishing: true)
 
@@ -110,10 +101,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
 
   it "should_discard_unpublishing_message_with_earlier_version" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
-    version1 = generate_random_example(
-      payload: { payload_version: 2 },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
-    )
+    version1 = generate_random_example(payload: { payload_version: 2 })
 
     base_path = version1["base_path"]
     process_message(version1)
@@ -128,7 +116,6 @@ RSpec.describe 'GovukIndex::VersioningTest' do
         payload_version: 1
       },
       excluded_fields: ["withdrawn_notice"],
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
     )
     process_message(version2, unpublishing: true)
 
@@ -139,10 +126,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
   it "should_ignore_event_for_non_indexable_formats" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
 
-    version1 = generate_random_example(
-      payload: { payload_version: 123 },
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" },
-    )
+    version1 = generate_random_example(payload: { payload_version: 123 })
 
     base_path = version1["base_path"]
     process_message(version1)

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
       payload: { expanded_links: {} },
       excluded_fields: ["withdrawn_notice"],
       regenerate_if: ->(example) {
-        example["publishing_app"] == "smartanswers" ||
-          @directly_mapped_fields.any? { |field| example[field] == '' }
+        @directly_mapped_fields.any? { |field| example[field] == '' }
       },
     )
 
@@ -44,7 +43,6 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     payload = generate_random_example(
       payload: defined_fields,
       excluded_fields: ["withdrawn_notice"],
-      regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" }
     )
 
     presenter = common_fields_presenter(payload)

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 
 RSpec.describe GovukIndex::ElasticsearchPresenter do
   it "identifier" do
-    payload = generate_random_example(payload: { payload_version: 1 },
-    regenerate_if: ->(example) { example["publishing_app"] == "smartanswers" })
+    payload = generate_random_example(payload: { payload_version: 1 })
 
     expected_identifier = {
       _type: payload["document_type"],


### PR DESCRIPTION
Since #1077, rummager has been able to index documents published by smartanswers, so we can remove the workaround that prevented tests from using smartanswers documents as random examples.