### PR TITLE
Revert external content migration

### DIFF
--- a/bin/stats
+++ b/bin/stats
@@ -8,7 +8,7 @@ $LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
 
 require "rummager"
 
-EXCLUDED_FORMATS = ["recommended-link"].freeze
+EXCLUDED_FORMATS = ["recommended-link", "inside-government-link"].freeze
 
 def all_documents(indices)
   Enumerator.new do |yielder|

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -39,7 +39,6 @@ migrated:
 - manual
 - manual_section
 - policy
-- recommended-link # Search admin
 - service_manual_guide
 - service_manual_homepage
 - service_manual_service_standard
@@ -52,7 +51,8 @@ migrated:
   - '/help'
   - '/find-local-council'
 
-indexable: []
+indexable:
+- recommended-link
 
 non_indexable:
 - calculator

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -1,5 +1,5 @@
 class SitemapGenerator
-  EXCLUDED_FORMATS = ["recommended-link"].freeze
+  EXCLUDED_FORMATS = ["recommended-link", "inside-government-link"].freeze
 
   def initialize(search_config)
     @search_config = search_config

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -95,6 +95,26 @@ RSpec.describe 'SitemapGeneratorTest' do
     expect(sitemap_xml[0]).not_to include("/external-example-answer")
   end
 
+  it "should_not_include_inside_government_links" do
+    generator = SitemapGenerator.new(SearchConfig.instance)
+    add_sample_documents(
+      [
+        {
+          "title" => "Some content from Inside Gov",
+          "description" => "We list some inside gov results in the mainstream index.",
+          "format" => "inside-government-link",
+          "link" => "https://www.gov.uk/government/some-content",
+        },
+      ],
+      index_name: 'government_test'
+    )
+
+    sitemap_xml = generator.sitemaps
+
+    expect(sitemap_xml.length).to eq(1)
+    expect(sitemap_xml[0]).not_to include("/government/some-content")
+  end
+
   it "links_should_include_timestamps" do
     generator = SitemapGenerator.new(SearchConfig.instance)
     add_sample_documents(


### PR DESCRIPTION
Temporarily revert migration of the `recommended-link` format, and a format cleanup which depends on it.

Using content IDs as document IDs for external content breaks best bets, because they depend on the link being the same as the document ID.

We can reapply these changes once we've fixed best bets.

https://trello.com/c/qzVTvlPe/539-mark-external-links-as-migrated