### PR TITLE
Publish advanced search finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ These are used by [search admin](https://github.com/alphagov/search-admin/).
 	functionality.
 - [Popularity information](doc/popularity.md): Rummager uses Google Analytics
 	data to improve search results.
+- [Publishing advanced search](doc/advanced-search.md): A task to publish the advanced search finder content item
 
 ## Licence
 

--- a/config/advanced-search.yml
+++ b/config/advanced-search.yml
@@ -1,0 +1,59 @@
+---
+base_path: "/search/advanced"
+content_id: 3df77dea-00c5-43f0-8f31-d08b8bd2a4d6
+content_purpose_document_supertype: navigation
+document_type: finder
+locale: en
+name: Advanced search
+phase: live
+pre_production: true
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder
+search_user_need_document_supertype: government
+title: Latest on GOV.UK
+update_type: minor
+details:
+  document_noun: result
+  reject:
+    content_store_document_type:
+    - browse
+  show_summaries: true
+  facets:
+  - filter_key: content_purpose_subgroup
+    key: subgroup
+    name: Publication type
+    type: text
+    preposition: in
+    display_as_result_metadata: false
+    filterable: true
+    allowed_values: []
+  - key: public_timestamp
+    name: Publication date
+    short_name: '' 
+    type: date
+    preposition: published
+    display_as_result_metadata: true
+    filterable: true
+  - filter_key: taxons
+    key: topic
+    name: Taxonomy
+    type: hidden
+    preposition: ''
+    display_as_result_metadata: true
+    filterable: true
+    allowed_values: []
+  - filter_key: content_purpose_supergroup
+    key: group
+    name: Content purpose supergroup
+    type: hidden
+    preposition: ''
+    display_as_result_metadata: false
+    filterable: true
+    allowed_values: []
+  default_documents_per_page: 20
+routes:
+- path: "/search/advanced"
+  type: exact
+- path: "/search/advanced.json"
+  type: exact

--- a/config/advanced-search.yml
+++ b/config/advanced-search.yml
@@ -2,7 +2,7 @@
 base_path: "/search/advanced"
 content_id: 3df77dea-00c5-43f0-8f31-d08b8bd2a4d6
 content_purpose_document_supertype: navigation
-document_type: finder
+document_type: search
 locale: en
 name: Advanced search
 phase: live

--- a/doc/advanced-search.md
+++ b/doc/advanced-search.md
@@ -1,0 +1,8 @@
+# Advanced search
+
+Advanced search is a custom finder available at the path `/search/advanced`.
+
+Rummager assumes the responsibility of publishing the Advanced Search Finder via a rake task.
+
+The rummager task `publishing_api:publish_advanced_search_finder` uses the contents of `config/advanced-search.yml`
+as the basis of a payload which is drafted and published to the Publishing API.

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -1,0 +1,80 @@
+require "gds_api/publishing_api_v2"
+
+class PublishingApiFinderPublisher
+  def initialize(finder, timestamp = Time.now.iso8601, logger = Logger.new(STDOUT))
+    @finder = finder
+    @logger = logger
+    @timestamp = timestamp
+  end
+
+  def call
+    if pre_production?(finder)
+      publish(finder)
+    else
+      logger.info("Not publishing #{finder['name']} because it's not pre_production")
+    end
+  end
+
+private
+
+  attr_reader :finder, :logger, :timestamp
+
+  def publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+      timeout: 10,
+    )
+  end
+
+  def publish(finder)
+    export_finder(finder)
+  end
+
+  def pre_production?(finder)
+    finder["pre_production"] == true
+  end
+
+  def export_finder(finder)
+    presenter = FinderContentItemPresenter.new(finder, timestamp)
+
+    logger.info("Publishing '#{presenter.name}' finder")
+
+    publishing_api.put_content(presenter.content_id, presenter.present)
+    publishing_api.patch_links(presenter.content_id, presenter.present_links)
+    publishing_api.publish(presenter.content_id)
+  end
+end
+
+class FinderContentItemPresenter
+  attr_reader :content_id, :finder, :name, :timestamp
+
+  def initialize(finder, timestamp)
+    @finder = finder
+    @content_id = finder["content_id"]
+    @name = finder["name"]
+    @timestamp = timestamp
+  end
+
+  def present
+    {
+      base_path: finder["base_path"],
+      description: finder["description"],
+      details: finder["details"].except("reject"),
+      document_type: finder["document_type"],
+      locale: "en",
+      phase: "live",
+      public_updated_at: timestamp,
+      publishing_app: finder["publishing_app"],
+      rendering_app: finder["rendering_app"],
+      routes: finder["routes"],
+      schema_name: finder["schema_name"],
+      title: finder["title"],
+      update_type: "minor",
+    }
+  end
+
+  def present_links
+    { content_id: content_id, links: {} }
+  end
+end

