### PR TITLE
Show all content tagged to taxon and below

### DIFF
--- a/config/advanced-search.yml
+++ b/config/advanced-search.yml
@@ -33,7 +33,7 @@ details:
     preposition: published
     display_as_result_metadata: true
     filterable: true
-  - filter_key: taxons
+  - filter_key: part_of_taxonomy_tree
     key: topic
     name: Taxonomy
     type: hidden


### PR DESCRIPTION
Related to https://github.com/alphagov/finder-frontend/pull/467

We want to replace filter_taxons in the rummager query with filter_part_of_taxonomy_tree so that we get taxon content for the given taxon and below.

**Before:**
<img width="634" alt="screen shot 2018-04-10 at 12 12 49" src="https://user-images.githubusercontent.com/29889908/38553879-9232cd20-3cb8-11e8-8bf1-c565c64e88de.png">

**After:**
<img width="644" alt="screen shot 2018-04-10 at 12 12 57" src="https://user-images.githubusercontent.com/29889908/38553873-8e6baeb4-3cb8-11e8-8bc3-9672c286a540.png">