### PR TITLE
Remove smart-answer customisation

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -43,7 +43,6 @@ migrated:
 - service_manual_homepage
 - service_manual_service_standard
 - service_manual_topic
-- smart-answer # transaction document type from the smart-answers publishing app
 - task_list
 - travel_advice
 - travel_advice_index

--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -3,7 +3,6 @@ base:
     # Mainstream formats
     service_manual_guide: 0.3
     service_manual_topic: 0.3
-    smart-answer: 1.5
     transaction: 1.5
     # Should appear below mainstream content
     aaib_report: 0.2

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -53,9 +53,6 @@ module GovukIndex
     end
 
     def format
-      # TODO: remove the special case for smart answers once it is fully migrated to
-      #   govuk as it's fallback `transaction` has the same implementation.
-      return 'smart-answer' if payload['publishing_app'] == 'smartanswers' && payload['document_type'] == 'transaction'
       document_type = payload['document_type']
       CUSTOM_FORMAT_MAP[document_type] || document_type
     end

--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -4,7 +4,6 @@ module GovukIndex
     BY_FORMAT = {
       'contact'       => %w(title description),
       'licence'       => %w(licence_short_description licence_overview),
-      'smart-answer'  => %w(introductory_paragraph more_information),
       'transaction'   => %w(introductory_paragraph more_information),
       'travel_advice' => %w(summary),
     }.freeze

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -35,20 +35,6 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest' do
     expect(@channel.acknowledged_state[:acked].count).to eq(1)
   end
 
-  it "indexed with a format of smart answers when publishing app is smart answers" do
-    allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
-    random_example = generate_random_example(
-      schema: 'transaction',
-      payload: { document_type: "transaction", payload_version: 123, publishing_app: "smartanswers" },
-    )
-
-    @queue.publish(random_example.to_json, content_type: "application/json")
-    commit_index 'govuk_test'
-
-    document = fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test", type: 'edition')
-    expect(document["_source"]["format"]).to eq("smart-answer")
-  end
-
   it "should_include_popularity_when_available" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
     random_example = generate_random_example(

--- a/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe GovukIndex::IndexableContentPresenter do
     end
   end
 
-  context "smart-answers" do
-    let(:format) { 'smart-answer' }
+  context "transaction with hidden_search_terms (smart answer start page)" do
+    let(:format) { 'transaction' }
     let(:details) do
       {
         "introductory_paragraph" =>  [

--- a/spec/unit/query_components/booster_spec.rb
+++ b/spec/unit/query_components/booster_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe QueryComponents::Booster do
 
     expect_format_boost(result, "contact", 0.3)
     expect_format_boost(result, "service_manual_guide", 0.3)
-    expect_format_boost(result, "smart-answer", 1.5)
+    expect_format_boost(result, "transaction", 1.5)
   end
 
   it "not apply a boost to unspecified formats" do


### PR DESCRIPTION
This aligns smart answers with documents with the same document_type, allowing
us to remove a number of customisations from the codebase.

https://trello.com/c/OBhgB1Lw/531-code-tidy-up