--- a/lib/tasks/advanced_search.rake
+++ b/lib/tasks/advanced_search.rake
@@ -1,0 +1,11 @@
+require "publishing_api_finder_publisher"
+
+namespace :publishing_api do
+  desc "Publish advanced-search finder."
+  task :publish_advanced_search_finder do
+    finder = YAML.load_file("config/advanced-search.yml")
+    timestamp = Time.now.iso8601
+
+    PublishingApiFinderPublisher.new(finder, timestamp).call
+  end
+end

--- a/spec/unit/publishing_api_finder_publisher_spec.rb
+++ b/spec/unit/publishing_api_finder_publisher_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+require "publishing_api_finder_publisher"
+
+RSpec.describe PublishingApiFinderPublisher do
+  subject(:instance) { described_class.new(finder, timestamp) }
+
+  let(:finder) {
+    YAML.load_file(File.join(Dir.pwd, "config", "advanced-search.yml"))
+  }
+  let(:content_id) { finder["content_id"] }
+  let(:timestamp) { Time.now.iso8601 }
+  let(:logger) { instance_double("Logger") }
+
+  before do
+    allow(Logger).to receive(:new).and_return(logger)
+  end
+
+  describe "#call" do
+    context "with a pre-production finder" do
+      let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+      let(:payload) {
+        FinderContentItemPresenter.new(finder, timestamp).present
+      }
+
+      before do
+        allow(logger).to receive(:info)
+        allow(GdsApi::PublishingApiV2).to receive(:new).and_return(publishing_api)
+        allow(publishing_api).to receive(:put_content)
+        allow(publishing_api).to receive(:patch_links)
+        allow(publishing_api).to receive(:publish)
+
+        instance.call
+      end
+
+      it "drafts the finder" do
+        expect(publishing_api).to have_received(:put_content).with(content_id, payload)
+      end
+
+      it "patches links for the finder" do
+        expect(publishing_api).to have_received(:patch_links)
+          .with(content_id, { content_id: content_id, links: {} })
+      end
+
+      it "publishes the finder to the Publishing API" do
+        expect(publishing_api).to have_received(:publish).with(content_id)
+      end
+    end
+
+    context "when a finder isn't pre-production" do
+      before do
+        finder.delete("pre_production")
+        allow(logger).to receive(:info)
+      end
+
+      it "reports that the finder is not pre-production" do
+        instance.call
+
+        expect(logger).to have_received(:info)
+          .with("Not publishing Advanced search because it's not pre_production")
+      end
+    end
+  end
+
+  describe FinderContentItemPresenter do
+    subject(:instance) { described_class.new(finder, timestamp) }
+
+    before do
+      GovukContentSchemaTestHelpers.configure do |config|
+        config.schema_type = 'publisher_v2'
+        config.project_root = File.expand_path(Dir.pwd)
+      end
+    end
+
+    it "presents a valid payload" do
+      validator = GovukContentSchemaTestHelpers::Validator.new("finder", "schema", instance.present)
+      validator.valid?
+
+      expect(validator.errors).to be_empty
+    end
+
+    it "exposes the content_id" do
+      expect(instance.content_id).to eq(content_id)
+    end
+
+    it "sets the public_updated_at value" do
+      expect(instance.present[:public_updated_at]).to eq(timestamp)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/ACZBT7Dk/120-build-a-way-to-publish-the-new-finder

Adds a Rake task and underlying class to publish a finder content item from YAML config (similar to the mechanics of publishing finders in Specialist Publisher).
