### PR TITLE
Set a tag for Sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,5 @@
 ---
+tag: rummager.publishing.service.gov.uk
 :concurrency: 5
 staging:
   :concurrency:  16


### PR DESCRIPTION
Currently the process monitoring through collectd, as configured by
govuk-puppet depends on the tag starting with "rummager" and ending
with "gov.uk". Setting the tag here should mean that process metrics
are available, as currently they are missing.

The tag seems to be automatically be set for other apps, I don't know
why it's not magically working here. It's also includes the
environment in staging and integration, which this change doesn't, but
it should still work in all environments.