### PR TITLE
Don't talk to Elasticsearch if the document updates are empty

### DIFF
--- a/lib/indexer/workers/amend_worker.rb
+++ b/lib/indexer/workers/amend_worker.rb
@@ -6,6 +6,7 @@ module Indexer
       logger.info "Amending document '#{document_link}' in '#{index_name}'"
       logger.info "Amending fields #{updates.keys.join(', ')}"
       logger.debug "Amendments: #{updates}"
+      return if updates.empty?
       begin
         index(index_name).amend(document_link, updates)
       rescue SearchIndices::IndexLocked


### PR DESCRIPTION
I'm not entirely sure why we would be getting these in the first place, but we've definitely found example of workers being queue with an empty `updates` hash. It doesn't seem like there's any reason to talk to Elasticsearch in this situation as there's nothing to update.

Recently during an incident where the Rummager queue reached 130k, 66k of the jobs were examples of this, and we cleared them manually without any effect.