### PR TITLE
Add expanded_search_result_fields to residential_property_tribunal_decision schema

### DIFF
--- a/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
@@ -3,5 +3,216 @@
     "tribunal_decision_category",
     "tribunal_decision_sub_category",
     "tribunal_decision_decision_date"
-  ]
+  ],
+
+  "expanded_search_result_fields": {
+    "tribunal_decision_category": [
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016"
+      },
+      {
+        "label": "Leasehold disputes (management)",
+        "value": "leasehold-disputes-management"
+      },
+      {
+        "label": "Leasehold enfranchisement and extension",
+        "value": "leasehold-enfranchisement-and-extension"
+      },
+      {
+        "label": "Park homes",
+        "value": "park-homes"
+      },
+      {
+        "label": "Rents",
+        "value": "rents"
+      },
+      {
+        "label": "Right to Buy",
+        "value": "right-to-buy"
+      },
+      {
+        "label": "Tenant associations",
+        "value": "tenant-associations"
+      }
+    ],
+    "tribunal_decision_sub_category": [
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Rent repayment orders",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---rent-repayment-orders"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Improvement notices",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---improvement-notices"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Prohibition orders",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---prohibition-orders"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Demolition and closing orders",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---demolition-and-closing-orders"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Emergency notices and orders",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---emergency-notices-and-orders"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Empty dwelling management orders",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---empty-dwelling-management-orders"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Houses in multiple occupation licensing",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---houses-in-multiple-occupation-licensing"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Selective licensing",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---selective-licensing"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Banning orders",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---banning-orders"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Civil financial penalties",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---civil-financial-penalties"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Management orders",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---management-orders"
+      },
+      {
+        "label": "Housing Act 2004 and Housing and Planning Act 2016 - Overcrowding notices",
+        "value": "housing-act-2004-and-housing-and-planning-act-2016---overcrowding-notices"
+      },
+      {
+        "label": "Leasehold disputes (management) - Service charges",
+        "value": "leasehold-disputes-management---service-charges"
+      },
+      {
+        "label": "Leasehold disputes (management) - Administration charges",
+        "value": "leasehold-disputes-management---administration-charges"
+      },
+      {
+        "label": "Leasehold disputes (management) - Appointment of manager",
+        "value": "leasehold-disputes-management---appointment-of-manager"
+      },
+      {
+        "label": "Leasehold disputes (management) - Right to Manage",
+        "value": "leasehold-disputes-management---right-to-manage"
+      },
+      {
+        "label": "Leasehold disputes (management) - Variation of leases",
+        "value": "leasehold-disputes-management---variation-of-leases"
+      },
+      {
+        "label": "Leasehold disputes (management) - Breach of lease/forfeiture",
+        "value": "leasehold-disputes-management---breach-of-lease-forfeiture"
+      },
+      {
+        "label": "Leasehold disputes (management) - Estate charges/estate management schemes",
+        "value": "leasehold-disputes-management---estate-charges-estate-management-schemes"
+      },
+      {
+        "label": "Leasehold enfranchisement and extension - Flats - lease extension",
+        "value": "leasehold-enfranchisement-and-extension---flats-lease-extension"
+      },
+      {
+        "label": "Leasehold enfranchisement and extension - Houses - enfranchisement",
+        "value": "leasehold-enfranchisement-and-extension---houses-enfranchisement"
+      },
+      {
+        "label": "Leasehold enfranchisement and extension - Flats - collective enfranchisement",
+        "value": "leasehold-enfranchisement-and-extension---flats-collective-enfranchisement"
+      },
+      {
+        "label": "Leasehold enfranchisement and extension - Right of first refusal",
+        "value": "leasehold-enfranchisement-and-extension---right-of-first-refusal"
+      },
+      {
+        "label": "Park homes - Pitch fee",
+        "value": "park-homes---pitch-fee"
+      },
+      {
+        "label": "Park homes - Section 4 - any Question Under Act or Agreement",
+        "value": "park-homes---section-4-any-question-under-act-or-agreement"
+      },
+      {
+        "label": "Park homes - Local authority compliance notice",
+        "value": "park-homes---local-authority-compliance-notice"
+      },
+      {
+        "label": "Park homes - Appeal against/alteration of a site licence condition",
+        "value": "park-homes---appeal-against-alteration-of-a-site-licence-condition"
+      },
+      {
+        "label": "Park homes - Local authority decision - emergency action",
+        "value": "park-homes---local-authority-decision-emergency-action"
+      },
+      {
+        "label": "Park homes - Local authority site licence refusal/refusal to transfer",
+        "value": "park-homes---local-authority-site-licence-refusal-refusal-to-transfer"
+      },
+      {
+        "label": "Park homes - Site owner's failure to deposit site rules with local authority",
+        "value": "park-homes---site-owners-failure-to-deposit-site-rules-with-local-authority"
+      },
+      {
+        "label": "Park homes - Site rule change - consultation response",
+        "value": "park-homes---site-rule-change-consultation-response"
+      },
+      {
+        "label": "Park homes - Park home having a detrimental effect",
+        "value": "park-homes---park-home-having-a-detrimental-effect"
+      },
+      {
+        "label": "Park homes - Order relating to implied and express terms",
+        "value": "park-homes---order-relating-to-implied-and-express-terms"
+      },
+      {
+        "label": "Park homes - Recognition of residents association",
+        "value": "park-homes---recognition-of-residents-association"
+      },
+      {
+        "label": "Park homes - Refusal orders against giving/assigning home",
+        "value": "park-homes---refusal-orders-against-giving-assigning-home"
+      },
+      {
+        "label": "Park homes - Site licence - payment of annual fee",
+        "value": "park-homes---site-licence-payment-of-annual-fee"
+      },
+      {
+        "label": "Park homes - Order requiring written statement of terms",
+        "value": "park-homes---order-requiring-written-statement-of-terms"
+      },
+      {
+        "label": "Park homes - Temporary re-siting/return of resited park home",
+        "value": "park-homes---temporary-re-siting-return-of-resited-park-home"
+      },
+      {
+        "label": "Park homes - Entitlement to terminate an agreement for occupation",
+        "value": "park-homes---entitlement-to-terminate-an-agreement-for-occupation"
+      },
+      {
+        "label": "Rents - Market rent (assured shorthold tenancy)",
+        "value": "rents---market-rent-assured-shorthold-tenancy"
+      },
+      {
+        "label": "Rents - Fair rent",
+        "value": "rents---fair-rent"
+      },
+      {
+        "label": "Right to Buy - Right to Buy appeals - elderly persons",
+        "value": "right-to-buy---right-to-buy-appeals-elderly-persons"
+      },
+      {
+        "label": "Tenant associations - Recognition of tenants association",
+        "value": "tenant-associations---recognition-of-tenants-association"
+      },
+      {
+        "label": "Tenant associations - Request for information",
+        "value": "tenant-associations---request-for-information"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
For: https://trello.com/c/qzSMAFHZ/6-3-moj-residential-tribunals-finder

This allows rummager to translate the computer-readable values from the
document into human-readable values when it presents the search results as
json.  This may be a bit of tech debt that we should clean up as we
thought this config was deprecated.  The approach under discussion is that
we either:

1. Push both human and computer readable values into the documents
   provided to rummager
2. Make finder-frontend do the same as government-frontend and use the
   facet definitions of the finder to do the translations for us.

See alphagov/specialist-publisher#1147 and alphagov/govuk-content-schemas#713 for comparisons.