### PR TITLE
Enable rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 Style/ConditionalAssignment:
   Enabled: false
 


### PR DESCRIPTION
rubocop-rspec is a dependency of govuk-lint, but it doesn't seem to be used by default.

See https://github.com/backus/rubocop-rspec#usage

Our tests aren't very idiomatic at the moment. Enabling this increases the total number of offenses commited in `spec/` from 90 to 1807. I'm not going to attempt to fix those now but enabling this should prompt us to improve any tests we change.

https://github.com/alphagov/rummager/issues/1107