### PR TITLE
Cap the limit of the "start" param

### DIFF
--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -649,13 +649,6 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response.fetch("total")).to eq(1)
   end
 
-  it "return 400 response for integers out of range" do
-    get '/search.json?count=50&start=7599999900'
-
-    expect(last_response).to be_bad_request
-    expect(last_response.body).to eq('Integer value of 7599999900 exceeds maximum allowed')
-  end
-
   it "return 400 response for query term length too long" do
     terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
     get "/search.json?q=#{terms}"

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -136,6 +136,14 @@ RSpec.describe SearchParameterParser do
     expect(expected_params(start: 2)).to eq(p.parsed_params)
   end
 
+  it "complains about a start parameter that is too large" do
+    p = described_class.new({ "start" => %w(999999) }, @schema)
+
+    expect(p.error).to eq("Maximum result set start point (as specified in 'start') is 900000")
+    expect(p).not_to be_valid
+    expect(expected_params(start: 0)).to eq(p.parsed_params)
+  end
+
   it "understands the count parameter" do
     p = described_class.new({ "count" => ["5"] }, @schema)
 


### PR DESCRIPTION
Values that are greater than around 900,000 result in a 500 error.  We currently have around 375,000 results in Rummager, so capping the maximum start value at 500,000 doesn't seem too bad.

We've experiencing repeated scanning requests to search pages which result in numbers (eg 29999800 from the below example) that are vexatious.  Platform Health have a card to relieve this in the longer term, but this will hopefully reduce the number of 500s we serve in the meantime and reduce the noise on 2nd line.

I've removed the test for expecting a 400 when submitting large integers to elasticsearch because in practice this results in a 503.  We're also putting defences in front of that now.

Example query:
`GET /search.json?count=100&start=29999800&fields=title%2Clink%2Cdescription%2Cpublic_timestamp%2Cpart_of_taxonomy_tree%2Corganisations&filter_organisations[]=department-for-work-pensions&order=-public_timestamp&facet_organisations=1500%2Corder%3Avalue.title HTTP/1.1`