### PR TITLE
Remove unused analyzers, update synonyms

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -5,12 +5,21 @@ index:
         # At index time, elasticsearch will use an analyzer named default in the index settings
         # if no analyzer is specified in the field mapping:
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/analyzer.html
+        #
+        # We don't need this at query time unless synonyms are disabled
+        # using a debug flag.
         default:
           type: custom
           tokenizer: standard
           filter: [standard, asciifolding, lowercase, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
+        # This analyzer does not filter out these stopwords:
+        # a, an, and, are, as, at, be, but, by,
+        # for, if, in, into, is, it,
+        # no, not, of, on, or, such,
+        # that, the, their, then, there, these,
+        # they, this, to, was, will, with
         searchable_text:
           type: custom
           tokenizer: standard

--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -33,43 +33,6 @@ index:
           filter: [standard, asciifolding, lowercase, search_synonym, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
-        # Analyzer used to search across pairs of adjacent words.
-        with_shingles:
-          type: custom
-          tokenizer: standard
-          filter: [standard, asciifolding, lowercase, stemmer_override, stemmer_english, text_shingles]
-          char_filter: [normalize_quotes, strip_quotes]
-
-        # Analyzer used to search for codes like "P46", allowing codes to be
-        # split by whitespace.  Finds "codes" which consist of some letters and
-        # some digits, possibly split into two by whitespace.
-        with_id_codes:
-          type: custom
-          tokenizer: id_codes_split_sentences
-          filter:
-            - asciifolding
-            - lowercase
-            - id_codes_find_phrases
-            - id_codes_strip_symbols
-            - id_codes_squash_multiple_spaces
-            - id_codes_min_length
-            - id_codes_make_groups
-            - id_codes_strip_spaces
-            - id_codes_require_digit
-            - id_codes_min_length
-          char_filter: [normalize_quotes]
-
-        # No longer used, but defined to avoid errors during deploy
-        # (specifically, if an index has been migrated, but beofre the app
-        # servers have been restarted, the "query_default" analyzer needs to
-        # exist or queries will fail due to the analyzer they're trying to use
-        # not being found).
-        query_default:
-          type: custom
-          tokenizer: standard
-          filter: [standard, lowercase, old_synonym, stop, stemmer_override, stemmer_english]
-          char_filter: [normalize_quotes, strip_quotes]
-
         # An analyzer for doing "exact" word matching (but stripping wrapping whitespace, and case insensitive).
         exact_match:
           type: custom
@@ -100,14 +63,6 @@ index:
 
       tokenizer:
 
-        # Split text on sentence separator characters.
-        #
-        # Doesn't split text on a period which isn't followed by a space (eg, a
-        # period in an acronym, or code, or number).
-        id_codes_split_sentences:
-          type: pattern
-          pattern: '(\.\s)|[!?"\n]'
-
       char_filter:
         strip_quotes:
           type: "pattern_replace"
@@ -127,106 +82,3 @@ index:
         stemmer_english:
           type: stemmer
           name: porter2
-
-        # Filter used in the analyzer for ".shingle" subfields
-        text_shingles:
-          type: shingle
-          max_shingle_size: 2
-          min_shingle_size: 2
-          output_unigrams: false
-
-        # Filter used in the analyzer for ".with_id_codes" subfields
-        # Breaks the text down into "phrases", defined here as sequences of
-        # letters or various special characters.
-        id_codes_find_phrases:
-          type: pattern_capture
-          preserve_original: false
-          patterns:
-            # Any of the allowed symbols
-            - '((?:[a-z0-9\.:/\\_\s\(\)-])+)'
-
-            # preserve_original being set to false is ignored if there are no
-            # matches.  We don't want this behaviour, so we hack around it by
-            # adding a fallback match for individual characters.  We then strip
-            # these out with a `length` filter setting the minimum length of a
-            # term produced here to 2 characters.  It would be better if
-            # `preserve_original => false` did what it said.
-            - '(.)'
-
-        # Strip any non alphanumeric (or space) characters,
-        # replacing them with spaces.
-        id_codes_strip_symbols:
-          type: pattern_replace
-          pattern: '[^a-z0-9\s]'
-          replacement: ' '
-
-        # Replace any multiple spaces with a single space.
-        id_codes_squash_multiple_spaces:
-          type: pattern_replace
-          pattern: '\s{2,}'
-          replacement: ' '
-
-        # Split text into "groups", where each group is either a
-        # single word or a pair of words.
-        id_codes_make_groups:
-          type: pattern_capture
-          preserve_original: false
-          patterns:
-
-            # Match overlapping pairs of "words"
-            - |-
-              (?x:
-
-                # Start a positive lookahead group.
-                # Stuff inside the lookahead section will match,
-                # but won't advance the cursor position for the
-                # next match.  This lets us make overlapping
-                # groups.
-                (?=
-
-                  ( # Capture pairs of "words"
-                    [a-z0-9]+
-                    \s
-                    [a-z0-9]+
-                  )
-                )
-
-                # This is outside the lookahead, and outside the
-                # capture group.  All it does is to advance the
-                # cursor for the next match past the current word.
-                [a-z0-9]+
-              )
-
-            # Match single "words"
-            - '([a-z0-9]+)'
-
-        # Remove any space characters.
-        id_codes_strip_spaces:
-          type: pattern_replace
-          pattern: '\s'
-          replacement: ''
-
-        # Only keep terms which have at least one digit.
-        id_codes_require_digit:
-          type: pattern_capture
-          preserve_original: false
-          patterns:
-            - '^(.*\d.*)$'
-
-            # preserve_original being set to false is ignored if there are no
-            # matches.  We don't want this behaviour, so we hack around it by
-            # adding a fallback match for individual characters.  We then strip
-            # these out with a `length` filter setting the minimum length of a
-            # term produced here to 2 characters.  It would be better if
-            # `preserve_original => false` did what it said.
-            - '(.)'
-
-        id_codes_min_length:
-          type: length
-          min: 2
-
-        # Shingle filter used for the old weighting
-        old_shingles:
-          type: shingle
-          max_shingle_size: 2
-          min_shingle_size: 2

--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -70,12 +70,6 @@ index:
           filter: [standard, lowercase, old_synonym, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
-        # Analyzer used at query time for old-style shingle matching.
-        shingled_query_analyzer:
-          type: custom
-          tokenizer: standard
-          filter: [standard, asciifolding, lowercase, stop, stemmer_override, stemmer_english, old_shingles]
-
         # An analyzer for doing "exact" word matching (but stripping wrapping whitespace, and case insensitive).
         exact_match:
           type: custom

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -57,24 +57,12 @@
           "include_in_all": false,
           "analyzer": "searchable_text"
         },
-        "shingles": {
-          "type": "string",
-          "index": "analyzed",
-          "include_in_all": false,
-          "analyzer": "with_shingles"
-        },
         "synonym": {
           "type": "string",
           "index": "analyzed",
           "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
-        },
-        "id_codes": {
-          "type": "string",
-          "index": "analyzed",
-          "include_in_all": false,
-          "analyzer": "with_id_codes"
         }
       }
     }
