### PR TITLE
Expect more base_paths to not be present

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -8,7 +8,26 @@ module GovukIndex
   class NotIdentifiable < StandardError; end
   class MissingExternalUrl < StandardError; end
 
-  DOCUMENT_TYPES_WITHOUT_BASE_PATH = %w(contact world_location).freeze
+  DOCUMENT_TYPES_WITHOUT_BASE_PATH =
+    %w(
+      contact
+      role_appointment
+      world_location
+
+      # role document types
+      ambassador_role
+      board_member_role
+      chief_professional_officer_role
+      chief_scientific_officer_role
+      deputy_head_of_mission_role
+      governor_role
+      high_commissioner_role
+      military_role
+      ministerial_role
+      special_representative_role
+      traffic_commissioner_role
+      worldwide_office_staff_role
+    ).freeze
 
   class PublishingEventWorker < Indexer::BaseWorker
     notify_of_failures


### PR DESCRIPTION
Fixes errors in https://sentry.io/govuk/app-rummager/?query=APP-RUMMAGER-FY that aren't really errors.

Rummager expects things to have a [base_path](https://github.com/alphagov/rummager/blob/0962e395ab4a9bc291aff61f637e5a15a2ae7310/lib/govuk_index/presenters/elasticsearch_presenter.rb#L141).

If it doesn't then an exception is raised when `valid!` is called on the presenter. [The exception is caught](https://github.com/alphagov/rummager/blob/0962e395ab4a9bc291aff61f637e5a15a2ae7310/lib/govuk_index/publishing_event_worker.rb#L67) if the `document_type` is in the allow list.

The allow list has got a little out of date.  This commit adds the document types that are relevant to the `role_appointment` and `role` schemas.  These are the schemas (besides `contact` and `world_location`) that have `base_path` set to `optional` in [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/tree/master/formats)

https://trello.com/c/CxGTjfcH/79-large-numbers-of-errors-are-sent-to-sentry-and-many-dont-arrive