### PR TITLE
Migrate external content

### DIFF
--- a/bin/stats
+++ b/bin/stats
@@ -8,7 +8,7 @@ $LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
 
 require "rummager"
 
-EXCLUDED_FORMATS = ["recommended-link", "inside-government-link"].freeze
+EXCLUDED_FORMATS = ["recommended-link"].freeze
 
 def all_documents(indices)
   Enumerator.new do |yielder|

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -39,6 +39,7 @@ migrated:
 - manual
 - manual_section
 - policy
+- recommended-link # Search admin
 - service_manual_guide
 - service_manual_homepage
 - service_manual_service_standard
@@ -51,8 +52,7 @@ migrated:
   - '/help'
   - '/find-local-council'
 
-indexable:
-- recommended-link
+indexable: []
 
 non_indexable:
 - calculator

--- a/lib/search/query_components/best_bets.rb
+++ b/lib/search/query_components/best_bets.rb
@@ -16,7 +16,7 @@ module QueryComponents
       }
 
       unless worst_bets.empty?
-        result[:bool][:must_not] = [{ ids: { values: worst_bets } }]
+        result[:bool][:must_not] = [{ terms: { link: worst_bets } }]
       end
 
       result
@@ -38,7 +38,7 @@ module QueryComponents
         {
           function_score: {
             query: {
-              ids: { values: links },
+              terms: { link: links },
             },
             boost_factor: (bb_max_position + 1 - position) * 1_000_000,
           }

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -1,5 +1,5 @@
 class SitemapGenerator
-  EXCLUDED_FORMATS = ["recommended-link", "inside-government-link"].freeze
+  EXCLUDED_FORMATS = ["recommended-link"].freeze
 
   def initialize(search_config)
     @search_config = search_config

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -95,26 +95,6 @@ RSpec.describe 'SitemapGeneratorTest' do
     expect(sitemap_xml[0]).not_to include("/external-example-answer")
   end
 
-  it "should_not_include_inside_government_links" do
-    generator = SitemapGenerator.new(SearchConfig.instance)
-    add_sample_documents(
-      [
-        {
-          "title" => "Some content from Inside Gov",
-          "description" => "We list some inside gov results in the mainstream index.",
-          "format" => "inside-government-link",
-          "link" => "https://www.gov.uk/government/some-content",
-        },
-      ],
-      index_name: 'government_test'
-    )
-
-    sitemap_xml = generator.sitemaps
-
-    expect(sitemap_xml.length).to eq(1)
-    expect(sitemap_xml[0]).not_to include("/government/some-content")
-  end
-
   it "links_should_include_timestamps" do
     generator = SitemapGenerator.new(SearchConfig.instance)
     add_sample_documents(

--- a/spec/unit/query_components/best_bets_spec.rb
+++ b/spec/unit/query_components/best_bets_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe QueryComponents::BestBets do
 
       result = builder.wrap('QUERY')
 
-      expected = { bool: { should: ['QUERY', { function_score: { query: { ids: { values: ["/best-bet"] } }, boost_factor: 1000000 } }] } }
+      expected = { bool: { should: ['QUERY', { function_score: { query: { terms: { link: ["/best-bet"] } }, boost_factor: 1000000 } }] } }
       expect(result).to eq(expected)
     end
   end
@@ -36,8 +36,8 @@ RSpec.describe QueryComponents::BestBets do
       expected = {
         bool: {
           should: ['QUERY',
-                   { function_score: { query: { ids: { values: ["/best-bet"] } }, boost_factor: 2000000 } },
-                   { function_score: { query: { ids: { values: ["/other-best-bet"] } }, boost_factor: 1000000 } }
+                   { function_score: { query: { terms: { link: ["/best-bet"] } }, boost_factor: 2000000 } },
+                   { function_score: { query: { terms: { link: ["/other-best-bet"] } }, boost_factor: 1000000 } }
             ]
         }
       }
@@ -53,7 +53,7 @@ RSpec.describe QueryComponents::BestBets do
 
       result = builder.wrap('QUERY')
 
-      expected = { bool: { should: ['QUERY', { function_score: { query: { ids: { values: ["/best-bet", "/other-best-bet"] } }, boost_factor: 1000000 } }] } }
+      expected = { bool: { should: ['QUERY', { function_score: { query: { terms: { link: ["/best-bet", "/other-best-bet"] } }, boost_factor: 1000000 } }] } }
       expect(result).to eq(expected)
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe QueryComponents::BestBets do
 
       result = builder.wrap({})
 
-      expected = { bool: { should: [{}], must_not: [{ ids: { values: ["/worst-bet", "/other-worst-bet"] } }] } }
+      expected = { bool: { should: [{}], must_not: [{ terms: { link: ["/worst-bet", "/other-worst-bet"] } }] } }
       expect(result).to eq(expected)
     end
   end


### PR DESCRIPTION
This reintroduces the change to start reading external content from the `govuk` index.

Best bets are now looked up by the `link` field, because that's what is actually written to the metasearch index.

This was previously relying on `link` and `id` being the same. We changed the `id` for external content to the `content_id` to make it easier to keep the data in sync with publishing api.

Trello: https://trello.com/c/qzVTvlPe/539-mark-external-links-as-migrated
  