### PR TITLE
[DO NOT MERGE]Check for documents in mainstream that are not in govuk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,4 +44,4 @@ group :development do
   gem "rainbow"
 end
 
-gem "pry-byebug", group: [:development, :test]
+gem "pry-byebug"


### PR DESCRIPTION
- Check for documents that are in `mainstream` but not in `govuk`.
- The result should be 0.
- We have created this check to be run before and after rebuilding `govuk` so we can determine that all of the documents have been successfully migrated.

We are not planning on merging this but would like another pair of eyes @suzannehamilton and @dwhenry.