### PR TITLE
Adopt the 'B' variant of our A/B test

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -70,13 +70,6 @@ index:
           filter: [standard, lowercase, old_synonym, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
-        # Analyzer used at query time for old-style synonym expansion.
-        query_with_old_synonyms:
-          type: custom
-          tokenizer: standard
-          filter: [standard, asciifolding, lowercase, old_synonym, stop, stemmer_override, stemmer_english]
-          char_filter: [normalize_quotes, strip_quotes]
-
         # Analyzer used at query time for old-style shingle matching.
         shingled_query_analyzer:
           type: custom

--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -22,31 +22,75 @@
 - search: opening times, opening hours
 - search: sickness, illness
 
-# Similar meanings
+# Expanding document text to capture similar meanings.
+
+# This can affect any searches containing any of these words,
+# rather than just these whole phrases, so we need to watch out for any
+# unexpected effects.
+- index: car tax bands, vehicle tax rates
+- index: hazardous substances, dangerous substances
+- index: holiday pay, holiday entitlement
+- index: pension forecast, pension statement
+- index: practical driving test, practical test
+- index: provisional driving licence, provisional licence
+- index: tariff classification, trade tariff
+- index: tariff codes, commodity codes
+
+# Expanding queries to capture similar meanings.
+
+# These terms are not interchangable, but they are closely related.
+# This will artificially increase the size of the user's query, so "minimum
+# should match" requirements can be easily met even if only part of the phrase
+# matches.
+- search: social fund, budgeting loans, crisis loans
+- search: work experience, internship, interns
 - search: apply, applying, application, claim, claiming
 - search: bank holiday, bank holidays, public holiday, public holidays
 - search: bankrupt, bankruptcy
 - search: car, vehicle
-- index: car tax bands, vehicle tax rates
 - search: copyright, intellectual property
 - search: death, bereavement
 - search: emissions, pollution
 - search: fees, costs, prices
-- index: hazardous substances, dangerous substances
-- index: holiday pay, holiday entitlement
-- search: how much => how much, fees, rates
-- index: pension forecast, pension statement
-- index: practical driving test, practical test
-- index: provisional driving licence, provisional licence
 - search: reduction, discount
 - search: renew, expired, out of date
 - search: self employed, self employment, sole trader, starting a business
-- index: social fund, budgeting loans, crisis loans
-- index: tariff classification, trade tariff
-- index: tariff codes, commodity codes
-- search: work experience, internship, interns
 
-# Unofficial or deprecated terms
+# Adding terms to return relevant content that doesn't mention the original search term
+- search: how much => how much, fees, rates
+- search: apostille => apostille, document legalised
+- search: bad weather, winter weather => cold weather, severe weather, winter weather, energy grants, heating
+- search: benefit checker, benefits checker => benefits adviser
+- search: bin collection => bin collection, rubbish collection
+- search: bno => overseas british passport
+- search: cancel child benefit => stop child benefit
+- search: curriculum vitae => cv, curriculum vitae
+# Seasonal need - also for Christmas and New Year payments
+- search: easter => easter, paid early
+- search: fiance, fiancee, fiancé, fiancée => partner, family, visa
+- search: flood alert, flood alerts => flood alerts, flood warnings
+- search: hpi check => used car check
+- search: intestacy => intestacy, wills, inherits
+- search: intestate => intestate, wills, inherits
+- search: kiev => kiev, kyiv, ukraine
+- search: mot checker => mot check
+# Student finance login
+- search: my account => your account, online account
+- search: not arrived => not arrived, contact dvla
+- search: not received => not received, contact dvla
+- search: refuse collection => refuse collection, rubbish collection
+- search: self certificate => self certification
+- search: sign off, signing off, starting work => sign off, signing off, starting work, from benefits to work, return to work, adviser
+- search: soc code, soc codes => soc code, sponsorship, skilled worker
+- search: social security => social security, benefits
+- search: sponsor login => sponsorship management system
+- search: spouse visa, spousal visa => spouse visa, partner visa, family
+- search: starting a company => starting a company, starting a business
+- search: under occupancy, underoccupancy => under occupancy, under occupied, bedroom, spare room
+- search: visa4uk => visa4uk, uk visa
+- search: waste carriers licence, waste carriers license => register as a waste carrier, licence
+
+# Unofficial or deprecated terms should expand to the preferred term
 - search: ancestral visa => ancestry visa
 - search: bedroom tax => spare bedroom, spare room
 - search: death duty => death duty, death duties, inheritance tax
@@ -72,7 +116,7 @@
 - search: winter payment, winter payments => winter fuel payment
 - search: xmas => christmas
 
-# Run-together terms
+# Separate run-together terms
 - search: bluebadge => blue badge
 - search: bonavacantia => bona vacantia
 - search: carersallowance => carer's allowance
@@ -213,68 +257,10 @@
 - search: n i => ni
 - search: p i p => pip
 
-# Adding terms to return relevant content that doesn't mention the original search term
-- search: apostille => apostille, document legalised
-- search: bad weather, winter weather => cold weather, severe weather, winter weather, energy grants, heating
-
-
-
-
-- search: benefit checker, benefits checker => benefits adviser
-- search: bin collection => bin collection, rubbish collection
-- search: bno => overseas british passport
-- search: cancel child benefit => stop child benefit
-- search: curriculum vitae => cv, curriculum vitae
-# Seasonal need - also for Christmas and New Year payments
-- search: easter => easter, paid early
-- search: fiance, fiancee, fiancé, fiancée => partner, family, visa
-
-
-- search: flood alert, flood alerts => flood alerts, flood warnings
-# heating => heating, energy grants, energy saving, cold, warm, winter
-- search: hpi check => used car check
-- search: intestacy => intestacy, wills, inherits
-
-- search: intestate => intestate, wills, inherits
-
-- search: kiev => kiev, kyiv, ukraine
-- search: mot checker => mot check
-# Student finance login
-- search: my account => your account, online account
-
-- search: not arrived => not arrived, contact dvla
-- search: not received => not received, contact dvla
-- search: refuse collection => refuse collection, rubbish collection
-- search: self certificate => self certification
-- search: sign off, signing off, starting work => sign off, signing off, starting work, from benefits to work, return to work, adviser
-
-
-
-
-
-# snow, snow code => snow, ice, grit, winter, weather, closures
-- search: soc code, soc codes => soc code, sponsorship, skilled worker
-
-
-- search: social security => social security, benefits
-- search: sponsor login => sponsorship management system
-- search: spouse visa, spousal visa => spouse visa, partner visa, family
-
-
-- search: starting a company => starting a company, starting a business
-- search: under occupancy, underoccupancy => under occupancy, under occupied, bedroom, spare room
-
-
-
-- search: visa4uk => visa4uk, uk visa
-- search: waste carriers licence, waste carriers license => register as a waste carrier, licence
-
 # Adding terms to raise the best results
 - search: british citizenship => british citizenship, british citizen
 - search: health check, health checks => nhs health check
 - search: job share, job sharing => job share, job sharing, flexible working
-
-
 
 # Removing terms to return relevant content
 - search: flood areas => flood
@@ -283,19 +269,14 @@
 
 # Forms and leaflets
 - search: adif => birth or adoption certificate form, student finance forms
-
 - search: br1, br 1 => br1, state pension claim form
-
 - search: br19, br 19 => br19, state pension statement
-
 - search: cwf1 => register for self assessment
 - search: d184 => divorce
 # 'D46P' appears in content but returns no results
 - search: d46p => d46p, renew 70
 - search: d777, d786b => d777b, digital tachograph driver card
-
 - search: d796 => d888, driver entitlement
-
 # 'D798' appears in content but returns no results
 - search: d798 => d798, renewal reminder
 - search: e15 => statutory maternity pay guidance
@@ -305,12 +286,10 @@
 - search: et3 => et3, employment tribunal
 - search: ex160, ex160a => court fees
 - search: ex321 => make a court claim for money, enforce a judgment
-
 - search: ex50 => court fees
 - search: flrm => flr m
 - search: flro => flr o
 - search: gv 262 => gv262, drivers hours
-
 - search: inf1d => driving licence application
 - search: inf2d => driving licence lorry or bus
 - search: inf4d => inf4d, medical condition
@@ -320,9 +299,7 @@
 - search: ipcbr1 => ipcbr1, ipc br1
 - search: jsa1, jsa1 ils, jsa1ils, jsa3, jsa4, jsa5, jsa6, jsa7, jsa9, jsa10, jsa10jp, jsa11, jsa12, jsa13, jsa28, jsa31, jsa40, jsa69, jsa460 => jobseeker's allowance
 - search: jsa esa10jp => jobseeker's allowance, employment support allowance
-
 - search: jsa2 => jobseeker's allowance, benefit integrity centre
-
 - search: lso1 => ls01
 - search: mi12 => mi12, mortgage interest
 - search: ni17a => maternity benefits
@@ -332,7 +309,6 @@
 - search: pr2 => pr2, student finance forms
 - search: r27 => after someone dies
 - search: sc1 => sc1, incapacity benefit
-
 - search: set m, setm => set m form
 - search: set o, seto => set o form
 - search: v100 => vehicle registration
@@ -363,7 +339,6 @@
 - search: unique tax => unique taxpayer
 
 # Correcting mistakes
-# advise => advise, advice
 - search: cy1 => cyi
 - search: dlva => dvla
 - search: e11 => e11, ehic
@@ -664,7 +639,7 @@
 - search: s76 => s76, sikorsky 76, sikorsky 76a, sikorsky 76b, sikorsky 76c
 - search: s92 => s92, sikorsky 92, sikorsky 92a
 
-# Temporary fix for MAA regulatory articles
+# 'Temporary' fix for MAA regulatory articles
 - search: ra1002 => ra 1002
 - search: ra1003 => ra 1003
 - search: ra1005 => ra 1005

--- a/doc/schemas.md
+++ b/doc/schemas.md
@@ -152,10 +152,3 @@ foo, bar or baz should return documents with any of them".
 Additional configuration is defined in the `elasticsearch_schema.yml` and
 `stems.yml` files.  This configuration is merged with the JSON configuration,
 and then passed to elasticsearch directly.
-
-The `old_synonyms.yml` contains a set of synonyms which were applied in an old,
-and moderately broken, way.  This is kept separate from the `synonyms.yml` file
-so that we can support and modify the lists for the new synonym approach
-without changing things for the old approach.  Once we're happy with the new
-approach, we'll delete the `old_synonyms.yml` file, and remove support for
-using it.

--- a/lib/debug/synonyms.rb
+++ b/lib/debug/synonyms.rb
@@ -1,39 +1,6 @@
 module Debug
   module Synonyms
-    class OldModel
-      attr_reader :client
-      attr_reader :index
-
-      def initialize(index: "govuk", client: Services.elasticsearch)
-        @client = client
-        @index = index
-      end
-
-      def search(query, pre_tags:, post_tags:)
-        search_query = {
-          query: {
-            multi_match: {
-              "query" => query,
-              "fields" => %w(title^1000 description),
-              "analyzer" => 'query_with_old_synonyms',
-            }
-          },
-          highlight: {
-            "fields" => { "title" => {}, "description" => {} },
-            "pre_tags" => pre_tags,
-            "post_tags" => post_tags
-          }
-        }
-
-        client.search(index: index, body: search_query)
-      end
-
-      def analyze_query(query)
-        client.indices.analyze text: query, analyzer: 'query_with_old_synonyms', index: index
-      end
-    end
-
-    class NewModel
+    class Analyzer
       attr_reader :client
       attr_reader :index
 

--- a/lib/govuk_index/client.rb
+++ b/lib/govuk_index/client.rb
@@ -1,6 +1,5 @@
 module GovukIndex
   class Client < Index::Client
-
   private
 
     def index_name

--- a/lib/legacy_search/advanced_search_query_builder.rb
+++ b/lib/legacy_search/advanced_search_query_builder.rb
@@ -98,7 +98,7 @@ module LegacySearch
                     {
                       query_string: {
                         query: escape(@keywords),
-                        analyzer: "query_with_old_synonyms"
+                        analyzer: "with_search_synonyms"
                       }
                     }
                   ]

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -57,12 +57,7 @@ module Search
                     core_query.match_phrase("indexable_content"),
                     core_query.match_all_terms(%w(title acronym description indexable_content)),
                     core_query.match_bigrams(%w(title acronym description indexable_content)),
