### PR TITLE
Allow remaining news formats to be indexed

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -13,6 +13,7 @@ employment_tribunal_decision: employment_tribunal_decision # Specialist Publishe
 esi_fund: european_structural_investment_fund # Specialist Publisher
 external_content: edition # Search Admin
 finder: edition # Specialist Publisher
+government_response: edition
 guide: edition
 help_page: edition
 hmrc_manual: hmrc_manual

--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -48,3 +48,4 @@ transaction: edition
 travel_advice: edition # Travel advice publisher
 travel_advice_index: edition # Travel advice publisher
 utaac_decision: utaac_decision # Specialist Publisher
+world_news_story: edition

--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -28,6 +28,7 @@ medical_safety_alert: medical_safety_alert # Specialist Publisher
 news_story: edition
 place: edition
 policy: policy # Policy Publisher
+press_release: edition
 raib_report: raib_report # Specialist Publisher
 residential_property_tribunal_decision: residential_property_tribunal_decision # Specialist Publisher
 service_manual_guide: service_manual_guide

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -4,6 +4,11 @@ migrated:
 - specialist_sector # topic format is mapped to specialist_sector in Rummager.
 # Contacts
 - contact
+# Content Publisher - formats not indexable when published by Whitehall
+- news_story:
+    publishing_app: content-publisher
+- press_release:
+    publishing_app: content-publisher
 # Publisher
 - answer
 - guide
@@ -48,8 +53,6 @@ migrated:
 - statutory_instrument
 - step_by_step_nav
 - task_list
-- news_story: # not indexable when published by Whitehall
-    publishing_app: content-publisher
 - taxon:
   - /world/afghanistan
   - /world/albania
@@ -385,7 +388,8 @@ non_indexable:
 - petitions_and_campaigns
 - policy_area
 - policy_paper
-- press_release
+- press_release: # indexable when published by Content Publisher
+    publishing_app: whitehall
 - procurement
 - promotional
 - publication

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -5,6 +5,8 @@ migrated:
 # Contacts
 - contact
 # Content Publisher - formats not indexable when published by Whitehall
+- government_response:
+    publishing_app: content-publisher
 - news_story:
     publishing_app: content-publisher
 - press_release:
@@ -363,7 +365,8 @@ non_indexable:
 #- finder # migrated
 - foi_release
 - form
-- government_response
+- government_response: # indexable when published by Content Publisher
+    publishing_app: whitehall
 - guidance
 - html_publication
 - impact_assessment

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -9,6 +9,8 @@ migrated:
     publishing_app: content-publisher
 - press_release:
     publishing_app: content-publisher
+- world_news_story:
+    publishing_app: content-publisher
 # Publisher
 - answer
 - guide
@@ -412,6 +414,7 @@ non_indexable:
 - welsh_language_scheme
 - working_group
 - world_location
-- world_news_story
+- world_news_story: # indexable when published by Content Publisher
+    publishing_app: whitehall
 - worldwide_organisation
 - written_statement


### PR DESCRIPTION
For https://trello.com/c/SlaLEmdQ/86-change-rummager-to-index-the-documents-were-publishing-l

This enables the remaining news formats that we will publish from Content Publisher to be indexed to the govuk index.