### PR TITLE
Update schema migration documentation

### DIFF
--- a/doc/adding-new-fields.md
+++ b/doc/adding-new-fields.md
@@ -25,12 +25,22 @@ Some fields get transformed by rummager before they are stored in Elasticsearch.
 
 Some fields get expanded by rummager when they are presented in search results. For example, `specialist_sector` links get expanded by looking up the corresponding documents from the search index and extracting title, content id, and link fields. This is handled by `Search::BaseRegistry`.
 
+### Updating Rummager schema indexes on all environments
+
+**Caution:** Do not run this rake task in production during working hours except in an emergency. Content published while the task is running will not be available in search results until the task completes. The impact of this can be reduced if you run the task out of peak publishing hours.
+
+In order for the new field to work as expected, you will need to run a Jenkins job on all environments. The job is "Search reindex with new schema" ([Link to integration version of task](https://deploy.integration.publishing.service.gov.uk/job/search_reindex_with_new_schema/)), and will run the `rummager:migrate_schema` rake task. It can take over 40 minutes to complete.
+
+This job will block other rake tasks from being run for 15 minutes to an hour.
+
+[Read more about re-indexing the elasticsearch indexes here](https://docs.publishing.service.gov.uk/manual/reindex-elasticsearch.html#how-to-reindex-an-elasticsearch-index).
+
 ### Troubleshooting
 
-#### The new field doesn't show up immediately
+#### The new field doesn't show up
 
-For the new elasticsearch configuration to take effect, you need to rebuild the search indexes.
+For the new elasticsearch configuration to take effect, you need to manually rebuild the search indexes.
 
-On production, this is done automatically every night by the [`search_fetch_analytics`](https://github.com/alphagov/search-analytics) jenkins job.
+In the past, this was done automatically every night by the [`search_fetch_analytics`](https://github.com/alphagov/search-analytics) jenkins job, but this automation [was reverted](https://github.com/alphagov/search-analytics/commit/a5c3ac58f7198eba74ab7b5bd5555aa07490442a#diff-0484c7ea1cf547a292a2190d0c1c060b). You must run this manually.
 
-For other environments, you can run `RUMMAGER_INDEX=all SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 rummager:migrate_schema`.
+If you prefer running a rake task rather than a pre-written Jenkins job, you can run `RUMMAGER_INDEX=all SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 rummager:migrate_schema`.


### PR DESCRIPTION
The documentation was out of date, as one must run this task manually as the automated nightly job that ran this task was removed ([here](https://github.com/alphagov/search-analytics/commit/a5c3ac58f7198eba74ab7b5bd5555aa07490442a#diff-0484c7ea1cf547a292a2190d0c1c060b), but maybe it also existed elsewhere).