@@ -94,12 +82,6 @@
           "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
-        },
-        "id_codes": {
-          "type": "string",
-          "index": "analyzed",
-          "include_in_all": false,
-          "analyzer": "with_id_codes"
         }
       }
     }
@@ -125,24 +107,12 @@
           "include_in_all": false,
           "analyzer": "searchable_text"
         },
-        "shingles": {
-          "type": "string",
-          "index": "analyzed",
-          "include_in_all": false,
-          "analyzer": "with_shingles"
-        },
         "synonym": {
           "type": "string",
           "index": "analyzed",
           "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
-        },
-        "id_codes": {
-          "type": "string",
-          "index": "analyzed",
-          "include_in_all": false,
-          "analyzer": "with_id_codes"
         }
       }
     }

--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -39,6 +39,7 @@
 # Multiword synonyms "play havoc" with term positions, so avoid creating index rules that change the phrase length.
 # See: https://www.elastic.co/guide/en/elasticsearch/guide/current/multi-word-synonyms.html
 # If a phrase expands to a longer phrase, extra words will be highlighted in search descriptions.
+# NOTE: terms like `practical_driving_test` are not marked as keywords so they are still stemmed.
 - both: practical test, practical tests => practical test, practical_driving_test
 - both: practical driving test, practical driving tests => practical driving test, practical_driving_test
 - both: provisional licence, provisional license => provisional licence, provisional_driving_licence

