### PR TITLE
Add missing require in unicorn config

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,3 +1,5 @@
+require "govuk_app_config"
+
 GovukUnicorn.configure(self)
 
 working_directory File.dirname(File.dirname(__FILE__))


### PR DESCRIPTION
We missed this step when updating govuk_app_config to version 1.3 in https://github.com/alphagov/rummager/pull/1167

This require statement is already included in rummager.rb, but the config file may be evaluated before that file is loaded.