### PR TITLE
ADR for moving whitehall to the new process

### DIFF
--- a/doc/arch/adr-006-transition-whitehall-to-publishing-api-index.md
+++ b/doc/arch/adr-006-transition-whitehall-to-publishing-api-index.md
@@ -1,0 +1,90 @@
+# Decision record: Transition whitehall documents to a Publishing API derived search index
+
+Date: 2017-12-21
+
+## Definitions
+
+Throughout this document, `format` refers to the Rummager field `format`, not the document type provided by Publishing API (`content_store_document_type`).
+
+Every `content_store_document_type` is mapped to a single `format`.
+
+## Context
+Publishing applications used to directly communicate with rummager to index
+documents, using the `/documents` HTTP API.
+
+We've removed this integration for all publishing apps except for whitehall publisher.
+The publishing API now notifies rummager of every update, using a RabbitMQ
+message queue. Rummager responds to these messages by updating the `govuk`
+index. This has allowed us to remove the old `mainstream` index, which contained
+all sorts of documents beyond what we normally think of as "mainstream" content.
+The `govuk` index can be rebuilt from scratch in about an hour by resending the content
+from publishing API.
+
+See [ADR 006](adr-004-transition-mainstream-to-publishing-api-index.md) for more
+details about moving mainstream content to the govuk index.
+
+This leaves two indexes that are populated the old way: `government` and `detailed`.
+
+`detailed` contains detailed guides and `government` contains everything else
+published by Whitehall publisher.
+
+We also have a separate worker (`publishing-queue-listener`) that listens to
+`*.links` notifications from publishing API, and *updates* the old indexes
+(but doesn't add any new content).
+
+## Decision
+
+We intend to get rid of the `government` and `detailed` indexes. Rummager
+should index Whitehall Publisher documents into the `govuk` index.
+
+All search indexing code should be removed from Whitehall Publisher.
+
+The old indexing code should be removed from Rummager:
+
+- Anything in `lib/indexer`
+- The `publishing-queue-listener` worker
+
+The [infrastructure to log indexing requests to disk](https://docs.publishing.service.gov.uk/manual/rummager-traffic-replay.html) can also be removed,
+since data from the publishing API can be resent at any time.
+
+## Consequences
+
+There are over 200,000 documents published by Whitehall Publisher.
+
+There is also a lot of information about content that isn't currently available to rummager. For example:
+
+- The **state** of a document, based on archiving policy and content audits
+- **Publishing history** details besides the `public_updated_at` value
+- **Who** the content is applicable to or **where** it is relevant
+- What **services** or **task lists** the content belongs to
+- Entities mentioned in the text of the page (or its attachments), like **people**, **organisations**, **places**, **deadlines** and **forms**.
+
+When all documents are indexed from the publishing API, we will be able to make better use of the available data to improve search,
+because there will be a single indexing process that we can change easily.
+
+This work is also a dependency for [running Rummager in the draft stack](https://github.com/alphagov/govuk-rfcs/pull/86), to support preview behaviour and draft taxonomies.
+
+Combining all of the indexes into a single index will change the document frequency statistics, which affects how search results are scored.
+
+
+
+## Action plan
+
+### Copy over documents as-is and test
+Before making any changes to Whitehall Publisher, we should copy all documents from the `government` and `detailed` indexes to the `govuk` index.
+
+These documents will be filtered out of search results, but will have an indirect impact on scoring of other documents.
+
+We can then run the search healthcheck to understand the impact of this. At this stage we may want to reevaluate how much each format gets boosted in the search query.
+
+Once this is done, the `govuk` indexing process can be extended to Whitehall Publisher formats.
+
+### Follow the process to move a document type to the new indexing process
+See [new indexing process](https://github.com/alphagov/rummager/blob/master/doc/new-indexing-process.md)
+
+ This process needs to be repeated for each document type or group of related document types.
+
+### Delete the old indexes
+Once every document type is done, check for missing documents and then remove the old indexes and indexing code.
+
+See [example script for checking all documents are indexed correctly](https://github.com/alphagov/rummager/pull/1120).

--- a/doc/new-indexing-process.md
+++ b/doc/new-indexing-process.md
@@ -5,6 +5,35 @@ These are the steps to move formats to the new indexing process described in [AD
 
 Note: if you're adding a brand new format, see [make a new document type available to search](https://docs.publishing.service.gov.uk/manual/make-a-new-document-type-available-to-search.html) instead.
 
+## Ensure the document type is migrated to publishing API
+The publishing app should already notify the publishing API when documents are published and unpublished.
+
+Example PRs for [adding a new document type](https://docs.publishing.service.gov.uk/manual/add-a-new-document-type.html):
+
+- [Add external_content schema and document type](https://github.com/alphagov/govuk-content-schemas/pull/690)
+- [Publish recommended links to publishing API](https://github.com/alphagov/search-admin/pull/97)
+- [Add rake task for publishing all external links to the publishing API](https://github.com/alphagov/search-admin/pull/100/files)
+
+Ensure that all fields the publishing app currently sends to Rummager are included in the payload send to publishing API. If anything is missing, you'll need to update the publishing app and content schemas, and then re-publish existing content to the publishing API.
+
+You may also want to clean up other inconsistencies before changing the indexing method.
+
+Example PRs:
+
+- [Prepare for moving to rummager](https://github.com/alphagov/calendars/pull/160/files)
+- [Ensure we pass the description text to publishing API](https://github.com/alphagov/calendars/pull/162/files)
+
+## Update the presenter to handle the new format
+You'll need to update the elasticsearch presenter in Rummager so that it handles any fields which are not yet used by other formats in the govuk index.
+
+Fields that are common to multiple document types should be handled in a consistent way by Rummager. Don't add in special cases without good reason, even if the publishing app used to do something different.
+
+This is especially true for key fields like `title`, `description`, and `indexable_content`, although in some cases we do prefix titles so that similar looking content is distinguishable.
+
+Example PRs:
+
+- [Make policies indexable](https://github.com/alphagov/rummager/pull/1053)
+
 ## Get the data in sync on integration
 
 1. [Optional] run the check to see the starting state of the `govuk` index:
@@ -61,3 +90,7 @@ If anything goes wrong, roll back to "indexed".
 ## Remove the indexing code from the publishing app
 Once everything is working, the publishing app doesn't need to integrate
 with rummager any more.
+
+Example PRs:
+
+- [Stop collections publishing to rummager](https://github.com/alphagov/collections-publisher/pull/259)


### PR DESCRIPTION
[Rendered ADR](https://github.com/alphagov/rummager/blob/6531004c96772aa4b0e8f21599d3d604fadaea2e/doc/arch/adr-006-transition-whitehall-to-publishing-api-index.md)

[Updated indexing steps](https://github.com/alphagov/rummager/blob/6531004c96772aa4b0e8f21599d3d604fadaea2e/doc/new-indexing-process.md)

Trello: https://trello.com/c/7U0d8KtF/545-adr-for-whitehall-migration