### PR TITLE
Remove Sentry logging of InvalidFormatError

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -7,7 +7,6 @@ module GovukIndex
   class UnknownDocumentTypeError < StandardError; end
   class NotIdentifiable < StandardError; end
   class MissingExternalUrl < StandardError; end
-  class InvalidFormatError < StandardError; end
 
   DOCUMENT_TYPES_WITHOUT_BASE_PATH = %w(contact world_location).freeze
 
@@ -61,7 +60,6 @@ module GovukIndex
         processor.save(presenter)
       else
         logger.info("#{routing_key} -> UNKNOWN #{identifier}")
-        GovukError.notify(InvalidFormatError.new, extra: { message_body: payload, error_message: "#{presenter.format} is an invalid format" })
       end
 
     # Rescuing as we don't want to retry this class of error

--- a/spec/unit/govuk_index/publishing_event_worker_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_worker_spec.rb
@@ -23,33 +23,6 @@ RSpec.describe GovukIndex::PublishingEventWorker do
       subject.perform([['routing.key', payload]])
     end
 
-    context "when a message containing an invalid format is received" do
-      let(:actions) { Index::ElasticsearchProcessor.govuk }
-      payload = {
-        "base_path" => "/cheese",
-        "document_type" => "dossier_of_cheese",
-        "title" => "We love cheese",
-        "content_id" => "sc8b0284-0deg-d4d2-8af0-29c50gd88b7e",
-      }
-
-      it "notifies of a validation error" do
-        expect(GovukError).to receive(:notify).with(
-          instance_of(GovukIndex::InvalidFormatError),
-          extra: {
-            message_body: {
-              "base_path" => "/cheese",
-              "document_type" => "dossier_of_cheese",
-              "title" => "We love cheese",
-              "content_id" => "sc8b0284-0deg-d4d2-8af0-29c50gd88b7e",
-            },
-            error_message: "dossier_of_cheese is an invalid format"
-          }
-        )
-
-        subject.perform([['routing.key', payload]])
-      end
-    end
-
     context "when a message to unpublish the document is received" do
       it "will delete the document" do
         payload = {


### PR DESCRIPTION
The invalid format error is an extremely common error - it is logged in
Sentry 152k times and we (those working on Publishing E2E Tests) see it
all the time in our logs.

Since this is not actually an exceptional circumstance and rather the
norm until something is set up then this shouldn't be logged in this
manner as it's unlikely to be providing any value.

Addresses: https://github.com/alphagov/publishing-e2e-tests/issues/208