### PR TITLE
Remove unused inside-government-link format

### DIFF
--- a/bin/stats
+++ b/bin/stats
@@ -8,7 +8,7 @@ $LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
 
 require "rummager"
 
-EXCLUDED_FORMATS = ["recommended-link", "inside-government-link"].freeze
+EXCLUDED_FORMATS = ["recommended-link"].freeze
 
 def all_documents(indices)
   Enumerator.new do |yielder|

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -1,5 +1,5 @@
 class SitemapGenerator
-  EXCLUDED_FORMATS = ["recommended-link", "inside-government-link"].freeze
+  EXCLUDED_FORMATS = ["recommended-link"].freeze
 
   def initialize(search_config)
     @search_config = search_config

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -95,26 +95,6 @@ RSpec.describe 'SitemapGeneratorTest' do
     expect(sitemap_xml[0]).not_to include("/external-example-answer")
   end
 
-  it "should_not_include_inside_government_links" do
-    generator = SitemapGenerator.new(SearchConfig.instance)
-    add_sample_documents(
-      [
-        {
-          "title" => "Some content from Inside Gov",
-          "description" => "We list some inside gov results in the mainstream index.",
-          "format" => "inside-government-link",
-          "link" => "https://www.gov.uk/government/some-content",
-        },
-      ],
-      index_name: 'government_test'
-    )
-
-    sitemap_xml = generator.sitemaps
-
-    expect(sitemap_xml.length).to eq(1)
-    expect(sitemap_xml[0]).not_to include("/government/some-content")
-  end
-
   it "links_should_include_timestamps" do
     generator = SitemapGenerator.new(SearchConfig.instance)
     add_sample_documents(


### PR DESCRIPTION
All `inside-government-link` documents were converted to `recommended-link` when external content was migrated to the govuk index.

https://trello.com/c/c1ThSRWk/550-remove-the-inside-government-link-format-from-rummager

Don't merge this until #1117 has been merged.