### PR TITLE
Adds two parameters to the analytics:delete_old_files task

### DIFF
--- a/lib/tasks/analytics.rake
+++ b/lib/tasks/analytics.rake
@@ -32,9 +32,12 @@ namespace :analytics do
   end
 
   desc "Delete old export files (specify the number to keep with EXPORT_FILE_LIMIT)"
-  task :delete_old_files do
-    path = ENV['EXPORT_PATH'] || 'data'
-    export_file_limit = ENV.fetch('EXPORT_FILE_LIMIT').to_i + 1
+  task :delete_old_files, [:path, :export_file_limit] do |_, args|
+    args.with_defaults(path: (ENV['EXPORT_PATH'] || 'data'),
+                       export_file_limit: (ENV['EXPORT_FILE_LIMIT'] || 10))
+    path = args[:path]
+    export_file_limit = args[:export_file_limit].to_i
+
     files = Dir["#{path}/analytics_data_import_*.csv"]
     files = files.sort
     files[0..-export_file_limit].each do |file|


### PR DESCRIPTION
This is run from the Jenkins run-rake-task task and requires
parameters to be set through rake instead of environment variables