### PR TITLE
Fix syntax of error notification in PublishingEventWorker

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -113,8 +113,10 @@ module GovukIndex
 
         GovukError.notify(
           ElasticsearchError.new,
-          action_type: action_type,
-          details: details,
+          extra: {
+            action_type: action_type,
+            details: details,
+          },
         )
         return false
       end


### PR DESCRIPTION
Wrap the error details in the new `extra` parameter to fix the `NoMethodError`s seen in Sentry (https://sentry.io/govuk/app-rummager/issues/420362018/).

Other calls to `GovukError.notify` have already been updated.