### PR TITLE
Fully migrate external content to the govuk index

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -39,6 +39,7 @@ migrated:
 - manual
 - manual_section
 - policy
+- recommended-link # Search admin
 - service_manual_guide
 - service_manual_homepage
 - service_manual_service_standard
@@ -51,8 +52,7 @@ migrated:
   - '/help'
   - '/find-local-council'
 
-indexable:
-- recommended-link
+indexable: []
 
 non_indexable:
 - calculator


### PR DESCRIPTION
Mark the `recommended-link` format (which corresponds to the `external_content` document type) as migrated because it is now indexed correctly in the govuk index.

https://trello.com/c/qzVTvlPe/539-mark-external-links-as-migrated

Marked as "do not merge" until we have run the comparison tool on production.