### PR TITLE
Check that new doc type is indexed

### DIFF
--- a/spec/integration/govuk_index/specialist_formats_spec.rb
+++ b/spec/integration/govuk_index/specialist_formats_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe 'SpecialistFormatTest' do
       maib_report
       medical_safety_alert
       raib_report
+      residential_property_tribunal_decision
       service_standard_report
       tax_tribunal_decision
       utaac_decision


### PR DESCRIPTION
This checks that the new `residential_property_tribunal_decision` doc type added is indexed

For: https://trello.com/c/qzSMAFHZ/6-3-moj-residential-tribunals-finder