--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -31,10 +31,18 @@
 - index: hazardous substances, dangerous substances
 - index: holiday pay, holiday entitlement
 - index: pension forecast, pension statement
-- index: practical driving test, practical test
-- index: provisional driving licence, provisional licence
 - index: tariff classification, trade tariff
 - index: tariff codes, commodity codes
+
+# Treat synonyms of differing lengths the same
+
+# Multiword synonyms "play havoc" with term positions, so avoid creating index rules that change the phrase length.
+# See: https://www.elastic.co/guide/en/elasticsearch/guide/current/multi-word-synonyms.html
+# If a phrase expands to a longer phrase, extra words will be highlighted in search descriptions.
+- both: practical test, practical tests => practical test, practical_driving_test
+- both: practical driving test, practical driving tests => practical driving test, practical_driving_test
+- both: provisional licence, provisional license, provisonal licence, provisonal license => provisional licence, provisional_driving_licence
+- both: provisional driving licence, provisional driving license, provisonal driving licence, provisonal driving license => provisional driving licence, provisional_driving_licence
 
 # Expanding queries to capture similar meanings.
 

--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -41,8 +41,8 @@
 # If a phrase expands to a longer phrase, extra words will be highlighted in search descriptions.
 - both: practical test, practical tests => practical test, practical_driving_test
 - both: practical driving test, practical driving tests => practical driving test, practical_driving_test
-- both: provisional licence, provisional license, provisonal licence, provisonal license => provisional licence, provisional_driving_licence
-- both: provisional driving licence, provisional driving license, provisonal driving licence, provisonal driving license => provisional driving licence, provisional_driving_licence
+- both: provisional licence, provisional license => provisional licence, provisional_driving_licence
+- both: provisional driving licence, provisional driving license => provisional driving licence, provisional_driving_licence
 
 # Expanding queries to capture similar meanings.
 

--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -53,21 +53,21 @@
 - search: emissions, pollution
 - search: fees, costs, prices
 - search: reduction, discount
-- search: renew, expired, out of date
-- search: self employed, self employment, sole trader, starting a business
+- search: expired, out of date => expired, out of date, renew
+- search: self employed, self employment, sole trader
 
 # Adding terms to return relevant content that doesn't mention the original search term
 - search: how much => how much, fees, rates
 - search: apostille => apostille, document legalised
-- search: bad weather, winter weather => cold weather, severe weather, winter weather, energy grants, heating
+- search: bad weather, winter weather => bad weather, cold weather, severe weather, winter weather, energy grants, heating
 - search: benefit checker, benefits checker => benefits adviser
 - search: bin collection => bin collection, rubbish collection
-- search: bno => overseas british passport
+- search: bno => bno, overseas british passport
 - search: cancel child benefit => stop child benefit
 - search: curriculum vitae => cv, curriculum vitae
 # Seasonal need - also for Christmas and New Year payments
 - search: easter => easter, paid early
-- search: fiance, fiancee, fiancé, fiancée => partner, family, visa
+- search: fiance, fiancee, fiancé, fiancée => fiance, fiancee, fiancé, fiancée, partner, family, visa
 - search: flood alert, flood alerts => flood alerts, flood warnings
 - search: hpi check => used car check
 - search: intestacy => intestacy, wills, inherits
