### PR TITLE
Add more non indexable formats

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -54,6 +54,8 @@ indexable:
   - '/find-local-council'
 
 non_indexable:
+- calculator
+- license_finder
 - smart_answer # this is the format for the `/<path>/y` flow landing page for smart answers
 - special_route:
   - '/homepage'


### PR DESCRIPTION
We do not want the calculator and lisense_finder formats to be indexed as they both have start pages (transaction format) which are already indexed.

https://trello.com/c/cBRbdmq1