### PR TITLE
Add more fields for organisations

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -1,7 +1,10 @@
 {
   "fields": [
     "acronym",
+    "analytics_identifier",
     "attachments",
+    "child_organisations",
+    "closed_at",
     "detailed_format",
     "display_type",
     "document_collections",
@@ -20,10 +23,12 @@
     "metadata",
     "operational_field",
     "organisation_brand",
+    "organisation_closed_state",
     "organisation_crest",
     "organisation_state",
     "organisation_type",
     "organisations",
+    "parent_organisations",
     "people",
     "policies",
     "policy_areas",
@@ -34,6 +39,8 @@
     "search_format_types",
     "slug",
     "specialist_sectors",
+    "superseded_organisations",
+    "superseding_organisations",
     "start_date",
     "statistics_announcement_state",
     "world_locations"

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -169,6 +169,11 @@
     "description": "End date for topical content. Assume null means in the past for topical event pages."
   },
 
+  "closed_at": {
+    "type": "date",
+    "description": "Closing date for closed organisations."
+  },
+
   "latest_change_note": {
     "description": "Note indicating what changed in the last major revision.",
     "type": "unsearchable_text"
@@ -182,6 +187,11 @@
   "acronym": {
     "description": "Acronym associated with the page title. Used for organisation pages.",
     "type": "searchable_text"
+  },
+
+  "analytics_identifier": {
+    "description": "A unique identifier used for analytics.",
+    "type": "identifier"
   },
 
   "attachments": {
@@ -232,6 +242,26 @@
     "type": "identifier"
   },
 
+  "child_organisations": {
+    "description": "A list of organisations that are children of the organisation.",
+    "type": "identifiers"
+  },
+
+  "parent_organisations": {
+    "description": "A list of organisations that are parents of the organisation.",
+    "type": "identifiers"
+  },
+
+  "superseded_organisations": {
+    "description": "A list of organisations that are superseded by the organisation.",
+    "type": "identifiers"
+  },
+
+  "superseding_organisations": {
+    "description": "A list of organisations that supersede the organisation.",
+    "type": "identifiers"
+  },
+
   "organisation_brand": {
     "description": "The branding (controls the colour) of the organisation logo",
     "type": "identifier"
@@ -244,6 +274,11 @@
 
   "organisation_state": {
     "description": "Status of an organisation page on GOV.UK: {live, joining, exempt, transitioning, closed, devolved}",
+    "type": "identifier"
+  },
+
+  "organisation_closed_state": {
+    "description": "Status of a closed organisation page on GOV.UK: {no_longer_exists, replaced, split, merged, changed_name, left_gov, devolved}",
     "type": "identifier"
   },
 

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -35,11 +35,18 @@ module Search
           slug content_id
           link title acronym
           organisation_type
+          organisation_closed_state
           organisation_state
           logo_formatted_title
           organisation_brand
           organisation_crest
           logo_url
+          closed_at public_timestamp
+          analytics_identifier
+          child_organisations
+          parent_organisations
+          superseded_organisations
+          superseding_organisations
         }
       )
     end


### PR DESCRIPTION
This commit adds the following new fields to the rummager schema:

* analytics_identifier
* child_organisations
* closed_at
* organisation_closed_state
* parent_organisations
* superseded_organisations
* superseding_organisations

These fields will be used by the new organisations API which will get its data from rummager.

Trello: https://trello.com/c/p7ywlbk1/130-migrate-organisations-api