### PR TITLE
Make external content indexable

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -11,6 +11,7 @@ drug_safety_update: drug_safety_update # Specialist Publisher
 employment_appeal_tribunal_decision: employment_appeal_tribunal_decision # Specialist Publisher
 employment_tribunal_decision: employment_tribunal_decision # Specialist Publisher
 esi_fund: european_structural_investment_fund # Specialist Publisher
+external_content: edition # Search Admin
 finder: edition # Specialist Publisher
 guide: edition
 help_page: edition

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -104,7 +104,7 @@ non_indexable:
   - "/sitemaps"
   - "/tour"
   - "/ukwelcomes"
-  
+
 # detailed formats
 - detailed_guide
 # whitehall formats

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -51,7 +51,8 @@ migrated:
   - '/help'
   - '/find-local-council'
 
-indexable: []
+indexable:
+- recommended-link
 
 non_indexable:
 - calculator

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -2,6 +2,7 @@ module GovukIndex
   class CommonFieldsPresenter
     CUSTOM_FORMAT_MAP = {
       "esi_fund" => "european_structural_investment_fund",
+      "external_content" => "recommended-link",
       "service_manual_homepage" => "service_manual_guide",
       "service_manual_service_standard" => "service_manual_guide",
       "topic" => "specialist_sector",
@@ -14,7 +15,6 @@ module GovukIndex
     delegate_to_payload :description
     delegate_to_payload :email_document_supertype
     delegate_to_payload :government_document_supertype
-    delegate_to_payload :link, hash_key: "base_path"
     delegate_to_payload :navigation_document_supertype
     delegate_to_payload :public_timestamp, hash_key: "public_updated_at"
     delegate_to_payload :publishing_app
@@ -24,6 +24,18 @@ module GovukIndex
 
     def initialize(payload)
       @payload = payload
+    end
+
+    def link
+      if format == "recommended-link"
+        payload["details"]["url"]
+      else
+        base_path
+      end
+    end
+
+    def base_path
+      payload["base_path"]
     end
 
     def title
@@ -36,7 +48,7 @@ module GovukIndex
 
     def popularity
       lookup = Indexer::PopularityLookup.new("govuk_index", SearchConfig.instance)
-      lookup.lookup_popularities([payload["base_path"]])[payload["base_path"]]
+      lookup.lookup_popularities([link])[link]
     end
 
     def format

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -8,6 +8,7 @@ module GovukIndex
 
     delegate_to_payload :licence_identifier
     delegate_to_payload :licence_short_description
+    delegate_to_payload :url
 
     def initialize(details:, format:)
       @details = details

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -19,7 +19,7 @@ module GovukIndex
     def identifier
       {
         _type: _type,
-        _id: base_path,
+        _id: link,
         version: payload["payload_version"],
         version_type: "external",
       }
@@ -123,11 +123,19 @@ module GovukIndex
     end
 
     def base_path
-      @_base_path ||= payload["base_path"]
+      common_fields.base_path
+    end
+
+    def link
+      common_fields.link
     end
 
     def valid!
-      base_path || raise(MissingBasePath, "base_path missing from payload")
+      if format == "recommended-link"
+        details.url || raise(MissingExternalUrl, "url missing from details section")
+      else
+        base_path || raise(MissingBasePath, "base_path missing from payload")
+      end
     end
 
   private

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -7,6 +7,7 @@ module GovukIndex
   class NotFoundError < StandardError; end
   class UnknownDocumentTypeError < StandardError; end
   class MissingBasePath < StandardError; end
+  class MissingExternalUrl < StandardError; end
 
   DOCUMENT_TYPES_WITHOUT_BASE_PATH = %w(contact world_location).freeze
 
@@ -41,7 +42,7 @@ module GovukIndex
       )
       presenter.valid!
 
-      identifier = "#{presenter.base_path} #{presenter.type || "'unmapped type'"}"
+      identifier = "#{presenter.link} #{presenter.type || "'unmapped type'"}"
       if presenter.unpublishing_type?
         logger.info("#{routing_key} -> DELETE #{identifier}")
         processor.delete(presenter)

--- a/spec/integration/govuk_index/external_content_spec.rb
+++ b/spec/integration/govuk_index/external_content_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe "external content publishing" do
+  before do
+    bunny_mock = BunnyMock.new
+    @channel = bunny_mock.start.channel
+
+    consumer = GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "external_content.test",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      rabbitmq_connection: bunny_mock
+    )
+
+    @queue = @channel.queue("external_content.test")
+    consumer.run
+  end
+
+  it "indexes a page of external content" do
+    random_example = generate_random_example(
+      schema: "external_content",
+      payload: {
+        document_type: "external_content",
+      },
+      details: {
+        hidden_search_terms: ["some, search, keywords"]
+      },
+    )
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("recommended-link" => :all)
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = {
+       "link" => random_example["details"]["url"],
+       "format" => "recommended-link",
+       "title" => random_example["title"],
+       "description" => random_example["description"],
+       "indexable_content" => "some, search, keywords",
+     }
+
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
+  end
+end

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     expect(presenter.link).to eq(payload["base_path"])
   end
 
+  it "uses the URL as the link for external content" do
+    payload = {
+      "document_type" => "external_content",
+      "details" => {
+        "url" => "some_url"
+      }
+    }
+
+    presenter = common_fields_presenter(payload)
+
+    expect(presenter.link).to eq("some_url")
+  end
+
   it "withdrawn_when_withdrawn_notice_present" do
     payload = {
       "base_path" => "/some/path",

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     }.to raise_error(GovukIndex::UnknownDocumentTypeError)
   end
 
-
-  it "raise_validation_error" do
+  it "is invalid if the base path is missing" do
     payload = {}
 
     presenter = elasticsearch_presenter(payload)
@@ -34,6 +33,34 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     expect {
       presenter.valid!
     }.to raise_error(GovukIndex::MissingBasePath)
+  end
+
+  context "external content" do
+    it "is valid if it has a URL" do
+      payload = {
+        "document_type" => "external_content",
+        "details" => {
+          "url" => "some URL"
+        },
+      }
+
+      presenter = elasticsearch_presenter(payload)
+
+      presenter.valid!
+    end
+
+    it "is invalid if the URL is missing" do
+      payload = {
+        "document_type" => "external_content",
+        "details" => {},
+      }
+
+      presenter = elasticsearch_presenter(payload)
+
+      expect {
+        presenter.valid!
+      }.to raise_error(GovukIndex::MissingExternalUrl)
+    end
   end
 
   def elasticsearch_presenter(payload, type = "aaib_report")


### PR DESCRIPTION
Map the `external_content` document type to the `recommended-link` format and migrate it to the govuk index.

The biggest difference between `external_content` and other formats is that it does not have a `base_path` field because it represents an external URL rather than a path on GOV.UK.

Instead, the document `link` is generated from the `url` in the details hash.

https://trello.com/c/xAo1n9Et/526-make-external-links-indexable-in-the-govuk-index

The presenter classes are becoming more of a mess. We were waiting to start whitehall before we refactored, but given that we're going to leave this code for a while it would be good to do some tidying while we still have all the context. @MatMoore - what do you think?