### PR TITLE
Don't send HTTPNotFound errors on the Publishing API to sentry

### DIFF
--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -83,6 +83,11 @@ module Indexer
           }
         )
         raise Indexer::PublishingApiError
+      rescue GdsApi::HTTPNotFound => e
+        # If the Content ID no longer exists in the Publishing API, there isn't really much
+        # we can do at this point. There doesn't seem to be any compelling reason to record
+        # this in Sentry as there is no bug to fix.
+        @logger.error("HTTP not found error fetching expanded links for #{content_id}: #{e.message}")
       rescue GdsApi::HTTPErrorResponse => e
         @logger.error("HTTP error fetching expanded links for #{content_id}: #{e.message}")
         # We capture all GdsApi HTTP exceptions here so that we can send them


### PR DESCRIPTION
This fills up Sentry with a lot of noise about a situation that we cannot fix or recover from.