### PR TITLE
Zip page traffic data on sidekiq

### DIFF
--- a/lib/govuk_index/page_traffic_worker.rb
+++ b/lib/govuk_index/page_traffic_worker.rb
@@ -4,7 +4,14 @@ module GovukIndex
     QUEUE_NAME = 'bulk'.freeze
     sidekiq_options queue: QUEUE_NAME
 
-    def perform(records, destination_index)
+    def self.perform_async(records, destination_index)
+      data = Base64.encode64(Zlib::Deflate.deflate(Sidekiq.dump_json(records)))
+      super(data, destination_index)
+    end
+
+    def perform(data, destination_index)
+      records = Sidekiq.load_json(Zlib::Inflate.inflate(Base64.decode64(data)))
+
       actions = Index::ElasticsearchProcessor.new(client: GovukIndex::Client.new(timeout: BULK_INDEX_TIMEOUT, index_name: destination_index))
 
       records.each_slice(2) do |identifier, document|

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -30,6 +30,7 @@ require 'time'
 require 'unf'
 require 'uri'
 require 'yaml'
+require 'zlib'
 
 initializers_path = File.expand_path("../config/initializers/*.rb", __dir__)
 Dir[initializers_path].each { |f| require f }


### PR DESCRIPTION
As we need to process the entire index onto the sidekiq queue we have added
zipping which see a reduction of about 60% in the amount of data put into
memory. This solution has been coded into teh actual worker so it is easy to
see the deflate/inflate methods being called.

https://trello.com/c/JHcwDJc0/81-compress-rummager-data-in-sidekiq-when-updating-pageviews