### PR TITLE
Remove underscores from spec names

### DIFF
--- a/lib/schema_migrator.rb
+++ b/lib/schema_migrator.rb
@@ -1,8 +1,9 @@
 class SchemaMigrator
-  def initialize(index_name, config, wait_between_task_list_check: 5)
+  def initialize(index_name, config, wait_between_task_list_check: 5, io: STDOUT)
     @index_name = index_name
     @config = config
     @wait_between_task_list_check = wait_between_task_list_check
+    @io = io
 
     index_group.current.with_lock do
       yield(self)
@@ -42,10 +43,12 @@ class SchemaMigrator
   end
 
   def comparison
-    @comparison ||= Indexer::Comparer.new(index_group.current.real_name, index.real_name).run
+    @comparison ||= Indexer::Comparer.new(index_group.current.real_name, index.real_name, io: io).run
   end
 
 private
+
+  attr_reader :io
 
   # this is awful but is caused by the return format of the tasks lists
   def running_tasks

--- a/spec/integration/analytics_data_spec.rb
+++ b/spec/integration/analytics_data_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'AnalyticsDataTest' do
     @analytics_data_fetcher = AnalyticsData.new(SearchConfig.instance.base_uri, %w(mainstream_test govuk_test))
   end
 
-  it "fetches_rows_of_analytics_dimensions" do
+  it "fetches rows of analytics dimensions" do
     document = {
       "content_id" => "587b0635-2911-49e6-af68-3f0ea1b07cc5",
       "link" => "/an-example-page",
@@ -79,7 +79,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(rows.to_a).to eq([expected_row])
   end
 
-  it "missing_data_is_nil" do
+  it "missing data is nil" do
     document = {}
     id = commit_document("mainstream_test", document)
 
@@ -90,7 +90,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(rows.to_a).to eq([expected_row])
   end
 
-  it "content_id_is_preferred_to_link_for_product_id" do
+  it "content_id is preferred to link for product id" do
     document = {
       "content_id" => "some_content_id",
       "link" => "/some/page/path",
@@ -102,7 +102,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(rows.first[0]).to eq("some_content_id")
   end
 
-  it "product_id_falls_back_to_link_if_content_id_is_missing" do
+  it "product id falls back to link if content_id is missing" do
     document = {
       "link" => "/some/page/path",
     }
@@ -113,7 +113,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(rows.first[0]).to eq("/some/page/path")
   end
 
-  it "document_type_is_preferred_to_format" do
+  it "document_type is preferred to format" do
     document = {
       "format" => "some_format",
       "content_store_document_type" => "some_document_type",
@@ -125,7 +125,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(rows.first[5]).to eq("some_document_type")
   end
 
-  it "document_type_falls_back_to_format_if_not_present" do
+  it "document_type falls back to format if not present" do
     document = {
       "format" => "some_format",
     }
@@ -136,7 +136,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(rows.first[5]).to eq("some_format")
   end
 
-  it "sanitises_unix_line_breaks_in_titles" do
+  it "sanitises unix line breaks in titles" do
     document = {
       "title" => <<~HEREDOC
         A page title
@@ -151,7 +151,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(rows.first[4]).to eq("A page title with some line breaks")
   end
 
-  it "sanitises_windows_line_breaks_in_titles" do
+  it "sanitises windows line breaks in titles" do
     document = {
       "title" => "A page title\r\nwith some\r\nline breaks"
     }
@@ -162,7 +162,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(rows.first[4]).to eq("A page title with some line breaks")
   end
 
-  it "fetches_all_rows" do
+  it "fetches all rows" do
     fixture_file = File.expand_path("../fixtures/content_for_analytics.json", __FILE__)
     documents = JSON.parse(File.read(fixture_file))
     documents.each do |document|
@@ -174,7 +174,7 @@ RSpec.describe 'AnalyticsDataTest' do
     expect(analytics_data.size).to eq(30)
   end
 
-  it "headers_and_rows_are_consisent" do
+  it "headers and rows are consisent" do
     document = {
       "content_id" => "587b0635-2911-49e6-af68-3f0ea1b07cc5",
       "link" => "/an-example-page",

--- a/spec/integration/app/content_endpoints_spec.rb
+++ b/spec/integration/app/content_endpoints_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe 'ContentEndpointsTest' do
-  it "content_document_not_found" do
+  it "content document not found" do
     get "/content?link=/a-document/that-does-not-exist"
 
     expect(last_response).to be_not_found
   end
 
-  it "that_getting_a_document_returns_the_document" do
+  it "that getting a document returns the document" do
     commit_document("mainstream_test", {
       "title" => "A nice title",
       "link" => "a-document/in-search",
@@ -19,7 +19,7 @@ RSpec.describe 'ContentEndpointsTest' do
     expect("title" => "A nice title", "link" => "a-document/in-search").to eq parsed_response['raw_source']
   end
 
-  it "deleting_a_document" do
+  it "deleting a document" do
     commit_document("mainstream_test", {
       "title" => "A nice title",
       "link" => "a-document/in-search",
@@ -30,13 +30,13 @@ RSpec.describe 'ContentEndpointsTest' do
     expect(last_response.status).to eq(204)
   end
 
-  it "deleting_a_document_that_doesnt_exist" do
+  it "deleting a document that doesnt exist" do
     delete "/content?link=a-document/in-search"
 
     expect(last_response).to be_not_found
   end
 
-  it "deleting_a_document_from_locked_index" do
+  it "deleting a document from locked index" do
     commit_document("mainstream_test", {
       "title" => "A nice title",
       "link" => "a-document/in-search",

--- a/spec/integration/app/status_spec.rb
+++ b/spec/integration/app/status_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'StatusTest' do
-  it "shows_queue_job_count" do
+  it "shows queue job count" do
     expect_any_instance_of(Sidekiq::Stats).to receive(:queues).and_return(
       { "bulk" => 12 }
     )
@@ -13,7 +13,7 @@ RSpec.describe 'StatusTest' do
     expect(parsed_response["queues"]["bulk"]["jobs"]).to eq(12)
   end
 
-  it "shows_per_queue_retry_count" do
+  it "shows per queue retry count" do
     retries = %w(bulk bulk something-else).map { |q| double(queue: q) }
 
     expect(Sidekiq::RetrySet).to receive(:new).and_return(retries)
@@ -27,7 +27,7 @@ RSpec.describe 'StatusTest' do
     expect(parsed_response["queues"]["bulk"]["retries"]).to eq(2)
   end
 
-  it "shows_zero_retry_count" do
+  it "shows zero retry count" do
     expect(Sidekiq::RetrySet).to receive(:new).and_return([])
     expect_any_instance_of(Sidekiq::Stats).to receive(:queues).and_return(
       { "bulk" => 12 }
@@ -39,7 +39,7 @@ RSpec.describe 'StatusTest' do
     expect(parsed_response["queues"]["bulk"]["retries"]).to eq(0)
   end
 
-  it "shows_per_queue_scheduled_count" do
+  it "shows per queue scheduled count" do
     scheduled = %w(bulk bulk something-else).map { |q| double(queue: q) }
 
     expect(Sidekiq::ScheduledSet).to receive(:new).and_return(scheduled)
@@ -53,7 +53,7 @@ RSpec.describe 'StatusTest' do
     expect(parsed_response["queues"]["bulk"]["scheduled"]).to eq(2)
   end
 
-  it "shows_zero_retry_count_scheduled" do
+  it "shows zero retry count scheduled" do
     expect(Sidekiq::ScheduledSet).to receive(:new).and_return([])
     expect_any_instance_of(Sidekiq::Stats).to receive(:queues).and_return(
       { "bulk" => 12 }

--- a/spec/integration/comparer_spec.rb
+++ b/spec/integration/comparer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'ComparerTest' do
-  it "for_sort_ordering" do
+  it "for sort ordering" do
     insert_document('mainstream_test', { some: 'data' }, id: 'ABC', type: 'edition')
     insert_document('mainstream_test', { some: 'data' }, id: 'DEF', type: 'hmrc_manual')
     commit_document('mainstream_test', { some: 'data' }, id: 'GHI', type: 'edition')
@@ -33,7 +33,7 @@ RSpec.describe 'ComparerTest' do
     ]).to eq results.to_a
   end
 
-  it "only_compares_filtered_formats" do
+  it "only compares filtered formats" do
     insert_document('mainstream_test', { some: 'data', format: 'edition' }, id: 'ABC', type: 'edition')
     insert_document('mainstream_test', { some: 'data', format: 'other' }, id: 'DEF', type: 'hmrc_manual')
     commit_document('mainstream_test', { some: 'data', format: 'other' }, id: 'GHI', type: 'edition')
@@ -57,7 +57,7 @@ RSpec.describe 'ComparerTest' do
     ]).to eq results.to_a
   end
 
-  it "comparison_output_works" do
+  it "comparison output works" do
     insert_document('mainstream_test', { some: 'data', format: 'edition', field: 1 }, id: 'ABC', type: 'edition')
     insert_document('mainstream_test', { some: 'data', format: 'other' }, id: 'DEF', type: 'other')
     commit_document('mainstream_test', { some: 'data', format: 'other' }, id: 'GHI', type: 'edition')

--- a/spec/integration/duplicate_deleter_spec.rb
+++ b/spec/integration/duplicate_deleter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'DuplicateDeleterTest' do
-  it "can_not_delete_when_only_a_single_document" do
+  it "can not delete when only a single document" do
     commit_document(
       "mainstream_test",
       {
@@ -17,7 +17,7 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
-  it "can_delete_duplicate_documents_on_different_types" do
+  it "can delete duplicate documents on different types" do
     commit_document(
       "mainstream_test",
       {
@@ -43,7 +43,7 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
-  it "cant_delete_a_type_that_doesnt_exist" do
+  it "cant delete a type that doesnt exist" do
     commit_document(
       "mainstream_test",
       {
@@ -68,7 +68,7 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
-  it "cant_delete_duplicate_content_ids_when_id_doesnt_match" do
+  it "cant delete duplicate content_ids when id doesnt match" do
     commit_document(
       "mainstream_test",
       {
@@ -93,7 +93,7 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_present_in_rummager(id: "/an-example-page", type: "cma_case")
   end
 
-  it "can_delete_duplicate_documents_on_different_types_using_link" do
+  it "can delete duplicate documents on different types using link" do
     commit_document(
       "mainstream_test",
       {
@@ -118,7 +118,7 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
-  it "cant_delete_duplicate_documents_using_link_with_different_content_ids" do
+  it "cant delete duplicate documents using link with different content_ids" do
     commit_document(
       "mainstream_test",
       {
@@ -143,7 +143,7 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
-  it "can_delete_duplicate_documents_if_bad_item_has_nil_content_id" do
+  it "can delete duplicate documents if bad item has nil content_id" do
     commit_document(
       "mainstream_test",
       { "link" => "/an-example-page" },
@@ -165,7 +165,7 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_missing_in_rummager(id: "/an-example-page", type: "edition")
   end
 
-  it "cant_delete_duplicate_documents_if_good_item_has_nil_content_id" do
+  it "cant delete duplicate documents if good item has nil content_id" do
     commit_document(
       "mainstream_test",
       {
@@ -187,7 +187,7 @@ RSpec.describe 'DuplicateDeleterTest' do
     expect_document_present_in_rummager(id: "/an-example-page", type: "edition")
   end
 
-  it "can_delete_duplicate_documents_on_different_types_using_link_when_both_content_ids_are_missing" do
+  it "can delete duplicate documents on different types using link when both content_ids are missing" do
     commit_document(
       "mainstream_test",
       { "link" => "/an-example-page" },

--- a/spec/integration/govuk_index/collections_spec.rb
+++ b/spec/integration/govuk_index/collections_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Collections publishing" do
     expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
   end
 
-  it "indexes a specialist_sector page" do
+  it "indexes a specialist sector page" do
     random_example = generate_random_example(
       schema: "topic",
       payload: {

--- a/spec/integration/govuk_index/specialist_formats_spec.rb
+++ b/spec/integration/govuk_index/specialist_formats_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'SpecialistFormatTest' do
     consumer.run
   end
 
-  it "specialist_publisher_finders_are_correctly_indexed" do
+  it "specialist publisher finders are correctly indexed" do
     random_example = generate_random_example(
       schema: "finder",
       payload: { document_type: "finder" },
@@ -28,7 +28,7 @@ RSpec.describe 'SpecialistFormatTest' do
     expect_document_is_in_rummager({ "link" => random_example["base_path"] }, index: "govuk_test", type: 'edition')
   end
 
-  it "specialist_documents_are_correctly_indexed" do
+  it "specialist documents are correctly indexed" do
     document_types = %w(
       aaib_report
       asylum_support_decision
@@ -63,7 +63,7 @@ RSpec.describe 'SpecialistFormatTest' do
     end
   end
 
-  it "esi_documents_are_correctly_indexed" do
+  it "esi documents are correctly indexed" do
     publisher_document_type = 'esi_fund'
     search_document_type = 'european_structural_investment_fund'
 
@@ -82,7 +82,7 @@ RSpec.describe 'SpecialistFormatTest' do
     )
   end
 
-  it "finders_email_signup_are_never_indexed" do
+  it "finders email signup are never indexed" do
     random_example = generate_random_example(
       schema: "finder_email_signup",
       payload: { document_type: "finder_email_signup" },

--- a/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
+++ b/spec/integration/govuk_index/switch_on_formats_in_govuk_index_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest' do
     commit_index('govuk_test')
   end
 
-  it "defaults_to_excluding_govuk_index_records" do
+  it "defaults to excluding govuk index records" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
 
     get "/search"
@@ -18,7 +18,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest' do
     expect(parsed_response['results'].map { |r| r['title'] }.sort).to eq(['mainstream answer', 'mainstream help'])
   end
 
-  it "can_enable_format_to_use_govuk_index" do
+  it "can enable format to use govuk index" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
 
     get "/search"
@@ -26,7 +26,7 @@ RSpec.describe 'GovukIndex::SwitchOnFormatsInGovukIndexTest' do
     expect(parsed_response['results'].map { |r| r['title'] }.sort).to eq(['govuk help', 'mainstream answer'])
   end
 
-  it "can_enable_multiple_formats_to_use_govuk_index" do
+  it "can enable multiple formats to use govuk index" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("help_page" => :all, "answer" => :all)
 
     get "/search"

--- a/spec/integration/govuk_index/sync_data_spec.rb
+++ b/spec/integration/govuk_index/sync_data_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'GovukIndex::SyncDataTest' do
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return('help_page' => :all)
   end
 
-  it "syncs_records_for_non_indexable_formats" do
+  it "syncs records for non indexable formats" do
     insert_document('mainstream_test', { link: '/test', popularity: 0.3, format: 'edition' }, id: '/test', type: 'edition')
     commit_index('mainstream_test')
 
@@ -14,7 +14,7 @@ RSpec.describe 'GovukIndex::SyncDataTest' do
     expect_document_is_in_rummager({ 'link' => '/test' }, type: 'edition', index: 'govuk_test')
   end
 
-  it "syncs_will_overwrite_existing_data" do
+  it "syncs will overwrite existing data" do
     insert_document('mainstream_test', { link: '/test', popularity: 0.3, format: 'edition' }, id: '/test', type: 'edition')
     commit_index('mainstream_test')
     insert_document('govuk_test', { link: '/test', popularity: 0.4, format: 'edition' }, id: '/test', type: 'edition')
@@ -26,7 +26,7 @@ RSpec.describe 'GovukIndex::SyncDataTest' do
   end
 
 
-  it "will_not_syncs_records_for_indexable_formats" do
+  it "will not syncs records for indexable formats" do
     insert_document('mainstream_test', { link: '/test', popularity: 0.3, format: 'help_page' }, id: '/test', type: 'edition')
     commit_index('mainstream_test')
     insert_document('govuk_test', { link: '/test', popularity: 0.4, format: 'help_page' }, id: '/test', type: 'edition')

--- a/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
+++ b/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'GovukIndex::UnpublishingMessageProcessing' do
-  it "unpublish_message_will_remove_record_from_elasticsearch" do
+  it "unpublish message will remove record from elasticsearch" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("answer" => :all)
 
     message = unpublishing_event_message(
@@ -28,7 +28,7 @@ RSpec.describe 'GovukIndex::UnpublishingMessageProcessing' do
     }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 
-  it "unpublish_withdrawn_messages_will_set_is_withdrawn_flag" do
+  it "unpublish withdrawn messages will set is withdrawn flag" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("help_page" => :all)
 
     message = unpublishing_event_message(

--- a/spec/integration/govuk_index/updating_popularity_data_spec.rb
+++ b/spec/integration/govuk_index/updating_popularity_data_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return('help_page' => :all)
   end
 
-  it "updates_the_popularity_when_it_exists" do
+  it "updates the popularity when it exists" do
     id = insert_document('govuk_test', { popularity: 0.222, format: 'help_page' }, type: 'edition')
     commit_index('govuk_test')
 
@@ -21,7 +21,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     expect_document_is_in_rummager({ 'link' => id, 'popularity' => popularity }, type: 'edition', index: 'govuk_test')
   end
 
-  it "set_the_popularity_to_the_lowest_popularity_when_it_doesnt_exist" do
+  it "set the popularity to the lowest popularity when it doesnt exist" do
     id = insert_document('govuk_test', { popularity: 0.222, format: 'help_page' }, type: 'edition')
     commit_index('govuk_test')
 
@@ -35,7 +35,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     expect_document_is_in_rummager({ 'link' => id, 'popularity' => popularity }, type: 'edition', index: 'govuk_test')
   end
 
-  it "ignores_popularity_update_if_version_has_moved_on" do
+  it "ignores popularity update if version has moved on" do
     id = insert_document('govuk_test', { popularity: 0.222, format: 'help_page' }, type: 'edition', version: 2)
     commit_index('govuk_test')
 
@@ -54,7 +54,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     expect_document_is_in_rummager({ 'link' => id, 'popularity' => 0.222 }, type: 'edition', index: 'govuk_test')
   end
 
-  it "copies_version_information" do
+  it "copies version information" do
     id = insert_document('govuk_test', { popularity: 0.222, format: 'help_page' }, type: 'edition', version: 3)
     commit_index('govuk_test')
     GovukIndex::PopularityUpdater.update('govuk_test')
@@ -63,7 +63,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     expect(document['_version']).to eq(3)
   end
 
-  it "skips_non_indexable_formats" do
+  it "skips non indexable formats" do
     id = insert_document('govuk_test', { popularity: 0.222, format: 'edition' }, type: 'edition', version: 3)
     commit_index('govuk_test')
     GovukIndex::PopularityUpdater.update('govuk_test')
@@ -72,7 +72,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     expect(0.222).to eq(document['_source']['popularity'])
   end
 
-  it "does_not_skips_non_indexable_formats_if_process_all_flag_is_set" do
+  it "does not skips non indexable formats if process all flag is set" do
     id = insert_document('govuk_test', { popularity: 0.222, format: 'edition' }, type: 'edition', version: 3)
     commit_index('govuk_test')
 

--- a/spec/integration/govuk_index/versioning_spec.rb
+++ b/spec/integration/govuk_index/versioning_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
     @processor = GovukIndex::PublishingEventProcessor.new
   end
 
-  it "should_successfully_index_increasing_version_numbers" do
+  it "should successfully index increasing version numbers" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
 
     version1 = generate_random_example(
@@ -28,7 +28,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
     expect(document["_source"]["title"]).to eq("new title")
   end
 
-  it "should_discard_message_with_same_version_as_existing_document" do
+  it "should discard message with same version as existing document" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
     version1 = generate_random_example(payload: { payload_version: 123 })
 
@@ -46,7 +46,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
     expect(version1["title"]).to eq(document["_source"]["title"])
   end
 
-  it "should_discard_message_with_earlier_version_than_existing_document" do
+  it "should discard message with earlier version than existing document" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
 
     version1 = generate_random_example(payload: { payload_version: 123 })
@@ -65,7 +65,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
     expect(version1["title"]).to eq(document["_source"]["title"])
   end
 
-  it "should_delete_and_recreate_document_when_unpublished_and_republished" do
+  it "should delete and recreate document when unpublished and republished" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
     version1 = generate_random_example(
       payload: { payload_version: 1 },
@@ -99,7 +99,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
     expect(document["_version"]).to eq(3)
   end
 
-  it "should_discard_unpublishing_message_with_earlier_version" do
+  it "should discard unpublishing message with earlier version" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
     version1 = generate_random_example(payload: { payload_version: 2 })
 
@@ -123,7 +123,7 @@ RSpec.describe 'GovukIndex::VersioningTest' do
     expect(document["_version"]).to eq(2)
   end
 
-  it "should_ignore_event_for_non_indexable_formats" do
+  it "should ignore event for non indexable formats" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable?).and_return(true)
 
     version1 = generate_random_example(payload: { payload_version: 123 })

--- a/spec/integration/indexer/amendment_spec.rb
+++ b/spec/integration/indexer/amendment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'ElasticsearchAmendmentTest' do
     stub_tagging_lookup
   end
 
-  it "should_amend_a_document" do
+  it "should amend a document" do
     commit_document("mainstream_test", {
       "title" => "The old title",
       "link" => "/an-example-answer",
@@ -19,7 +19,7 @@ RSpec.describe 'ElasticsearchAmendmentTest' do
     }, type: "edition")
   end
 
-  it "should_amend_a_document_from_non_edition_docs" do
+  it "should amend a document from non edition docs" do
     commit_document("mainstream_test", {
       "title" => "The old title",
       "link" => "/an-example-answer",
@@ -33,7 +33,7 @@ RSpec.describe 'ElasticsearchAmendmentTest' do
     }, type: "aaib_report")
   end
 
-  it "should_amend_a_document_queued" do
+  it "should amend a document queued" do
     commit_document("mainstream_test", {
       "title" => "The old title",
       "link" => "/an-example-answer",

--- a/spec/integration/indexer/change_notification_processor_spec.rb
+++ b/spec/integration/indexer/change_notification_processor_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'ChangeNotificationProcessorTest' do
-  it "triggering_a_reindex" do
+  it "triggering a reindex" do
     publishing_api_has_lookups(
       "/foo" => "DOCUMENT-CONTENT-ID"
     )

--- a/spec/integration/indexer/closing_spec.rb
+++ b/spec/integration/indexer/closing_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'ElasticsearchClosingTest' do
     stub_tagging_lookup
   end
 
-  it "should_fail_to_insert_or_get_when_index_closed" do
+  it "should fail to insert or get when index closed" do
     index = search_server.index_group(SearchConfig.instance.default_index_name).current
     index.close
 

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'ElasticsearchDeletionTest' do
     expect_document_missing_in_rummager(id: "/an-example-page", index: "mainstream_test")
   end
 
-  it "removes a document from the index_queued" do
+  it "removes a document from the index queued" do
     commit_document("mainstream_test", {
       "link" => "/an-example-page"
     })

--- a/spec/integration/indexer/index_group_spec.rb
+++ b/spec/integration/indexer/index_group_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'ElasticsearchIndexGroupTest' do
     @index_group.switch_to(index)
   end
 
-  it "should_create_index" do
+  it "should create index" do
     expect(@index_group.index_names).to be_empty
     index = @index_group.create_index
 
@@ -27,14 +27,14 @@ RSpec.describe 'ElasticsearchIndexGroupTest' do
     ).to eq(index.mappings)
   end
 
-  it "should_alias_index" do
+  it "should alias index" do
     index = @index_group.create_index
     @index_group.switch_to(index)
 
     expect(index.real_name).to eq(@index_group.current.real_name)
   end
 
-  it "should_switch_index" do
+  it "should switch index" do
     old_index = @index_group.create_index
     @index_group.switch_to(old_index)
 
@@ -44,7 +44,7 @@ RSpec.describe 'ElasticsearchIndexGroupTest' do
     expect(new_index.real_name).to eq(@index_group.current.real_name)
   end
 
-  it "should_clean_indices" do
+  it "should clean indices" do
     @index_group.create_index
     @index_group.switch_to(@index_group.create_index)
 

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/publishing_api_v2"
 RSpec.describe 'TaglookupDuringIndexingTest' do
   include GdsApi::TestHelpers::PublishingApiV2
 
-  it "indexes_document_without_publishing_api_content_unchanged" do
+  it "indexes document without publishing api content unchanged" do
     publishing_api_has_lookups({})
 
     post "/documents", {
@@ -16,7 +16,7 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
     )
   end
 
-  it "indexes_document_with_external_url_unchanged" do
+  it "indexes document with external url unchanged" do
     publishing_api_has_lookups({})
 
     post "/documents", {
@@ -28,7 +28,7 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
     )
   end
 
-  it "indexes_documents_with_links_from_publishing_api" do
+  it "indexes documents with links from publishing api" do
     publishing_api_has_lookups(
       "/foo/bar" => "DOCUMENT-CONTENT-ID"
     )
@@ -95,7 +95,7 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
     )
   end
 
-  it "skips_content_id_lookup_if_it_already_has_a_content_id" do
+  it "skips content id lookup if it already has a content_id" do
     publishing_api_has_expanded_links(
       content_id: "CONTENT-ID-OF-DOCUMENT",
       expanded_links: {
@@ -121,7 +121,7 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
     )
   end
 
-  it "extracts_parts_of_taxonomy" do
+  it "extracts parts of taxonomy" do
     grandparent_1_content_id = "22aadc14-9bca-40d9-abb4-4f21f9792a05"
     grandparent_1 = {
       "content_id" => grandparent_1_content_id,

--- a/spec/integration/indexer/locking_spec.rb
+++ b/spec/integration/indexer/locking_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'ElasticsearchLockingTest' do
     stub_tagging_lookup
   end
 
-  it "should_fail_to_insert_when_index_locked" do
+  it "should fail to insert when index locked" do
     index = search_server.index_group(SearchConfig.instance.default_index_name).current
     with_lock(index) do
       expect {
@@ -14,7 +14,7 @@ RSpec.describe 'ElasticsearchLockingTest' do
     end
   end
 
-  it "should_fail_to_amend_when_index_locked" do
+  it "should fail to amend when index locked" do
     index = search_server.index_group(SearchConfig.instance.default_index_name).current
     index.add([sample_document])
 
@@ -25,7 +25,7 @@ RSpec.describe 'ElasticsearchLockingTest' do
     end
   end
 
-  it "should_fail_to_delete_when_index_locked" do
+  it "should fail to delete when index locked" do
     index = search_server.index_group(SearchConfig.instance.default_index_name).current
     index.add([sample_document])
 
@@ -36,7 +36,7 @@ RSpec.describe 'ElasticsearchLockingTest' do
     end
   end
 
-  it "should_unlock_index" do
+  it "should unlock index" do
     index = search_server.index_group(SearchConfig.instance.default_index_name).current
     with_lock(index) do
       # Nothing to do here

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'MissingMetadataTest' do
-  it "finds_missing_content_id" do
+  it "finds missing content_id" do
     commit_document(
       'mainstream_test',
       'link' => '/path/to_page',
@@ -13,7 +13,7 @@ RSpec.describe 'MissingMetadataTest' do
     expect([{ _id: '/path/to_page', index: 'mainstream_test' }]).to eq results
   end
 
-  it "ignores_already_set_content_id" do
+  it "ignores already set content_id" do
     commit_document(
       'mainstream_test',
       'link' => '/path/to_page',
@@ -26,7 +26,7 @@ RSpec.describe 'MissingMetadataTest' do
     expect(results).to be_empty
   end
 
-  it "finds_missing_document_type" do
+  it "finds missing document_type" do
     commit_document(
       'mainstream_test',
       'link' => '/path/to_page',
@@ -39,7 +39,7 @@ RSpec.describe 'MissingMetadataTest' do
     expect([{ _id: '/path/to_page', index: 'mainstream_test', content_id: '8aea1742-9cc6-4dfb-a63b-12c3e66a601f' }]).to eq results
   end
 
-  it "ignores_already_set_document_type" do
+  it "ignores already set document_type" do
     commit_document(
       'mainstream_test',
       'link' => '/path/to_page',

--- a/spec/integration/schema/stemming_spec.rb
+++ b/spec/integration/schema/stemming_spec.rb
@@ -7,44 +7,44 @@ RSpec.describe 'SettingsTest' do
       "It's Mitt’s" => %w(it mitt)
   end
 
-  it "uses_correct_stemming" do
+  it "uses correct stemming" do
     expect_tokenisation :default,
       "news" => ["news"]
   end
 
-  it "query_default" do
+  it "query default" do
     expect_tokenisation :query_default,
       "It's A Small World" => %w(it small world),
       "It's, It’s Mr. O'Neill" => %w(it it mr oneil)
   end
 
-  it "shingled_query_analyzer" do
+  it "shingled query analyzer" do
     expect_tokenisation :shingled_query_analyzer,
       "Hello Hallo" => ["hello", "hello hallo", "hallo"],
       "H'lo ’Hallo" => ["h'lo", "h'lo hallo", "hallo"]
   end
 
-  it "exact_match" do
+  it "exact match" do
     expect_tokenisation :exact_match,
       "It’s A Small W'rld" => ["it's a small w'rld"]
   end
 
-  it "best_bet_stemmed_match" do
+  it "best bet stemmed match" do
     expect_tokenisation :best_bet_stemmed_match,
       "It’s A Small W'rld" => %w(it a small wrld)
   end
 
-  it "spelling_analyzer" do
+  it "spelling analyzer" do
     expect_tokenisation :spelling_analyzer,
       "It’s Grammed" => ["its", "its grammed", "grammed"]
   end
 
-  it "string_for_sorting" do
+  it "string for sorting" do
     expect_tokenisation :string_for_sorting,
       "It's A Small W’rld" => ["its a small wrld"]
   end
 
-  it "with_shingles_analyzer" do
+  it "with shingles analyzer" do
     expect_tokenisation :with_shingles,
       "The small brown dog" => ["the small", "small brown", "brown dog"]
   end

--- a/spec/integration/schema_migrator_spec.rb
+++ b/spec/integration/schema_migrator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SchemaMigrator do
     index_group = search_server.index_group("govuk_test")
     original_index = index_group.current_real
 
-    SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
+    SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
       migrator.reindex
       migrator.switch_to_new_index
     end
@@ -40,7 +40,7 @@ RSpec.describe SchemaMigrator do
     it "identifies when content has not changed" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" })
 
-      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
+      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         expect(migrator).not_to be_changed
@@ -50,7 +50,7 @@ RSpec.describe SchemaMigrator do
     it "finds added content" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" })
 
-      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
+      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
@@ -63,7 +63,7 @@ RSpec.describe SchemaMigrator do
     it "finds removed content" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" }, type: "edition")
 
-      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
+      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
@@ -79,7 +79,7 @@ RSpec.describe SchemaMigrator do
         { "link" => "/some-page", "title" => "Original title" }
       )
 
-      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
+      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock

--- a/spec/integration/scroll_enumerator_spec.rb
+++ b/spec/integration/scroll_enumerator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'ScrollEnumeratorTest' do
-  it "returns_expected_results_for_unsorted_search" do
+  it "returns expected results for unsorted search" do
     10.times.each do |id|
       commit_document("mainstream_test", { some: 'data' }, id: "id-#{id}", type: "edition")
     end
@@ -16,7 +16,7 @@ RSpec.describe 'ScrollEnumeratorTest' do
     expect(results.count).to eq(10)
   end
 
-  it "returns_expected_results_for_sorted_search" do
+  it "returns expected results for sorted search" do
     10.times.each do |id|
       commit_document("mainstream_test", { some: 'data' }, id: "id-#{id}", type: "edition")
     end
@@ -31,7 +31,7 @@ RSpec.describe 'ScrollEnumeratorTest' do
     expect(results.count).to eq(10)
   end
 
-  it "returns_expected_results_when_empty_result_set" do
+  it "returns expected results when empty result set" do
     results = ScrollEnumerator.new(
       client: client,
       index_names: 'mainstream_test',

--- a/spec/integration/search/aggregates_spec.rb
+++ b/spec/integration/search/aggregates_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'search queries' do
   end
 
   context "migrated formats" do
-    it "does not include duplicate documents in govuk_index within the count" do
+    it "does not include duplicate documents in govuk index within the count" do
       commit_document('govuk_test', { organisations: ['org1'] })
       commit_document('mainstream_test', { organisations: ['org1'] })
 
@@ -153,7 +153,7 @@ RSpec.describe 'search queries' do
     end
   end
 
-  it "returns count when there are missing_options" do
+  it "returns count when there are missing options" do
     build_sample_documents_on_content_indices(documents_per_index: 2)
 
     get "/search?q=important&aggregate_mainstream_browse_pages=1"
@@ -172,7 +172,7 @@ RSpec.describe 'search queries' do
     )
   end
 
-  it "returns count when filtering on a field within an all_filters scope" do
+  it "returns count when filtering on a field within an all filters scope" do
     build_sample_documents_on_content_indices(documents_per_index: 2)
 
     get "/search?q=important&aggregate_mainstream_browse_pages=2,scope:all_filters&filter_mainstream_browse_pages=browse/page/1"

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'BoosterTest' do
-  it "service_manual_formats_are_weighted_down" do
+  it "service manual formats are weighted down" do
     commit_document("govuk_test",
       "title" => "Agile is good",
       "link" => "/agile-is-good",

--- a/spec/integration/search/expands_values_from_schema_spec.rb
+++ b/spec/integration/search/expands_values_from_schema_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'ExpandsValuesFromSchemaTest' do
-  it "extra_fields_decorated_by_schema" do
+  it "extra fields decorated by schema" do
     commit_document("mainstream_test", {
       "link" => "/cma-cases/sample-cma-case",
       "case_type" => "mergers",

--- a/spec/integration/search/legacy_search_spec.rb
+++ b/spec/integration/search/legacy_search_spec.rb
@@ -83,14 +83,14 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest' do
     expect(total).to eq(parsed_response['total'])
   end
 
-  it "should_search_by_keywords" do
+  it "should search by keywords" do
     get "/#{@index_name}/advanced_search.json?per_page=1&page=1&keywords=cheese"
     expect(last_response).to be_ok
     expect_result_total 2
     expect_result_links "/an-example-answer"
   end
 
-  it "should_search_by_nested_data" do
+  it "should search by nested data" do
     get "/#{@index_name}/advanced_search.json?per_page=1&page=1&keywords=#{CGI.escape('Special thing')}"
 
     expect(last_response).to be_ok
@@ -98,7 +98,7 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest' do
     expect_result_links "/doc-with-attachments"
   end
 
-  it "should_escape_lucene_characters" do
+  it "should escape lucene characters" do
     ["badger)", "badger\\"].each do |problem|
       get "/#{@index_name}/advanced_search.json?per_page=1&page=1&keywords=#{CGI.escape(problem)}"
       expect(last_response).to be_ok
@@ -106,42 +106,42 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest' do
     end
   end
 
-  it "should_allow_paging_through_keyword_search" do
+  it "should allow paging through keyword search" do
     get "/#{@index_name}/advanced_search.json?per_page=1&page=2&keywords=cheese"
     expect(last_response).to be_ok
     expect_result_total 2
     expect_result_links "/yet-another-example-answer"
   end
 
-  it "should_filter_results_by_a_property" do
+  it "should filter results by a property" do
     get "/#{@index_name}/advanced_search.json?per_page=2&page=1&mainstream_browse_pages=crime/example"
     expect(last_response).to be_ok
     expect_result_total 2
     expect_result_links "/another-example-answer", "/yet-another-example-answer", order: false
   end
 
-  it "should_filter_results_by_a_nested_property" do
+  it "should filter results by a nested property" do
     get "/#{@index_name}/advanced_search.json?per_page=2&page=1&attachments.command_paper_number=1234"
     expect(last_response).to be_ok
     expect_result_total 1
     expect_result_links "/doc-with-attachments"
   end
 
-  it "should_allow_boolean_filtering" do
+  it "should allow boolean filtering" do
     get "/#{@index_name}/advanced_search.json?per_page=3&page=1&relevant_to_local_government=true"
     expect(last_response).to be_ok
     expect_result_total 3
     expect_result_links "/an-example-answer", "/yet-another-example-answer", "/pork-pies", order: false
   end
 
-  it "should_allow_date_filtering" do
+  it "should allow date filtering" do
     get "/#{@index_name}/advanced_search.json?per_page=3&page=1&updated_at[before]=2012-01-03"
     expect(last_response).to be_ok
     expect_result_total 3
     expect_result_links "/an-example-answer", "/another-example-answer", "/pork-pies", order: false
   end
 
-  it "should_allow_combining_all_filters" do
+  it "should allow combining all filters" do
     # add another doc to make the filter combination need everything to pick
     # the one we want
     more_documents = [
@@ -169,7 +169,7 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest' do
     expect_result_links "/yet-another-example-answer"
   end
 
-  it "should_not_expand_organisations" do
+  it "should not expand organisations" do
     # The new organisation registry expands organisations from slugs into
     # hashes; for backwards compatibility, we shouldn't do this until it's
     # configured (and until clients can handle either format).
@@ -180,14 +180,14 @@ RSpec.describe 'ElasticsearchAdvancedSearchTest' do
     expect(parsed_response["results"][0]["organisations"]).to eq(["ministry-of-cheese"])
   end
 
-  it "should_allow_ordering_by_properties" do
+  it "should allow ordering by properties" do
     get "/#{@index_name}/advanced_search.json?per_page=4&page=1&order[updated_at]=desc"
     expect(last_response).to be_ok
     expect_result_total 5
     expect_result_links "/yet-another-example-answer", "/another-example-answer", "/pork-pies", "/an-example-answer"
   end
 
-  it "does_not_allow_page_to_be_super_high" do
+  it "does not allow page to be super high" do
     get "/#{@index_name}/advanced_search.json?per_page=4&page=500001&order[updated_at]=desc"
 
     expect(last_response.status).to eq(422)

--- a/spec/integration/search/more_like_this_spec.rb
+++ b/spec/integration/search/more_like_this_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
 RSpec.describe 'MoreLikeThisTest' do
-  it "returns_success" do
+  it "returns success" do
     get "/search?similar_to=/mainstream-1"
 
     expect(last_response).to be_ok
   end
 
-  it "returns_no_results_without_documents" do
+  it "returns no results without documents" do
     get "/search?similar_to=/mainstream-1"
 
     expect(result_links).to be_empty
   end
 
-  it "returns_results_from_mainstream_index" do
+  it "returns results from mainstream index" do
     add_sample_documents('mainstream_test', 15)
 
     get "/search?similar_to=/mainstream-1&count=20&start=0"
@@ -22,7 +22,7 @@ RSpec.describe 'MoreLikeThisTest' do
     expect(result_links.count).to eq(14)
   end
 
-  it "returns_results_from_government_index" do
+  it "returns results from government index" do
     add_sample_documents('government_test', 15)
 
     get "/search?similar_to=/government-1&count=20&start=0"
@@ -31,7 +31,7 @@ RSpec.describe 'MoreLikeThisTest' do
     expect(result_links.count).to eq(14)
   end
 
-  it "returns_similar_docs" do
+  it "returns similar docs" do
     add_sample_documents('mainstream_test', 15)
     add_sample_documents('government_test', 15)
 

--- a/spec/integration/search/quoted_and_unquoted_searches_spec.rb
+++ b/spec/integration/search/quoted_and_unquoted_searches_spec.rb
@@ -7,49 +7,49 @@ RSpec.describe 'QuotedAndUnquotedSearchTest' do
     Rummager.class_variable_set(:'@@registries', nil)
   end
 
-  it "old_weighting_three_matches_found_for_london" do
+  it "old weighting three matches found for london" do
     commit_london_transport_docs
     get "/search?q=london"
     expect(last_response.status).to eq(200)
     expect(parsed_response["results"].size).to eq(3)
   end
 
-  it "old_weighting_three_matches_found_for_transport" do
+  it "old weighting three matches found for transport" do
     commit_london_transport_docs
     get "/search?q=transport"
     expect(last_response.status).to eq(200)
     expect(parsed_response["results"].size).to eq(3)
   end
 
-  it "old_weighting_three_matches_found_for_unquoted_london_transport" do
+  it "old weighting three matches found for unquoted london transport" do
     commit_london_transport_docs
     get "/search?q=london+transport"
     expect(last_response.status).to eq(200)
     expect(parsed_response["results"].size).to eq(3)
   end
 
-  it "old_weighting_one_match_found_for_quoted_london_transport" do
+  it "old weighting one match found for quoted london transport" do
     commit_london_transport_docs
     get "/search?q=%22london+transport%22"
     expect(last_response.status).to eq(200)
     expect(parsed_response["results"].size).to eq(1)
   end
 
-  it "old_weighting_synonyms_are_returned_with_unquoted_phrases" do
+  it "old weighting synonyms are returned with unquoted phrases" do
     commit_synonym_documents
     get "/search?q=driving+abroad"
     expect(last_response.status).to eq(200)
     expect(parsed_response["results"].size).to eq(2)
   end
 
-  it "old_weighting_stemming_is_in_place_for_unquoted_phrases" do
+  it "old weighting stemming is in place for unquoted phrases" do
     commit_stemming_documents
     get "/search?q=dog"
     expect(last_response.status).to eq(200)
     expect(parsed_response["results"].size).to eq(2)
   end
 
-  it "old_weighting_stemming_is_still_in_place_even_for_quoted_phrases" do
+  it "old weighting stemming is still in place even for quoted phrases" do
     commit_stemming_documents
     get "/search?q=%22dog%22"
     expect(last_response.status).to eq(200)

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'ResultsWithHighlightingTest' do
-  it "returns_highlighted_title" do
+  it "returns highlighted title" do
     commit_document("mainstream_test",
       "title" => "I am the result",
       "link" => "/some-nice-link",
@@ -13,7 +13,7 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     expect(first_search_result['title_with_highlighting']).to eq("I am the <mark>result</mark>")
   end
 
-  it "returns_highlighted_title_fallback" do
+  it "returns highlighted title fallback" do
     commit_document("mainstream_test",
       "title" => "Thing without",
       "description" => "I am the result",
@@ -26,7 +26,7 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     expect(first_search_result['title_with_highlighting']).to eq("Thing without")
   end
 
-  it "returns_highlighted_description" do
+  it "returns highlighted description" do
     commit_document("mainstream_test",
       "link" => "/some-nice-link",
       "description" => "This is a test search result of many results."
@@ -40,7 +40,7 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     )
   end
 
-  it "returns_documents_html_escaped" do
+  it "returns documents html escaped" do
     commit_document("mainstream_test",
       "title" => "Escape & highlight my title",
       "link" => "/some-nice-link",
@@ -57,7 +57,7 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     )
   end
 
-  it "returns_truncated_correctly_where_result_at_start_of_description" do
+  it "returns truncated correctly where result at start of description" do
     commit_document("mainstream_test",
       "link" => "/some-nice-link",
       "description" => "word " + ("something " * 200)
@@ -70,7 +70,7 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     expect(description.ends_with?("…")).to be_truthy
   end
 
-  it "returns_truncated_correctly_where_result_at_end_of_description" do
+  it "returns truncated correctly where result at end of description" do
     commit_document("mainstream_test",
       "link" => "/some-nice-link",
       "description" => ("something " * 200) + " word"
@@ -83,7 +83,7 @@ RSpec.describe 'ResultsWithHighlightingTest' do
     expect(description.size < 350).to be_truthy
   end
 
-  it "returns_truncated_correctly_where_result_in_middle_of_description" do
+  it "returns truncated correctly where result in middle of description" do
     commit_document("mainstream_test",
       "link" => "/some-nice-link",
       "description" => ("something " * 200) + " word " + ("something " * 200)

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe 'SearchTest' do
-  it "returns_success" do
+  it "returns success" do
     get "/search?q=important"
 
     expect(last_response).to be_ok
   end
 
-  it "spell_checking_with_typo" do
+  it "spell checking with typo" do
     commit_document("mainstream_test",
       "title" => "I am the result",
       "description" => "This is a test search result",
@@ -19,7 +19,7 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response['suggested_queries']).to eq(['search'])
   end
 
-  it "spell_checking_with_blacklisted_typo" do
+  it "spell checking with blacklisted typo" do
     commit_document("mainstream_test",
       "title" => "Brexitt",
       "description" => "Brexitt",
@@ -30,7 +30,7 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response['suggested_queries']).to eq([])
   end
 
-  it "spell_checking_without_typo" do
+  it "spell checking without typo" do
     build_sample_documents_on_content_indices(documents_per_index: 1)
 
     get "/search?q=milliband"
@@ -38,7 +38,7 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response['suggested_queries']).to eq([])
   end
 
-  it "returns_docs_from_all_indexes" do
+  it "returns docs from all indexes" do
     build_sample_documents_on_content_indices(documents_per_index: 1)
 
     get "/search?q=important"
@@ -47,7 +47,7 @@ RSpec.describe 'SearchTest' do
     expect(result_links).to include "/mainstream-1"
   end
 
-  it "sort_by_date_ascending" do
+  it "sort by date ascending" do
     build_sample_documents_on_content_indices(documents_per_index: 2)
 
     get "/search?q=important&order=public_timestamp"
@@ -55,7 +55,7 @@ RSpec.describe 'SearchTest' do
     expect(result_links.take(2)).to eq(["/government-1", "/government-2"])
   end
 
-  it "sort_by_date_descending" do
+  it "sort by date descending" do
     build_sample_documents_on_content_indices(documents_per_index: 2)
 
     get "/search?q=important&order=-public_timestamp"
@@ -65,7 +65,7 @@ RSpec.describe 'SearchTest' do
     expect(result_links.take(2)).to eq(["/government-2", "/government-1"])
   end
 
-  it "sort_by_title_ascending" do
+  it "sort by title ascending" do
     build_sample_documents_on_content_indices(documents_per_index: 1)
 
     get "/search?order=title"
@@ -74,7 +74,7 @@ RSpec.describe 'SearchTest' do
     expect(lowercase_titles).to eq(lowercase_titles.sort)
   end
 
-  it "filter_by_field" do
+  it "filter by field" do
     build_sample_documents_on_content_indices(documents_per_index: 1)
 
     get "/search?filter_mainstream_browse_pages=browse/page/1"
@@ -82,7 +82,7 @@ RSpec.describe 'SearchTest' do
     expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
   end
 
-  it "reject_by_field" do
+  it "reject by field" do
     build_sample_documents_on_content_indices(documents_per_index: 2)
 
     get "/search?reject_mainstream_browse_pages=browse/page/1"
@@ -90,7 +90,7 @@ RSpec.describe 'SearchTest' do
     expect(result_links.sort).to eq(["/government-2", "/mainstream-2"])
   end
 
-  it "can_filter_for_missing_field" do
+  it "can filter for missing field" do
     build_sample_documents_on_content_indices(documents_per_index: 1)
 
     get "/search?filter_specialist_sectors=_MISSING"
@@ -98,7 +98,7 @@ RSpec.describe 'SearchTest' do
     expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
   end
 
-  it "can_filter_for_missing_or_specific_value_in_field" do
+  it "can filter for missing or specific value in field" do
     build_sample_documents_on_content_indices(documents_per_index: 1)
 
     get "/search?filter_specialist_sectors[]=_MISSING&filter_specialist_sectors[]=farming"
@@ -106,7 +106,7 @@ RSpec.describe 'SearchTest' do
     expect(result_links.sort).to eq(["/government-1", "/mainstream-1"])
   end
 
-  it "can_filter_and_reject" do
+  it "can filter and reject" do
     build_sample_documents_on_content_indices(documents_per_index: 2)
 
     get "/search?reject_mainstream_browse_pages=1&filter_specialist_sectors[]=farming"
@@ -117,7 +117,7 @@ RSpec.describe 'SearchTest' do
     ]).to eq(result_links.sort)
   end
 
-  it "only_contains_fields_which_are_present" do
+  it "only contains fields which are present" do
     build_sample_documents_on_content_indices(documents_per_index: 2)
 
     get "/search?q=important&order=public_timestamp"
@@ -127,27 +127,27 @@ RSpec.describe 'SearchTest' do
     expect(results[1]["specialist_sectors"]).to eq([{ "slug" => "farming" }])
   end
 
-  it "validates_integer_params" do
+  it "validates integer params" do
     get "/search?start=a"
 
     expect(last_response.status).to eq(422)
     expect(parsed_response).to eq({ "error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)" })
   end
 
-  it "allows_integer_params_leading_zeros" do
+  it "allows integer params leading zeros" do
     get "/search?start=09"
 
     expect(last_response).to be_ok
   end
 
-  it "validates_unknown_params" do
+  it "validates unknown params" do
     get "/search?foo&bar=1"
 
     expect(last_response.status).to eq(422)
     expect(parsed_response).to eq("error" => "Unexpected parameters: foo, bar")
   end
 
-  it "debug_explain_returns_explanations" do
+  it "debug explain returns explanations" do
     build_sample_documents_on_content_indices(documents_per_index: 1)
 
     get "/search?debug=explain"
@@ -159,7 +159,7 @@ RSpec.describe 'SearchTest' do
     expect(first_hit_explain.keys).to include("details")
   end
 
-  it "can_scope_by_elasticsearch_type" do
+  it "can scope by elasticsearch type" do
     commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
 
     get "/search?filter_document_type=cma_case"
@@ -177,7 +177,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "can_filter_between_dates" do
+  it "can filter between dates" do
     commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
 
     get "/search?filter_document_type=cma_case&filter_opened_date=from:2014-03-31,to:2014-04-02"
@@ -194,7 +194,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "can_filter_between_dates_with_reversed_parameter_order" do
+  it "can filter between dates with reversed parameter order" do
     commit_document("mainstream_test", cma_case_attributes, type: "cma_case")
 
     get "/search?filter_document_type=cma_case&filter_opened_date=to:2014-04-02,from:2014-03-31"
@@ -338,7 +338,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "cannot_provide_date_filter_key_multiple_times" do
+  it "cannot provide date filter key multiple times" do
     get "/search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
 
     expect(last_response.status).to eq(422)
@@ -349,7 +349,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "cannot_provide_invalid_dates_for_date_filter" do
+  it "cannot provide invalid dates for date filter" do
     get "/search?filter_document_type=cma_case&filter_opened_date=from:not-a-date"
 
     expect(last_response.status).to eq(422)
@@ -360,7 +360,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "expandinging_of_organisations" do
+  it "expandinging of organisations" do
     commit_document("mainstream_test",
       "title" => 'Advice on Treatment of Dragons',
       "link" => '/dragon-guide',
@@ -383,7 +383,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "expandinging_of_organisations_via_content_id" do
+  it "expandinging of organisations via content_id" do
     commit_document(
       "mainstream_test",
       "title" => 'Advice on Treatment of Dragons',
@@ -424,7 +424,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "search_for_expanded_organisations_works" do
+  it "search for expanded organisations works" do
     commit_document(
       "mainstream_test",
       "title" => 'Advice on Treatment of Dragons',
@@ -446,7 +446,7 @@ RSpec.describe 'SearchTest' do
     expect(first_result['expanded_organisations']).to be_truthy
   end
 
-  it "filter_by_organisation_content_ids_works" do
+  it "filter by organisation content_ids works" do
     commit_document(
       "mainstream_test",
       "title" => 'Advice on Treatment of Dragons',
@@ -468,7 +468,7 @@ RSpec.describe 'SearchTest' do
     expect(first_result['expanded_organisations']).to be_truthy
   end
 
-  it "expandinging_of_topics" do
+  it "expandinging of topics" do
     commit_document("mainstream_test",
       "title" => 'Advice on Treatment of Dragons',
       "link" => '/dragon-guide',
@@ -504,7 +504,7 @@ RSpec.describe 'SearchTest' do
     expect(first_result['topic_content_ids']).to eq(['topic-content-id'])
   end
 
-  it "filter_by_topic_content_ids_works" do
+  it "filter by topic content_ids works" do
     commit_document("mainstream_test",
       "title" => 'Advice on Treatment of Dragons',
       "link" => '/dragon-guide',
@@ -524,7 +524,7 @@ RSpec.describe 'SearchTest' do
     expect(first_result['expanded_topics']).to be_truthy
   end
 
-  it "withdrawn_content" do
+  it "withdrawn content" do
     commit_document("mainstream_test",
       "title" => "I am the result",
       "description" => "This is a test search result",
@@ -536,7 +536,7 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response.fetch("total")).to eq(0)
   end
 
-  it "withdrawn_content_with_flag" do
+  it "withdrawn content with flag" do
     commit_document("mainstream_test",
       "title" => "I am the result",
       "description" => "This is a test search result",
@@ -549,7 +549,7 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response.dig("results", 0, "is_withdrawn")).to be true
   end
 
-  it "withdrawn_content_with_flag_with_aggregations" do
+  it "withdrawn content with flag with aggregations" do
     commit_document("mainstream_test",
       "title" => "I am the result",
       "organisation" => "Test Org",
@@ -562,13 +562,13 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response.fetch("total")).to eq(1)
   end
 
-  it "show_the_query" do
+  it "show the query" do
     get "/search?q=test&debug=show_query"
 
     expect(parsed_response.fetch("elasticsearch_query")).to be_truthy
   end
 
-  it "taxonomy_can_be_returned" do
+  it "taxonomy can be returned" do
     commit_document("mainstream_test",
       "title" => "I am the result",
       "description" => "This is a test search result",
@@ -583,7 +583,7 @@ RSpec.describe 'SearchTest' do
     expect(taxons).to eq(["eb2093ef-778c-4105-9f33-9aa03d14bc5c"])
   end
 
-  it "taxonomy_can_be_filtered" do
+  it "taxonomy can be filtered" do
     commit_document("mainstream_test",
       "title" => "I am the result",
       "description" => "This is a test search result",
@@ -605,7 +605,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "taxonomy_can_be_filtered_by_part" do
+  it "taxonomy can be filtered by part" do
     commit_document("mainstream_test",
       "title" => "I am the result",
       "description" => "This is a test search result",
@@ -625,14 +625,14 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response.fetch("total")).to eq(1)
   end
 
-  it "return_400_response_for_integers_out_of_range" do
+  it "return 400 response for integers out of range" do
     get '/search.json?count=50&start=7599999900'
 
     expect(last_response).to be_bad_request
     expect(last_response.body).to eq('Integer value of 7599999900 exceeds maximum allowed')
   end
 
-  it "return_400_response_for_query_term_length_too_long" do
+  it "return 400 response for query term length too long" do
     terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
     get "/search.json?q=#{terms}"
 

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'SitemapGeneratorTest' do
 
-  it "should_generate_multiple_sitemaps" do
+  it "should generate multiple sitemaps" do
     allow(SitemapGenerator).to receive(:sitemap_limit).and_return(2)
     add_sample_documents(
       [
@@ -39,7 +39,7 @@ RSpec.describe 'SitemapGeneratorTest' do
     expect(expected_sitemap_count).to eq(sitemap_xml.length)
   end
 
-  it "does_not_include_migrated_formats_from_mainstream" do
+  it "does not include migrated formats from mainstream" do
     allow(SitemapGenerator).to receive(:sitemap_limit).and_return(2)
     add_sample_documents(
       [
@@ -61,7 +61,7 @@ RSpec.describe 'SitemapGeneratorTest' do
     expect(sitemap_xml[0]).not_to include("/an-example-answer")
   end
 
-  it "should_include_homepage" do
+  it "should include homepage" do
     generator = SitemapGenerator.new(SearchConfig.instance)
     sitemap_xml = generator.sitemaps
 
@@ -73,7 +73,7 @@ RSpec.describe 'SitemapGeneratorTest' do
     expect(pages[0].css("priority").text).to eq("0.5")
   end
 
-  it "should_not_include_recommended_links" do
+  it "should not include recommended links" do
     generator = SitemapGenerator.new(SearchConfig.instance)
     add_sample_documents(
       [
@@ -95,7 +95,7 @@ RSpec.describe 'SitemapGeneratorTest' do
     expect(sitemap_xml[0]).not_to include("/external-example-answer")
   end
 
-  it "links_should_include_timestamps" do
+  it "links should include timestamps" do
     generator = SitemapGenerator.new(SearchConfig.instance)
     add_sample_documents(
       [
@@ -121,7 +121,7 @@ RSpec.describe 'SitemapGeneratorTest' do
     expect(pages[0].css("lastmod").text).to eq("2017-07-01T12:41:34+00:00")
   end
 
-  it "links_should_include_priorities" do
+  it "links should include priorities" do
     generator = SitemapGenerator.new(SearchConfig.instance)
     add_sample_documents(
       [

--- a/spec/integration/sitemap/sitemap_spec.rb
+++ b/spec/integration/sitemap/sitemap_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'SitemapTest' do
     FileUtils.rm_rf(@path)
   end
 
-  it "it_creates_symbolic_links_to_the_sitemap_files" do
+  it "it creates symbolic links to the sitemap files" do
     filename = create_test_file
     link_name = "sitemap_1.xml"
     link_full_name = "#{@path}/sitemaps/sitemap_1.xml"
@@ -24,7 +24,7 @@ RSpec.describe 'SitemapTest' do
     expect(File.readlink(link_full_name)).to eq("#{@path}/sitemaps/#{filename}")
   end
 
-  it "it_creates_an_index_pointing_to_the_symbolic_links" do
+  it "it creates an index pointing to the symbolic links" do
     filename = create_test_file
     link_name = "sitemap_1.xml"
     allow_any_instance_of(SitemapWriter).to receive(:write_sitemaps).and_return([[filename, link_name]])
@@ -49,7 +49,7 @@ RSpec.describe 'SitemapTest' do
     expect(File.readlink(index_linkname)).to eq(index_filename)
   end
 
-  it "it_does_not_cleanup_the_symbolic_link_files_or_linked_files" do
+  it "it does not cleanup the symbolic link files or linked files" do
     create_test_file("sitemap_1_2017-01-01T06.xml")
     create_test_file("sitemap_1_2017-01-02T06.xml")
     create_test_file("sitemap_1_2017-01-03T06.xml")
@@ -70,7 +70,7 @@ RSpec.describe 'SitemapTest' do
     expect(File.exist?("#{@path}/sitemaps/sitemap.xml")).to eq(true)
   end
 
-  it "it_can_overwrite_existing_links" do
+  it "it can overwrite existing links" do
     create_test_file("sitemap_1_2017-01-01T06.xml")
     filename =  create_test_file("sitemap_1_2017-01-02T06.xml")
 

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Document do
-  it "should_turn_hash_into_document" do
+  it "should turn hash into document" do
     hash = {
       "_type" => "edition",
       "title" => "TITLE",
@@ -20,7 +20,7 @@ RSpec.describe Document do
     expect(document.indexable_content).to eq("HERE IS SOME CONTENT")
   end
 
-  it "should_permit_nonedition_documents" do
+  it "should permit nonedition documents" do
     hash = {
       "_id" => "jobs_exact",
       "_type" => "best_bet",
@@ -39,7 +39,7 @@ RSpec.describe Document do
     expect(document.elasticsearch_export["_type"]).to eq("best_bet")
   end
 
-  it "should_reject_document_with_no_type" do
+  it "should reject document with no type" do
     hash = {
       "_id" => "some_id",
     }
@@ -49,7 +49,7 @@ RSpec.describe Document do
     }.to raise_error(/missing/i)
   end
 
-  it "should_raise_helpful_error_for_unconfigured_types" do
+  it "should raise helpful error for unconfigured types" do
     hash = {
       "_id" => "jobs_exact",
       "_type" => "cheese"
@@ -60,7 +60,7 @@ RSpec.describe Document do
     }.to raise_error(RuntimeError)
   end
 
-  it "should_ignore_fields_not_in_mappings" do
+  it "should ignore fields not in mappings" do
     hash = {
       "_type" => "edition",
       "title" => "TITLE",
@@ -76,7 +76,7 @@ RSpec.describe Document do
     expect(document.respond_to?("some_other_field")).to be_falsey
   end
 
-  it "should_recognise_symbol_keys_in_hash" do
+  it "should recognise symbol keys in hash" do
     hash = {
       "_type" => "edition",
       title: "TITLE",
@@ -91,7 +91,7 @@ RSpec.describe Document do
     expect(document.title).to eq("TITLE")
   end
 
-  it "should_skip_metadata_fields_in_to_hash" do
+  it "should skip metadata fields in to hash" do
     expected_hash = {
       "title" => "TITLE",
       "description" => "DESCRIPTION",
@@ -105,12 +105,12 @@ RSpec.describe Document do
     expect(expected_hash).to eq(document.to_hash)
   end
 
-  it "should_skip_missing_fields_in_to_hash" do
+  it "should skip missing fields in to hash" do
     document = described_class.from_hash({ "_type" => "edition" }, sample_elasticsearch_types)
     expect(document.to_hash.keys).to eq([])
   end
 
-  it "should_skip_missing_fields_in_elasticsearch_export" do
+  it "should skip missing fields in elasticsearch export" do
     hash = {
         "_type" => "edition",
         "title" => "TITLE",
@@ -123,28 +123,28 @@ RSpec.describe Document do
     expect(hash.keys.sort).to eq(document.elasticsearch_export.keys.sort)
   end
 
-  it "should_include_result_score" do
+  it "should include result score" do
     hash = { "link" => "/batman" }
     field_names = ["link"]
 
     expect(5.2).to eq(described_class.new(sample_field_definitions(field_names), hash, 5.2).es_score)
   end
 
-  it "includes_elasticsearch_score_in_hash" do
+  it "includes elasticsearch score in hash" do
     hash = { "link" => "/batman" }
     field_names = ["link"]
 
     expect(5.2).to eq(described_class.new(sample_field_definitions(field_names), hash, 5.2).to_hash["es_score"])
   end
 
-  it "leaves_out_blank_score" do
+  it "leaves out blank score" do
     hash = { "link" => "/batman" }
     field_names = ["link"]
 
     expect(described_class.new(sample_field_definitions(field_names), hash).to_hash).not_to include("es_score")
   end
 
-  it "should_handle_opaque_object_fields" do
+  it "should handle opaque object fields" do
     metadata = { "foo" => true, "bar" => 1 }
     document_hash = {
       "metadata" => metadata

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SearchIndices::Index do
     @index = build_mainstream_index
   end
 
-  it "real name" do
+  it "has returns the name of the index as real_name" do
     stub_request(:get, "http://example.com:9200/mainstream_test/_aliases")
       .to_return(
         body: { "real-name" => { "aliases" => { "mainstream_test" => {} } } }.to_json,
@@ -17,7 +17,7 @@ RSpec.describe SearchIndices::Index do
     expect(@index.real_name).to eq("real-name")
   end
 
-  it "real name when no index" do
+  it "returns nil for real_name when elasticsearch returns a 404 response" do
     stub_request(:get, "http://example.com:9200/mainstream_test/_aliases")
       .to_return(
         status: 404,
@@ -28,7 +28,7 @@ RSpec.describe SearchIndices::Index do
     expect(@index.real_name).to be_nil
   end
 
-  it "real name when no index es0 20" do
+  it "returns nil for real_name when elasticsearch reports the index as missing" do
     # elasticsearch is weird: even though /index/_status 404s if the index
     # doesn't exist, /index/_aliases returns a 200.
     stub_request(:get, "http://example.com:9200/mainstream_test/_aliases")
@@ -83,7 +83,7 @@ RSpec.describe SearchIndices::Index do
     end
   end
 
-  it "raw search" do
+  it "can be searched" do
     stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/_search").with(
       body: %r{"query":"keyword search"},
     ).to_return(
@@ -96,7 +96,7 @@ RSpec.describe SearchIndices::Index do
     assert_requested(stub_get)
   end
 
-  it "raw search with type" do
+  it "can be searched for a specific type" do
     stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/test-type/_search").with(
       body: %r{"query":"keyword search"},
     ).to_return(
@@ -109,7 +109,7 @@ RSpec.describe SearchIndices::Index do
     assert_requested(stub_get)
   end
 
-  it "commit" do
+  it "can manually commit changes" do
     refresh_url = "http://example.com:9200/mainstream_test/_refresh"
     stub_request(:post, refresh_url).to_return(
       body: '{"ok":true,"_shards":{"total":1,"successful":1,"failed":0}}',
@@ -175,8 +175,7 @@ RSpec.describe SearchIndices::Index do
     expect((1..10).map { |i| "/organisation-#{i}" }).to eq(result.map { |r| r['link'] })
   end
 
-  it "all documents size" do
-    # Test that we can count the documents without retrieving them all
+  it "can count the documents without retrieving them all" do
     search_pattern = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=50&version=true"
     stub_request(:get, search_pattern).with(
       body: { query: expected_all_documents_query }.to_json
@@ -187,7 +186,7 @@ RSpec.describe SearchIndices::Index do
     expect(@index.all_documents.size).to eq(100)
   end
 
-  it "all documents" do
+  it "can retrieve all documents" do
     search_uri = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=50&version=true"
 
     stub_request(:get, search_uri).with(
@@ -217,7 +216,7 @@ RSpec.describe SearchIndices::Index do
     expect(all_documents.last.link).to eq("/foo-100")
   end
 
-  it "changing scroll id" do
+  it "can scroll through the documents" do
     search_uri = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=2&version=true"
 
     allow(SearchIndices::Index).to receive(:scroll_batch_size).and_return(2)

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SearchIndices::Index do
     @index = build_mainstream_index
   end
 
-  it "real_name" do
+  it "real name" do
     stub_request(:get, "http://example.com:9200/mainstream_test/_aliases")
       .to_return(
         body: { "real-name" => { "aliases" => { "mainstream_test" => {} } } }.to_json,
@@ -17,7 +17,7 @@ RSpec.describe SearchIndices::Index do
     expect(@index.real_name).to eq("real-name")
   end
 
-  it "real_name_when_no_index" do
+  it "real name when no index" do
     stub_request(:get, "http://example.com:9200/mainstream_test/_aliases")
       .to_return(
         status: 404,
@@ -28,7 +28,7 @@ RSpec.describe SearchIndices::Index do
     expect(@index.real_name).to be_nil
   end
 
-  it "real_name_when_no_index_es0_20" do
+  it "real name when no index es0 20" do
     # elasticsearch is weird: even though /index/_status 404s if the index
     # doesn't exist, /index/_aliases returns a 200.
     stub_request(:get, "http://example.com:9200/mainstream_test/_aliases")
@@ -50,7 +50,7 @@ RSpec.describe SearchIndices::Index do
     expect(@index).to be_exists
   end
 
-  it "should_raise_error_for_failures_in_bulk_update" do
+  it "should raise error for failures in bulk update" do
     stub_tagging_lookup
     stub_traffic_index
     stub_popularity_index_requests(["/foo/bar", "/foo/baz"], 1.0, 20)
@@ -83,7 +83,7 @@ RSpec.describe SearchIndices::Index do
     end
   end
 
-  it "raw_search" do
+  it "raw search" do
     stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/_search").with(
       body: %r{"query":"keyword search"},
     ).to_return(
@@ -96,7 +96,7 @@ RSpec.describe SearchIndices::Index do
     assert_requested(stub_get)
   end
 
-  it "raw_search_with_type" do
+  it "raw search with type" do
     stub_get = stub_request(:get, "http://example.com:9200/mainstream_test/test-type/_search").with(
       body: %r{"query":"keyword search"},
     ).to_return(
@@ -121,7 +121,7 @@ RSpec.describe SearchIndices::Index do
     assert_requested :post, refresh_url
   end
 
-  it "can_fetch_documents_by_format" do
+  it "can fetch documents by format" do
     search_pattern = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=500&version=true"
     stub_request(:get, search_pattern).with(
       body: { query: { term: { format: "organisation" } }, fields: %w{title link} }
@@ -147,7 +147,7 @@ RSpec.describe SearchIndices::Index do
     expect((1..10).map { |i| "Organisation #{i}" }).to eq(result.map { |r| r['title'] })
   end
 
-  it "can_fetch_documents_by_format_with_certain_fields" do
+  it "can fetch documents by format with certain fields" do
     search_pattern = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=500&version=true"
 
     stub_request(:get, search_pattern).with(
@@ -175,7 +175,7 @@ RSpec.describe SearchIndices::Index do
     expect((1..10).map { |i| "/organisation-#{i}" }).to eq(result.map { |r| r['link'] })
   end
 
-  it "all_documents_size" do
+  it "all documents size" do
     # Test that we can count the documents without retrieving them all
     search_pattern = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=50&version=true"
     stub_request(:get, search_pattern).with(
@@ -187,7 +187,7 @@ RSpec.describe SearchIndices::Index do
     expect(@index.all_documents.size).to eq(100)
   end
 
-  it "all_documents" do
+  it "all documents" do
     search_uri = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=50&version=true"
 
     stub_request(:get, search_uri).with(
@@ -217,7 +217,7 @@ RSpec.describe SearchIndices::Index do
     expect(all_documents.last.link).to eq("/foo-100")
   end
 
-  it "changing_scroll_id" do
+  it "changing scroll id" do
     search_uri = "http://example.com:9200/mainstream_test/_search?scroll=1m&search_type=scan&size=2&version=true"
 
     allow(SearchIndices::Index).to receive(:scroll_batch_size).and_return(2)

--- a/spec/unit/govuk_index/document_type_mapper_spec.rb
+++ b/spec/unit/govuk_index/document_type_mapper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GovukIndex::DocumentTypeMapper do
-  it "infer_payload_document_type" do
+  it "infer payload document_type" do
     payload = {
       "base_path" => "/cheese",
       "document_type" => "help_page"

--- a/spec/unit/govuk_index/popularity_worker_spec.rb
+++ b/spec/unit/govuk_index/popularity_worker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GovukIndex::PopularityWorker do
-  it "should_save_all_records" do
+  it "should save all records" do
     stub_popularity_data
     processor = double(:processor)
     allow(Index::ElasticsearchProcessor).to receive(:new).and_return(processor)
@@ -16,7 +16,7 @@ RSpec.describe GovukIndex::PopularityWorker do
     subject.perform(records, "govuk_test")
   end
 
-  it "should_update_popularity_field" do
+  it "should update popularity field" do
     stub_popularity_data('record_1' => 0.7)
 
     processor = double(:processor)

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     )
   end
 
-  it "directly_mapped_fields" do
+  it "directly mapped fields" do
     payload = generate_random_example(
       payload: { expanded_links: {} },
       excluded_fields: ["withdrawn_notice"],
@@ -34,7 +34,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     end
   end
 
-  it "non_directly_mapped_fields" do
+  it "non directly mapped fields" do
     defined_fields = {
       base_path: "/some/path",
       expanded_links: {},
@@ -65,7 +65,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     expect(presenter.link).to eq("some_url")
   end
 
-  it "withdrawn_when_withdrawn_notice_present" do
+  it "withdrawn when withdrawn notice present" do
     payload = {
       "base_path" => "/some/path",
       "withdrawn_notice" => {
@@ -79,7 +79,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     expect(presenter.is_withdrawn).to eq(true)
   end
 
-  it "popularity_when_value_is_returned_from_lookup" do
+  it "popularity when value is returned from lookup" do
     payload = { "base_path" => "/some/path" }
 
     popularity = 0.0125356
@@ -92,7 +92,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     expect(popularity).to eq(presenter.popularity)
   end
 
-  it "no_popularity_when_no_value_is_returned_from_lookup" do
+  it "no popularity when no value is returned from lookup" do
     payload = { "base_path" => "/some/path" }
 
     expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance).and_return(@popularity_lookup)

--- a/spec/unit/govuk_index/presenters/elasticsearch_delete_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_delete_presenter_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe GovukIndex::ElasticsearchDeletePresenter do
     expect { presenter.type }.to raise_error(GovukIndex::NotFoundError)
   end
 
-  it "is invalid if the base path is missing" do
+  it "is invalid if the base_path is missing" do
     payload = {}
 
     presenter = described_class.new(payload: payload)

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     expect(expected_identifier).to eq(presenter.identifier)
   end
 
-  it "raise UnknownDocumentTypeError if the document type does not have a valid mapping" do
+  it "raise UnknownDocumentTypeError if the document_type does not have a valid mapping" do
     payload = generate_random_example(payload: { payload_version: 1 })
     presenter = elasticsearch_presenter(payload, nil)
 
@@ -25,7 +25,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     }.to raise_error(GovukIndex::UnknownDocumentTypeError)
   end
 
-  it "is invalid if the base path is missing" do
+  it "is invalid if the base_path is missing" do
     payload = {}
 
     presenter = elasticsearch_presenter(payload)

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GovukIndex::ExpandedLinksPresenter do
-  it "mainstream_browse_pages" do
+  it "mainstream browse pages" do
     expanded_links = {
       "mainstream_browse_pages" => [
           {

--- a/spec/unit/govuk_index/specialist_formats_spec.rb
+++ b/spec/unit/govuk_index/specialist_formats_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     allow_any_instance_of(Indexer::PopularityLookup).to receive(:lookup_popularities).and_return({})
   end
 
-  it "aaib_report" do
+  it "aaib report" do
     custom_metadata = {
       "date_of_occurrence" => "2015-10-10",
       "aircraft_category" => ["commercial-fixed-wing"],
@@ -22,7 +22,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
-  it "asylum_support_decision" do
+  it "asylum support decision" do
     custom_metadata = {
       "hidden_indexable_content" => "some hidden content",
       "tribunal_decision_categories" => ["section-95-support-for-asylum-seekers"],
@@ -42,7 +42,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect(document[:indexable_content]).to eq("some hidden content")
   end
 
-  it "business_finance_support_scheme" do
+  it "business finance support scheme" do
     custom_metadata = {
       "business_sizes" => ["under-10", "between-10-and-249"],
       "business_stages" => ["start-up"],
@@ -55,7 +55,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata)
   end
 
-  it "cma_case" do
+  it "cma case" do
     custom_metadata = {
       "opened_date" => "2014-01-01",
       "closed_date" => "2015-01-01",
@@ -72,7 +72,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
-  it "countryside_stewardship_grant" do
+  it "countryside stewardship grant" do
     custom_metadata = {
       "grant_type" => "option",
       "land_use" => ["priority-habitats", "trees-non-woodland", "uplands"],
@@ -86,7 +86,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
-  it "dfid_research_output" do
+  it "dfid research output" do
     custom_metadata = {
       "dfid_document_type" => "book_chapter",
       "country" => ["GB"],
@@ -98,7 +98,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata)
   end
 
-  it "drug_safety_update" do
+  it "drug safety update" do
     custom_metadata = {
       "therapeutic_area" => ["cancer", "haematology", "immunosuppression-transplantation"],
     }
@@ -106,7 +106,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata)
   end
 
-  it "employment_appeal_tribunal_decision" do
+  it "employment appeal tribunal decision" do
     custom_metadata = {
       "hidden_indexable_content" => "hidden content",
       "tribunal_decision_categories" => ["age-discrimination"],
@@ -119,7 +119,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect(document[:indexable_content]).to eq("hidden content")
   end
 
-  it "employment_tribunal_decision" do
+  it "employment tribunal decision" do
     custom_metadata = {
       "hidden_indexable_content" => "hidden etd content",
       "tribunal_decision_categories" => ["age-discrimination"],
@@ -131,7 +131,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect(document[:indexable_content]).to eq("hidden etd content")
   end
 
-  it "european_structural_investment_fund" do
+  it "european structural investment fund" do
     custom_metadata = {
       "closing_date" => "2016-01-01",
       "fund_state" => "open",
@@ -146,7 +146,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
-  it "international_development_fund" do
+  it "international development fund" do
     custom_metadata = {
       "closing_date" => "2016-01-01",
       "fund_state" => "open",
@@ -161,7 +161,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
-  it "maib_report" do
+  it "maib report" do
     custom_metadata = {
       "date_of_occurrence" => "2015-10-10",
       "report_type" => "investigation-report",
@@ -174,7 +174,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
-  it "medical_safety_alert" do
+  it "medical safety alert" do
     custom_metadata = {
       "alert_type" => "company-led-drugs",
       "issued_date" => "2016-02-01",
@@ -187,7 +187,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
-  it "raib_report" do
+  it "raib report" do
     custom_metadata = {
       "date_of_occurrence" => "2015-10-10",
       "report_type" => "investigation-report",
@@ -200,7 +200,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
   end
 
-  it "service_standard_report" do
+  it "service standard report" do
     custom_metadata = {
       "assessment_date" => "2016-10-10"
     }
@@ -209,7 +209,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
   end
 
 
-  it "tax_tribunal_decision" do
+  it "tax tribunal decision" do
     custom_metadata = {
       "hidden_indexable_content" => "hidden ttd content",
       "tribunal_decision_category" => "banking",
@@ -220,7 +220,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect(document[:indexable_content]).to eq("hidden ttd content")
   end
 
-  it "utaac_decision" do
+  it "utaac decision" do
     custom_metadata = {
       "hidden_indexable_content" => "hidden utaac content",
       "tribunal_decision_categories" => ["Benefits for children"],

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -7,20 +7,20 @@ RSpec.describe Helpers do
     instance
   end
 
-  it "simple_json_result_ok" do
+  it "simple json result ok" do
     expect(subject).to receive(:content_type).with(:json)
     # 200 is the default status: whether it gets called or not, we don't mind
     expect(subject).to receive(:status).with(200).once
     expect(subject.simple_json_result(true)).to eq('{"result":"OK"}')
   end
 
-  it "simple_json_result_error" do
+  it "simple json result error" do
     expect(subject).to receive(:content_type).with(:json)
     expect(subject).to receive(:status).with(500)
     expect(subject.simple_json_result(false)).to eq('{"result":"error"}')
   end
 
-  it "parse_query_string" do
+  it "parse query string" do
     [
       ["foo=bar", { "foo" => ["bar"] }],
       ["foo[]=bar", { "foo" => ["bar"] }],

--- a/spec/unit/index/elasticsearch_processor_spec.rb
+++ b/spec/unit/index/elasticsearch_processor_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Index::ElasticsearchProcessor do
   subject { described_class.govuk }
 
-  it "should_save_valid_document" do
+  it "should save valid document" do
     presenter = double(:presenter)
     allow(presenter).to receive(:identifier).and_return(
       _type: "help_page",
@@ -22,7 +22,7 @@ RSpec.describe Index::ElasticsearchProcessor do
     subject.commit
   end
 
-  it "should_delete_valid_document" do
+  it "should delete valid document" do
     presenter = double(:presenter)
     allow(presenter).to receive(:identifier).and_return(
       _type: "help_page",

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SearchIndices::IndexGroup do
     )
   end
 
-  it "create_index" do
+  it "create index" do
     expected_body = {
       "settings" => @schema.elasticsearch_settings("mainstream"),
       "mappings" => @schema.elasticsearch_mappings("mainstream"),
@@ -37,7 +37,7 @@ RSpec.describe SearchIndices::IndexGroup do
     expect(index.index_name).to match(/^mainstream-/)
   end
 
-  it "switch_index_with_no_existing_alias" do
+  it "switch index with no existing alias" do
     new_index = double("New index", index_name: "test-new")
     get_stub = stub_request(:get, "#{SearchConfig.instance.base_uri}/_aliases")
       .to_return(
@@ -65,7 +65,7 @@ RSpec.describe SearchIndices::IndexGroup do
     assert_requested(post_stub)
   end
 
-  it "switch_index_with_existing_alias" do
+  it "switch index with existing alias" do
     new_index = double("New index", index_name: "test-new")
     get_stub = stub_request(:get, "#{SearchConfig.instance.base_uri}/_aliases")
       .to_return(
@@ -93,7 +93,7 @@ RSpec.describe SearchIndices::IndexGroup do
     assert_requested(post_stub)
   end
 
-  it "switch_index_with_multiple_existing_aliases" do
+  it "switch index with multiple existing aliases" do
     # Not expecting the system to get into this state, but it should cope
     new_index = double("New index", index_name: "test-new")
     get_stub = stub_request(:get, "#{SearchConfig.instance.base_uri}/_aliases")
@@ -124,7 +124,7 @@ RSpec.describe SearchIndices::IndexGroup do
     assert_requested(post_stub)
   end
 
-  it "switch_index_with_existing_real_index" do
+  it "switch index with existing real index" do
     new_index = double("New index", index_name: "test-new")
     stub_request(:get, "#{SearchConfig.instance.base_uri}/_aliases")
       .to_return(
@@ -140,7 +140,7 @@ RSpec.describe SearchIndices::IndexGroup do
     }.to raise_error(RuntimeError)
   end
 
-  it "index_names_with_no_indices" do
+  it "index names with no indices" do
     stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
       .to_return(
         status: 200,
@@ -151,7 +151,7 @@ RSpec.describe SearchIndices::IndexGroup do
     expect(@server.index_group("test").index_names).to eq([])
   end
 
-  it "index_names_with_index" do
+  it "index names with index" do
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
       .to_return(
@@ -165,7 +165,7 @@ RSpec.describe SearchIndices::IndexGroup do
     expect(@server.index_group("test").index_names).to eq([index_name])
   end
 
-  it "index_names_with_other_groups" do
+  it "index names with other groups" do
     this_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     other_name = "fish-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"
 
@@ -182,7 +182,7 @@ RSpec.describe SearchIndices::IndexGroup do
     expect(@server.index_group("test").index_names).to eq([this_name])
   end
 
-  it "clean_with_no_indices" do
+  it "clean with no indices" do
     stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
       .to_return(
         status: 200,
@@ -193,7 +193,7 @@ RSpec.describe SearchIndices::IndexGroup do
     @server.index_group("test").clean
   end
 
-  it "clean_with_dead_index" do
+  it "clean with dead index" do
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
       .to_return(
@@ -212,7 +212,7 @@ RSpec.describe SearchIndices::IndexGroup do
     assert_requested delete_stub
   end
 
-  it "clean_with_live_index" do
+  it "clean with live index" do
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
       .to_return(
@@ -226,7 +226,7 @@ RSpec.describe SearchIndices::IndexGroup do
     @server.index_group("test").clean
   end
 
-  it "clean_with_multiple_indices" do
+  it "clean with multiple indices" do
     index_names = [
       "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012",
       "test-2012-03-01t12:00:00z-abcdefab-abcd-abcd-abcd-abcdefabcdef"
@@ -251,7 +251,7 @@ RSpec.describe SearchIndices::IndexGroup do
     delete_stubs.each do |delete_stub| assert_requested delete_stub end
   end
 
-  it "clean_with_live_and_dead_indices" do
+  it "clean with live and dead indices" do
     live_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     dead_name = "test-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"
 
@@ -273,7 +273,7 @@ RSpec.describe SearchIndices::IndexGroup do
     assert_requested delete_stub
   end
 
-  it "clean_with_other_alias" do
+  it "clean with other alias" do
     # If there's an alias we don't know about, that should save the index
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
@@ -288,7 +288,7 @@ RSpec.describe SearchIndices::IndexGroup do
     @server.index_group("test").clean
   end
 
-  it "clean_with_other_groups" do
+  it "clean with other groups" do
     # Check we don't go around deleting index from other groups
     this_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     other_name = "fish-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"

--- a/spec/unit/indexer/change_notification_processor_spec.rb
+++ b/spec/unit/indexer/change_notification_processor_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Indexer::ChangeNotificationProcessor do
-  it "rejects_base_pathless_documents" do
+  it "rejects base_pathless documents" do
     message_payload = {
       "content_id" => "4711fc53-673a-4211-bae6-e0a3d3afd82f",
       "base_path" => nil,
@@ -16,7 +16,7 @@ RSpec.describe Indexer::ChangeNotificationProcessor do
     expect(:rejected).to eq(result)
   end
 
-  it "rejects_invalid_documents" do
+  it "rejects invalid documents" do
     message_payload = {}
 
     result = described_class.trigger(message_payload)
@@ -24,7 +24,7 @@ RSpec.describe Indexer::ChangeNotificationProcessor do
     expect(:rejected).to eq(result)
   end
 
-  it "rejects_missing_documents" do
+  it "rejects missing documents" do
     message_payload = {
       "content_id" => "4711fc53-673a-4211-bae6-e0a3d3afd82f",
       "base_path" => "/does-not-exist",
@@ -43,7 +43,7 @@ RSpec.describe Indexer::ChangeNotificationProcessor do
     expect(:rejected).to eq(result)
   end
 
-  it "accepts_existing_documents" do
+  it "accepts existing documents" do
     message_payload = {
       "content_id" => "4711fc53-673a-4211-bae6-e0a3d3afd82f",
       "base_path" => "/does-exist",

--- a/spec/unit/indexer/compare_enumerator_spec.rb
+++ b/spec/unit/indexer/compare_enumerator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Indexer::CompareEnumerator do
-  it "when_matching_keys_exist" do
+  it "when matching keys exist" do
     data_left = { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data_left' }
     data_right = { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data_right' }
 
@@ -11,7 +11,7 @@ RSpec.describe Indexer::CompareEnumerator do
     expect(results).to eq([[data_left, data_right]])
   end
 
-  it "when_key_only_exists_in_left_index" do
+  it "when key only exists in left index" do
     data = { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data_left' }
 
     stub_scroll_enumerator(left_request: [data], right_request: [])
@@ -21,7 +21,7 @@ RSpec.describe Indexer::CompareEnumerator do
   end
 
 
-  it "when_key_only_exists_in_right_index" do
+  it "when key only exists in right index" do
     data = { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data_right' }
 
     stub_scroll_enumerator(left_request: [], right_request: [data])
@@ -30,7 +30,7 @@ RSpec.describe Indexer::CompareEnumerator do
     expect(results).to eq([[described_class::NO_VALUE, data]])
   end
 
-  it "with_matching_ids_but_different_types" do
+  it "with matching ids but different types" do
     data_left = { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data_left' }
     data_right = { '_root_id' => 'abc', '_root_type' => 'other_stuff', 'custom' => 'data_right' }
 
@@ -43,7 +43,7 @@ RSpec.describe Indexer::CompareEnumerator do
     ])
   end
 
-  it "with_different_ids" do
+  it "with different ids" do
     data_left = { '_root_id' => 'abc', '_root_type' => 'stuff', 'custom' => 'data_left' }
     data_right = { '_root_id' => 'def', '_root_type' => 'stuff', 'custom' => 'data_right' }
 
@@ -56,7 +56,7 @@ RSpec.describe Indexer::CompareEnumerator do
     ])
   end
 
-  it "correct_aligns_records_with_matching_keys" do
+  it "correct aligns records with matching keys" do
     key1 = { '_root_id' => 'abc', '_root_type' => 'stuff' }
     key2 = { '_root_id' => 'def', '_root_type' => 'stuff' }
     key3 = { '_root_id' => 'ghi', '_root_type' => 'stuff' }
@@ -75,7 +75,7 @@ RSpec.describe Indexer::CompareEnumerator do
     ])
   end
 
-  it "scroll_enumerator_mappings" do
+  it "scroll enumerator mappings" do
     data = { '_id' => 'abc', '_type' => 'stuff', '_source' => { 'custom' => 'data' } }
     stub_client_for_scroll_enumerator(return_values: [[data], []])
 
@@ -86,7 +86,7 @@ RSpec.describe Indexer::CompareEnumerator do
     ])
   end
 
-  it "scroll_enumerator_mappings_when_filter_is_passed_in" do
+  it "scroll enumerator mappings when filter is passed in" do
     data = { '_id' => 'abc', '_type' => 'stuff', '_source' => { 'custom' => 'data' } }
     search_body = { query: 'custom_filter', sort: 'by_stuff' }
 
@@ -99,7 +99,7 @@ RSpec.describe Indexer::CompareEnumerator do
     ])
   end
 
-  it "scroll_enumerator_mappings_without_sorting" do
+  it "scroll enumerator mappings without sorting" do
     data = { '_id' => 'abc', '_type' => 'stuff', '_source' => { 'custom' => 'data' } }
     search_body = { query: 'custom_filter' }
 

--- a/spec/unit/indexer/comparer_spec.rb
+++ b/spec/unit/indexer/comparer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Indexer::Comparer do
-  it "can_detect_when_a_record_is_added" do
+  it "can detect when a record is added" do
     setup_enumerator_response(Indexer::CompareEnumerator::NO_VALUE, { some: 'data' })
 
     comparer = described_class.new(
@@ -13,7 +13,7 @@ RSpec.describe Indexer::Comparer do
     expect(outcome).to eq({ added_items: 1 })
   end
 
-  it "can_detect_when_a_record_is_removed" do
+  it "can detect when a record is removed" do
     setup_enumerator_response({ some: 'data' }, Indexer::CompareEnumerator::NO_VALUE)
 
     comparer = described_class.new(
@@ -25,7 +25,7 @@ RSpec.describe Indexer::Comparer do
     expect(outcome).to eq({ removed_items: 1 })
   end
 
-  it "can_detect_when_a_record_has_changed" do
+  it "can detect when a record has changed" do
     setup_enumerator_response({ data: 'old' }, { data: 'new' })
 
     comparer = described_class.new(
@@ -37,7 +37,7 @@ RSpec.describe Indexer::Comparer do
     expect(outcome).to eq(changed: 1, 'changes: data': 1)
   end
 
-  it "can_detect_when_a_record_is_unchanged" do
+  it "can detect when a record is unchanged" do
     setup_enumerator_response({ data: 'some' }, { data: 'some' })
 
     comparer = described_class.new(
@@ -49,7 +49,7 @@ RSpec.describe Indexer::Comparer do
     expect(outcome).to eq({ unchanged: 1 })
   end
 
-  it "can_detect_when_a_record_is_unchanged_apart_from_ignored_fields" do
+  it "can detect when a record is unchanged apart from ignored fields" do
     setup_enumerator_response({ data: 'some', ignore: 'me' }, { data: 'some' })
 
     comparer = described_class.new(
@@ -62,7 +62,7 @@ RSpec.describe Indexer::Comparer do
     expect(outcome).to eq({ unchanged: 1 })
   end
 
-  it "can_detect_when_a_record_is_unchanged_apart_from_default_ignored_fields" do
+  it "can detect when a record is unchanged apart from default ignored fields" do
     setup_enumerator_response({ data: 'some', 'popularity' => '100' }, { data: 'some' })
 
     comparer = described_class.new(

--- a/spec/unit/indexer/document_preparer_spec.rb
+++ b/spec/unit/indexer/document_preparer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Indexer::DocumentPreparer do
       expect(0.5).to eq(updated_doc_hash["popularity"])
     end
 
-    it "adds document type groupings" do
+    it "adds document_type groupings" do
       stub_tagging_lookup
 
       doc_hash = {

--- a/spec/unit/indexer/links_lookup_spec.rb
+++ b/spec/unit/indexer/links_lookup_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Indexer::LinksLookup do
   include GdsApi::TestHelpers::PublishingApiV2
 
-  it "retry_links_on_timeout" do
+  it "retry links on timeout" do
     content_id = "DOCUMENT_CONTENT_ID"
     endpoint = Plek.current.find('publishing-api') + '/v2'
     expanded_links_url = endpoint + "/expanded-links/" + content_id

--- a/spec/unit/indexer/workers/amend_worker_spec.rb
+++ b/spec/unit/indexer/workers/amend_worker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Indexer::AmendWorker do
-  it "amends_documents" do
+  it "amends documents" do
     mock_index = double("index")
     expect(mock_index).to receive(:amend).with("/foobang", "title" => "New title")
     expect_any_instance_of(SearchIndices::SearchServer).to receive(:index)
@@ -12,7 +12,7 @@ RSpec.describe Indexer::AmendWorker do
     worker.perform("test-index", "/foobang", "title" => "New title")
   end
 
-  it "retries_when_index_locked" do
+  it "retries when index locked" do
     lock_delay = Indexer::DeleteWorker::LOCK_DELAY
     mock_index = double("index")
     expect(mock_index).to receive(:amend).and_raise(SearchIndices::IndexLocked)
@@ -27,7 +27,7 @@ RSpec.describe Indexer::AmendWorker do
     worker.perform("test-index", "/foobang", "title" => "New title")
   end
 
-  it "forwards_to_failure_queue" do
+  it "forwards to failure queue" do
     stub_message = {}
     expect(GovukError).to receive(:notify).with(Indexer::FailedJobException.new, extra: stub_message)
     fail_block = described_class.sidekiq_retries_exhausted_block

--- a/spec/unit/indexer/workers/bulk_index_worker_spec.rb
+++ b/spec/unit/indexer/workers/bulk_index_worker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Indexer::BulkIndexWorker do
     { link: "/#{slug}", title: slug.capitalize }
   end
 
-  it "indexes_documents" do
+  it "indexes documents" do
     mock_index = double("index")
     expect(mock_index).to receive(:bulk_index).with(SAMPLE_DOCUMENT_HASHES)
     allow_any_instance_of(SearchIndices::SearchServer).to receive(:index)
@@ -16,7 +16,7 @@ RSpec.describe Indexer::BulkIndexWorker do
     worker.perform("test-index", SAMPLE_DOCUMENT_HASHES)
   end
 
-  it "retries_when_index_locked" do
+  it "retries when index locked" do
     lock_delay = described_class::LOCK_DELAY
 
     mock_index = double("index")
@@ -32,7 +32,7 @@ RSpec.describe Indexer::BulkIndexWorker do
     worker.perform("test-index", SAMPLE_DOCUMENT_HASHES)
   end
 
-  it "forwards_to_failure_queue" do
+  it "forwards to failure queue" do
     stub_message = {}
     expect(GovukError).to receive(:notify).with(Indexer::FailedJobException.new, extra: stub_message)
     fail_block = described_class.sidekiq_retries_exhausted_block

--- a/spec/unit/indexer/workers/delete_worker_spec.rb
+++ b/spec/unit/indexer/workers/delete_worker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Indexer::DeleteWorker do
-  it "deletes_documents" do
+  it "deletes documents" do
     mock_index = double("index")
     expect(mock_index).to receive(:delete).with("edition", "/foobang")
     expect_any_instance_of(SearchIndices::SearchServer).to receive(:index)
@@ -12,7 +12,7 @@ RSpec.describe Indexer::DeleteWorker do
     worker.perform("test-index", "edition", "/foobang")
   end
 
-  it "retries_when_index_locked" do
+  it "retries when index locked" do
     lock_delay = described_class::LOCK_DELAY
     mock_index = double("index")
     expect(mock_index).to receive(:delete).and_raise(SearchIndices::IndexLocked)
@@ -27,7 +27,7 @@ RSpec.describe Indexer::DeleteWorker do
     worker.perform("test-index", "edition", "/foobang")
   end
 
-  it "forwards_to_failure_queue" do
+  it "forwards to failure queue" do
     stub_message = {}
     expect(GovukError).to receive(:notify).with(Indexer::FailedJobException.new, extra: stub_message)
     fail_block = described_class.sidekiq_retries_exhausted_block

--- a/spec/unit/legacy_client/multivalue_converter_spec.rb
+++ b/spec/unit/legacy_client/multivalue_converter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe LegacyClient::MultivalueConverter do
-  it "keeps_multivalue_fields_as_array" do
+  it "keeps multivalue fields as array" do
     fields = {
       "title" => ["the title"],
       "organisations" => %w(hmrc dvla),
@@ -12,7 +12,7 @@ RSpec.describe LegacyClient::MultivalueConverter do
     expect(%w(hmrc dvla)).to eq(converted_hash["organisations"])
   end
 
-  it "converts_single_value_fields_as_single_value" do
+  it "converts single value fields as single value" do
     fields = {
       "title" => ["the title"],
       "organisations" => %w(hmrc dvla),
@@ -24,7 +24,7 @@ RSpec.describe LegacyClient::MultivalueConverter do
   end
 
   # This might not be necessary since the new ES.
-  it "converts_also_from_single_value_fields" do
+  it "converts also from single value fields" do
     fields = {
       "title" => "the title",
       "organisations" => %w(hmrc dvla),

--- a/spec/unit/legacy_search/advanced_search_query_builder_spec.rb
+++ b/spec/unit/legacy_search/advanced_search_query_builder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LegacySearch::AdvancedSearchQueryBuilder do
     described_class.new(keywords, filter_params, sort_order, mappings)
   end
 
-  it "builder_excludes_withdrawn" do
+  it "builder excludes withdrawn" do
     builder = build_builder
     query_hash = builder.filter_query_hash
 
@@ -19,7 +19,7 @@ RSpec.describe LegacySearch::AdvancedSearchQueryBuilder do
   end
 
 
-  it "builder_single_filters" do
+  it "builder single filters" do
     builder = build_builder("how to drive", { "format" => "organisation" })
     query_hash = builder.filter_query_hash
 
@@ -33,7 +33,7 @@ RSpec.describe LegacySearch::AdvancedSearchQueryBuilder do
     )
   end
 
-  it "builder_multiple_filters" do
+  it "builder multiple filters" do
     builder = build_builder("how to drive", { "format" => "organisation", "specialist_sectors" => "driving" })
     query_hash = builder.filter_query_hash
 

--- a/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
+++ b/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     @wrapper = described_class.new(base_uri, "mainstream_test", "mainstream_test", default_mappings, search_config)
   end
 
-  it "pagination_params_are_required" do
+  it "pagination params are required" do
     stub_empty_search
 
     expect_rejected_search("Pagination params are required.", {})
     expect(@wrapper.advanced_search({ 'page' => '1', 'per_page' => '1' })).to be_truthy
   end
 
-  it "pagination_params_are_converted_to_from_and_to_correctly" do
+  it "pagination params are converted to from and to correctly" do
     stub_empty_search(body: /\"from\":0,\"size\":10/)
     @wrapper.advanced_search({ 'page' => '1', 'per_page' => '10' })
 
@@ -24,7 +24,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     @wrapper.advanced_search({ 'page' => '3', 'per_page' => '3' })
   end
 
-  it "keyword_param_is_converted_to_a_boosted_title_and_unboosted_general_query" do
+  it "keyword param is converted to a boosted title and unboosted general query" do
     stub_empty_search(body: {
       "from" => 0,
       "size" => 1,
@@ -71,12 +71,12 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     @wrapper.advanced_search(default_params.merge('keywords' => 'happy fun time'))
   end
 
-  it "missing_keyword_param_means_a_match_all_query" do
+  it "missing keyword param means a match all query" do
     stub_empty_search(body: /#{Regexp.escape("\"query\":{\"match_all\":{}}")}/)
     @wrapper.advanced_search(default_params)
   end
 
-  it "single_value_filter_param_is_turned_into_a_term_filter" do
+  it "single value filter param is turned into a term filter" do
     stub_empty_search(body: /#{Regexp.escape("\"term\":{\"mainstream_browse_pages\":\"jones\"}")}/)
     @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => 'jones'))
 
@@ -84,31 +84,31 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => ['jones']))
   end
 
-  it "multiple_value_filter_param_is_turned_into_a_terms_filter" do
+  it "multiple value filter param is turned into a terms filter" do
     stub_empty_search(body: /#{Regexp.escape("\"terms\":{\"mainstream_browse_pages\":[\"jones\",\"richards\"]}")}/)
     @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => %w(jones richards)))
   end
 
-  it "filter_params_are_turned_into_anded_term_filters_on_that_property" do
+  it "filter params are turned into anded term filters on that property" do
     stub_empty_search(body: /#{Regexp.escape("\"filter\":{\"and\":[{\"term\":{\"mainstream_browse_pages\":\"jones\"}},{\"term\":{\"link\":\"richards\"}},")}/)
     @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => ['jones'], 'link' => ['richards']))
   end
 
-  it "filter_params_on_a_boolean_mapping_property_are_convered_to_true_based_on_something_that_looks_truthy" do
+  it "filter params on a boolean mapping property are convered to true based on something that looks truthy" do
     @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
     stub_empty_search(body: /#{Regexp.escape("{\"term\":{\"boolean_property\":true}")}/)
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'true'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => '1'))
   end
 
-  it "filter_params_on_a_boolean_mapping_property_are_convered_to_false_based_on_something_that_looks_falsey" do
+  it "filter params on a boolean mapping property are convered to false based on something that looks falsey" do
     @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
     stub_empty_search(body: /#{Regexp.escape("\"term\":{\"boolean_property\":false}")}/)
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'false'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => '0'))
   end
 
-  it "filter_params_on_a_boolean_mapping_property_are_rejected_if_they_dont_look_truthy_or_falsey" do
+  it "filter params on a boolean mapping property are rejected if they dont look truthy or falsey" do
     @wrapper.mappings['edition']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
     stub_empty_search
 
@@ -119,7 +119,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     expect_rejected_search('Invalid value "cheese" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'cheese'))
   end
 
-  it "filter_params_on_a_date_mapping_property_are_turned_into_a_range_filter_with_order_based_on_the_key_in_the_value" do
+  it "filter params on a date mapping property are turned into a range filter with order based on the key in the value" do
     @wrapper.mappings['edition']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
 
     stub_empty_search(body: /#{Regexp.escape("\"range\":{\"date_property\":{\"to\":\"2013-02-02\"}}")}/)
@@ -139,7 +139,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     @wrapper.advanced_search(default_params.merge('date_property' => { 'after' => '2013-02-02' }))
   end
 
-  it "filter_params_on_a_date_mapping_property_without_a_before_or_after_key_in_the_value_are_rejected" do
+  it "filter params on a date mapping property without a before or after key in the value are rejected" do
     @wrapper.mappings['edition']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
     stub_empty_search
 
@@ -150,7 +150,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     expect_rejected_search('Invalid value {"before"=>"2013-02-02", "up-to"=>"2013-02-02"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2013-02-02', 'up-to' => '2013-02-02' }))
   end
 
-  it "filter_params_on_a_date_mapping_property_without_a_incorrectly_formatted_date_are_rejected" do
+  it "filter params on a date mapping property without a incorrectly formatted date are rejected" do
     @wrapper.mappings['edition']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
     stub_empty_search
 
@@ -160,27 +160,27 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     expect_rejected_search('Invalid value {"before"=>"2013-2-2"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2013-2-2' }))
   end
 
-  it "filter_params_that_are_not_index_properties_are_not_allowed" do
+  it "filter params that are not index properties are not allowed" do
     expect_rejected_search('Querying unknown properties ["brian", "keith"]', default_params.merge('brian' => 'jones', 'keith' => 'richards'))
   end
 
-  it "order_params_are_turned_into_a_sort_query" do
+  it "order params are turned into a sort query" do
     stub_empty_search(body: /#{Regexp.escape("\"sort\":[{\"title\":\"asc\"}]")}/)
     @wrapper.advanced_search(default_params.merge('order' => { 'title' => 'asc' }))
   end
 
-  it "order_params_on_properties_not_in_the_mappings_are_not_allowed" do
+  it "order params on properties not in the mappings are not allowed" do
     expect_rejected_search('Sorting on unknown property ["brian"]', default_params.merge('order' => { 'brian' => 'asc' }))
   end
 
-  it "returns_the_total_and_the_hits" do
+  it "returns the total and the hits" do
     stub_empty_search
     result_set = @wrapper.advanced_search(default_params)
     expect(result_set.total).to eq(0)
     expect(result_set.results).to eq([])
   end
 
-  it "returns_the_hits_converted_into_documents" do
+  it "returns the hits converted into documents" do
     stub_request(:get, "http://example.com:9200/mainstream_test/_search")
       .to_return(
         status: 200,

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SearchParameterParser do
     allow(@schema).to receive(:allowed_filter_fields).and_return(allowed_filter_fields)
   end
 
-  it "return valid params given nothing" do
+  it "returns valid params given nothing" do
     p = described_class.new({}, @schema)
 
     expect(p.error).to eq("")
@@ -74,7 +74,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about an unknown parameter" do
+  it "complains about an unknown parameter" do
     p = described_class.new({ "p" => ["extra"] }, @schema)
 
     expect(p.error).to eq("Unexpected parameters: p")
@@ -82,7 +82,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "allow the c parameter to be anything" do
+  it "allows the c parameter to be anything" do
     p = described_class.new({ "c" => ["1234567890"] }, @schema)
 
     expect(p).to be_valid
@@ -97,14 +97,14 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "understand the start parameter" do
+  it "understands the start parameter" do
     p = described_class.new({ "start" => ["5"] }, @schema)
     expect(p.error).to eq("")
     expect(p).to be_valid
     expect(expected_params(start: 5)).to eq(p.parsed_params)
   end
 
-  it "complain about a non-integer start parameter" do
+  it "complains about a non-integer start parameter" do
     p = described_class.new({ "start" => ["5.5"] }, @schema)
 
     expect(p.error).to eq("Invalid value \"5.5\" for parameter \"start\" (expected positive integer)")
@@ -112,7 +112,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a negative start parameter" do
+  it "complains about a negative start parameter" do
     p = described_class.new({ "start" => ["-1"] }, @schema)
 
     expect(p.error).to eq("Invalid negative value \"-1\" for parameter \"start\" (expected positive integer)")
@@ -120,7 +120,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a non-decimal start parameter" do
+  it "complains about a non-decimal start parameter" do
     p = described_class.new({ "start" => ["x"] }, @schema)
 
     expect(p.error).to eq("Invalid value \"x\" for parameter \"start\" (expected positive integer)")
@@ -128,7 +128,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated start parameter" do
+  it "complains about a repeated start parameter" do
     p = described_class.new({ "start" => %w(2 3) }, @schema)
 
     expect(%{Too many values (2) for parameter "start" (must occur at most once)}).to eq(p.error)
@@ -136,7 +136,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(start: 2)).to eq(p.parsed_params)
   end
 
-  it "understand the count parameter" do
+  it "understands the count parameter" do
     p = described_class.new({ "count" => ["5"] }, @schema)
 
     expect(p.error).to eq("")
@@ -144,7 +144,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(count: 5)).to eq(p.parsed_params)
   end
 
-  it "complain about a non-integer count parameter" do
+  it "complains about a non-integer count parameter" do
     p = described_class.new({ "count" => ["5.5"] }, @schema)
 
     expect(p.error).to eq("Invalid value \"5.5\" for parameter \"count\" (expected positive integer)")
@@ -152,7 +152,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a negative count parameter" do
+  it "complains about a negative count parameter" do
     p = described_class.new({ "count" => ["-1"] }, @schema)
 
     expect(p.error).to eq("Invalid negative value \"-1\" for parameter \"count\" (expected positive integer)")
@@ -160,7 +160,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a non-decimal count parameter" do
+  it "complains about a non-decimal count parameter" do
     p = described_class.new({ "count" => ["x"] }, @schema)
 
     expect(p.error).to eq("Invalid value \"x\" for parameter \"count\" (expected positive integer)")
@@ -168,7 +168,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated count parameter" do
+  it "complains about a repeated count parameter" do
     p = described_class.new({ "count" => %w(2 3) }, @schema)
 
     expect(%{Too many values (2) for parameter "count" (must occur at most once)}).to eq(p.error)
@@ -176,7 +176,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(count: 2)).to eq(p.parsed_params)
   end
 
-  it "complain about an overly large count parameter" do
+  it "complains about an overly large count parameter" do
     p = described_class.new({ "count" => %w(1001) }, @schema)
 
     expect(%{Maximum result set size (as specified in 'count') is 1000}).to eq(p.error)
@@ -184,7 +184,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(count: 10)).to eq(p.parsed_params)
   end
 
-  it "understand the q parameter" do
+  it "understands the q parameter" do
     p = described_class.new({ "q" => ["search-term"] }, @schema)
 
     expect(p.error).to eq("")
@@ -192,7 +192,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(query: "search-term")).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated q parameter" do
+  it "complains about a repeated q parameter" do
     p = described_class.new({ "q" => %w(hello world) }, @schema)
 
     expect(%{Too many values (2) for parameter "q" (must occur at most once)}).to eq(p.error)
@@ -200,7 +200,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(query: "hello")).to eq(p.parsed_params)
   end
 
-  it "strip whitespace from the query" do
+  it "strips whitespace from the query" do
     p = described_class.new({ "q" => ["cheese "] }, @schema)
 
     expect(p.error).to eq("")
@@ -208,7 +208,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(query: "cheese")).to eq(p.parsed_params)
   end
 
-  it "put the query in normalized form" do
+  it "puts the query in normalized form" do
     p = described_class.new({ "q" => ["cafe\u0300 "] }, @schema)
 
     expect(p.error).to eq("")
@@ -216,7 +216,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(query: "caf\u00e8")).to eq(p.parsed_params)
   end
 
-  it "complain about invalid unicode in the query" do
+  it "complains about invalid unicode in the query" do
     p = described_class.new({ "q" => ["\xff"] }, @schema)
 
     expect(p.error).to eq("Invalid unicode in query")
@@ -224,7 +224,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(query: nil)).to eq(p.parsed_params)
   end
 
-  it "understand the similar to parameter" do
+  it "understands the similar_to parameter" do
     p = described_class.new({ "similar_to" => ["/search-term"] }, @schema)
 
     expect(p.error).to eq("")
@@ -232,7 +232,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/search-term")).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated similar to parameter" do
+  it "complains about a repeated similar_to parameter" do
     p = described_class.new({ "similar_to" => %w(/hello /world) }, @schema)
 
     expect(%{Too many values (2) for parameter "similar_to" (must occur at most once)}).to eq(p.error)
@@ -240,7 +240,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/hello")).to eq(p.parsed_params)
   end
 
-  it "strip whitespace from similar to parameter" do
+  it "strips whitespace from similar_to parameter" do
     p = described_class.new({ "similar_to" => ["/cheese "] }, @schema)
 
     expect(p.error).to eq("")
@@ -248,7 +248,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/cheese")).to eq(p.parsed_params)
   end
 
-  it "put the similar to parameter in normalized form" do
+  it "puts the similar_to parameter in normalized form" do
     p = described_class.new({ "similar_to" => ["/cafe\u0300 "] }, @schema)
 
     expect(p.error).to eq("")
@@ -256,7 +256,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/caf\u00e8")).to eq(p.parsed_params)
   end
 
-  it "complain about invalid unicode in the similar to parameter" do
+  it "complains about invalid unicode in the similar_to parameter" do
     p = described_class.new({ "similar_to" => ["\xff"] }, @schema)
 
     expect(p.error).to eq("Invalid unicode in similar_to")
@@ -264,7 +264,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: nil)).to eq(p.parsed_params)
   end
 
-  it "complain when both q and similar to parameters are provided" do
+  it "complains when both q and similar_to parameters are provided" do
     p = described_class.new({ "q" => ["hello"], "similar_to" => ["/world"] }, @schema)
 
     expect(p.error).to eq("Parameters 'q' and 'similar_to' cannot be used together")
@@ -272,7 +272,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(query: "hello", similar_to: "/world")).to eq(p.parsed_params)
   end
 
-  it "set the order parameter to nil when the similar to parameter is provided" do
+  it "sets the order parameter to nil when the similar_to parameter is provided" do
     p = described_class.new({ "similar_to" => ["/hello"], "order" => ["title"] }, @schema)
 
     expect(p.error).to eq("")
@@ -280,7 +280,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/hello")).to eq(p.parsed_params)
   end
 
-  it "understand filter paramers" do
+  it "understands filter paramers" do
     p = described_class.new({ "filter_organisations" => ["hm-magic"] }, @schema)
 
     expect(p.error).to eq("")
@@ -294,7 +294,7 @@ RSpec.describe SearchParameterParser do
     )
   end
 
-  it "understand reject paramers" do
+  it "understands reject paramers" do
     p = described_class.new({ "reject_organisations" => ["hm-magic"] }, @schema)
 
     expect(p.error).to eq("")
@@ -308,7 +308,7 @@ RSpec.describe SearchParameterParser do
     )
   end
 
-  it "understand some rejects and some filter paramers" do
+  it "understands some rejects and some filter paramers" do
     p = described_class.new({
       "reject_organisations" => ["hm-magic"],
       "filter_mainstream_browse_pages" => ["cheese"],
@@ -326,7 +326,7 @@ RSpec.describe SearchParameterParser do
     )
   end
 
-  it "understand multiple filter paramers" do
+  it "understands multiple filter paramers" do
     p = described_class.new({ "filter_organisations" => ["hm-magic", "hmrc"] }, @schema)
 
     expect(p.error).to eq("")
@@ -346,7 +346,7 @@ RSpec.describe SearchParameterParser do
     )
   end
 
-  it "understand filter for missing field" do
+  it "understands filter for missing field" do
     p = described_class.new({ "filter_organisations" => ["_MISSING"] }, @schema)
 
     expect(p.error).to eq("")
@@ -359,7 +359,7 @@ RSpec.describe SearchParameterParser do
     expect(filters[0].values).to eq([])
   end
 
-  it "understand filter for missing field or specific value" do
+  it "understands filter for missing field or specific value" do
     p = described_class.new({ "filter_organisations" => %w(_MISSING hmrc) }, @schema)
 
     expect(p.error).to eq("")
@@ -372,7 +372,7 @@ RSpec.describe SearchParameterParser do
     expect(filters[0].values).to eq(["hmrc"])
   end
 
-  it "complain about disallowed filter fields" do
+  it "complains about disallowed filter fields" do
     p = described_class.new(
       {
         "filter_spells" => ["levitation"],
@@ -390,7 +390,7 @@ RSpec.describe SearchParameterParser do
     )
   end
 
-  it "complain about disallowed reject fields" do
+  it "complains about disallowed reject fields" do
     p = described_class.new(
       {
         "reject_spells" => ["levitation"],
@@ -409,7 +409,7 @@ RSpec.describe SearchParameterParser do
   end
 
   # TODO: this is deprecated behaviour
-  it "rewrite document_type filter to  type filter" do
+  it "rewrites a document_type filter to a _type filter" do
     parser = described_class.new(
       { "filter_document_type" => ["cma_case"] },
       @schema,
@@ -423,7 +423,7 @@ RSpec.describe SearchParameterParser do
   end
 
   context "when the filter field is a date type" do
-    it "include the type in return value of #parsed params" do
+    it "includes the type in return value of #parsed params" do
       params = {
         "filter_document_type" => ["cma_case"],
         "filter_opened_date" => "from:2014-04-01 05:08,to:2014-04-02 17:43:12",
@@ -442,7 +442,7 @@ RSpec.describe SearchParameterParser do
         .to eq(DateTime.new(2014, 4, 2, 17, 43, 12))
     end
 
-    it "understand date filter for missing field or specific value" do
+    it "understands a date filter for a missing value or a specific value" do
       parser = described_class.new({
         "filter_document_type" => ["cma_case"],
         "filter_opened_date" => ["_MISSING", "from:2014-04-01 00:00,to:2014-04-02 00:00"],
@@ -484,7 +484,7 @@ RSpec.describe SearchParameterParser do
   end
 
   context "filtering a date field with invalid parameters" do
-    it "does not filter on date if date is invalid" do
+    it "does not filter on date if the date is invalid" do
       params = {
         "filter_document_type" => ["cma_case"],
         "filter_opened_date" => "from:2014-bananas-01 00:00,to:2014-04-02 00:00",
@@ -513,7 +513,7 @@ RSpec.describe SearchParameterParser do
     end
   end
 
-  it "understand an ascending sort" do
+  it "understands an ascending sort" do
     p = described_class.new({ "order" => ["public_timestamp"] }, @schema)
 
     expect(p.error).to eq("")
@@ -521,7 +521,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({ order: %w(public_timestamp asc) })).to eq(p.parsed_params)
   end
 
-  it "understand a descending sort" do
+  it "understands a descending sort" do
     p = described_class.new({ "order" => ["-public_timestamp"] }, @schema)
 
     expect(p.error).to eq("")
@@ -529,7 +529,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({ order: %w(public_timestamp desc) })).to eq(p.parsed_params)
   end
 
-  it "complain about disallowed sort fields" do
+  it "complains about disallowed sort fields" do
     p = described_class.new({ "order" => ["spells"] }, @schema)
 
     expect(%{"spells" is not a valid sort field}).to eq(p.error)
@@ -537,7 +537,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about disallowed descending sort fields" do
+  it "complains about disallowed descending sort fields" do
     p = described_class.new({ "order" => ["-spells"] }, @schema)
 
     expect(%{"spells" is not a valid sort field}).to eq(p.error)
@@ -545,7 +545,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated sort parameter" do
+  it "complains about a repeated sort parameter" do
     p = described_class.new({ "order" => %w(public_timestamp something_else) }, @schema)
 
     expect(%{Too many values (2) for parameter "order" (must occur at most once)}).to eq(p.error)
@@ -553,7 +553,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(order: %w(public_timestamp asc))).to eq(p.parsed_params)
   end
 
-  it "understand a aggregate field" do
+  it "understands a aggregate field" do
     p = described_class.new({ "aggregate_organisations" => ["10"] }, @schema)
 
     expect(p.error).to eq("")
@@ -563,7 +563,7 @@ RSpec.describe SearchParameterParser do
     ).to eq(p.parsed_params)
   end
 
-  it "understand multiple aggregate fields" do
+  it "understands multiple aggregate fields" do
     p = described_class.new({
       "aggregate_organisations" => ["10"],
       "aggregate_mainstream_browse_pages" => ["5"],
@@ -581,7 +581,7 @@ RSpec.describe SearchParameterParser do
     ).to eq(p.parsed_params)
   end
 
-  it "complain about disallowed aggregates fields" do
+  it "complains about disallowed aggregates fields" do
     p = described_class.new({
       "aggregate_spells" => ["10"],
       "aggregate_organisations" => ["10"],
@@ -594,7 +594,7 @@ RSpec.describe SearchParameterParser do
     ).to eq(p.parsed_params)
   end
 
-  it "complain about invalid values for aggregate parameter" do
+  it "complains about invalid values for aggregate parameter" do
     p = described_class.new({
       "aggregate_spells" => ["levitation"],
       "aggregate_organisations" => ["magic"],
@@ -605,7 +605,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about empty values for aggregate parameter" do
+  it "complains about empty values for aggregate parameter" do
     p = described_class.new({ "aggregate_organisations" => [""] }, @schema)
 
     expect(%{Invalid value "" for first parameter for aggregate "organisations" (expected positive integer)}).to eq(p.error)
@@ -613,7 +613,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated aggregate parameter" do
+  it "complains about a repeated aggregate parameter" do
     p = described_class.new({ "aggregate_organisations" => %w(5 6) }, @schema)
 
     expect(%{Too many values (2) for parameter "aggregate_organisations" (must occur at most once)}).to eq(p.error)
@@ -623,7 +623,7 @@ RSpec.describe SearchParameterParser do
     ).to eq(p.parsed_params)
   end
 
-  it "allow options in the values for the aggregate parameter" do
+  it "allows options in the values for the aggregate parameter" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:global"],
     }, @schema)
@@ -641,7 +641,7 @@ RSpec.describe SearchParameterParser do
     )).to eq(p.parsed_params)
   end
 
-  it "understand the order option in aggregate parameters" do
+  it "understands the order option in aggregate parameters" do
     p = described_class.new({
       "aggregate_organisations" => ["10,order:filtered:value.link:-count"],
     }, @schema)
@@ -657,7 +657,7 @@ RSpec.describe SearchParameterParser do
     )).to eq(p.parsed_params)
   end
 
-  it "complain about invalid order options in aggregate parameters" do
+  it "complains about invalid order options in aggregate parameters" do
     p = described_class.new({
       "aggregate_organisations" => ["10,order:filt:value.unknown"],
     }, @schema)
@@ -668,7 +668,7 @@ RSpec.describe SearchParameterParser do
   end
 
 
-  it "handle repeated order options in aggregate parameters" do
+  it "handles repeated order options in aggregate parameters" do
     p = described_class.new({
       "aggregate_organisations" => ["10,order:filtered,order:value.link:-count"],
     }, @schema)
@@ -684,7 +684,7 @@ RSpec.describe SearchParameterParser do
     )).to eq(p.parsed_params)
   end
 
-  it "understand the scope option in aggregate parameters" do
+  it "understands the scope option in aggregate parameters" do
     p = described_class.new({
       "aggregate_organisations" => ["10,scope:all_filters"],
     }, @schema)
@@ -700,7 +700,7 @@ RSpec.describe SearchParameterParser do
     )).to eq(p.parsed_params)
   end
 
-  it "complain about invalid scope options in aggregate parameters" do
+  it "complains about invalid scope options in aggregate parameters" do
     p = described_class.new({
       "aggregate_organisations" => ["10,scope:unknown"],
     }, @schema)
@@ -710,7 +710,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated examples option" do
+  it "complains about a repeated examples option" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,examples:6,example_scope:global"],
     }, @schema)
@@ -720,7 +720,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "merge fields from repeated example fields options" do
+  it "merges fields from repeated example fields options" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_fields:slug,example_fields:title:link,example_scope:global"],
     }, @schema)
@@ -738,7 +738,7 @@ RSpec.describe SearchParameterParser do
     )).to eq(p.parsed_params)
   end
 
-  it "require the example scope to be set" do
+  it "requires the example scope to be set" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title"],
     }, @schema)
@@ -748,7 +748,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({ aggregates: {} })).to eq(p.parsed_params)
   end
 
-  it "allow example scope to be set to 'query'" do
+  it "allows example scope to be set to 'query'" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:query"],
     }, @schema)
@@ -765,7 +765,7 @@ RSpec.describe SearchParameterParser do
     )).to eq(p.parsed_params)
   end
 
-  it "complain about an invalid example scope option" do
+  it "complains about an invalid example scope option" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_scope:invalid"],
     }, @schema)
@@ -775,7 +775,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated example scope option" do
+  it "complains about a repeated example scope option" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_scope:global,example_scope:global"],
     }, @schema)
@@ -785,7 +785,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "validate options in the values for the aggregate parameter" do
+  it "validates options in the values for the aggregate parameter" do
     p = described_class.new({
       "aggregate_organisations" => ["10,example:5,examples:lots,example_fields:unknown:title"],
     }, @schema)
@@ -799,7 +799,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "accept facets as a alias for aggregates" do
+  it "accepts facets as a alias for aggregates" do
     aggregate_p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:query"],
     }, @schema)
@@ -812,7 +812,7 @@ RSpec.describe SearchParameterParser do
     expect(aggregate_p.parsed_params['aggregates']).to eq(facet_p.parsed_params['facets'])
   end
 
-  it "compalin with facets are used in combination with aggregates" do
+  it "compalins with facets are used in combination with aggregates" do
     p = described_class.new({
       "aggregate_organisations" => ["10"],
       "facet_mainstream_browse_pages" => ["10"],
@@ -824,7 +824,7 @@ RSpec.describe SearchParameterParser do
     expect(p).not_to be_valid
   end
 
-  it "understand the fields parameter" do
+  it "understands the fields parameter" do
     p = described_class.new({ "fields" => %w(title description) }, @schema)
 
     expect(p.error).to eq("")
@@ -832,7 +832,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(return_fields: %w(title description))).to eq(p.parsed_params)
   end
 
-  it "complain about invalid fields parameters" do
+  it "complains about invalid fields parameters" do
     p = described_class.new({ "fields" => %w(title waffle) }, @schema)
 
     expect(p.error).to eq("Some requested fields are not valid return fields: [\"waffle\"]")
@@ -840,7 +840,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(return_fields: ["title"])).to eq(p.parsed_params)
   end
 
-  it "understand the debug parameter" do
+  it "understands the debug parameter" do
     p = described_class.new({ "debug" => ["disable_best_bets,disable_popularity,,unknown_option"] }, @schema)
 
     expect(%{Unknown debug option "unknown_option"}).to eq(p.error)
@@ -848,7 +848,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(debug: { disable_best_bets: true, disable_popularity: true })).to eq(p.parsed_params)
   end
 
-  it "merge values from repeated debug parameters" do
+  it "merges values from repeated debug parameters" do
     p = described_class.new({ "debug" => ["disable_best_bets,explain", "disable_popularity"] }, @schema)
 
     expect(p.error).to eq("")
@@ -856,7 +856,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(debug: { disable_best_bets: true, explain: true, disable_popularity: true })).to eq(p.parsed_params)
   end
 
-  it "ignore empty options in the debug parameter" do
+  it "ignores empty options in the debug parameter" do
     p = described_class.new({ "debug" => [",,"] }, @schema)
 
     expect(p.error).to eq("")
@@ -864,35 +864,35 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(debug: {})).to eq(p.parsed_params)
   end
 
-  it "understand explain in the debug parameter" do
+  it "understands explain in the debug parameter" do
     p = described_class.new({ "debug" => ["explain"] }, @schema)
 
     expect(p).to be_valid
     expect(expected_params(debug: { explain: true })).to eq(p.parsed_params)
   end
 
-  it "understand disable synonyms in the debug parameter" do
+  it "understands disable synonyms in the debug parameter" do
     p = described_class.new({ "debug" => ["disable_synonyms"] }, @schema)
 
     expect(p).to be_valid
     expect(expected_params(debug: { disable_synonyms: true })).to eq(p.parsed_params)
   end
 
-  it "understand the test variant parameter" do
+  it "understands the test variant parameter" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length:A"] }, @schema)
 
     expect(p).to be_valid
     expect(expected_params(ab_tests: { min_should_match_length: 'A' })).to eq(p.parsed_params)
   end
 
-  it "understand multiple test variant parameters" do
+  it "understands multiple test variant parameters" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length:A,other_test_case:B"] }, @schema)
 
     expect(p).to be_valid
     expect(expected_params(ab_tests: { min_should_match_length: 'A', other_test_case: 'B' })).to eq(p.parsed_params)
   end
 
-  it "complain about invalid test variant where no variant type is provided" do
+  it "complains about invalid test variant where no variant type is provided" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length"] }, @schema)
 
     expect(p).not_to be_valid

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(query: nil)).to eq(p.parsed_params)
   end
 
-  it "understand the similar_to parameter" do
+  it "understand the similar to parameter" do
     p = described_class.new({ "similar_to" => ["/search-term"] }, @schema)
 
     expect(p.error).to eq("")
@@ -232,7 +232,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/search-term")).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated similar_to parameter" do
+  it "complain about a repeated similar to parameter" do
     p = described_class.new({ "similar_to" => %w(/hello /world) }, @schema)
 
     expect(%{Too many values (2) for parameter "similar_to" (must occur at most once)}).to eq(p.error)
@@ -240,7 +240,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/hello")).to eq(p.parsed_params)
   end
 
-  it "strip whitespace from similar_to parameter" do
+  it "strip whitespace from similar to parameter" do
     p = described_class.new({ "similar_to" => ["/cheese "] }, @schema)
 
     expect(p.error).to eq("")
@@ -248,7 +248,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/cheese")).to eq(p.parsed_params)
   end
 
-  it "put the similar_to parameter in normalized form" do
+  it "put the similar to parameter in normalized form" do
     p = described_class.new({ "similar_to" => ["/cafe\u0300 "] }, @schema)
 
     expect(p.error).to eq("")
@@ -256,7 +256,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: "/caf\u00e8")).to eq(p.parsed_params)
   end
 
-  it "complain about invalid unicode in the similar_to parameter" do
+  it "complain about invalid unicode in the similar to parameter" do
     p = described_class.new({ "similar_to" => ["\xff"] }, @schema)
 
     expect(p.error).to eq("Invalid unicode in similar_to")
@@ -264,7 +264,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(similar_to: nil)).to eq(p.parsed_params)
   end
 
-  it "complain when both q and similar_to parameters are provided" do
+  it "complain when both q and similar to parameters are provided" do
     p = described_class.new({ "q" => ["hello"], "similar_to" => ["/world"] }, @schema)
 
     expect(p.error).to eq("Parameters 'q' and 'similar_to' cannot be used together")
@@ -272,7 +272,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(query: "hello", similar_to: "/world")).to eq(p.parsed_params)
   end
 
-  it "set the order parameter to nil when the similar_to parameter is provided" do
+  it "set the order parameter to nil when the similar to parameter is provided" do
     p = described_class.new({ "similar_to" => ["/hello"], "order" => ["title"] }, @schema)
 
     expect(p.error).to eq("")
@@ -409,7 +409,7 @@ RSpec.describe SearchParameterParser do
   end
 
   # TODO: this is deprecated behaviour
-  it "rewrite document_type filter to _type filter" do
+  it "rewrite document_type filter to  type filter" do
     parser = described_class.new(
       { "filter_document_type" => ["cma_case"] },
       @schema,
@@ -423,7 +423,7 @@ RSpec.describe SearchParameterParser do
   end
 
   context "when the filter field is a date type" do
-    it "include the type in return value of #parsed_params" do
+    it "include the type in return value of #parsed params" do
       params = {
         "filter_document_type" => ["cma_case"],
         "filter_opened_date" => "from:2014-04-01 05:08,to:2014-04-02 17:43:12",
@@ -720,7 +720,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "merge fields from repeated example_fields options" do
+  it "merge fields from repeated example fields options" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_fields:slug,example_fields:title:link,example_scope:global"],
     }, @schema)
@@ -738,7 +738,7 @@ RSpec.describe SearchParameterParser do
     )).to eq(p.parsed_params)
   end
 
-  it "require the example_scope to be set" do
+  it "require the example scope to be set" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title"],
     }, @schema)
@@ -748,7 +748,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({ aggregates: {} })).to eq(p.parsed_params)
   end
 
-  it "allow example_scope to be set to 'query'" do
+  it "allow example scope to be set to 'query'" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_fields:slug:title,example_scope:query"],
     }, @schema)
@@ -765,7 +765,7 @@ RSpec.describe SearchParameterParser do
     )).to eq(p.parsed_params)
   end
 
-  it "complain about an invalid example_scope option" do
+  it "complain about an invalid example scope option" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_scope:invalid"],
     }, @schema)
@@ -775,7 +775,7 @@ RSpec.describe SearchParameterParser do
     expect(expected_params({})).to eq(p.parsed_params)
   end
 
-  it "complain about a repeated example_scope option" do
+  it "complain about a repeated example scope option" do
     p = described_class.new({
       "aggregate_organisations" => ["10,examples:5,example_scope:global,example_scope:global"],
     }, @schema)
@@ -871,28 +871,28 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(debug: { explain: true })).to eq(p.parsed_params)
   end
 
-  it "understand disable_synonyms in the debug parameter" do
+  it "understand disable synonyms in the debug parameter" do
     p = described_class.new({ "debug" => ["disable_synonyms"] }, @schema)
 
     expect(p).to be_valid
     expect(expected_params(debug: { disable_synonyms: true })).to eq(p.parsed_params)
   end
 
-  it "understand the test_variant parameter" do
+  it "understand the test variant parameter" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length:A"] }, @schema)
 
     expect(p).to be_valid
     expect(expected_params(ab_tests: { min_should_match_length: 'A' })).to eq(p.parsed_params)
   end
 
-  it "understand multiple test_variant parameters" do
+  it "understand multiple test variant parameters" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length:A,other_test_case:B"] }, @schema)
 
     expect(p).to be_valid
     expect(expected_params(ab_tests: { min_should_match_length: 'A', other_test_case: 'B' })).to eq(p.parsed_params)
   end
 
-  it "complain about invalid test_variant where no variant_type is provided" do
+  it "complain about invalid test variant where no variant type is provided" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length"] }, @schema)
 
     expect(p).not_to be_valid

--- a/spec/unit/result_set_presenter_spec.rb
+++ b/spec/unit/result_set_presenter_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Search::ResultSetPresenter do
       end
     end
 
-    it "have the score in es_score" do
+    it "have the score in es score" do
       @output[:results].zip(sample_docs).each do |result, doc|
         expect(result.keys).not_to include("_score")
         expect(result[:es_score]).not_to be_nil
@@ -283,7 +283,7 @@ RSpec.describe Search::ResultSetPresenter do
       end
     end
 
-    it "have the score in es_score" do
+    it "have the score in es score" do
       @output[:results].zip(sample_docs).each do |result, doc|
         expect(result.keys).not_to include("_score")
         expect(result[:es_score]).not_to be_nil

--- a/spec/unit/schema/combined_index_schema_spec.rb
+++ b/spec/unit/schema/combined_index_schema_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CombinedIndexSchema do
     @combined_schema = described_class.new(@index_names, search_config.schema_config)
   end
 
-  it "basic_field_definitions" do
+  it "basic field definitions" do
     # The title and public_timestamp fields are defined in the
     # base_elasticsearch_type, so are available in all documents holding content.
     expect(@combined_schema.field_definitions["title"].type.name).to eq("searchable_sortable_text")
@@ -15,7 +15,7 @@ RSpec.describe CombinedIndexSchema do
     expect(@combined_schema.field_definitions["public_timestamp"].type.name).to eq("date")
   end
 
-  it "merged_field_definitions" do
+  it "merged field definitions" do
     # The location field is defined in both the
     # international_development_fund document type, and in the
     # european_structural_investment_fund document type, with different
@@ -25,7 +25,7 @@ RSpec.describe CombinedIndexSchema do
     expect(locations).to include({ "label" => "North East", "value" => "north-east" })
   end
 
-  it "allowed_filter_fields" do
+  it "allowed filter fields" do
     expect(@combined_schema.allowed_filter_fields).not_to include "title"
     expect(@combined_schema.allowed_filter_fields).to include "organisations"
   end

--- a/spec/unit/schema/elasticsearch_types_parser_spec.rb
+++ b/spec/unit/schema/elasticsearch_types_parser_spec.rb
@@ -29,17 +29,17 @@ RSpec.describe ElasticsearchTypesParser do
       @identifier_es_config = { "type" => "string", "index" => "not_analyzed", "include_in_all" => false }
     end
 
-    it "recognise the `manual_section` type" do
+    it "recognise the `manual section` type" do
       expect(@types["manual_section"].name).to eq("manual_section")
     end
 
-    it "know that the `manual_section` type has a `manual` field" do
+    it "know that the `manual section` type has a `manual` field" do
       manual_field = @types["manual_section"].fields["manual"]
       expect(manual_field).not_to be_nil
       expect(manual_field.name).to eq("manual")
     end
 
-    it "know that the `manual_section` type inherits the `link` field from the base type" do
+    it "know that the `manual section` type inherits the `link` field from the base type" do
       link_field = @types["manual_section"].fields["link"]
       expect(link_field).not_to be_nil
       expect(link_field.name).to eq("link")
@@ -47,7 +47,7 @@ RSpec.describe ElasticsearchTypesParser do
       expect(link_field.type.name).to eq("identifier")
     end
 
-    it "produce appropriate elasticsearch configuration for the `manual_section` type" do
+    it "produce appropriate elasticsearch configuration for the `manual section` type" do
       es_config = @types["manual_section"].es_config
       expect(
         hash_including({
@@ -57,11 +57,11 @@ RSpec.describe ElasticsearchTypesParser do
       ).to eq(es_config)
     end
 
-    it "not specify expanded_search_result_fields for the `organisations` field" do
+    it "not specify expanded search result fields for the `organisations` field" do
       expect(@types["manual_section"].fields["organisations"].expanded_search_result_fields).to be_nil
     end
 
-    it "include expanded_search_result_fields in the cma_case `case_state` field" do
+    it "include expanded search result fields in the cma case `case state` field" do
       expect(
         cma_case_expanded_search_result_fields
       ).to eq(
@@ -69,7 +69,7 @@ RSpec.describe ElasticsearchTypesParser do
       )
     end
 
-    it "expanded_search_result_fields on a field should also be available from the document type" do
+    it "expanded search result fields on a field should also be available from the document_type" do
       expect(
         @types["cma_case"].fields["case_state"].expanded_search_result_fields
       ).to eq(
@@ -84,19 +84,19 @@ RSpec.describe ElasticsearchTypesParser do
       @parser = ElasticsearchTypeParser.new("/config/path/doc_type.json", nil, @definitions)
     end
 
-    it "fail if document type doesn't specify `fields`" do
+    it "fail if document_type doesn't specify `fields`" do
       allow_any_instance_of(ElasticsearchTypeParser).to receive(:load_json).and_return({})
       expect_raises_message(%{Missing "fields", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
 
-    it "fail if document type specifies unknown entries in `fields`" do
+    it "fail if document_type specifies unknown entries in `fields`" do
       allow_any_instance_of(ElasticsearchTypeParser).to receive(:load_json).and_return({
         "fields" => ["unknown_field"],
       })
       expect_raises_message(%{Undefined field \"unknown_field\", in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
 
-    it "fail if document type has an unknown property" do
+    it "fail if document_type has an unknown property" do
       allow_any_instance_of(ElasticsearchTypeParser).to receive(:load_json).and_return({
         "fields" => [],
         "unknown" => [],
@@ -104,7 +104,7 @@ RSpec.describe ElasticsearchTypesParser do
       expect_raises_message(%{Unknown keys (unknown), in document type definition in "/config/path/doc_type.json"}) { @parser.parse }
     end
 
-    it "fail if `expanded_search_result_fields` are specified in base type" do
+    it "fail if `expanded search result fields` are specified in base type" do
       allow_any_instance_of(ElasticsearchTypeParser).to receive(:load_json).and_return({
         "fields" => ["case_state"],
         "expanded_search_result_fields" => {
@@ -119,7 +119,7 @@ RSpec.describe ElasticsearchTypesParser do
       expect_raises_message(%{Specifying `expanded_search_result_fields` in base document type is not supported, in document type definition in "/config/path/subtype.json"}) { subtype_parser.parse }
     end
 
-    it "fail if expanded_search_result_fields are set for fields which aren't known" do
+    it "fail if expanded search result fields are set for fields which aren't known" do
       allow_any_instance_of(ElasticsearchTypeParser).to receive(:load_json).and_return({
         "fields" => ["case_state"],
         "expanded_search_result_fields" => {

--- a/spec/unit/schema/field_definition_parser_spec.rb
+++ b/spec/unit/schema/field_definition_parser_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe FieldDefinitionParser do
       expect(@definitions["link"].children).to be_nil
     end
 
-    it "know that the `attachments` field has a child of `title` of type searchable_text" do
+    it "know that the `attachments` field has a child of `title` of type searchable text" do
       expect(@definitions["attachments"].children["title"].type.name).to eq("searchable_text")
     end
 

--- a/spec/unit/schema/field_types_spec.rb
+++ b/spec/unit/schema/field_types_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe FieldTypes do
       expect(@types.get("objects").children).to eq("named")
     end
 
-    it "know that the `opaque_object` type has dynamic children" do
+    it "know that the `opaque object` type has dynamic children" do
       expect(@types.get("opaque_object").children).to eq("dynamic")
     end
 
@@ -46,14 +46,14 @@ RSpec.describe FieldTypes do
       @types = described_class.new("/config/path")
     end
 
-    it "fail if a field type has no es_config property" do
+    it "fail if a field type has no es config property" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return({ "identifier" => {} })
       expect_raises_message(%{Missing "es_config" in field type "identifier" in "/config/path/field_types.json"}) do
         @types.get("identifier")
       end
     end
 
-    it "fail if a field type has an invalid `filter_type` property" do
+    it "fail if a field type has an invalid `filter type` property" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return(
         { "identifier" => { "es_config" => {}, "filter_type" => "bad value" } }
       )

--- a/spec/unit/schema/index_schema_parser_spec.rb
+++ b/spec/unit/schema/index_schema_parser_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe IndexSchemaParser do
       expect(@index_schemas["mainstream"].name).to eq("mainstream")
     end
 
-    it "include configuration for the `manual_section` type in the `mainstream` index" do
+    it "include configuration for the `manual section` type in the `mainstream` index" do
       es_mappings = @index_schemas["mainstream"].es_mappings
       expect(es_mappings.keys).to include("manual_section")
       expect(
@@ -42,14 +42,14 @@ RSpec.describe IndexSchemaParser do
       @parser = described_class.new("index", "index.json", elasticsearch_types)
     end
 
-    it "fail if index schema specifies an unknown document type" do
+    it "fail if index schema specifies an unknown document_type" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return({
         "elasticsearch_types" => ["unknown_doc_type"],
       })
       expect_raises_message(%{Unknown document type "unknown_doc_type", in index definition in "index.json"}) { @parser.parse }
     end
 
-    it "fail if index schema doesn't specify `elasticsearch_types`" do
+    it "fail if index schema doesn't specify `elasticsearch types`" do
       allow_any_instance_of(described_class).to receive(:load_json).and_return({})
       expect_raises_message(%{Missing "elasticsearch_types", in index definition in "index.json"}) { @parser.parse }
     end

--- a/spec/unit/search/aggregate_option_spec.rb
+++ b/spec/unit/search/aggregate_option_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Search::AggregateOption do
-  it "convert_to_hash" do
+  it "convert to hash" do
     expect(
       value: { "title" => "Hello" }, documents: 1
     ).to eq(
@@ -9,34 +9,34 @@ RSpec.describe Search::AggregateOption do
     )
   end
 
-  it "id_is_slug" do
+  it "id is slug" do
     expect("a_slug").to eq(
       described_class.new({ "title" => "Hello", "slug" => "a_slug" }, 1, true, []).id,
     )
   end
 
-  it "compare_by_filtered_first" do
+  it "compare by filtered first" do
     orderings = [[:filtered, 1]]
     expect(
       described_class.new({}, 0, true, orderings)
     ).to be < described_class.new({}, 0, false, orderings)
   end
 
-  it "compare_by_filtered_last" do
+  it "compare by filtered last" do
     orderings = [[:filtered, -1]]
     expect(
       described_class.new({}, 0, false, orderings)
     ).to be < described_class.new({}, 0, true, orderings)
   end
 
-  it "compare_by_count_ascending" do
+  it "compare by count ascending" do
     orderings = [[:count, 1]]
     expect(
       described_class.new({}, 5, false, orderings)
     ).to be < described_class.new({}, 6, false, orderings)
   end
 
-  it "compare_by_count_descending" do
+  it "compare by count descending" do
     orderings = [[:count, -1]]
     expect(
       described_class.new({}, 6, false, orderings)
@@ -44,70 +44,70 @@ RSpec.describe Search::AggregateOption do
   end
 
 
-  it "compare_by_slug_ascending" do
+  it "compare by slug ascending" do
     orderings = [[:"value.slug", 1]]
     expect(
       described_class.new({ "slug" => "a" }, 0, false, orderings)
     ).to be < described_class.new({ "slug" => "b" }, 0, false, orderings)
   end
 
-  it "compare_by_slug_descending" do
+  it "compare by slug descending" do
     orderings = [[:"value.slug", -1]]
     expect(
       described_class.new({ "slug" => "b" }, 0, false, orderings)
     ).to be < described_class.new({ "slug" => "a" }, 0, false, orderings)
   end
 
-  it "compare_by_title_ascending" do
+  it "compare by title ascending" do
     orderings = [[:"value.title", 1]]
     expect(
       described_class.new({ "title" => "a" }, 0, false, orderings)
     ).to be < described_class.new({ "title" => "b" }, 0, false, orderings)
   end
 
-  it "compare_by_title_descending" do
+  it "compare by title descending" do
     orderings = [[:"value.title", -1]]
     expect(
       described_class.new({ "title" => "b" }, 0, false, orderings)
     ).to be < described_class.new({ "title" => "a" }, 0, false, orderings)
   end
 
-  it "compare_by_title_ignores_case" do
+  it "compare by title ignores case" do
     orderings = [[:"value.title", 1]]
     expect(
       described_class.new({ "title" => "a" }, 0, false, orderings)
     ).to be < described_class.new({ "title" => "Z" }, 0, false, orderings)
   end
 
-  it "compare_by_link_ascending" do
+  it "compare by link ascending" do
     orderings = [[:"value.link", 1]]
     expect(
       described_class.new({ "link" => "a" }, 0, false, orderings)
     ).to be < described_class.new({ "link" => "b" }, 0, false, orderings)
   end
 
-  it "compare_by_link_descending" do
+  it "compare by link descending" do
     orderings = [[:"value.link", -1]]
     expect(
       described_class.new({ "link" => "b" }, 0, false, orderings)
     ).to be < described_class.new({ "link" => "a" }, 0, false, orderings)
   end
 
-  it "compare_by_value" do
+  it "compare by value" do
     orderings = [[:value, 1]]
     expect(
       described_class.new("a", 0, false, orderings)
     ).to be < described_class.new("b", 0, false, orderings)
   end
 
-  it "compare_by_value_with_title" do
+  it "compare by value with title" do
     orderings = [[:value, 1]]
     expect(
       described_class.new({ "title" => "a" }, 0, false, orderings)
     ).to be < described_class.new({ "title" => "b" }, 0, false, orderings)
   end
 
-  it "fall_back_to_slug_ordering" do
+  it "fall back to slug ordering" do
     orderings = [[:count, 1]]
     expect(
       described_class.new({ "slug" => "a" }, 5, false, orderings)

--- a/spec/unit/search/base_registry_spec.rb
+++ b/spec/unit/search/base_registry_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Search::BaseRegistry do
     }
   end
 
-  it "uses_time_as_default_clock" do
+  it "uses time as default clock" do
     # This is to make sure the cache expiry is expressed in seconds; DateTime,
     # for example, treats number addition as a number of days.
     expect(Search::TimedCache).to receive(:new).with(an_instance_of(Integer), Time)
     described_class.new(@index, sample_field_definitions, "example-format")
   end
 
-  it "can_fetch_document_series_by_slug" do
+  it "can fetch document series by slug" do
     allow(@index).to receive(:documents_by_format)
       .with("example-format", anything)
       .and_return([example_document])
@@ -31,21 +31,21 @@ RSpec.describe Search::BaseRegistry do
     expect(example_document).to eq(fetched_document)
   end
 
-  it "only_required_fields_are_requested_from_index" do
+  it "only required fields are requested from index" do
     expect(@index).to receive(:documents_by_format)
       .with("example-format", sample_field_definitions(%w{slug link title content_id}))
 
     @base_registry["example-document"]
   end
 
-  it "returns_nil_if_document_collection_not_found" do
+  it "returns nil if document collection not found" do
     allow(@index).to receive(:documents_by_format)
       .with("example-format", anything)
       .and_return([example_document])
     expect(@base_registry["non-existent-document"]).to be_nil
   end
 
-  it "document_enumerator_is_traversed_only_once" do
+  it "document enumerator is traversed only once" do
     document_enumerator = double("enumerator")
     expect(document_enumerator).to receive(:to_a).once.and_return([example_document])
     allow(@index).to receive(:documents_by_format)
@@ -56,14 +56,14 @@ RSpec.describe Search::BaseRegistry do
     expect(@base_registry["example-document"]).to be_truthy
   end
 
-  it "uses_cache" do
+  it "uses cache" do
     # Make sure we're using TimedCache#get; TimedCache is tested elsewhere, so
     # we don't need to worry about cache expiry tests here.
     expect_any_instance_of(Search::TimedCache).to receive(:get).with(no_args).and_return([example_document])
     expect(@base_registry["example-document"]).to be_truthy
   end
 
-  it "find_by_content_id" do
+  it "find by content_id" do
     allow(@index).to receive(:documents_by_format)
       .with("example-format", anything)
       .and_return([example_document])

--- a/spec/unit/search/elasticsearch_escaping_spec.rb
+++ b/spec/unit/search/elasticsearch_escaping_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Search::Escaping do
     instance
   end
 
-  it "escapes_the_query_for_lucene_chars" do
+  it "escapes the query for lucene chars" do
     expect(subject.escape("how?")).to eq("how\\?")
   end
 
-  it "escapes_the_query_for_lucene_booleans" do
+  it "escapes the query for lucene booleans" do
     expect(subject.escape("fish AND chips")).to eq('fish "AND" chips')
   end
 end

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Search::FormatMigrator do
-  it "when_base_query_without_migrated_formats" do
+  it "when base query without migrated formats" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
     base_query = { filter: 'component' }
     expected = {
@@ -16,7 +16,7 @@ RSpec.describe Search::FormatMigrator do
     expect(described_class.new(base_query).call).to eq(expected)
   end
 
-  it "when_base_query_with_migrated_formats" do
+  it "when base query with migrated formats" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
     base_query = { filter: 'component' }
     expected = {
@@ -39,7 +39,7 @@ RSpec.describe Search::FormatMigrator do
     expect(described_class.new(base_query).call).to eq(expected)
   end
 
-  it "when_no_base_query_without_migrated_formats" do
+  it "when no base query without migrated formats" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
     expected = {
       indices: {
@@ -51,7 +51,7 @@ RSpec.describe Search::FormatMigrator do
     expect(described_class.new(nil).call).to eq(expected)
   end
 
-  it "when_no_base_query_with_migrated_formats" do
+  it "when no base query with migrated formats" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
     expected = {
       indices: {

--- a/spec/unit/search/matcher_set_spec.rb
+++ b/spec/unit/search/matcher_set_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe Search::MatcherSet do
-  it "should_match_strings" do
+  it "should match strings" do
     matcher_set = described_class.new(%w(foo bang))
     expect(matcher_set).to include("foo")
     expect(matcher_set).not_to include("baz")
   end
 
-  it "should_match_strings_case_insensitively" do
+  it "should match strings case insensitively" do
     matcher_set = described_class.new(["foo"])
     expect(matcher_set).to include("Foo")
   end
 
-  it "should_match_regexes" do
+  it "should match regexes" do
     matcher_set = described_class.new([/oo/])
     expect(matcher_set).to include("Foo")
     expect(matcher_set).not_to include("Fopo")
   end
 
-  it "matchers_should_be_immutable" do
+  it "matchers should be immutable" do
     members = ["foo"]
     matcher_set = described_class.new(members)
     members.pop

--- a/spec/unit/search/presenters/entity_expander_spec.rb
+++ b/spec/unit/search/presenters/entity_expander_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Search::EntityExpander do
   # Since expanding is being done in the same way we only have to test one
   # case (organisations). Integration tests cover the rest.
-  it "expands_elements_in_document" do
+  it "expands elements in document" do
     expandable_target = {
         "slug" => "rail-statistics",
         "link" => "/government/organisations/department-for-transport/series/rail-statistics",

--- a/spec/unit/search/presenters/result_presenter_spec.rb
+++ b/spec/unit/search/presenters/result_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Search::ResultPresenter do
-  it "conversion_values_to_single_objects" do
+  it "conversion values to single objects" do
     document = {
       '_type' => 'raib_report',
       '_index' => 'mainstream_test',
@@ -13,7 +13,7 @@ RSpec.describe Search::ResultPresenter do
     expect(result["format"]).to eq("a-string")
   end
 
-  it "conversion_values_to_labelled_objects" do
+  it "conversion values to labelled objects" do
     document = {
       '_type' => 'raib_report',
       '_index' => 'mainstream_test',

--- a/spec/unit/search/presenters/temporary_link_fix_spec.rb
+++ b/spec/unit/search/presenters/temporary_link_fix_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
-  it "appending_a_slash_to_the_link_field" do
+  it "appending a slash to the link field" do
     document = {
       '_type' => 'raib_report',
       '_index' => 'mainstream_test',
@@ -13,7 +13,7 @@ RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
     expect(result["link"]).to eq("/some/link")
   end
 
-  it "keep_http_links_intact" do
+  it "keep http links intact" do
     document = {
       '_type' => 'raib_report',
       '_index' => 'mainstream_test',
@@ -25,7 +25,7 @@ RSpec.describe Search::ResultPresenter, 'Temporary Link Fix' do
     expect(result["link"]).to eq("http://example.org/some-link")
   end
 
-  it "keep_correct_links_intact" do
+  it "keep correct links intact" do
     document = {
       '_type' => 'raib_report',
       '_index' => 'mainstream_test',

--- a/spec/unit/search/result_set_spec.rb
+++ b/spec/unit/search/result_set_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Search::ResultSet do
       expect(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total).to eq(1)
     end
 
-    it "pass the fields to Document.from_hash" do
+    it "pass the fields to Document.from hash" do
       expected_hash = hash_including("foo" => "bar")
       expect(Document).to receive(:from_hash).with(expected_hash, sample_elasticsearch_types, anything).and_return(:doc)
 
@@ -50,7 +50,7 @@ RSpec.describe Search::ResultSet do
       expect(result_set.results).to eq([:doc])
     end
 
-    it "pass the result score to Document.from_hash" do
+    it "pass the result score to Document.from hash" do
       expect(Document).to receive(:from_hash).with(an_instance_of(Hash), sample_elasticsearch_types, 12).and_return(:doc)
 
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)

--- a/spec/unit/search/result_set_spec.rb
+++ b/spec/unit/search/result_set_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Search::ResultSet do
-  context "empty result set" do
+  context "an empty result set" do
     before do
       @response = {
         "hits" => {
@@ -11,17 +11,17 @@ RSpec.describe Search::ResultSet do
       }
     end
 
-    it "report zero results" do
+    it "reports zero results" do
       expect(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total).to eq(0)
     end
 
-    it "have an empty result set" do
+    it "has a size of zero" do
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
       expect(result_set.results.size).to eq(0)
     end
   end
 
-  context "single result" do
+  context "a result set containing a single result" do
     before do
       @response = {
         "hits" => {
@@ -38,11 +38,11 @@ RSpec.describe Search::ResultSet do
       }
     end
 
-    it "report one result" do
+    it "reports one result" do
       expect(described_class.from_elasticsearch(sample_elasticsearch_types, @response).total).to eq(1)
     end
 
-    it "pass the fields to Document.from hash" do
+    it "passes the fields to Document.from_hash" do
       expected_hash = hash_including("foo" => "bar")
       expect(Document).to receive(:from_hash).with(expected_hash, sample_elasticsearch_types, anything).and_return(:doc)
 
@@ -50,14 +50,14 @@ RSpec.describe Search::ResultSet do
       expect(result_set.results).to eq([:doc])
     end
 
-    it "pass the result score to Document.from hash" do
+    it "passes the result score to Document.from_hash" do
       expect(Document).to receive(:from_hash).with(an_instance_of(Hash), sample_elasticsearch_types, 12).and_return(:doc)
 
       result_set = described_class.from_elasticsearch(sample_elasticsearch_types, @response)
       expect(result_set.results).to eq([:doc])
     end
 
-    it "populate the document id and type from the metafields" do
+    it "populates the document id and type from the metafields" do
       expected_hash = hash_including("_type" => "contact", "_id" => "some_id")
       expect(Document).to receive(:from_hash).with(expected_hash, sample_elasticsearch_types, anything).and_return(:doc)
 

--- a/spec/unit/search/specialist_sector_registry_spec.rb
+++ b/spec/unit/search/specialist_sector_registry_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Search::BaseRegistry, 'Specialist Sector' do
     }
   end
 
-  it "can_fetch_sector_by_slug" do
+  it "can fetch sector by slug" do
     allow(@index).to receive(:documents_by_format)
       .with("specialist_sector", anything)
       .and_return([oil_and_gas])
@@ -22,14 +22,14 @@ RSpec.describe Search::BaseRegistry, 'Specialist Sector' do
     expect(oil_and_gas).to eq(sector)
   end
 
-  it "only_required_fields_are_requested_from_index" do
+  it "only required fields are requested from index" do
     expect(@index).to receive(:documents_by_format)
       .with("specialist_sector", sample_field_definitions(%w{link slug title content_id}))
       .and_return([])
     @specialist_sector_registry["oil-and-gas/licensing"]
   end
 
-  it "returns_nil_if_sector_not_found" do
+  it "returns nil if sector not found" do
     allow(@index).to receive(:documents_by_format)
       .with("specialist_sector", anything)
       .and_return([oil_and_gas])
@@ -37,7 +37,7 @@ RSpec.describe Search::BaseRegistry, 'Specialist Sector' do
     expect(sector).to be_nil
   end
 
-  it "uses_300_second_cache_lifetime" do
+  it "uses 300 second cache lifetime" do
     expect(Search::TimedCache).to receive(:new).with(300, anything)
 
     described_class.new(@index, sample_field_definitions, "specialist_sector")

--- a/spec/unit/search/timed_cache_spec.rb
+++ b/spec/unit/search/timed_cache_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe Search::TimedCache do
-  it "result_is_not_called_until_needed" do
+  it "result is not called until needed" do
     fetch = double("fetch")
     expect(fetch).to receive(:call).never
 
     described_class.new(5) { fetch.call }
   end
 
-  it "result_is_cached" do
+  it "result is cached" do
     fetch = double("fetch")
     expect(fetch).to receive(:call).and_return("foo").once
 
@@ -16,7 +16,7 @@ RSpec.describe Search::TimedCache do
     2.times { expect(cache.get).to eq("foo") }
   end
 
-  it "cache_does_not_expire_within_lifetime" do
+  it "cache does not expire within lifetime" do
     fetch = double("fetch")
     expect(fetch).to receive(:call).and_return("foo").once
 
@@ -34,7 +34,7 @@ RSpec.describe Search::TimedCache do
     cache.get
   end
 
-  it "cache_expires" do
+  it "cache expires" do
     fetch = double("fetch")
     expect(fetch).to receive(:call).and_return("foo").twice
 

--- a/spec/unit/search_server_spec.rb
+++ b/spec/unit/search_server_spec.rb
@@ -8,35 +8,35 @@ RSpec.describe SearchIndices::SearchServer do
     schema
   end
 
-  it "returns_an_index" do
+  it "returns an index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index("mainstream_test")
     expect(index).to be_a(SearchIndices::Index)
     expect(index.index_name).to eq("mainstream_test")
   end
 
-  it "returns_an_index_for_govuk_index" do
+  it "returns an index for govuk index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index("govuk_test")
     expect(index).to be_a(SearchIndices::Index)
     expect(index.index_name).to eq("govuk_test")
   end
 
-  it "raises_an_error_for_unknown_index" do
+  it "raises an error for unknown index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     expect {
       search_server.index("z")
     }.to raise_error(SearchIndices::NoSuchIndex)
   end
 
-  it "can_get_multi_index" do
+  it "can get multi index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     index = search_server.index_for_search(%w{mainstream_test page-traffic_test})
     expect(index).to be_a(LegacyClient::IndexForSearch)
     expect(index.index_names).to eq(["mainstream_test", "page-traffic_test"])
   end
 
-  it "raises_an_error_for_unknown_index_in_multi_index" do
+  it "raises an error for unknown index in multi index" do
     search_server = described_class.new("http://l", schema_config, ["mainstream_test", "page-traffic_test"], 'govuk_test', ["mainstream_test"], SearchConfig.new)
     expect {
       search_server.index_for_search(%w{mainstream_test unknown})

--- a/spec/unit/sitemap/property_boost_calculator_spec.rb
+++ b/spec/unit/sitemap/property_boost_calculator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require "sitemap/sitemap"
 
 RSpec.describe PropertyBoostCalculator do
-  it "boosts_are_between_0_and_1" do
+  it "boosts are between 0 and 1" do
     stub_boost_config({
       "format" => {
         "format1" => 0,
@@ -22,7 +22,7 @@ RSpec.describe PropertyBoostCalculator do
     expect(calculator.boost(build_document(format: "format5"))).to eq(1)
   end
 
-  it "unboosted_format_has_default_boost" do
+  it "unboosted format has default boost" do
     stub_boost_config({
       "format" => {
         "some_format" => 1,
@@ -34,7 +34,7 @@ RSpec.describe PropertyBoostCalculator do
     expect(0.5).to eq(calculator.boost(build_document(format: "some_format")))
   end
 
-  it "boosts_limit_is_1" do
+  it "boosts limit is 1" do
     stub_boost_config({
       "format" => {
         "format1" => 10,
@@ -50,7 +50,7 @@ RSpec.describe PropertyBoostCalculator do
     expect(calculator.boost(build_document(format: "format3"))).to eq(1)
   end
 
-  it "unconfigured_format_has_default_boost" do
+  it "unconfigured format has default boost" do
     stub_boost_config({
       "format" => {
         "some_format" => 0.3,
@@ -62,7 +62,7 @@ RSpec.describe PropertyBoostCalculator do
     expect(0.5).to eq(calculator.boost(build_document(format: "other_format")))
   end
 
-  it "unconfigured_property_has_default_boost" do
+  it "unconfigured property has default boost" do
     stub_boost_config({
       "some_other_property" => {
         "some_value" => 0.3,
@@ -74,7 +74,7 @@ RSpec.describe PropertyBoostCalculator do
     expect(0.5).to eq(calculator.boost(build_document(document_type: "some_doc_type")))
   end
 
-  it "boosts_are_rounded" do
+  it "boosts are rounded" do
     stub_boost_config({
       "format" => {
         "format1" => 0.123,
@@ -88,7 +88,7 @@ RSpec.describe PropertyBoostCalculator do
     expect(0.27).to eq(calculator.boost(build_document(format: "format2")))
   end
 
-  it "boosts_for_different_fields_are_combined" do
+  it "boosts for different fields are combined" do
     stub_boost_config({
       "format" => {
         "publication" => 0.5,
@@ -115,7 +115,7 @@ RSpec.describe PropertyBoostCalculator do
     expect(0.07).to eq(calculator.boost(document))
   end
 
-  it "external_search_overrides_are_applied" do
+  it "external search overrides are applied" do
     config = {
       "base" => {
         "format" => {

--- a/spec/unit/sitemap/sitemap_cleanup_spec.rb
+++ b/spec/unit/sitemap/sitemap_cleanup_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SitemapCleanup do
-  it "should_delete_old_sitemaps" do
+  it "should delete old sitemaps" do
     allow(Dir).to receive(:glob).and_return(%w{
       sitemap_2015-03-05T01.xml
       sitemap_1_2015-03-05T01.xml
@@ -26,7 +26,7 @@ RSpec.describe SitemapCleanup do
     cleanup.delete_excess_sitemaps
   end
 
-  it "should_delete_old_sitemaps_with_a_gap_in_days" do
+  it "should delete old sitemaps with a gap in days" do
     allow(Dir).to receive(:glob).and_return(%w{
       sitemap_2015-03-05T01.xml
       sitemap_1_2015-03-05T01.xml

--- a/spec/unit/sitemap/sitemap_generator_spec.rb
+++ b/spec/unit/sitemap/sitemap_generator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator do
-  it "should_generate_sitemap" do
+  it "should generate sitemap" do
     sitemap = described_class.new(index_names: '')
 
     sitemap_xml = sitemap.generate_xml([
@@ -17,7 +17,7 @@ RSpec.describe SitemapGenerator do
     expect(urls[2]).to eq("http://www.dev.gov.uk/yet-another-page")
   end
 
-  it "links_should_include_timestamps" do
+  it "links should include timestamps" do
     sitemap = described_class.new(index_names: '')
 
     sitemap_xml = sitemap.generate_xml([
@@ -29,7 +29,7 @@ RSpec.describe SitemapGenerator do
     expect(pages[0].css("lastmod").text).to eq("2014-01-28T14:41:50+00:00")
   end
 
-  it "missing_timestamps_are_ignored" do
+  it "missing timestamps are ignored" do
     sitemap = described_class.new(index_names: '')
 
     sitemap_xml = sitemap.generate_xml([
@@ -41,7 +41,7 @@ RSpec.describe SitemapGenerator do
     expect_page_has_no_lastmod(pages[0])
   end
 
-  it "page_priority_is_document_priority" do
+  it "page priority is document priority" do
     sitemap = described_class.new(index_names: '')
 
     document = build_document('/some-path')

--- a/spec/unit/sitemap/sitemap_index_spec.rb
+++ b/spec/unit/sitemap/sitemap_index_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Sitemap, 'Index' do
-  it "should_generate_index_sitemap" do
+  it "should generate index sitemap" do
     index_file = StringIO.new
     allow(File).to receive(:open).and_yield(index_file)
     sitemap = described_class.new('/foo')

--- a/spec/unit/sitemap/sitemap_presenter_spec.rb
+++ b/spec/unit/sitemap/sitemap_presenter_spec.rb
@@ -9,25 +9,25 @@ RSpec.describe SitemapPresenter do
     allow(@boost_calculator).to receive(:boost).and_return(1)
   end
 
-  it "url_is_document_link_if_link_is_http_url" do
+  it "url is document link if link is http url" do
     document = build_document(url: "http://some.url")
     presenter = described_class.new(document, @boost_calculator)
     expect(presenter.url).to eq("http://some.url")
   end
 
-  it "url_is_document_link_if_link_is_https_url" do
+  it "url is document link if link is https url" do
     document = build_document(url: "https://some.url")
     presenter = described_class.new(document, @boost_calculator)
     expect(presenter.url).to eq("https://some.url")
   end
 
-  it "url_appends_host_name_if_link_is_a_path" do
+  it "url appends host name if link is a path" do
     document = build_document(url: "/some/path")
     presenter = described_class.new(document, @boost_calculator)
     expect(presenter.url).to eq("https://website_root/some/path")
   end
 
-  it "last_updated_is_timestamp_if_timestamp_is_date_time" do
+  it "last updated is timestamp if timestamp is date time" do
     document = build_document(
       url: "/some/path",
       timestamp: "2014-01-28T14:41:50+00:00"
@@ -36,7 +36,7 @@ RSpec.describe SitemapPresenter do
     expect(presenter.last_updated).to eq("2014-01-28T14:41:50+00:00")
   end
 
-  it "last_updated_is_timestamp_if_timestamp_is_date" do
+  it "last updated is timestamp if timestamp is date" do
     document = build_document(
       url: "/some/path",
       timestamp: "2017-07-12"
@@ -45,7 +45,7 @@ RSpec.describe SitemapPresenter do
     expect(presenter.last_updated).to eq("2017-07-12")
   end
 
-  it "last_updated_is_limited_to_recent_date" do
+  it "last updated is limited to recent date" do
     document = build_document(
       url: "/some/path",
       timestamp: "1995-06-01"
@@ -54,7 +54,7 @@ RSpec.describe SitemapPresenter do
     expect(presenter.last_updated).to eq("2012-10-17T00:00:00+00:00")
   end
 
-  it "last_updated_is_omitted_if_timestamp_is_missing" do
+  it "last updated is omitted if timestamp is missing" do
     document = build_document(
       url: "/some/path",
       timestamp: nil
@@ -63,7 +63,7 @@ RSpec.describe SitemapPresenter do
     expect(presenter.last_updated).to be_nil
   end
 
-  it "last_updated_is_omitted_if_timestamp_is_invalid" do
+  it "last updated is omitted if timestamp is invalid" do
     document = build_document(
       url: "/some/path",
       timestamp: "not-a-date"
@@ -72,7 +72,7 @@ RSpec.describe SitemapPresenter do
     expect(presenter.last_updated).to be_nil
   end
 
-  it "last_updated_is_omitted_if_timestamp_is_in_invalid_format" do
+  it "last updated is omitted if timestamp is in invalid format" do
     document = build_document(
       url: "/some/path",
       timestamp: "01-01-2017"
@@ -81,7 +81,7 @@ RSpec.describe SitemapPresenter do
     expect(presenter.last_updated).to be_nil
   end
 
-  it "default_page_priority_is_maximum_value" do
+  it "default page priority is maximum value" do
     document = build_document(
       url: "/some/path",
       is_withdrawn: false
@@ -90,7 +90,7 @@ RSpec.describe SitemapPresenter do
     expect(presenter.priority).to eq(1)
   end
 
-  it "withdrawn_page_has_lower_priority" do
+  it "withdrawn page has lower priority" do
     document = build_document(
       url: "/some/path",
       is_withdrawn: true
@@ -99,7 +99,7 @@ RSpec.describe SitemapPresenter do
     expect(0.25).to eq(presenter.priority)
   end
 
-  it "page_with_no_withdrawn_flag_has_maximum_priority" do
+  it "page with no withdrawn flag has maximum priority" do
     document = build_document(
       url: "/some/path"
     )
@@ -107,7 +107,7 @@ RSpec.describe SitemapPresenter do
     expect(presenter.priority).to eq(1)
   end
 
-  it "page_with_boosted_format_has_adjusted_priority" do
+  it "page with boosted format has adjusted priority" do
     document = build_document(
       url: "/some/path",
       format: "aaib_report"


### PR DESCRIPTION
These are still not always readable, but I think it's slightly better than before. Thoughts?