### PR TITLE
Correct insert stemmed_query_as_term for metasearch index

### DIFF
--- a/lib/metasearch_index/client.rb
+++ b/lib/metasearch_index/client.rb
@@ -1,5 +1,13 @@
 module MetasearchIndex
   class Client < Index::Client
+    class << self
+      delegate :analyze, to: :instance
+    end
+
+    def analyze(params)
+      client.indices.analyze(params.merge(index: index_name))
+    end
+
   private
 
     def index_name

--- a/lib/metasearch_index/inserter.rb
+++ b/lib/metasearch_index/inserter.rb
@@ -24,9 +24,17 @@ module MetasearchIndex
         {
           exact_query: @document["exact_query"],
           stemmed_query: @document["stemmed_query"],
-          stemmed_query_as_term: @document["stemmed_query_as_term"],
+          stemmed_query_as_term: @document["stemmed_query"].presence && " #{analyzed_stemmed_query} ",
           details: @document["details"],
         }
+      end
+
+      def analyzed_stemmed_query
+        analyzed_query = MetasearchIndex::Client.analyze(
+          body: @document["stemmed_query"],
+          analyzer: "best_bet_stemmed_match",
+        )
+        analyzed_query["tokens"].map { |token_info| token_info["token"] }.join(" ")
       end
     end
   end

--- a/spec/integration/metasearch_index/inserter_spec.rb
+++ b/spec/integration/metasearch_index/inserter_spec.rb
@@ -34,12 +34,28 @@ RSpec.describe MetasearchIndex::Inserter::V2 do
       "details" => %[{"best_bets":[{"link":"/government/publications/national-insurance-statement-of-national-insurance-contributions-ca3916","position":1}],"worst_bets":[]}],
       "exact_query" => "ca3916",
       "stemmed_query" => nil,
-      "stemmed_query_as_term" => nil,
     }
     described_class.new(id: "ca3916-exact", document: document).insert
     commit_index("metasearch_test")
 
     expect_document_is_in_rummager(document, type: "best_bet", index: "metasearch_test", id: "ca3916-exact")
+  end
+
+  it "can insert a new stemmed document" do
+    document = {
+      "details" => %[{"best_bets":[{"link":"/government/publications/national-insurance-statement-of-national-insurance-contributions-ca3916","position":1}],"worst_bets":[]}],
+      "exact_query" => nil,
+      "stemmed_query" => "car taxes",
+    }
+    described_class.new(id: "car tax-stemmed", document: document).insert
+    commit_index("metasearch_test")
+
+    expect_document_is_in_rummager(
+      document.merge("stemmed_query_as_term" => " car tax "),
+      type: "best_bet",
+      index: "metasearch_test",
+      id: "car tax-stemmed",
+    )
   end
 
   it "can overwrite an existing document" do
@@ -53,7 +69,6 @@ RSpec.describe MetasearchIndex::Inserter::V2 do
       "details" => %[{"best_bets":[{"link":"/government/publications/national-insurance-statement-of-national-insurance-contributions-ca3916","position":1}],"worst_bets":[]}],
       "exact_query" => "ca3916",
       "stemmed_query" => nil,
-      "stemmed_query_as_term" => nil,
     }
     described_class.new(id: "ca3916-exact", document: document).insert
     commit_index("metasearch_test")
@@ -70,7 +85,6 @@ RSpec.describe MetasearchIndex::Inserter::V2 do
       "details" => %[{"best_bets":[{"link":"/government/publications/national-insurance-statement-of-national-insurance-contributions-ca3916","position":1}],"worst_bets":[]}],
       "exact_query" => "ca3916",
       "stemmed_query" => nil,
-      "stemmed_query_as_term" => nil,
     }
     expect do
       described_class.new(id: "ca3916-exact", document: document).insert


### PR DESCRIPTION
This value is generated on insertion which was missed from the initial
implementation. This creates a bug which effects multiple word stemmed
queries.

https://trello.com/c/9DQzn47B/554-bets-bets-bug-with-stemmed-car-hire-query-matching-any-queries-containing-car
  