### PR TITLE
Allow more taxon faceting

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -89,9 +89,11 @@ class BaseParameterParser
     manual
     navigation_document_supertype
     organisations
+    part_of_taxonomy_tree
     publishing_app
     rendering_app
     specialist_sectors
+    taxons
   ).freeze
 
   # The keys by which aggregates values can be sorted (using the "order" option).

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -56,6 +56,7 @@ class BaseParameterParser
     navigation_document_supertype
     organisation_type
     organisations
+    part_of_taxonomy_tree
     people
     policies
     policy_areas


### PR DESCRIPTION
One of the x-factors with retirement of legacy topic is that they power the "services and information" pages like https://www.gov.uk/government/organisations/hm-revenue-customs/services-information.

I want to experiment with a similar page that uses the new taxonomy. For this we need to allow faceting and facet examples for both taxonomy fields. This is already allowed for topics ("specialist sectors") so that Collections can do this:

https://github.com/alphagov/collections/blob/6ebae1b5bf095c15258a26ce89882808093e0a04/app/lib/services_and_information_links_grouper.rb#L15-L19

 
