### PR TITLE
Resolve expanded links error

### DIFF
--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -88,6 +88,7 @@ module Indexer
         # we can do at this point. There doesn't seem to be any compelling reason to record
         # this in Sentry as there is no bug to fix.
         @logger.error("HTTP not found error fetching expanded links for #{content_id}: #{e.message}")
+        nil
       rescue GdsApi::HTTPErrorResponse => e
         @logger.error("HTTP error fetching expanded links for #{content_id}: #{e.message}")
         # We capture all GdsApi HTTP exceptions here so that we can send them

--- a/spec/unit/indexer/links_lookup_spec.rb
+++ b/spec/unit/indexer/links_lookup_spec.rb
@@ -3,10 +3,11 @@ require 'spec_helper'
 RSpec.describe Indexer::LinksLookup do
   include GdsApi::TestHelpers::PublishingApiV2
 
+  let(:content_id) { "DOCUMENT_CONTENT_ID" }
+  let(:endpoint) { Plek.current.find('publishing-api') + '/v2' }
+  let(:expanded_links_url) { endpoint + "/expanded-links/" + content_id }
+
   it "retry links on timeout" do
-    content_id = "DOCUMENT_CONTENT_ID"
-    endpoint = Plek.current.find('publishing-api') + '/v2'
-    expanded_links_url = endpoint + "/expanded-links/" + content_id
     stub_request(:get, expanded_links_url).to_timeout
 
     expect {
@@ -17,5 +18,16 @@ RSpec.describe Indexer::LinksLookup do
     }.to raise_error(Indexer::PublishingApiError)
 
     assert_requested :get, expanded_links_url, times: 5
+  end
+
+  it "doesn't error if content no longer exists" do
+    stub_request(:get, expanded_links_url).to_return(body: "Not found", status: 404)
+
+    expanded_content = described_class.prepare_tags({
+      "content_id" => content_id,
+      "link" => "/my-base-path",
+    })
+
+    expect(expanded_content).to eq("content_id" => content_id, "link" => "/my-base-path")
   end
 end


### PR DESCRIPTION
I think this should resolve the following error:
https://sentry.io/govuk/app-rummager/issues/521134930/?query=is:unresolved

The error is due to the fact that `@logger.error()` returns `true` which means the guard clause `return doc_hash unless links` doesn't work because `links` is `true` (but needs to be a hash).