### PR TITLE
Enable the root_taxon link_type to be used in parts_of_taxonomy

### DIFF
--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -81,7 +81,8 @@ module GovukIndex
     def parts_of_taxonomy(taxon_hash)
       parents = [taxon_hash["content_id"]]
 
-      direct_parents = taxon_hash.dig("links", "parent_taxons")
+      direct_parents = direct_parent_taxons(taxon_hash)
+
       while direct_parents && !direct_parents.empty?
         # There should not be more than one parent for a taxon. If there is,
         # make an arbitrary choice.
@@ -89,10 +90,16 @@ module GovukIndex
 
         parents << direct_parent["content_id"]
 
-        direct_parents = direct_parent.dig("links", "parent_taxons") || []
+        direct_parents = direct_parent_taxons(direct_parent)
       end
 
       parents.reverse
+    end
+
+    def direct_parent_taxons(taxon)
+      taxon.dig("links", "parent_taxons") ||
+        taxon.dig("links", "root_taxon") ||
+        []
     end
   end
 end

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -86,7 +86,17 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
                       "content_id" => "206b7f3a-49b5-476f-af0f-fd27e2a68473",
                       "locale" => "en",
                       "title" => "Parenting, childcare and children's services ",
-                      "links" => {}
+                      "links" => {
+                        "root_taxon" => [
+                          {
+                            "base_path" => '/',
+                            "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                            "locale" => "en",
+                            "title" => "GOV.UK homepage",
+                            "links" => {}
+                          }
+                        ]
+                      }
                     }
                   ]
                 }
@@ -100,6 +110,7 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     presenter = expanded_links_presenter(expanded_links)
 
     expected_taxonomy_tree = [
+      "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
       "206b7f3a-49b5-476f-af0f-fd27e2a68473",
       "5a9e6b26-ae64-4129-93ee-968028381e83",
       "13bba81c-b2b1-4b13-a3de-b24748977198"


### PR DESCRIPTION
To be able to use the homepages content_id in a query using the
parts_of_taxonomy filter.