@@ -75,24 +75,24 @@
 - search: kiev => kiev, kyiv, ukraine
 - search: mot checker => mot check
 # Student finance login
-- search: my account => your account, online account
+- search: my account => my account, your account, online account
 - search: not arrived => not arrived, contact dvla
 - search: not received => not received, contact dvla
 - search: refuse collection => refuse collection, rubbish collection
-- search: self certificate => self certification
+- search: self certificate => self certificate, self certification
 - search: sign off, signing off, starting work => sign off, signing off, starting work, from benefits to work, return to work, adviser
 - search: soc code, soc codes => soc code, sponsorship, skilled worker
 - search: social security => social security, benefits
 - search: sponsor login => sponsorship management system
 - search: spouse visa, spousal visa => spouse visa, partner visa, family
-- search: starting a company => starting a company, starting a business
+- search: starting a company => starting a company, starting a business, set up a business
 - search: under occupancy, underoccupancy => under occupancy, under occupied, bedroom, spare room
 - search: visa4uk => visa4uk, uk visa
-- search: waste carriers licence, waste carriers license => register as a waste carrier, licence
+- search: waste carriers licence, waste carriers license => waste carriers licence, register as a waste carrier
 
 # Unofficial or deprecated terms should expand to the preferred term
 - search: ancestral visa => ancestry visa
-- search: bedroom tax => spare bedroom, spare room
+- search: bedroom tax => bedroom tax, spare bedroom, spare room
 - search: death duty => death duty, death duties, inheritance tax
 - search: drivers licence => drivers licence, driving licence
 - search: dole => dole, jobseeker's allowance
@@ -104,17 +104,16 @@
 - search: fired => fired, dismissed, dismissal
 - search: firing => firing, dismiss, dismissing, dismissal
 - search: heating allowance => winter fuel payment
-- search: independent safeguarding authority => disclosure and barring service
-- search: inland revenue => hmrc, hm revenue customs
+- search: inland revenue => inland revenue, hmrc, hm revenue customs
 - search: nextstep => careers, national careers service
-- search: old age pension => state pension
+- search: old age pension => old age pension, state pension
 - search: rfl refund => vehicle tax refunds
 - search: road tax => road tax, car tax
-- search: unemployment benefit => jobseeker's allowance
+- search: unemployment benefit => unemployment benefit, jobseeker's allowance
 - search: unsorn, un sorn, cancel sorn => sorn
 - search: winter fuel allowance, winter allowance => winter fuel payment
 - search: winter payment, winter payments => winter fuel payment
-- search: xmas => christmas
+- search: xmas => xmas, christmas
 
 # Separate run-together terms
 - search: bluebadge => blue badge
@@ -189,15 +188,16 @@
 
 # Acronyms
 - search: aspp, additional paternity pay
-- search: crb, criminal records bureau, dbs, disclosure and barring service
+- search: crb, criminal records bureau => crb, criminal records bureau, dbs, disclosure and barring service
 - search: csco, carbon saving community obligation
-- search: cwp => cold weather
+- search: cwp => cwp, cold weather
 - search: dada, dance and drama awards
+- search: dbs, disclosure and barring service
 - search: dda, disability discrimination act
 - search: dfe, department for education
 - search: dfid, department for international development
 - search: dh, department of health
-- search: doh => department of health
+- search: doh => doh, department of health
 - search: dhp, discretionary housing payment
 - search: dla, disability living allowance
 - search: ea, environment agency
@@ -209,42 +209,41 @@
 - search: fco, foreign commonwealth office
 - search: fcoc, future character of conflict
 - search: foi, freedom of information
-- search: gae => government authorised exchange
+- search: gae => gae, government authorised exchange
 - search: gdhif, green deal home improvement fund
-- search: gsc => government security classifications
+- search: gsc => gsc, government security classifications
 - search: hmcs, hmcts, hm courts tribunals service
 - search: idi, immigration directorate instructions
