### PR TITLE
Add json finder route for ajax filtering

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -562,5 +562,7 @@ details:
 routes:
 - path: "/find-eu-exit-guidance-business"
   type: exact
+- path: "/find-eu-exit-guidance-business.json"
+  type: exact
 document_type: finder
 schema_name: finder


### PR DESCRIPTION
https://trello.com/c/2BGHlD7M/13-make-it-possible-to-publish-finder

Ajax filtering occurs when facets are selected or deselected so this
route needs to be registered for the finder.

![screenshot from 2018-11-20 14-13-05](https://user-images.githubusercontent.com/93511/48778948-6bc08f80-ecce-11e8-89ef-fd4cd715d1b5.png)
