### PR TITLE
Add image_url to editions

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -15,6 +15,7 @@
     "has_command_paper",
     "has_official_document",
     "id",
+    "image_url",
     "important_to_policy",
     "is_historic",
     "is_political",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -227,6 +227,11 @@
     "type": "identifiers"
   },
 
+  "image_url": {
+    "description": "The URL of the image associated with an edition",
+    "type": "identifier"
+  },
+
   "release_timestamp": {
     "description": "When statistics will be released, for statistics announcement pages.",
     "type": "date"

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -35,6 +35,10 @@ module GovukIndex
       service_manual || details.dig("manual", "base_path")
     end
 
+    def image_url
+      details.dig("image", "url")
+    end
+
   private
 
     def service_manual

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -50,6 +50,7 @@ module GovukIndex
         grant_type:                          specialist.grant_type,
         hidden_indexable_content:            specialist.hidden_indexable_content,
         hmrc_manual_section_id:              common_fields.section_id,
+        image_url:                           details.image_url,
         indexable_content:                   indexable.indexable_content,
         industries:                          specialist.industries,
         is_withdrawn:                        common_fields.is_withdrawn,

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GovukIndex::DetailsPresenter do
-  subject { described_class.new(details: details, format: format) }
+  subject(:presented_details) { described_class.new(details: details, format: format) }
 
   context "licence format" do
     let(:format) { 'licence' }
@@ -20,8 +20,8 @@ RSpec.describe GovukIndex::DetailsPresenter do
     }
 
     it "should extract licence specific fields" do
-      expect(subject.licence_identifier).to eq(details["licence_identifier"])
-      expect(subject.licence_short_description).to eq(details["licence_short_description"])
+      expect(presented_details.licence_identifier).to eq(details["licence_identifier"])
+      expect(presented_details.licence_short_description).to eq(details["licence_short_description"])
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       }
 
       it "has no image" do
-        expect(subject.image_url).to be nil
+        expect(presented_details.image_url).to be nil
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       }
 
       it "has an image" do
-        expect(subject.image_url).to eq("https://assets.publishing.service.gov.uk/christmas.jpg")
+        expect(presented_details.image_url).to eq("https://assets.publishing.service.gov.uk/christmas.jpg")
       end
     end
   end
@@ -67,7 +67,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       let(:details) { {} }
 
       it "should have no latest change note" do
-        expect(subject.latest_change_note).to be_nil
+        expect(presented_details.latest_change_note).to be_nil
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       }
 
       it "should have no latest change note" do
-        expect(subject.latest_change_note).to be_nil
+        expect(presented_details.latest_change_note).to be_nil
       end
     end
 
@@ -105,7 +105,7 @@ RSpec.describe GovukIndex::DetailsPresenter do
       }
 
       it "should combine the title and description from the most recent change note" do
-        expect(subject.latest_change_note).to eq("Change 3 in Manual section B")
+        expect(presented_details.latest_change_note).to eq("Change 3 in Manual section B")
       end
     end
   end

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -25,6 +25,41 @@ RSpec.describe GovukIndex::DetailsPresenter do
     end
   end
 
+  context "images" do
+    context "document without an image" do
+      let(:format) { 'answer' }
+
+      let(:details) {
+        {
+          "body" => "<p>Gallwch ddefnyddio’r gwasanaethau canlynol gan Gyllid a Thollau Ei Mawrhydi </p>\n\n",
+          "external_related_links" => []
+        }
+      }
+
+      it "has no image" do
+        expect(subject.image_url).to be nil
+      end
+    end
+
+    context "document with an image" do
+      let(:format) { 'news_article' }
+
+      let(:details) {
+        {
+          "image" => {
+            "alt_text" => "Christmas",
+            "url" => "https://assets.publishing.service.gov.uk/christmas.jpg"
+          },
+          "body" => "<div class=\"govspeak\"><p>We wish you a merry Christmas.</p></div>",
+        }
+      }
+
+      it "has an image" do
+        expect(subject.image_url).to eq("https://assets.publishing.service.gov.uk/christmas.jpg")
+      end
+    end
+  end
+
   context "hmrc_manual format" do
     let(:format) { "hmrc_manual" }
 


### PR DESCRIPTION
This is present in the details hash of editions like [news articles](https://github.com/alphagov/govuk-content-schemas/blob/master/examples/news_article/frontend/news_article.json#L62).  

We'll be using this in taxonomy navigation to show images for content where they exist.

I've tested this on integration (after following https://docs.publishing.service.gov.uk/apis/search/add-new-fields-or-document-types.html#troubleshooting) and it works

https://trello.com/c/MoyJIc4n/36-index-image-information-for-news-pages