### PR TITLE
Remove description duplication in ES content

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -11,6 +11,7 @@ module GovukIndex
     delegate_to_payload :content_id
     delegate_to_payload :content_purpose_document_supertype
     delegate_to_payload :content_store_document_type, hash_key: "document_type"
+    delegate_to_payload :description
     delegate_to_payload :email_document_supertype
     delegate_to_payload :government_document_supertype
     delegate_to_payload :link, hash_key: "base_path"
@@ -25,22 +26,8 @@ module GovukIndex
       @payload = payload
     end
 
-    def description
-      if format == "policy"
-        summary = [] << payload["details"]["summary"]
-        sanitiser = GovukIndex::IndexableContentSanitiser.new
-        sanitiser.clean(summary)
-      else
-        payload["description"]
-      end
-    end
-
     def title
       [section_id, payload["title"]].compact.join(" - ")
-    end
-
-    def indexable_description
-      format == "service_manual_topic" ? description.prepend("#{title} ") : description
     end
 
     def is_withdrawn

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -62,7 +62,7 @@ module GovukIndex
         grant_type:                          specialist.grant_type,
         hidden_indexable_content:            specialist.hidden_indexable_content,
         hmrc_manual_section_id:              common_fields.section_id,
-        indexable_content:                   indexable_content,
+        indexable_content:                   indexable.indexable_content,
         industries:                          specialist.industries,
         is_withdrawn:                        common_fields.is_withdrawn,
         issued_date:                         specialist.issued_date,
@@ -134,28 +134,12 @@ module GovukIndex
 
     attr_reader :payload
 
-    INDEX_DESCRIPTION_FIELD = %w(
-      finder
-      manual
-      service_manual_topic
-      special_route
-      travel_advice_index
-    ).freeze
-
     def indexable
       IndexableContentPresenter.new(
         format: common_fields.format,
         details: payload["details"],
         sanitiser: IndexableContentSanitiser.new,
       )
-    end
-
-    def indexable_content
-      if INDEX_DESCRIPTION_FIELD.include?(format)
-        common_fields.indexable_description
-      else
-        indexable.indexable_content
-      end
     end
 
     def slug

--- a/spec/integration/govuk_index/manuals_spec.rb
+++ b/spec/integration/govuk_index/manuals_spec.rb
@@ -39,10 +39,11 @@ RSpec.describe "Manual publishing" do
     @queue.publish(random_example.to_json, content_type: "application/json")
 
     expected_document = {
-       "link" => random_example["base_path"],
-       "indexable_content" => "Manual description",
-       "latest_change_note" => nil
-     }
+      "link" => random_example["base_path"],
+      "indexable_content" => nil,
+      "description" => "Manual description",
+      "latest_change_note" => nil
+    }
 
     expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "manual")
   end

--- a/spec/integration/govuk_index/policy_spec.rb
+++ b/spec/integration/govuk_index/policy_spec.rb
@@ -53,12 +53,13 @@ RSpec.describe "Policy publishing" do
     random_example = generate_random_example(
       schema: "policy",
       payload: {
+        description: "Description about policy.",
         document_type: "policy",
         base_path: "/government/policies/hs2-high-speed-rail",
         expanded_links: {
           working_groups: working_groups,
           people: people
-        }
+        },
       },
       details: { summary: "<p>Description about policy.</p>\n" },
     )
@@ -68,11 +69,12 @@ RSpec.describe "Policy publishing" do
     @queue.publish(random_example.to_json, content_type: "application/json")
 
     expected_document = {
-       "link" => random_example["base_path"],
-       "people" => ["person-1", "person-2"],
-       "policy_groups" => ["working-group-1", "working-group-2"],
-       "description" => "Description about policy.",
-       "slug" => "hs2-high-speed-rail",
+      "link" => random_example["base_path"],
+      "people" => ["person-1", "person-2"],
+      "policy_groups" => ["working-group-1", "working-group-2"],
+      "description" => "Description about policy.",
+      "indexable_content" => nil,
+      "slug" => "hs2-high-speed-rail",
      }
 
     expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "policy")

--- a/spec/integration/govuk_index/service_manual_topic_spec.rb
+++ b/spec/integration/govuk_index/service_manual_topic_spec.rb
@@ -30,9 +30,11 @@ RSpec.describe "Service Manual Topic publishing" do
     @queue.publish(random_example.to_json, content_type: "application/json")
 
     expected_document = {
-       "link" => random_example["base_path"],
-       "indexable_content" => "#{random_example["title"]} #{random_example["description"]}",
-       "manual" => "/service-manual"
+      "link" => random_example["base_path"],
+      "indexable_content" => nil,
+      "title" => random_example["title"],
+      "description" => random_example["description"],
+      "manual" => "/service-manual"
     }
 
     expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "service_manual_topic")


### PR DESCRIPTION
This duplication added to the complexity of the code 
as we needed to look in multiple places on a format 
specific basis. Removing this functionality simplifies
the code, if we do need to re-introduce boosting for 
this formats we should do this using the standard 
boosting functionality.

We need to check if these changes have any effect on the health check sore before we merge.

https://trello.com/c/OBhgB1Lw/531-code-tidy-up