### PR TITLE
Add statutory instrument as a migrated format

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -45,6 +45,7 @@ migrated:
 - service_manual_homepage
 - service_manual_service_standard
 - service_manual_topic
+- statutory_instrument
 - step_by_step_nav
 - task_list
 - taxon:


### PR DESCRIPTION
It's not technically a migrated format, it's a new format, but rummager won't index documents if their formats aren't in this list.