### PR TITLE
Increase max result count

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -5,7 +5,7 @@ class SearchParameterParser < BaseParameterParser
     expanded_topics
     expanded_organisations
   ].freeze
-  MAX_RESULTS = 1000
+  MAX_RESULTS = 1500
 
   def initialize(params, schema)
     @schema = schema

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -177,9 +177,9 @@ RSpec.describe SearchParameterParser do
   end
 
   it "complains about an overly large count parameter" do
-    p = described_class.new({ "count" => %w(1001) }, @schema)
+    p = described_class.new({ "count" => %w(1501) }, @schema)
 
-    expect(%{Maximum result set size (as specified in 'count') is 1000}).to eq(p.error)
+    expect(%{Maximum result set size (as specified in 'count') is 1500}).to eq(p.error)
     expect(p).not_to be_valid
     expect(expected_params(count: 10)).to eq(p.parsed_params)
   end

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe SearchParameterParser do
   it "complains about an overly large count parameter" do
     p = described_class.new({ "count" => %w(1501) }, @schema)
 
-    expect(%{Maximum result set size (as specified in 'count') is 1500}).to eq(p.error)
+    expect(p.error).to eq(%{Maximum result set size (as specified in 'count') is 1500})
     expect(p).not_to be_valid
     expect(expected_params(count: 10)).to eq(p.parsed_params)
   end


### PR DESCRIPTION
We have over 1000 organisations.  These are commonly used as facets, so we need to be able to return all of them at once.  1500 is a bit arbitrary, but given that the org count only ever goes up, it's useful to have some headroom.