### PR TITLE
Replace search_user_need_document_usertype boosting

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -22,28 +22,27 @@ base:
     # Topics
     specialist_sector: 2.5
   content_store_document_type:
-    answer: 2.5
+    answer: 3.75
     contact: 2.5
     detailed_guide: 2.5
     document_collection: 2.5
     foi_release: 0.2
     form: 2.5
     guidance: 2.5
-    guide: 2.5
+    guide: 3.75
     licence: 2.5
     local_transaction: 2.5
     manual: 2.5
     map: 2.5
-    place: 2.5
+    place: 3.75
     promotional: 2.5
     regulation: 2.5
-    simple_smart_answer: 2.5
-    smart_answer: 2.5
+    simple_smart_answer: 3.75
+    smart_answer: 3.75
     statutory_guidance: 2.5
-    transaction: 2.5
-    travel_advice: 2.5
-  search_user_need_document_supertype:
-    core: 1.5
+    transaction: 3.75
+    travel_advice_index: 1.5
+    travel_advice: 3.75
   organisation_state:
     closed: 0.2
     devolved: 0.3


### PR DESCRIPTION
The removed `search_user_need_document_usertype` (https://github.com/alphagov/govuk_document_types/pull/44) contains these document types:

- answer
- guide
- local_transaction
- place
- simple_smart_answer
- smart_answer
- transaction
- travel_advice
- travel_advice_index

For each of those, I've multiplied the `search_user_need_document_usertype` boost with the existing boost. If I understand elasticsearch correctly, this way the boosts will stay the same.

`travel_advice_index` wasn't previously in the list, so it's not multiplied and gets 1.5.

https://trello.com/c/6wRHXCyT

