### PR TITLE
Permit filtering by Organisation

### DIFF
--- a/config/advanced-search.yml
+++ b/config/advanced-search.yml
@@ -49,6 +49,14 @@ details:
     display_as_result_metadata: false
     filterable: true
     allowed_values: []
+  - filter_key: organisations
+    key: organisations
+    name: Organisations
+    type: hidden
+    preposition: ''
+    display_as_result_metadata: false
+    filterable: true
+    allowed_values: []
   default_documents_per_page: 20
 routes:
 - path: "/search/advanced"


### PR DESCRIPTION
This change affects the Advanced Search Finder. It adds organisations as a hidden facet.
These facets are published, via a rake task, to the publishing-api. Once published, the
facets are accessible to finder-frontend for use in making requests.
More details: https://github.com/alphagov/finder-frontend/blob/master/docs/advanced-search-finder.md

Once merged, we'll need to run a rake task publishing_api:publish_advanced_search_finder in order
to publish this new hidden facet.

To test locally:
```
cd /path/to/govuk-puppet/development-vm
bundle exec bowl publishing-api
cd /path/to/rummager
bundle exec rake publishing_api:publish_advanced_search_finder
```

There are no visible changes for end users. In future we will need to add the organisation facet to
an advanced search filter form for users to filter by organisation (currently filtering is only possible
by changing the URL to include e.g. &organisations=department-of-education.

TODO: It would be nice to stop publishing new facets this way, and instead permit any/all filters in
finder-frontend.

Thanks to @MahmudH for pairing with me on this!