### PR TITLE
add logo_url to index for organisations

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -16,6 +16,7 @@
     "is_historic",
     "is_political",
     "logo_formatted_title",
+    "logo_url",
     "metadata",
     "operational_field",
     "organisation_brand",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -418,6 +418,11 @@
     "type": "identifier"
   },
 
+  "logo_url": {
+    "description": "The url of the custom logo - applies to organisations with a custom logo",
+    "type": "identifier"
+  },
+
   "manual": {
     "type": "identifier",
     "description": "Base path of the manual this document belongs to. Eg `/service-manual` or `/hmrc-internal-manuals/air-passenger-duty`"

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -39,6 +39,7 @@ module Search
           logo_formatted_title
           organisation_brand
           organisation_crest
+          logo_url
         }
       )
     end

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -87,7 +87,8 @@ RSpec.describe 'ElasticsearchIndexingTest' do
       "end_date" => "2017-01-01T00:00:00Z",
       'logo_formatted_title' => 'The\nTitle',
       'organisation_brand' => 'cabinet-office',
-      'organisation_crest' => 'single-identity'
+      'organisation_crest' => 'single-identity',
+      'logo_url' => 'http://url/to/logo.png'
     }.to_json
 
     expect_document_is_in_rummager(
@@ -100,7 +101,8 @@ RSpec.describe 'ElasticsearchIndexingTest' do
         "end_date" => "2017-01-01T00:00:00Z",
         'logo_formatted_title' => 'The\nTitle',
         'organisation_brand' => 'cabinet-office',
-        'organisation_crest' => 'single-identity'
+        'organisation_crest' => 'single-identity',
+        'logo_url' => 'http://url/to/logo.png'
       },
       index: "government_test",
     )


### PR DESCRIPTION
Added logo_url to organisations in registries.json and to
editions.json and field_definitions.json

We want to display search results for organisation as logos in the collections app for the Trello card [Show the department logo in the Organisations list](https://trello.com/c/wSDRcUwW/27-show-the-department-logo-in-the-organisations-list). This PR includes logo_url for organisations with custom logos.

There is a related [PR in whitehall](https://github.com/alphagov/whitehall/pull/3976)
