### PR TITLE
Revert using foreman in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME rummager
 ENV REDIS_HOST redis
@@ -19,4 +20,4 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-CMD bundle exec foreman run web
+CMD foreman run web

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 5.1.5"
 gem "elasticsearch", "~> 2"
-gem "foreman", "~> 0.84"
 gem "gds-api-adapters", "~> 51.2"
 gem "govuk_app_config", "~> 1.3.1"
 gem "govuk_document_types", "~> 0.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,6 @@ GEM
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     gds-api-adapters (51.2.0)
       addressable
       link_header
@@ -217,7 +215,6 @@ GEM
       rack-protection (= 2.0.1)
       tilt (~> 2.0)
     statsd-ruby (1.4.0)
-    thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
@@ -244,7 +241,6 @@ DEPENDENCIES
   activesupport (~> 5.1.5)
   bunny-mock (~> 1.7)
   elasticsearch (~> 2)
-  foreman (~> 0.84)
   gds-api-adapters (~> 51.2)
   govuk-content-schema-test-helpers (~> 1.6.0)
   govuk-lint (~> 3.6.0)


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

This removes foreman from the Gemfile and instead installs foreman
separately via `gem install` in the Dockerfile so that it can be used in the
docker environment.

The reason for this is that running everything via unicorn in dev can
cause some wtfs (such as breaking better_errors) and installing foreman
via Gemfile does contradict some contenious advice given by the foreman
gem maintainer.