### PR TITLE
Be consistent in how we present specialist metadata

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -55,6 +55,7 @@ module GovukIndex
         industries:                          specialist.industries,
         is_withdrawn:                        common_fields.is_withdrawn,
         issued_date:                         specialist.issued_date,
+        laid_date:                           specialist.laid_date,
         land_use:                            specialist.land_use,
         latest_change_note:                  details.latest_change_note,
         licence_identifier:                  details.licence_identifier,
@@ -82,6 +83,9 @@ module GovukIndex
         registration:                        specialist.registration,
         rendering_app:                       common_fields.rendering_app,
         report_type:                         specialist.report_type,
+        sift_end_date:                       specialist.sift_end_date,
+        sifting_status:                      specialist.sifting_status,
+        subject:                             specialist.subject,
         search_user_need_document_supertype: common_fields.search_user_need_document_supertype,
         slug:                                slug,
         specialist_sectors:                  expanded_links.specialist_sectors,
@@ -104,6 +108,7 @@ module GovukIndex
         value_of_funding:                    specialist.value_of_funding,
         vessel_type:                         specialist.vessel_type,
         will_continue_on:                    specialist.will_continue_on,
+        withdrawn_date:                      specialist.withdrawn_date,
       }.reject { |_, v| v.nil? }
     end
 

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -32,6 +32,7 @@ module GovukIndex
     delegate_to_payload :hidden_indexable_content
     delegate_to_payload :industries
     delegate_to_payload :issued_date
+    delegate_to_payload :laid_date
     delegate_to_payload :land_use
     delegate_to_payload :location, convert_to_array: true
     delegate_to_payload :market_sector
@@ -41,6 +42,9 @@ module GovukIndex
     delegate_to_payload :railway_type
     delegate_to_payload :report_type, convert_to_array: true
     delegate_to_payload :registration
+    delegate_to_payload :sift_end_date
+    delegate_to_payload :sifting_status
+    delegate_to_payload :subject
     delegate_to_payload :therapeutic_area
     delegate_to_payload :tiers_or_standalone_items
     delegate_to_payload :tribunal_decision_categories
@@ -56,6 +60,7 @@ module GovukIndex
     delegate_to_payload :value_of_funding
     delegate_to_payload :vessel_type
     delegate_to_payload :will_continue_on
+    delegate_to_payload :withdrawn_date
 
     def initialize(metadata:)
       @metadata = metadata || {}

--- a/spec/unit/govuk_index/specialist_formats_spec.rb
+++ b/spec/unit/govuk_index/specialist_formats_spec.rb
@@ -208,6 +208,22 @@ RSpec.describe GovukIndex::ElasticsearchPresenter, 'Specialist formats' do
     expect_document_include_hash(document, custom_metadata)
   end
 
+  it "statutory instrument" do
+    custom_metadata = {
+      "laid_date" => "2018-06-01",
+      "sift_end_date" => "2018-09-01",
+      "sifting_status" => "closed",
+      "withdrawn_date" => "2018-07-01",
+    }
+    special_formated_output = {
+      "laid_date" => "2018-06-01",
+      "sifting_status" => "closed",
+    }
+    document = build_example_with_metadata(custom_metadata)
+    expect_document_include_hash(document, custom_metadata.merge(special_formated_output))
+  end
+
+
 
   it "tax tribunal decision" do
     custom_metadata = {


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3154348

The statutory instrument finder is not filtering documents by facets correctly.

* Adds statutory instrument metadata fields to relevant presenters.
* Adds a test to cover missing fields.