-- search: iib => industrial injuries disablement benefit
-- search: ilr => indefinite leave, settle, individualised learner record
+- search: iib => iib, industrial injuries disablement benefit
+- search: ilr => ilr, indefinite leave, settle, individualised learner record
 - search: jsa, jobseeker's allowance
 - search: lha, local housing allowance
 - search: lpa, lasting power of attorney
-- search: nasm => noise amelioration scheme military
+- search: nasm => nasm, noise amelioration scheme military
 - search: nea, new enterprise allowance
-- search: ni => national insurance
-- search: nin, nino => national insurance number
-- search: nppg => national planning practice guidance
+- search: nin, nino => nin, nino, national insurance number
+- search: nppg => nppg, national planning practice guidance
 - search: ntl, no time limit
 - search: ogn, operational guidance note
 - search: ospp, ordinary statutory paternity pay
 - search: pcdl, professional and career development loan
 - search: pilon, payment in lieu of notice, pay in lieu of notice
-- search: ppg => pollution prevention guidance
-- search: psw => post study work
+- search: ppg => ppg, pollution prevention guidance
+- search: psw => psw, post study work
 - search: rlmt, resident labour market test
 - search: rnps, register of number plate suppliers
 - search: rti, real time information
-- search: s2p => state second pension
+- search: s2p => s2p, state second pension
 - search: sap, statutory adoption pay
 - search: sar, subject access request
-- search: sf => student finance
-- search: sfe => student finance england
+- search: sf => sf, student finance
+- search: sfe => sfe, student finance england
 - search: slc, student loans company
 - search: sms, sponsorship management system
-- search: spol => state pension online
+- search: spol => spol, state pension online
 - search: spp, statutory paternity pay
-- search: twov => transit without visa
-- search: uj, ujm => universal jobmatch
+- search: twov => twov, transit without visa
+- search: uj, ujm => uj, ujm, universal jobmatch
 - search: ukba, border agency, uk ba => ukba, border agency, ukvi, uk visas and immigration
 - search: utr, unique taxpayer reference
 
@@ -315,28 +314,34 @@
 - search: v149 => v149, vehicle tax rates
 - search: v188 => disability exemption
 - search: v5 => v5, v5c
-- search: v888 => v888, vehicle information
-- search: v890 => sorn
+- search: v888 => v888, information about a vehicle
+- search: v890 => v890, sorn
 - search: vaf4 => vaf4a
-- search: vat1, vat 1, vat2, vat 2, vat50, vat 50, vat51, vat 51, vat1a, vat 1a, vat1b, vat 1b => vat registration
+- search: vat 1 => vat1, vat 1
+- search: vat 2 => vat2, vat 2
+- search: vat 50 => vat50, vat 50
+- search: vat 51 => vat51, vat 51
+- search: vat 1a => vat1a, vat 1a
+- search: vat 1b => vat1b, vat 1b
+- search: vat 1c => vat1c, vat 1c
 
 # Job searches
 # Birmingham Airport jobs
 - search: b26 3qz => jobs
 
 # Abbreviations
-- search: cert => certificate
-- search: digi => digital
-- search: gov => government
-- search: hep => hepatitis
-- search: lic => licence
+- search: cert => cert, certificate
+- search: digi => digi, digital
+- search: gov => gov, government
+- search: hep => hep, hepatitis
+- search: lic => lic, licence
 - search: min wage => minimum wage
 - search: no plate => number plate
-- search: reg => registration
+- search: reg => reg, registration
 - search: ref number => ref number, reference number
-- search: tacho, tacho graph, taco, taco graph => tachograph
+- search: tacho, tacho graph, taco, taco graph => tacho, tachograph
 # eg unique tax reference, unique tax code
-- search: unique tax => unique taxpayer
+- search: unique tax => unique tax, unique taxpayer
 
 # Correcting mistakes
 - search: cy1 => cyi
@@ -360,7 +365,7 @@
 - search: direct gov => directgov
 - search: flood line => floodline
 - search: heat wave => heatwave
