### PR TITLE
Index documents tagged to world locations in govuk index

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -114,6 +114,7 @@ module GovukIndex
         vessel_type:                         specialist.vessel_type,
         will_continue_on:                    specialist.will_continue_on,
         withdrawn_date:                      specialist.withdrawn_date,
+        world_locations:                     expanded_links.world_locations
       }.reject { |_, v| v.nil? }
     end
 

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -54,6 +54,12 @@ module GovukIndex
       end
     end
 
+    def world_locations
+      expanded_links.fetch("world_locations", {}).map do |world_location|
+        world_location.fetch("title").parameterize
+      end
+    end
+
   private
 
     attr_reader :expanded_links

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -81,6 +81,56 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.topical_events).to eq(expected_topical_events)
   end
 
+  it "world_locations" do
+    expanded_links = {
+      "world_locations" => [
+        {
+          "content_id" => "5e9f420d-7706-11e4-a3cb-005056011aef",
+          "title" => "Bonaire/St Eustatius/Saba",
+          "schema_name" => "world_location",
+          "locale" => "en",
+          "analytics_identifier" => "WL224",
+          "links" => {}
+        },
+        {
+          "content_id" => "dc258e77-8731-4c7f-9a6f-df508b991298",
+          "title" => "Saint-Barthélemy",
+          "schema_name" => "world_location",
+          "locale" => "en",
+          "analytics_identifier" => "WL247",
+          "links" => {}
+        },
+        {
+          "content_id" => "5e9f3c6b-7706-11e4-a3cb-005056011aef",
+          "title" => "St Helena, Ascension and Tristan da Cunha",
+          "schema_name" => "world_location",
+          "locale" => "en",
+          "analytics_identifier" => "WL216",
+          "links" => {}
+        },
+        {
+          "content_id" => "5e9f3c18-7706-11e4-a3cb-005056011aef",
+          "title" =>
+          "The UK Permanent Delegation to the OECD (Organisation for Economic Co-operation and Development)",
+          "schema_name" => "world_location",
+          "locale" => "en",
+          "analytics_identifier" => "WL210",
+          "links" => {}
+        },
+      ]
+    }
+    presenter = expanded_links_presenter(expanded_links)
+
+    expected_world_locations = [
+      "bonaire-st-eustatius-saba",
+      "saint-barthelemy",
+      "st-helena-ascension-and-tristan-da-cunha",
+      "the-uk-permanent-delegation-to-the-oecd-organisation-for-economic-co-operation-and-development"
+    ]
+
+    expect(presenter.world_locations).to eq(expected_world_locations)
+  end
+
   it "taxons" do
     expanded_links = {
       "taxons" => [


### PR DESCRIPTION
Previously, all tagging to world_locations were handled in whitehall.
When a document is published whitehall would update the government index
in rummager which is the older index. The search endpoint would return
results from both the new (govuk index) and the old (government index).

Content-publisher can now tag world_locations to a document however the
index it populates (govuk index) does not index this field currently,
this change enables documents published by content publisher which are
tagged to world_locations to be indexed so the search endpoint can
return these results.

## Local search result for a document published by content-publisher with world locations from the govuk index.
<img width="979" alt="screen shot 2018-11-06 at 15 31 35" src="https://user-images.githubusercontent.com/24479188/48075067-3b5ef880-e1da-11e8-88f7-c54eed1f6816.png">

Trello:
https://trello.com/c/GByG04gX/387-populate-world-locations-in-rummager-for-content-publisher-content

