### PR TITLE
Update advanced search content item

### DIFF
--- a/config/advanced-search.yml
+++ b/config/advanced-search.yml
@@ -6,7 +6,6 @@ document_type: search
 locale: en
 name: Advanced search
 phase: live
-pre_production: true
 publishing_app: rummager
 rendering_app: finder-frontend
 schema_name: finder

--- a/config/advanced-search.yml
+++ b/config/advanced-search.yml
@@ -29,7 +29,6 @@ details:
     allowed_values: []
   - key: public_timestamp
     name: Publication date
-    short_name: '' 
     type: date
     preposition: published
     display_as_result_metadata: true

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -8,11 +8,7 @@ class PublishingApiFinderPublisher
   end
 
   def call
-    if pre_production?(finder)
-      publish(finder)
-    else
-      logger.info("Not publishing #{finder['name']} because it's not pre_production")
-    end
+    publish(finder)
   end
 
 private
@@ -28,14 +24,6 @@ private
   end
 
   def publish(finder)
-    export_finder(finder)
-  end
-
-  def pre_production?(finder)
-    finder["pre_production"] == true
-  end
-
-  def export_finder(finder)
     presenter = FinderContentItemPresenter.new(finder, timestamp)
 
     logger.info("Publishing '#{presenter.name}' finder")

--- a/spec/unit/publishing_api_finder_publisher_spec.rb
+++ b/spec/unit/publishing_api_finder_publisher_spec.rb
@@ -16,48 +16,32 @@ RSpec.describe PublishingApiFinderPublisher do
   end
 
   describe "#call" do
-    context "with a pre-production finder" do
-      let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
-      let(:payload) {
-        FinderContentItemPresenter.new(finder, timestamp).present
-      }
+    let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+    let(:payload) {
+      FinderContentItemPresenter.new(finder, timestamp).present
+    }
 
-      before do
-        allow(logger).to receive(:info)
-        allow(GdsApi::PublishingApiV2).to receive(:new).and_return(publishing_api)
-        allow(publishing_api).to receive(:put_content)
-        allow(publishing_api).to receive(:patch_links)
-        allow(publishing_api).to receive(:publish)
+    before do
+      allow(logger).to receive(:info)
+      allow(GdsApi::PublishingApiV2).to receive(:new).and_return(publishing_api)
+      allow(publishing_api).to receive(:put_content)
+      allow(publishing_api).to receive(:patch_links)
+      allow(publishing_api).to receive(:publish)
 
-        instance.call
-      end
-
-      it "drafts the finder" do
-        expect(publishing_api).to have_received(:put_content).with(content_id, payload)
-      end
-
-      it "patches links for the finder" do
-        expect(publishing_api).to have_received(:patch_links)
-          .with(content_id, { content_id: content_id, links: {} })
-      end
-
-      it "publishes the finder to the Publishing API" do
-        expect(publishing_api).to have_received(:publish).with(content_id)
-      end
+      instance.call
     end
 
-    context "when a finder isn't pre-production" do
-      before do
-        finder.delete("pre_production")
-        allow(logger).to receive(:info)
-      end
+    it "drafts the finder" do
+      expect(publishing_api).to have_received(:put_content).with(content_id, payload)
+    end
 
-      it "reports that the finder is not pre-production" do
-        instance.call
+    it "patches links for the finder" do
+      expect(publishing_api).to have_received(:patch_links)
+        .with(content_id, { content_id: content_id, links: {} })
+    end
 
-        expect(logger).to have_received(:info)
-          .with("Not publishing Advanced search because it's not pre_production")
-      end
+    it "publishes the finder to the Publishing API" do
+      expect(publishing_api).to have_received(:publish).with(content_id)
     end
   end
 


### PR DESCRIPTION
* Removes an empty label from the publication date facet on the advanced search finder
* Removes redundant `pre_production` check in the finder publisher