### PR TITLE
Add business readiness fields to specialist schemas

### DIFF
--- a/config/schema/elasticsearch_types/aaib_report.json
+++ b/config/schema/elasticsearch_types/aaib_report.json
@@ -1,11 +1,19 @@
 {
   "fields": [
     "aircraft_category",
-    "report_type",
-    "date_of_occurrence",
-    "registration",
     "aircraft_type",
-    "location"
+    "date_of_occurrence",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "location",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "registration",
+    "regulations_and_standards",
+    "report_type",
+    "sector_business_area"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/asylum_support_decision.json
+++ b/config/schema/elasticsearch_types/asylum_support_decision.json
@@ -1,5 +1,13 @@
 {
   "fields": [
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
     "tribunal_decision_categories",
     "tribunal_decision_category",
     "tribunal_decision_category_name",

--- a/config/schema/elasticsearch_types/business_finance_support_scheme.json
+++ b/config/schema/elasticsearch_types/business_finance_support_scheme.json
@@ -2,8 +2,16 @@
   "fields": [
     "business_sizes",
     "business_stages",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
     "industries",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
     "regions",
+    "regulations_and_standards",
+    "sector_business_area",
     "types_of_support"
   ],
 

--- a/config/schema/elasticsearch_types/cma_case.json
+++ b/config/schema/elasticsearch_types/cma_case.json
@@ -1,11 +1,19 @@
 {
   "fields": [
-    "case_type",
     "case_state",
+    "case_type",
+    "closed_date",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
     "market_sector",
-    "outcome_type",
     "opened_date",
-    "closed_date"
+    "outcome_type",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/countryside_stewardship_grant.json
+++ b/config/schema/elasticsearch_types/countryside_stewardship_grant.json
@@ -1,9 +1,17 @@
 {
   "fields": [
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "funding_amount",
     "grant_type",
+    "intellectual_property",
     "land_use",
-    "tiers_or_standalone_items",
-    "funding_amount"
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
+    "tiers_or_standalone_items"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/dfid_research_output.json
+++ b/config/schema/elasticsearch_types/dfid_research_output.json
@@ -1,11 +1,19 @@
 {
   "fields": [
     "country",
-    "first_published_at",
     "dfid_authors",
+    "dfid_document_type",
     "dfid_review_status",
     "dfid_theme",
-    "dfid_document_type"
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "first_published_at",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area"
   ],
   "expanded_search_result_fields": {
     "dfid_review_status": [

--- a/config/schema/elasticsearch_types/drug_safety_update.json
+++ b/config/schema/elasticsearch_types/drug_safety_update.json
@@ -1,7 +1,15 @@
 {
   "fields": [
-    "therapeutic_area",
-    "first_published_at"
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "first_published_at",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
+    "therapeutic_area"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/employment_appeal_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/employment_appeal_tribunal_decision.json
@@ -1,5 +1,13 @@
 {
   "fields": [
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
     "tribunal_decision_categories",
     "tribunal_decision_categories_name",
     "tribunal_decision_decision_date",

--- a/config/schema/elasticsearch_types/employment_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/employment_tribunal_decision.json
@@ -1,5 +1,13 @@
 {
   "fields": [
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
     "tribunal_decision_categories",
     "tribunal_decision_categories_name",
     "tribunal_decision_country",

--- a/config/schema/elasticsearch_types/european_structural_investment_fund.json
+++ b/config/schema/elasticsearch_types/european_structural_investment_fund.json
@@ -1,10 +1,18 @@
 {
   "fields": [
+    "closing_date",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
     "fund_state",
     "fund_type",
-    "location",
     "funding_source",
-    "closing_date"
+    "intellectual_property",
+    "location",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/export_health_certificate.json
+++ b/config/schema/elasticsearch_types/export_health_certificate.json
@@ -2,7 +2,15 @@
   "fields": [
     "certificate_status",
     "commodity_type",
-    "destination_country"
+    "destination_country",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/international_development_fund.json
+++ b/config/schema/elasticsearch_types/international_development_fund.json
@@ -1,9 +1,17 @@
 {
   "fields": [
-    "fund_state",
-    "location",
     "development_sector",
+    "doing_business_in_the_eu",
     "eligible_entities",
+    "employ_eu_citizens",
+    "fund_state",
+    "intellectual_property",
+    "location",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
     "value_of_funding"
   ],
 

--- a/config/schema/elasticsearch_types/maib_report.json
+++ b/config/schema/elasticsearch_types/maib_report.json
@@ -1,8 +1,16 @@
 {
   "fields": [
-    "vessel_type",
+    "date_of_occurrence",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
     "report_type",
-    "date_of_occurrence"
+    "sector_business_area",
+    "vessel_type"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/medical_safety_alert.json
+++ b/config/schema/elasticsearch_types/medical_safety_alert.json
@@ -1,8 +1,16 @@
 {
   "fields": [
     "alert_type",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "issued_date",
     "medical_specialism",
-    "issued_date"
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/raib_report.json
+++ b/config/schema/elasticsearch_types/raib_report.json
@@ -1,8 +1,16 @@
 {
   "fields": [
+    "date_of_occurrence",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
     "railway_type",
+    "receiving_eu_funding",
+    "regulations_and_standards",
     "report_type",
-    "date_of_occurrence"
+    "sector_business_area"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
@@ -1,8 +1,16 @@
 {
   "fields": [
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
     "tribunal_decision_category",
-    "tribunal_decision_sub_category",
-    "tribunal_decision_decision_date"
+    "tribunal_decision_decision_date",
+    "tribunal_decision_sub_category"
   ],
 
   "expanded_search_result_fields": {

--- a/config/schema/elasticsearch_types/service_standard_report.json
+++ b/config/schema/elasticsearch_types/service_standard_report.json
@@ -1,5 +1,13 @@
 {
   "fields": [
-    "assessment_date"
+    "assessment_date",
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area"
   ]
 }

--- a/config/schema/elasticsearch_types/statutory_instrument.json
+++ b/config/schema/elasticsearch_types/statutory_instrument.json
@@ -1,6 +1,14 @@
 {
   "fields": [
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
     "laid_date",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
     "sift_end_date",
     "sifting_status",
     "subject",

--- a/config/schema/elasticsearch_types/tax_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/tax_tribunal_decision.json
@@ -1,5 +1,13 @@
 {
   "fields": [
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
     "tribunal_decision_category",
     "tribunal_decision_category_name",
     "tribunal_decision_decision_date"

--- a/config/schema/elasticsearch_types/utaac_decision.json
+++ b/config/schema/elasticsearch_types/utaac_decision.json
@@ -1,5 +1,13 @@
 {
   "fields": [
+    "doing_business_in_the_eu",
+    "employ_eu_citizens",
+    "intellectual_property",
+    "personal_data",
+    "public_sector_procurement",
+    "receiving_eu_funding",
+    "regulations_and_standards",
+    "sector_business_area",
     "tribunal_decision_categories",
     "tribunal_decision_categories_name",
     "tribunal_decision_decision_date",


### PR DESCRIPTION
Finishes off #1324 

~We probably don't need these facets in all specialist document types - will a business need to look at RAIB reports to prepare for brexit?~ . We're going ahead with all of the types for now.