### PR TITLE
Index documents tagged to topical events in govuk index

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -97,6 +97,7 @@ module GovukIndex
         tiers_or_standalone_items:           specialist.tiers_or_standalone_items,
         title:                               common_fields.title,
         topic_content_ids:                   expanded_links.topic_content_ids,
+        topical_events:                      expanded_links.topical_events,
         tribunal_decision_categories:        specialist.tribunal_decision_categories,
         tribunal_decision_category:          specialist.tribunal_decision_category,
         tribunal_decision_country:           specialist.tribunal_decision_country,

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -36,6 +36,10 @@ module GovukIndex
       content_ids("topics")
     end
 
+    def topical_events
+      slugs("topical_events", "/government/topical-events/")
+    end
+
     def specialist_sectors
       slugs("topics", "/topic/")
     end

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -64,6 +64,23 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.primary_publishing_organisation).to eq(expected_primary_publishing_organisation)
   end
 
+  it "topical_events" do
+    expanded_links = {
+      "topical_events" => [
+        {
+          "base_path" => "/government/topical-events/budget",
+          "content_id" => "ca2326a6-b6c4-4750-917f-9fe12d0c59c9",
+          "locale" => "en",
+          "title" => "The budget"
+        }
+      ]
+    }
+    presenter = expanded_links_presenter(expanded_links)
+
+    expected_topical_events = %w[budget]
+    expect(presenter.topical_events).to eq(expected_topical_events)
+  end
+
   it "taxons" do
     expanded_links = {
       "taxons" => [


### PR DESCRIPTION
Previously, all tagging to topical events were handled in whitehall. When a document is published whitehall would update the government index in rummager which is the older index. The search endpoint would return results from both the new (govuk index) and the old (government index).

Content-publisher can now tag topical events to a document however the index it populates (govuk index) when publishing does not index this field currently, this change enables documents published by content publisher which are tagged to topical events to be indexed so the search endpoint can return these results.

## Local search result for a document published by content-publisher with topical events from the govuk index.
<img width="729" alt="screen shot 2018-11-05 at 11 48 27" src="https://user-images.githubusercontent.com/24479188/47998171-47718a00-e0f6-11e8-87f6-fe90c269ffc2.png">

The topical events tagged to a document are saved as a hash with topical_events being the key and the slugs being the values in the govuk index, this follows the same pattern as how topical events are indexed in the the government index. E.g

## Search result returning topical events tagged to a document from the government index.
<img width="1054" alt="screen shot 2018-11-05 at 12 30 31" src="https://user-images.githubusercontent.com/24479188/47998552-a4217480-e0f7-11e8-9c97-cf7e31b2e895.png">

Trello:
https://trello.com/c/Nx5jjnIj/373-populate-topical-events-in-rummager-for-content-publisher-content