-
-                    if search_params.synonym_b_variant?
-                      core_query.minimum_should_match("all_searchable_text")
-                    else
-                      core_query.minimum_should_match("_all")
-                    end
+                    core_query.minimum_should_match("all_searchable_text")
                   ],
                 }
               }

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -2,7 +2,6 @@ require "search/query_helpers"
 
 module QueryComponents
   class CoreQuery < BaseComponent
-    DEFAULT_QUERY_ANALYZER = "query_with_old_synonyms".freeze
     DEFAULT_QUERY_ANALYZER_WITHOUT_SYNONYMS = "default".freeze
 
     # Used with foo.synonym fields. Passing this is not necessary because
@@ -114,7 +113,7 @@ module QueryComponents
     # Use the synonym variant of the field unless we're disabling synonyms
     def synonym_field(field_name)
       return field_name if search_params.disable_synonyms?
-      return field_name if !search_params.synonym_b_variant?
+
       raise ValueError if field_name.include?(".")
 
       field_name + ".synonym"
@@ -126,12 +125,9 @@ module QueryComponents
       if search_params.disable_synonyms?
         # this is the default defined in the mapping for regular fields
         DEFAULT_QUERY_ANALYZER_WITHOUT_SYNONYMS
-      elsif search_params.synonym_b_variant?
+      else
         # this is the default defined in the mapping for *.synonym fields
         QUERY_TIME_SYNONYMS_ANALYZER
