### PR TITLE
Handle messages with no details hash in tests

### DIFF
--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -44,7 +44,12 @@ module SpecHelpers
     retry_attempts.times do
       random_example = GovukSchemas::RandomExample.for_schema(notification_schema: schema) do |hash|
         hash.merge!(payload.stringify_keys)
-        hash["details"].merge!(details.stringify_keys)
+
+        unless details.empty?
+          document_details = hash["details"] || {}
+          hash["details"] = document_details.merge(details.stringify_keys)
+        end
+
         hash.delete_if { |k, _| excluded_fields.include?(k) }
         hash
       end


### PR DESCRIPTION
Allow the tests to handle randomly generated schema examples which do not include a `details` hash.

Rummager can already process content without `details` because Redirect and Vanish messages do not have this field. This change allows us to add the same constraint to the content schemas.

https://trello.com/c/uV5zDvzu/97-add-schema-tests-to-the-publishing-api

This should fix the failing downstream test in alphagov/govuk-content-schemas#700.