### PR TITLE
Fix topic expansion in filters

### DIFF
--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -37,7 +37,7 @@ module Search
 
     def specialist_sectors
       BaseRegistry.new(
-        search_server.index_for_search(search_config.content_index_names),
+        search_server.index_for_search([search_config.govuk_index_name]),
         field_definitions,
         "specialist_sector"
       )

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "expandinging of organisations" do
+  it "expands organisations" do
     commit_document("government_test",
       "title" => 'Advice on Treatment of Dragons',
       "link" => '/dragon-guide',
@@ -383,7 +383,7 @@ RSpec.describe 'SearchTest' do
     )
   end
 
-  it "expandinging of organisations via content_id" do
+  it "expands organisations via content_id" do
     commit_document(
       "government_test",
       "title" => 'Advice on Treatment of Dragons',
@@ -468,14 +468,14 @@ RSpec.describe 'SearchTest' do
     expect(first_result['expanded_organisations']).to be_truthy
   end
 
-  it "expandinging of topics" do
+  it "expands topics" do
     commit_document("government_test",
       "title" => 'Advice on Treatment of Dragons',
       "link" => '/dragon-guide',
       "topic_content_ids" => ['topic-content-id']
     )
 
-    commit_document("government_test",
+    commit_document("govuk_test",
       "content_id" => 'topic-content-id',
       "slug" => 'topic-magic',
       "title" => 'Magic topic',


### PR DESCRIPTION
When search results are aggregated by topic (aka specialist sector), rummager should expand the topic details to add other fields like title and content ID. This expanded data comes from a one-off query stored in a registry.

This expansion broke when we retired the mainstream index because topics were stored in the mainstream index but the registries code had _not_ been migrated to use the govuk index.

This broke pages which rely on topic aggregation, such as https://www.gov.uk/government/organisations/environment-agency/services-information

All other registries use the government index (which has not yet been migrated to govuk), so they can be left as they are.
  