### PR TITLE
Add withdrawn_date to statutory instruments

### DIFF
--- a/config/schema/elasticsearch_types/statutory_instrument.json
+++ b/config/schema/elasticsearch_types/statutory_instrument.json
@@ -3,7 +3,8 @@
     "laid_date",
     "sift_end_date",
     "sifting_status",
-    "subject"
+    "subject",
+    "withdrawn_date"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -680,5 +680,10 @@
   "sift_end_date": {
     "description": "The date on which sifting of a statutory instrument ends",
     "type": "date"
+  },
+
+  "withdrawn_date": {
+    "description": "The date on which a statutory instrument was withdrawn",
+    "type": "date"
   }
 }


### PR DESCRIPTION
Makes the field `withdrawn_date` a filterable facet on statutory instruments finder.