-      else
-        # this includes the old synonym filter
-        DEFAULT_QUERY_ANALYZER
       end
     end
 

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -48,10 +48,6 @@ module Search
       query && suggest.include?('spelling')
     end
 
-    def synonym_b_variant?
-      ab_tests[:synonyms] == 'B'
-    end
-
   private
 
     def determine_if_quoted_phrase

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -23,7 +23,7 @@ namespace :debug do
 
   desc "New synonyms test"
   task :show_new_synonyms, [:query] do |_, args|
-    model = Debug::Synonyms::NewModel.new
+    model = Debug::Synonyms::Analyzer.new
 
     search_tokens = model.analyze_query(args.query)
     index_tokens = model.analyze_index(args.query)
@@ -46,32 +46,6 @@ namespace :debug do
       hits.each do |hit|
         title = hit.dig("highlight", "title.synonym") || hit.dig("_source", "title")
         description = hit.dig("highlight", "description.synonym") || hit.dig("_source", "description")
-        puts title
-        puts description if description
-        puts ""
-      end
-    end
-  end
-
-  desc "Old synonyms test"
-  task :show_old_synonyms, [:query] do |_, args|
-    model = Debug::Synonyms::OldModel.new
-    search_tokens = model.analyze_query(args.query)
-    search_results = model.search(args.query, pre_tags: [ANSI_GREEN], post_tags: [ANSI_RESET])
-
-    puts Rainbow("Query interpretation for '#{args.query}':").yellow
-    puts search_tokens["tokens"]
-    puts ""
-
-    puts Rainbow("Sample matches (basic query with synonyms):").yellow
-
-    hits = search_results["hits"]["hits"]
-    if hits.empty?
-      puts Rainbow("No results found").red
-    else
-      hits.each do |hit|
-        title = hit.dig("highlight", "title") || hit.dig("_source", "title")
-        description = hit.dig("highlight", "description") || hit.dig("_source", "description")
         puts title
         puts description if description
         puts ""

