### PR TITLE
Simplify page traffic import

### DIFF
--- a/bin/page_traffic_load
+++ b/bin/page_traffic_load
@@ -1,6 +1,14 @@
 #!/usr/bin/env ruby
 
-require "slop"
+# Usage: #{File.basename(__FILE__)}
+#
+# Bulk loads data from stdin to the page traffic index. The data should be in the
+# format accepted by the elastic search bulk command[1].
+#
+# Loading is done in an unconnected index alias and on completion of the index
+# load the alias is switched over.
+#
+# [1] http://www.elasticsearch.org/guide/reference/api/bulk/
 
 PROJECT_ROOT = File.dirname(__FILE__) + "/../"
 LIBRARY_PATH = PROJECT_ROOT + "lib/"
@@ -9,25 +17,4 @@ $LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
 
 require "rummager"
 
-Slop.parse(help: true) do
-  banner <<~DOC
-    Usage: #{File.basename(__FILE__)}
-
-    Bulk loads data from stdin to the page traffic index. The data should be in the
-    format accepted by the elastic search bulk command[1].
-    
-    Loading is done in an unconnected index alias and on completion of the index
-    load the alias is switched over.
-    
-    [1] http://www.elasticsearch.org/guide/reference/api/bulk/
-  DOC
-
-  run do |_opts, args|
-    if args.empty?
-      GovukIndex::PageTrafficLoader.new.load_from($stdin)
-    else
-      puts self
-      exit 1
-    end
-  end
-end
+GovukIndex::PageTrafficLoader.new.load_from($stdin)


### PR DESCRIPTION
This a simple script that reads from STDIN.

The only slop feature it's currently using is the banner, which breaks
if you upgrade slop to the latest version.

This script doesn't need a fancy CLI, (it's run by a jenkins
job) so just remove it.