### PR TITLE
Add image hash to rummager

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -15,6 +15,7 @@
     "has_command_paper",
     "has_official_document",
     "id",
+    "image",
     "important_to_policy",
     "is_historic",
     "is_political",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -64,6 +64,11 @@
     "type": "searchable_text"
   },
 
+  "image": {
+    "description": "Information about the image for this page including a link and alternative text.",
+    "type": "opaque_object"
+  },
+
   "link": {
     "description": "The link to the document.  This is usually the path component of the URL of the document, including a leading slash, but sometimes omits the leading slash, and is sometimes an absolute URL of related content which does not appear on GOV.UK",
     "type": "identifier"

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -6,6 +6,7 @@ module GovukIndex
 
     set_payload_method :details
 
+    delegate_to_payload :image
     delegate_to_payload :licence_identifier
     delegate_to_payload :licence_short_description
     delegate_to_payload :url

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -50,6 +50,7 @@ module GovukIndex
         grant_type:                          specialist.grant_type,
         hidden_indexable_content:            specialist.hidden_indexable_content,
         hmrc_manual_section_id:              common_fields.section_id,
+        image:                               details.image,
         indexable_content:                   indexable.indexable_content,
         industries:                          specialist.industries,
         is_withdrawn:                        common_fields.is_withdrawn,

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GovukIndex::DetailsPresenter do
-  subject { described_class.new(details: details, format: format) }
+  subject(:presented_details) { described_class.new(details: details, format: format) }
 
   context "licence format" do
     let(:format) { 'licence' }
@@ -20,8 +20,8 @@ RSpec.describe GovukIndex::DetailsPresenter do
     }
 
     it "should extract licence specific fields" do
-      expect(subject.licence_identifier).to eq(details["licence_identifier"])
-      expect(subject.licence_short_description).to eq(details["licence_short_description"])
+      expect(presented_details.licence_identifier).to eq(details["licence_identifier"])
+      expect(presented_details.licence_short_description).to eq(details["licence_short_description"])
     end
   end
 
@@ -35,8 +35,8 @@ RSpec.describe GovukIndex::DetailsPresenter do
         }
       }
 
-      it "should have no image" do
-        expect(subject.image).to be nil
+      it "has no image" do
+        expect(presented_details.image).to be nil
       end
     end
 
@@ -52,8 +52,8 @@ RSpec.describe GovukIndex::DetailsPresenter do
         }
       }
 
-      it "should have an image" do
-        expect(subject.image).to eq({
+      it "has an image" do
+        expect(presented_details.image).to eq({
           "alt_text" => "Christmas",
           "url" => "https://assets.publishing.service.gov.uk/christmas.jpg"
         })
@@ -68,7 +68,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       let(:details) { {} }
 
       it "should have no latest change note" do
-        expect(subject.latest_change_note).to be_nil
+        expect(presented_details.latest_change_note).to be_nil
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       }
 
       it "should have no latest change note" do
-        expect(subject.latest_change_note).to be_nil
+        expect(presented_details.latest_change_note).to be_nil
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       }
 
       it "should combine the title and description from the most recent change note" do
-        expect(subject.latest_change_note).to eq("Change 3 in Manual section B")
+        expect(presented_details.latest_change_note).to eq("Change 3 in Manual section B")
       end
     end
   end

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -25,6 +25,42 @@ RSpec.describe GovukIndex::DetailsPresenter do
     end
   end
 
+  context "images" do
+    context "document without an image" do
+      let(:format) { 'answer' }
+      let(:details) {
+        {
+          "body" => "<p>Gallwch ddefnyddio’r gwasanaethau canlynol gan Gyllid a Thollau Ei Mawrhydi </p>\n\n",
+          "external_related_links" => []
+        }
+      }
+
+      it "should have no image" do
+        expect(subject.image).to be nil
+      end
+    end
+
+    context "document with an image" do
+      let(:format) { 'news_article' }
+      let(:details) {
+        {
+          "image" => {
+            "alt_text" => "Christmas",
+            "url" => "https://assets.publishing.service.gov.uk/christmas.jpg"
+          },
+          "body" => "<div class=\"govspeak\"><p>We wish you a merry Christmas.</p></div>",
+        }
+      }
+
+      it "should have an image" do
+        expect(subject.image).to eq({
+          "alt_text" => "Christmas",
+          "url" => "https://assets.publishing.service.gov.uk/christmas.jpg"
+        })
+      end
+    end
+  end
+
   context "hmrc_manual format" do
     let(:format) { "hmrc_manual" }
 


### PR DESCRIPTION
We want to be able to retrieve image information from search results for things like news_articles s that we can show them in navigation. (Example of a page that has an image section that we want: https://www-origin.integration.publishing.service.gov.uk/government/news/alternative-provision-progress-made-but-more-still-to-be-done )

Images are within the details hash and look like this:

```
"details" {
  "image": {
    "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/41367/s300_holidygov.png",
    "caption": null,
    "alt_text": "Holiday image"
  }
}
```

An `opaque_object` is intended to be something that is not searchable and has an undefined format.  Given that we don't want to have to keep rummager schemas up to date if the format of an image section changes this seems OK.

The existing [`metadata` field also uses this type](https://docs.publishing.service.gov.uk/apis/search/fields.html)


https://trello.com/c/MoyJIc4n/36-index-image-information-for-news-pages