### PR TITLE
Add residential property tribunal decisions schema

### DIFF
--- a/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
@@ -1,0 +1,7 @@
+{
+  "fields": [
+    "tribunal_decision_category",
+    "tribunal_decision_sub_category",
+    "tribunal_decision_decision_date"
+  ]
+}

--- a/config/schema/indexes/govuk.json
+++ b/config/schema/indexes/govuk.json
@@ -21,6 +21,7 @@
     "medical_safety_alert",
     "policy",
     "raib_report",
+    "residential_property_tribunal_decision",
     "service_manual_guide",
     "service_manual_topic",
     "service_standard_report",


### PR DESCRIPTION
The Residential Property Tribunal Judiciary publishes decisions that describe the outcome of a residential property tribunal case. This commit adds the schema for such a decision. 

For: https://trello.com/c/qzSMAFHZ/6-3-moj-residential-tribunals-finder