### PR TITLE
Allow filtering with topical_events

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -34,6 +34,7 @@
     "taxons",
     "title",
     "topic_content_ids",
+    "topical_events",
     "updated_at",
     "user_journey_document_supertype"
   ]

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -104,6 +104,11 @@
     "type": "identifiers"
   },
 
+  "topical_events": {
+    "description": "The topical events related to this page. These are \"slug\" identifiers.",
+    "type": "identifiers"
+  },
+
   "policies": {
     "description": "Policy content related to the page (https://www.gov.uk/government/policies).",
     "type": "identifiers"

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -67,6 +67,7 @@ class BaseParameterParser
     search_user_need_document_supertype
     specialist_sectors
     taxons
+    topical_events
     user_journey_document_supertype
     world_locations
   ).freeze
@@ -94,6 +95,7 @@ class BaseParameterParser
     rendering_app
     specialist_sectors
     taxons
+    topical_events
   ).freeze
 
   # The keys by which aggregates values can be sorted (using the "order" option).
@@ -137,6 +139,7 @@ class BaseParameterParser
     policy_areas
     world_locations
     topic_content_ids
+    topical_events
     expanded_topics
     organisation_content_ids
     expanded_organisations

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -468,6 +468,30 @@ RSpec.describe 'SearchTest' do
     expect(first_result['expanded_organisations']).to be_truthy
   end
 
+  it 'will filter by topical_events slug' do
+    topical_event_of_interest = 'quiddich-world-cup-2018'
+
+    # we DON'T want this document in our search results
+    commit_document("government_test",
+      "title" => 'Rules of Quiddich (2017)',
+      "link" => '/quiddich-rules-2017',
+      "format" => 'detailed_guidance',
+      "topical_events" => ['quiddich-world-cup-2017'])
+
+    # we DO want this document in our search results
+    commit_document("government_test",
+      "title" => 'Rules of Quiddich (2018)',
+      "link" => '/quiddich-rules-2018',
+      "format" => 'detailed_guidance',
+      "topical_events" => [topical_event_of_interest])
+
+    get "/search.json?filter_topical_events=#{topical_event_of_interest}"
+
+    expect(first_result['topical_events']).to be_truthy
+    expect(first_result['topical_events']).to eq([topical_event_of_interest])
+    expect(parsed_response['results'].length).to eq 1
+  end
+
   it "expands topics" do
     commit_document("government_test",
       "title" => 'Advice on Treatment of Dragons',


### PR DESCRIPTION
This makes it possible to search for documents related to topical_events.
For example: `rummager.search(filter_topical_events: 'budget-2018')`.

`topical_events` are currently slugs like `budget-2018`, not full topical event resources.

This change enables some Whitehall finders to use rummager.

Related Trello card: https://trello.com/c/FSMKn70m/26-make-it-possible-to-filter-rummager-by-topical-events.

Example Trello card this unblocks: https://trello.com/c/Dl8JvGH4/16-allow-news-to-appear-on-topical-event-pages.

This currently is an incomplete task, as we will need to populate the topical_events field
we will need to also make a change in Whitehall and possibly also the publishing-api in
order to make filtering by topical events useful.

According to the [adding new field](https://github.com/alphagov/rummager/blob/master/doc/adding-new-fields.md) doc, the field will become usable after 24 hours:

> On production, this is done automatically every night by the search_fetch_analytics jenkins job.