### PR TITLE
Set encoding to UTF-8

### DIFF
--- a/lib/rummager/config.rb
+++ b/lib/rummager/config.rb
@@ -31,3 +31,6 @@ Raven.configure do |config|
 
   use Raven::Rack
 end
+
+Encoding.default_external = "UTF-8"
+Encoding.default_internal = "UTF-8"


### PR DESCRIPTION
This is an attempt to fix a problem we're seeing in Sentry where Sidekiq cannot JSON encoding a hash because it has non ASCII characters in it.

https://sentry.io/govuk/app-rummager/issues/450374046/