### PR TITLE
Make news_story indexable when published by Content Publisher

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -25,6 +25,7 @@ mainstream_browse_page: edition # Collections Publisher
 manual: manual
 manual_section: manual_section
 medical_safety_alert: medical_safety_alert # Specialist Publisher
+news_story: edition
 place: edition
 policy: policy # Policy Publisher
 raib_report: raib_report # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -48,6 +48,8 @@ migrated:
 - statutory_instrument
 - step_by_step_nav
 - task_list
+- news_story: # not indexable when published by Whitehall
+    publishing_app: content-publisher
 - taxon:
   - /world/afghanistan
   - /world/albania
@@ -369,7 +371,8 @@ non_indexable:
 - ministerial_role
 - national_statistics
 - national_statistics_announcement
-- news_story
+- news_story: # indexable when published by Content Publisher
+    publishing_app: whitehall
 - notice
 - official_statistics
 - official_statistics_announcement

--- a/lib/govuk_index/migrated_formats.rb
+++ b/lib/govuk_index/migrated_formats.rb
@@ -5,7 +5,7 @@ module GovukIndex
     def non_indexable?(format, path, app)
       non_indexable_formats[format] &&
         (non_indexable_formats[format] == :all || non_indexable_formats[format].include?(path) ||
-          published_by_whitehall?(format, app))
+          published_by_non_indexable_app?(format, app))
     end
 
     def non_indexable_formats
@@ -14,7 +14,7 @@ module GovukIndex
 
     def indexable?(format, path, app)
       indexable_formats[format] && (indexable_formats[format] == :all ||
-        indexable_formats[format].include?(path) || published_by_content_publisher?(format, app))
+        indexable_formats[format].include?(path) || published_by_indexable_app?(format, app))
     end
 
     def indexable_formats
@@ -42,14 +42,14 @@ module GovukIndex
       end
     end
 
-    def published_by_content_publisher?(format, app)
-      return false unless app == "content-publisher"
-      indexable_formats[format]["publishing_app"]&.include?("content-publisher")
+    def published_by_indexable_app?(format, app)
+      return false unless indexable_formats[format].is_a?(Hash)
+      indexable_formats[format]["publishing_app"] == app
     end
 
-    def published_by_whitehall?(format, app)
-      return false unless app == "whitehall"
-      non_indexable_formats[format]["publishing_app"]&.include?("whitehall")
+    def published_by_non_indexable_app?(format, app)
+      return false unless non_indexable_formats[format].is_a?(Hash)
+      non_indexable_formats[format]["publishing_app"] == app
     end
   end
 end

--- a/lib/govuk_index/migrated_formats.rb
+++ b/lib/govuk_index/migrated_formats.rb
@@ -2,17 +2,19 @@ module GovukIndex
   module MigratedFormats
     extend self
 
-    def non_indexable?(format, path)
+    def non_indexable?(format, path, app)
       non_indexable_formats[format] &&
-        (non_indexable_formats[format] == :all || non_indexable_formats[format].include?(path))
+        (non_indexable_formats[format] == :all || non_indexable_formats[format].include?(path) ||
+          published_by_whitehall?(format, app))
     end
 
     def non_indexable_formats
       @blacklist_formats ||= convert_to_allowed_hash(data_file['non_indexable'])
     end
 
-    def indexable?(format, path)
-      indexable_formats[format] && (indexable_formats[format] == :all || indexable_formats[format].include?(path))
+    def indexable?(format, path, app)
+      indexable_formats[format] && (indexable_formats[format] == :all ||
+        indexable_formats[format].include?(path) || published_by_content_publisher?(format, app))
     end
 
     def indexable_formats
@@ -38,6 +40,16 @@ module GovukIndex
           hash
         end
       end
+    end
+
+    def published_by_content_publisher?(format, app)
+      return false unless app == "content-publisher"
+      indexable_formats[format]["publishing_app"]&.include?("content-publisher")
+    end
+
+    def published_by_whitehall?(format, app)
+      return false unless app == "whitehall"
+      non_indexable_formats[format]["publishing_app"]&.include?("whitehall")
     end
   end
 end

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -119,6 +119,10 @@ module GovukIndex
       common_fields.link
     end
 
+    def publishing_app
+      common_fields.publishing_app
+    end
+
     def valid!
       if format == "recommended-link"
         details.url || raise(MissingExternalUrl, "url missing from details section")

--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -53,9 +53,9 @@ module GovukIndex
       if type_mapper.unpublishing_type?
         logger.info("#{routing_key} -> DELETE #{identifier}")
         processor.delete(presenter)
-      elsif MigratedFormats.non_indexable?(presenter.format, presenter.base_path)
+      elsif MigratedFormats.non_indexable?(presenter.format, presenter.base_path, presenter.publishing_app)
         logger.info("#{routing_key} -> BLACKLISTED #{identifier}")
-      elsif MigratedFormats.indexable?(presenter.format, presenter.base_path)
+      elsif MigratedFormats.indexable?(presenter.format, presenter.base_path, presenter.publishing_app)
         logger.info("#{routing_key} -> INDEX #{identifier}")
         processor.save(presenter)
       else

--- a/spec/unit/govuk_index/migrated_formats_spec.rb
+++ b/spec/unit/govuk_index/migrated_formats_spec.rb
@@ -18,9 +18,26 @@ RSpec.describe GovukIndex::MigratedFormats do
     non_indexable = described_class.non_indexable_formats
 
     duplicate_keys = indexable.keys & non_indexable.keys
-
     duplicate_keys.each do |duplicate_key|
-      expect(indexable[duplicate_key] & non_indexable[duplicate_key]).to be_empty
+      expect(indexable[duplicate_key].to_a & non_indexable[duplicate_key].to_a).to be_empty
+    end
+  end
+
+  describe 'content that can be published by both Content Publisher and Whitehall' do
+    it '#non_indexable? returns false if content is published by Content Publisher' do
+      expect(described_class.non_indexable?('news_story', '/a-path', 'content-publisher')).to be false
+    end
+
+    it '#non_indexable? returns true if content is published by Whitehall' do
+      expect(described_class.non_indexable?('news_story', '/a-path', 'whitehall')).to be true
+    end
+
+    it '#indexable? returns true if content is published by Content Publisher' do
+      expect(described_class.indexable?('news_story', '/a-path', 'content-publisher')).to be true
+    end
+
+    it '#indexable? returns false if content is published by Whitehall' do
+      expect(described_class.indexable?('news_story', '/a-path', 'whitehall')).to be false
     end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/SlaLEmdQ/86-change-rummager-to-index-the-documents-were-publishing-l

The `news_story` document type will soon be publishable by Content Publisher as
well as Whitehall. Whitehall indexes its content to Rummager directly, whereas
Content Publisher will use the conventional way of relying on Publishing API to
take care of communicating with Rummager. In order to make it possible for
Content Publisher content to be indexable, we whitelist `news_story` as an
indexable format and specify Content Publisher as the publishing app for it.
`news_story` remains in the non_indexable list as well and we specify Whitehall
as the publishing app here. This approach will allow us to check the publishing
app for a piece of content and use this to determine whether it should be
indexed or not.