### PR TITLE
Revert "Add first_published_at to all content"

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -8,7 +8,6 @@
     "content_store_document_type",
     "description",
     "email_document_supertype",
-    "first_published_at",
     "format",
     "government_document_supertype",
     "indexable_content",

--- a/config/schema/elasticsearch_types/dfid_research_output.json
+++ b/config/schema/elasticsearch_types/dfid_research_output.json
@@ -1,6 +1,7 @@
 {
   "fields": [
     "country",
+    "first_published_at",
     "dfid_authors",
     "dfid_review_status",
     "dfid_theme",

--- a/config/schema/elasticsearch_types/drug_safety_update.json
+++ b/config/schema/elasticsearch_types/drug_safety_update.json
@@ -1,6 +1,7 @@
 {
   "fields": [
-    "therapeutic_area"
+    "therapeutic_area",
+    "first_published_at"
   ],
 
   "expanded_search_result_fields": {

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -14,7 +14,6 @@ module GovukIndex
     delegate_to_payload :content_store_document_type, hash_key: "document_type"
     delegate_to_payload :description
     delegate_to_payload :email_document_supertype
-    delegate_to_payload :first_published_at
     delegate_to_payload :government_document_supertype
     delegate_to_payload :navigation_document_supertype
     delegate_to_payload :public_timestamp, hash_key: "public_updated_at"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -40,7 +40,7 @@ module GovukIndex
         dfid_theme:                          specialist.dfid_theme,
         eligible_entities:                   specialist.eligible_entities,
         email_document_supertype:            common_fields.email_document_supertype,
-        first_published_at:                  common_fields.first_published_at,
+        first_published_at:                  specialist.first_published_at,
         format:                              common_fields.format,
         fund_state:                          specialist.fund_state,
         fund_type:                           specialist.fund_type,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -23,6 +23,7 @@ module GovukIndex
     delegate_to_payload :dfid_review_status
     delegate_to_payload :dfid_theme
     delegate_to_payload :eligible_entities
+    delegate_to_payload :first_published_at
     delegate_to_payload :fund_state, convert_to_array: true
     delegate_to_payload :fund_type
     delegate_to_payload :funding_amount

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     @directly_mapped_fields = %w(
       content_id
       email_document_supertype
-      first_published_at
       government_document_supertype
       navigation_document_supertype
       publishing_app

--- a/spec/unit/govuk_index/specialist_formats_spec.rb
+++ b/spec/unit/govuk_index/specialist_formats_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
       "country" => ["GB"],
       "dfid_authors" => ["Mr. Potato Head", "Mrs. Potato Head"],
       "dfid_theme" => ["infrastructure"],
+      "first_published_at" => "2016-04-28",
     }
     document = build_example_with_metadata(custom_metadata)
     expect_document_include_hash(document, custom_metadata)


### PR DESCRIPTION
Reverts alphagov/rummager#1254

This hasn't worked and appears to have caused a problem with the DFID finder.  The `first_published_at` used by the DFID finder lives within `["details"]["metadata"]["first_published_at"]` whereas the one I was hoping to populate lives at the root of the content item.

I don't think this is used anywhere else yet.  We did this at the time to be able to determine whether content had been updated or newly created, but didn't implement anything that used it.

Will fix https://govuk.zendesk.com/agent/tickets/3153878 when deployed, but will require republishing of the DFID specialist content.

https://trello.com/c/mgqxWPuz/167-fix-firstpublishedat-in-rummager