### PR TITLE
Set encoding to UTF-8

### DIFF
--- a/lib/rummager/config.rb
+++ b/lib/rummager/config.rb
@@ -31,3 +31,6 @@ Raven.configure do |config|
 
   use Raven::Rack
 end
+
+Encoding.default_external = "UTF-8"
+Encoding.default_internal = "UTF-8"


### PR DESCRIPTION
Rebased version of #1214 (silly github doesn't let you reopen a PR if the branch has been force-pushed).

---

Tested on integration, which was previously seeing encoding errors crop up every few seconds, resulting in massive log files.  With this change deployed, all is good.

Before deploying this, I did a quick sanity check that sidekiq is actually using UTF-8 normally:

```
$ cat /tmp/sidekiq.yml 
---
:require: /tmp/sidekiq.rb

$ cat /tmp/sidekiq.rb 
puts "external: #{Encoding.default_external}"
puts "internal: #{Encoding.default_internal}"

$ bundle exec sidekiq -C /tmp/sidekiq.yml
external: UTF-8
internal: 
```

Which looks reasonable to me.  So I don't know what the underlying problem is, oh well.