-- search: help line => helpline
+- search: help line => help line, helpline
 - search: jelly fish => jellyfish
 - search: job centre => jobcentre
 - search: job match => job match, jobmatch
@@ -371,7 +376,14 @@
 - search: tax payer => tax payer, taxpayer
 
 # Foreign language
-- search: visum, viza, vize, visado, visados, visto, vistos, visti => visa
+- search: visum => visum, visa
+- search: viza => viza, visa
+- search: vize => vize, visa
+- search: visado => visado, visa
+- search: visados => visados, visa
+- search: visto => visto, visa
+- search: vistos => vistos, visa
+- search: visti => visti, visa
 
 # Common misspellings
 - search: addres => address
@@ -436,7 +448,7 @@
 - search: cossh => coshh
 - search: crisi => crisis
 - search: crissis => crisis
-- search: deregistration => de registration
+- search: deregistration => deregistration, de registration
 - search: diability => disability
 - search: disabilty => disability
 - search: disk => disk, disc
@@ -503,7 +515,7 @@
 - search: pention => pension
 - search: pentions => pensions
 - search: perscriptions => prescriptions
-- search: pra => practical
+- search: pra => pra, practical
 - search: pract => practical
 - search: pratical => practical
 - search: pregancy => pregnancy

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -56,7 +56,7 @@ module Search
                     core_query.match_phrase("description"),
                     core_query.match_phrase("indexable_content"),
                     core_query.match_all_terms(%w(title acronym description indexable_content)),
-                    core_query.match_bigrams(%w(title acronym description indexable_content)),
+                    core_query.match_any_terms(%w(title acronym description indexable_content)),
                     core_query.minimum_should_match("all_searchable_text")
                   ],
                 }

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -97,7 +97,7 @@ module QueryComponents
       }
     end
 
-    def match_bigrams(fields)
+    def match_any_terms(fields)
       fields = fields.map { |f| synonym_field(f) }
 
       {
@@ -105,7 +105,7 @@ module QueryComponents
           query: escape(search_term),
           operator: "or",
           fields: fields,
-          analyzer: "shingled_query_analyzer"
+          analyzer: query_analyzer
         }
       }
     end

--- a/spec/integration/schema/stemming_spec.rb
+++ b/spec/integration/schema/stemming_spec.rb
@@ -12,12 +12,6 @@ RSpec.describe 'SettingsTest' do
       "news" => ["news"]
   end
 
-  it "query default" do
-    expect_tokenisation :query_default,
-      "It's A Small World" => %w(it small world),
-      "It's, It’s Mr. O'Neill" => %w(it it mr oneil)
-  end
-
   it "exact match" do
     expect_tokenisation :exact_match,
       "It’s A Small W'rld" => ["it's a small w'rld"]
@@ -36,11 +30,6 @@ RSpec.describe 'SettingsTest' do
   it "string for sorting" do
     expect_tokenisation :string_for_sorting,
       "It's A Small W’rld" => ["its a small wrld"]
-  end
-
-  it "with shingles analyzer" do
-    expect_tokenisation :with_shingles,
-      "The small brown dog" => ["the small", "small brown", "brown dog"]
   end
 
 private

--- a/spec/integration/schema/stemming_spec.rb
+++ b/spec/integration/schema/stemming_spec.rb
@@ -1,33 +1,49 @@
 require 'spec_helper'
 
 RSpec.describe 'SettingsTest' do
-  it "default" do
-    expect_tokenisation :default,
-      "It's A Small’s World" => %w(it small world),
-      "It's Mitt’s" => %w(it mitt)
+  describe 'the default analyzer' do
+    it "reduces words to their stems" do
+      expect_tokenisation :default,
+        "It's A Small’s World" => %w(it small world),
+        "It's Mitt’s" => %w(it mitt)
+    end
+
+    it "doesn't over-stem important words" do
+      expect_tokenisation :default,
+        "news" => %w(news)
+    end
   end
 
