### PR TITLE
Revert "Remove "content_purpose_document_supertype""

### DIFF
--- a/config/advanced-search.yml
+++ b/config/advanced-search.yml
@@ -1,6 +1,7 @@
 ---
 base_path: "/search/advanced"
 content_id: 3df77dea-00c5-43f0-8f31-d08b8bd2a4d6
+content_purpose_document_supertype: navigation
 document_type: search
 locale: en
 name: Advanced search

--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -2,6 +2,7 @@
   "fields": [
     "all_searchable_text",
     "content_id",
+    "content_purpose_document_supertype",
     "content_purpose_subgroup",
     "content_purpose_supergroup",
     "content_store_document_type",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -9,6 +9,11 @@
     "type": "identifier"
   },
 
+  "content_purpose_document_supertype": {
+    "description": "Grouping for content performance supertypes. See https://github.com/alphagov/govuk_document_types/blob/master/data/supertypes.yml",
+    "type": "identifier"
+  },
+
   "content_purpose_supergroup": {
     "description": "Grouping for content purpose supergroups. See https://github.com/alphagov/govuk_document_types/blob/master/data/supertypes.yml",
     "type": "identifier"

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -10,6 +10,7 @@ module GovukIndex
     extend MethodBuilder
 
     delegate_to_payload :content_id
+    delegate_to_payload :content_purpose_document_supertype
     delegate_to_payload :content_store_document_type, hash_key: "document_type"
     delegate_to_payload :description
     delegate_to_payload :email_document_supertype

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -25,6 +25,7 @@ module GovukIndex
         closing_date:                        specialist.closing_date,
         contact_groups:                      details.contact_groups,
         content_id:                          common_fields.content_id,
+        content_purpose_document_supertype:  common_fields.content_purpose_document_supertype,
         content_purpose_supergroup:          common_fields.content_purpose_supergroup,
         content_purpose_subgroup:            common_fields.content_purpose_subgroup,
         content_store_document_type:         common_fields.content_store_document_type,

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -41,6 +41,7 @@ class BaseParameterParser
   # The fields listed here are the only ones which can be used to calculated
   # aggregates for.  This should be a subset of allowed_filter_fields
   ALLOWED_AGGREGATE_FIELDS = %w(
+    content_purpose_document_supertype
     content_purpose_subgroup
     content_purpose_supergroup
     content_store_document_type


### PR DESCRIPTION
Reverts alphagov/rummager#1221 for safety, we want to deploy https://github.com/alphagov/rummager/pull/1226 today.