### PR TITLE
Add a synonym of "Brexit" for "EU Exit"

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -18,6 +18,7 @@
 
 # Same meanings
 - search: abroad, overseas
+- search: brexit, eu exit => brexit, eu exit
 - search: motorbike, motorcycle
 - search: opening times, opening hours
 - search: sickness, illness


### PR DESCRIPTION
This ensures that searches for "brexit" return results that have the word "EU Exit" in the searchable fields.

This is useful because brexit is a common search term, but on production there are far fewer results for brexit than there are for EU Exit:

17234 results for [eu exit](https://www.gov.uk/search.json?q=eu%20exit)
1337 results for [brexit](https://www.gov.uk/search.json?q=brexit)

This should surface much more content when searching across gov.uk
for brexit, even if brexit has been omitted from the documents
searchable fields.

A schema migration will be necessary after this change across all
environments:
See https://github.com/alphagov/rummager#changing-the-schemareindexing.

https://trello.com/c/LgqvNg72/153-add-a-synonym-brexit-eu-exit-to-rummager