-  it "uses correct stemming" do
-    expect_tokenisation :default,
-      "news" => ["news"]
+  describe "exact matching" do
+    it "preserves quotes" do
+      expect_tokenisation :exact_match,
+        "It’s A Small W'rld" => ["it's a small w'rld"]
+    end
+
+    it "preserves stopwords" do
+      expect_tokenisation :exact_match,
+        "to" => %w(to)
+    end
   end
 
-  it "exact match" do
-    expect_tokenisation :exact_match,
-      "It’s A Small W'rld" => ["it's a small w'rld"]
+  describe "searchable text" do
+    it "preserves stopwords" do
+      expect_tokenisation :searchable_text,
+        "to be or not to be" => %w(to be or not to be)
+    end
   end
 
-  it "best bet stemmed match" do
+  it "stems best bets" do
     expect_tokenisation :best_bet_stemmed_match,
       "It’s A Small W'rld" => %w(it a small wrld)
   end
 
-  it "spelling analyzer" do
+  it "uses the default shingle filter for spelling suggestions" do
     expect_tokenisation :spelling_analyzer,
       "It’s Grammed" => ["its", "its grammed", "grammed"]
   end
 
-  it "string for sorting" do
+  it "ignores quotes for sorting" do
     expect_tokenisation :string_for_sorting,
       "It's A Small W’rld" => ["its a small wrld"]
   end
@@ -39,7 +55,7 @@ private
   def expect_tokenisation(analyzer, assertions)
     assertions.each do |query, expected_output|
       tokens = fetch_tokens_for_analyzer(query, analyzer)
-      expect(expected_output).to eq(tokens)
+      expect(tokens).to eq(expected_output)
     end
   end
 

--- a/spec/integration/schema/stemming_spec.rb
+++ b/spec/integration/schema/stemming_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe 'SettingsTest' do
       "It's, It’s Mr. O'Neill" => %w(it it mr oneil)
   end
 
-  it "shingled query analyzer" do
-    expect_tokenisation :shingled_query_analyzer,
-      "Hello Hallo" => ["hello", "hello hallo", "hallo"],
-      "H'lo ’Hallo" => ["h'lo", "h'lo hallo", "hallo"]
-  end
-
   it "exact match" do
     expect_tokenisation :exact_match,
       "It’s A Small W'rld" => ["it's a small w'rld"]


### PR DESCRIPTION
cc @tarastockford 

Sorry for the mega PR. This branch does two things:
- removes elasticsearch configuration that is not used any more or has never been used in production
- changes and removes some synonym rules that weren't working well

I'd like to deploy both at the same time since we need to reindex for both.

`shingled_query_analyzer` is supposed to incorporate bigrams (pairs of adjacent words) into the search query.

This is useful because part of the meaning of a sentence comes from the word order, for example: `book a driving test for someone else` vs `driving someone else for a test book`.

However, this code never worked as intended because it only analyzed queries. So a query was broken down into single words and bigrams, but it compared those tokens to analyzed text that didn't contain any bigrams at all.

This means the bigram part of the query is only functioning as a single word match. This is very confusing when trying to understand what Rummager is doing.

I've changed it to use the normal query analyzer. This will change results slightly, because the shingles analyzer didn't include synonyms, but the new analyzer does.

Bigram matching was implemented properly as part of the 'new weighting' code a couple of years ago, but it never went live. This is something that could be revisited in future.

I've also removed:

- The reworked shingles analyzer (see https://trello.com/c/Zvdw9TLW/67-make-synonyms-work-properly-other-ranking-fixes)
- The ID codes analyser (see https://trello.com/c/lrYj5PdF/146-enable-searching-for-id-codes-with-or-without-spaces-punctuation)
- `query_default` which has been unused for some time
  
Trello:

- https://trello.com/c/VJXHCfYg/546-investigate-broken-search-term-highlighting
- https://trello.com/c/co7EVcJq/551-cleanuptimebox-remove-unused-analyzers-from-rummager