--- a/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
+++ b/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
                   "query_string" =>
                   {
                     "query" => "happy fun time",
-                    "analyzer" => "query_with_old_synonyms"
+                    "analyzer" => "with_search_synonyms"
                   }
                 }
               ]

--- a/spec/unit/query_components/core_query_spec.rb
+++ b/spec/unit/query_components/core_query_spec.rb
@@ -1,24 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe QueryComponents::CoreQuery do
-  context "the search query with the B variant synonym analysis" do
-    it "uses the new synonyms field" do
-      builder = described_class.new(search_query_params(ab_tests: { synonyms: 'B' }))
+  context "the search query" do
+    it "uses the synonyms analyzer" do
+      builder = described_class.new(search_query_params)
 
       query = builder.minimum_should_match("all_searchable_text")
 
       expect(query.to_s).to match(/all_searchable_text\.synonym/)
-      expect(query.to_s).not_to match(/query_with_old_synonyms/)
-    end
-  end
-
-  context "the search query" do
-    it "uses the query_with_old_synonyms analyzer" do
-      builder = described_class.new(search_query_params)
-
-      query = builder.minimum_should_match("_all")
-
-      expect(query.to_s).to match(/query_with_old_synonyms/)
     end
 
     it "down-weight results which match fewer words in the search term" do
@@ -36,7 +25,7 @@ RSpec.describe QueryComponents::CoreQuery do
       query = builder.minimum_should_match("_all")
 
       expect(query.to_s).to match(/default/)
-      expect(query.to_s).not_to match(/query_with_old_synonyms/)
+      expect(query.to_s).not_to match(/all_searchable_text\.synonym/)
     end
   end
 end


### PR DESCRIPTION
This replaces `query_with_old_synonyms` with `with_search_synonyms`,
the new analyzer with a reduced set of synonyms, and some index time synonyms.

This also updates the old "advanced search" API to use this analyzer,
and removes some debugging code.

Before merging we need to check whether we want to modify any of the synonyms.

When we release this we should reindex as I've removed the old analyzer.

Trello: https://trello.com/c/iscPFTgY/472-measure-the-synonyms-a-b-test-and-deploy-changes