### PR TITLE
Remove deprecated search

### DIFF
--- a/lib/search/query_components/filter.rb
+++ b/lib/search/query_components/filter.rb
@@ -6,40 +6,14 @@ module QueryComponents
       user_filter = QueryComponents::UserFilter.new(search_params)
       visibility_filter = QueryComponents::VisibilityFilter.new(search_params)
 
-      user_rejected = combine_filters(
-        user_filter.rejected_queries(excluded_field_names),
-        :and
-      )
-      visibility_rejected = combine_filters(
-        visibility_filter.rejected_queries,
-        :and
-      )
-      all_rejected_queries = [user_rejected, visibility_rejected]
+      rejected = user_filter.rejected_queries(excluded_field_names) + visibility_filter.rejected_queries
 
-      # *all* filters must be true to *include* in the result
-      selected = combine_filters(user_filter.selected_queries(excluded_field_names), :and)
+      selected = user_filter.selected_queries(excluded_field_names)
 
-      # *any* rejects can be true to *exclude* from the result
-      rejected = combine_filters(all_rejected_queries, :or)
-
-      if selected
-        if rejected
-          {
-            bool: {
-              must: selected,
-              must_not: rejected,
-            }
-          }
-        else
-          selected
-        end
-      elsif rejected
-        {
-          bool: {
-            must_not: rejected,
-          }
-        }
-      end
+      result = {}
+      result[:must] = selected unless selected.empty?
+      result[:must_not] = rejected unless rejected.empty?
+      result.empty? ? {} : { bool: result }
     end
   end
 end

--- a/lib/search/query_components/user_filter.rb
+++ b/lib/search/query_components/user_filter.rb
@@ -6,17 +6,7 @@ module QueryComponents
 
     def initialize(search_params = QueryParameters.new)
       super
-
-      @rejects = []
-      @filters = []
-
-      search_params.filters.each do |filter|
-        if filter.reject
-          @rejects << filter
-        else
-          @filters << filter
-        end
-      end
+      @rejects, @filters = search_params.filters.partition(&:reject)
     end
 
     def selected_queries(excluding = [])
@@ -50,7 +40,7 @@ module QueryComponents
         raise "Filter type not supported"
       end
 
-      combine_filters(es_filters, :or)
+      combine_by_should(es_filters)
     end
 
     def exclude_fields_from_filters(excluded_field_names, filters)

--- a/lib/search/query_helpers.rb
+++ b/lib/search/query_helpers.rb
@@ -3,21 +3,14 @@ module Search
   module QueryHelpers
   private
 
-    # Combine filters using an operator
-    #
-    # `filters` should be a sequence of filters. nil filters are ignored.
-    # `op` should be :and or :or
-    #
-    # If 0 non-nil filters are supplied, returns nil.  Otherwise returns the
-    # elasticsearch query required to match the filters
-    def combine_filters(filters, op)
+    def combine_by_should(filters)
       filters = filters.compact
       if filters.empty?
         nil
       elsif filters.length == 1
         filters.first
       else
-        { op => filters }
+        { bool: { should: filters } }
       end
     end
 

--- a/spec/unit/query_components/filter_spec.rb
+++ b/spec/unit/query_components/filter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      expect(result).to eq("terms" => { "organisations" => ["hm-magic"] })
+      expect(result).to eq(bool: { must: ["terms" => { "organisations" => ["hm-magic"] }] })
     end
 
     it "append the correct date filters" do
@@ -35,7 +35,7 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      expect(result).to eq("range" => { "field_with_date" => { "from" => "2014-04-01T00:00:00+00:00", "to" => "2014-04-02T00:00:00+00:00" } })
+      expect(result).to eq(bool: { must: ["range" => { "field_with_date" => { "from" => "2014-04-01T00:00:00+00:00", "to" => "2014-04-02T00:00:00+00:00" } }] })
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe QueryComponents::Filter do
 
       result = builder.payload
 
-      expect(result).to eq("terms" => { "organisations" => ["hm-magic", "hmrc"] })
+      expect(result).to eq(bool: { must: ["terms" => { "organisations" => ["hm-magic", "hmrc"] }] })
     end
   end
 
@@ -66,8 +66,8 @@ RSpec.describe QueryComponents::Filter do
 
       expect(result).to eq(
         bool: {
-          must: { "terms" => { "organisations" => ["hm-magic", "hmrc"] } },
-          must_not: { "terms" => { "mainstream_browse_pages" => ["benefits"] } },
+          must: [{ "terms" => { "organisations" => ["hm-magic", "hmrc"] } }],
+          must_not: [{ "terms" => { "mainstream_browse_pages" => %w[benefits] } }],
         }
       )
     end
@@ -87,10 +87,12 @@ RSpec.describe QueryComponents::Filter do
       result = builder.payload
 
       expect(result).to eq(
-        and: [
-          { "terms" => { "organisations" => ["hm-magic", "hmrc"] } },
-          { "terms" => { "mainstream_browse_pages" => ["levitation"] } },
-        ].compact
+        bool: {
+          must: [
+            { "terms" => { "organisations" => ["hm-magic", "hmrc"] } },
+            { "terms" => { "mainstream_browse_pages" => %w[levitation] } },
+          ].compact
+        }
       )
     end
   end


### PR DESCRIPTION
- Removes deprecated 'or' and 'and' filters and replaces them with 'bool' filters
- Simplifies some of the code

https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-and-query.html
https://www.elastic.co/guide/en/elasticsearch/guide/current/combining-filters.html#bool-filter