### PR TITLE
Stop double rendering of smart answers

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -43,6 +43,7 @@ migrated:
 - service_manual_homepage
 - service_manual_service_standard
 - service_manual_topic
+- smart-answer # needed to stop these rendering from mainstream. THis can be removed once we stop using mainstream.
 - task_list
 - travel_advice
 - travel_advice_index


### PR DESCRIPTION
This is caused by us updating the format to be transaction in govuk and then
removing the migrated flag. The end result was it being rendered from
mainstream and govuk.