### PR TITLE
Update duplicate deleter to wrok with govuk migrated documents

### DIFF
--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,8 +1,6 @@
 require 'rummager'
 
 namespace :delete do
-  CONTENT_SEARCH_INDICES = %w(mainstream detailed government).freeze
-
   desc "
   Delete duplicates with the content IDs and/or links provided
   Usage
@@ -29,7 +27,7 @@ namespace :delete do
 
     elasticsearch_config = SearchConfig.new.elasticsearch
 
-    links = DuplicateLinksFinder.new(elasticsearch_config["base_uri"], CONTENT_SEARCH_INDICES).find_exact_duplicates
+    links = DuplicateLinksFinder.new.find_exact_duplicates
 
     puts "Found #{links.size} duplicate links to delete"
 

--- a/spec/integration/duplicate_link_finder_spec.rb
+++ b/spec/integration/duplicate_link_finder_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe DuplicateLinksFinder do
+  subject { described_class.new(indices: %w(government_test mainstream_test govuk_test)) }
+
+  it "finds duplicates" do
+    create_document_with(type: "edition")
+    create_document_with(type: "policy")
+
+    expect(subject.find_exact_duplicates).to eq(["/an-example-page"])
+  end
+
+  it "does not incorrectly report dupliciates" do
+    create_document_with(link: "/document-1")
+    create_document_with(link: "/document-2")
+
+    expect(subject.find_exact_duplicates).to eq([])
+  end
+
+  it "detects duplicates across indices" do
+    create_document_with(index: "government_test")
+    create_document_with(index: "mainstream_test")
+
+    expect(subject.find_exact_duplicates).to eq(["/an-example-page"])
+  end
+
+  it "does not detect duplicates in ignored indices" do
+    create_document_with(index: "government_test")
+    create_document_with(index: "mainstream_test")
+
+    finder = described_class.new(indices: %w(mainstream_test))
+    expect(finder.find_exact_duplicates).to eq([])
+    expect(subject.find_exact_duplicates).to eq(["/an-example-page"])
+  end
+
+  it "does not incorrect detect duplicates in migrated data" do
+    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
+    create_document_with(index: "mainstream_test", format: "help_page")
+    create_document_with(index: "govuk_test", format: "help_page")
+
+    expect(subject.find_exact_duplicates).to eq([])
+  end
+
+  it "can detect duplicates in govuk migrated data" do
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return('help_page' => :all)
+    create_document_with(index: "mainstream_test", format: "edition")
+    create_document_with(index: "govuk_test", format: "help_page")
+
+    expect(subject.find_exact_duplicates).to eq(["/an-example-page"])
+  end
+
+  def create_document_with(type: "edition", index: "government_test", link: "/an-example-page", format: "edition")
+    commit_document(
+      index,
+      {
+        "content_id" => "3c824d6b-d982-4426-9a7d-43f2b865e77c",
+        "link" => link,
+        "format" => format
+      },
+      type: type,
+    )
+  end
+end


### PR DESCRIPTION
https://trello.com/c/OTlU3gDU/435-make-rake-task-also-delete-duplicates-from-govuk-index