### PR TITLE
Add mutual synonym of "Asad" and "Assad"

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -1107,3 +1107,6 @@
 - search: form an, an form => form an application for naturalisation as a british citizen
 - search: guide an, an guide => naturalisation guide
 - search: will, wills
+
+# Common misspellings of key people, in both publishing and searching
+- both: asad, assad


### PR DESCRIPTION
Departments and agencies other than FCO tend to publish content
referring to the President of Syria with the spelling “Assad”. FCO use
the agreed form “Asad”. Users need to see both sets of content when
searching for either spelling.

This is a synonym for both searching and indexing so that combined
frequencies of the terms are taken into account, which will make search
perform better.

https://govuk.zendesk.com/agent/tickets/2726646