### PR TITLE
Amend tagging task to process csv

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -17,8 +17,10 @@ module Indexer
         metadata["appear_in_find_eu_exit_guidance_business_finder"] = "yes"
 
         item_in_search = SearchConfig.instance.content_index.get_document_by_link(base_path)
-        index_to_update = item_in_search["real_index_name"]
-        Indexer::AmendWorker.new.perform(index_to_update, base_path, metadata)
+        if item_in_search
+          index_to_update = item_in_search["real_index_name"]
+          Indexer::AmendWorker.new.perform(index_to_update, base_path, metadata)
+        end
       end
     end
 

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -1,16 +1,164 @@
+require 'csv'
+
 module Indexer
   class MetadataTagger
     def self.amend_indexes_for_file(file_name)
-      file = File.read(file_name)
-      json = JSON.parse(file)
+      file = CSV.read(file_name)
 
-      # the key is our base path, the value a hash of metadata to amend
-      # base_path: { key: value, key: value }
-      json.each do |base_path, metadata|
+      file.each do |row|
+        base_path = row[0]
+
+        if row[1] == "yes"
+          metadata = create_all_metadata
+        else
+          metadata = specific_metadata(row)
+        end
+
+        metadata["appear_in_find_eu_exit_guidance_business_finder"] = "yes"
+
         item_in_search = SearchConfig.instance.content_index.get_document_by_link(base_path)
         index_to_update = item_in_search["real_index_name"]
         Indexer::AmendWorker.new.perform(index_to_update, base_path, metadata)
       end
+    end
+
+    def self.create_all_metadata
+      {
+        "sector_business_area" => all_sector_business_area,
+        "employ_eu_citizens" => all_employ_eu_citizens,
+        "doing_business_in_the_eu" => all_doing_business_in_the_eu,
+        "regulations_and_standards" => all_regulations_and_standards,
+        "personal_data" => all_personal_data,
+        "intellectual_property" => all_intellectual_property,
+        "receiving_eu_funding" => all_receiving_eu_funding,
+        "public_sector_procurement" => all_public_sector_procurement
+      }
+    end
+
+    def self.specific_metadata(row)
+      {
+        "sector_business_area" => row.fetch(2, "").split(","),
+        "employ_eu_citizens" => row.fetch(3, "").split(","),
+        "doing_business_in_the_eu" => row.fetch(4, "").split(","),
+        "regulations_and_standards" => row.fetch(5, "").split(","),
+        "personal_data" => row.fetch(6, "").split(","),
+        "intellectual_property" => row.fetch(7, "").split(","),
+        "receiving_eu_funding" => row.fetch(8, "").split(","),
+        "public_sector_procurement" => row.fetch(9, "").split(",")
+      }.reject do |_, value|
+        value == []
+      end
+    end
+
+    def self.all_sector_business_area
+      [
+        "accommodation-restaurants-and-catering-services",
+        "aerospace",
+        "agriculture",
+        "air-transport-aviation",
+        "ancillary-services",
+        "animal-health",
+        "automotive",
+        "banking-market-infrastructure",
+        "broadcasting",
+        "chemicals",
+        "computer-services",
+        "construction-contracting",
+        "education",
+        "electricity",
+        "electronics",
+        "environmental-services",
+        "fisheries",
+        "food-and-drink",
+        "furniture-and-other-manufacturing",
+        "gas-markets",
+        "goods-sectors-each-0-4-of-gva",
+        "imports",
+        "imputed-rent",
+        "insurance",
+        "land-transport-excl-rail",
+        "medical-services",
+        "motor-trades",
+        "network-industries-0-3-of-gva",
+        "oil-and-gas-production",
+        "other-personal-services",
+        "parts-and-machinery",
+        "pharmaceuticals",
+        "post",
+        "professional-and-business-services",
+        "public-administration-and-defence",
+        "rail",
+        "real-estate-excl-imputed-rent",
+        "retail",
+        "service-sectors-each-1-of-gva",
+        "social-work",
+        "steel-and-other-metals-commodities",
+        "telecoms",
+        "textiles-and-clothing",
+        "top-ten-trade-partners-by-value",
+        "warehousing-and-support-for-transportation",
+        "water-transport-maritime-ports",
+        "wholesale-excl-motor-vehicles"
+      ]
+    end
+
+    def self.all_employ_eu_citizens
+      %w(yes no dont-know)
+    end
+
+    def self.all_doing_business_in_the_eu
+      [
+        "do-business-in-the-eu",
+        "buying",
+        "selling",
+        "transporting",
+        "other-eu",
+        "other-rest-of-the-world"
+      ]
+    end
+
+    def self.all_regulations_and_standards
+      %w(products-or-goods)
+    end
+
+    def self.all_personal_data
+      [
+        "processing-personal-data",
+        "interacting-with-eea-website",
+        "digital-service-provider"
+      ]
+    end
+
+    def self.all_intellectual_property
+      [
+        "have-intellectual-property",
+        "copyright",
+        "trademarks",
+        "designs",
+        "patents",
+        "exhaustion-of-rights"
+      ]
+    end
+
+    def self.all_receiving_eu_funding
+      [
+        "horizon-2020",
+        "cosme",
+        "european-investment-bank-eib",
+        "european-structural-fund-esf",
+        "eurdf",
+        "etcf",
+        "esc",
+        "ecp",
+        "etf"
+      ]
+    end
+
+    def self.all_public_sector_procurement
+      [
+        "civil-government-contracts",
+        "defence-contracts"
+      ]
     end
   end
 end

--- a/lib/tasks/metadata_tagger.rake
+++ b/lib/tasks/metadata_tagger.rake
@@ -1,7 +1,7 @@
 require 'rummager'
 
 desc "Apply metadata from the json file"
-task :tag_json_metadata do
-  file_path = File.join(settings.root, '../../config/metadata.json')
+task :tag_metadata do
+  file_path = File.join(settings.root, '../../config/metadata.csv')
   Indexer::MetadataTagger.amend_indexes_for_file(file_path)
 end

--- a/spec/unit/indexer/fixtures/metadata.csv
+++ b/spec/unit/indexer/fixtures/metadata.csv
@@ -1,0 +1,1 @@
+/a_base_path,,"aerospace,agriculture",yes

--- a/spec/unit/indexer/fixtures/metadata.json
+++ b/spec/unit/indexer/fixtures/metadata.json
@@ -1,5 +1,0 @@
-{
-    "/foobang": {
-        "aircraft_category": "big"
-    }
-}

--- a/spec/unit/indexer/fixtures/metadata_for_all.csv
+++ b/spec/unit/indexer/fixtures/metadata_for_all.csv
@@ -1,0 +1,1 @@
+/a_base_path,yes

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 RSpec.describe Indexer::MetadataTagger do
   # rubocop:disable RSpec/VerifiedDoubles, RSpec/AnyInstance, RSpec/MessageSpies
   it "amends documents" do
-    fixture_file = File.expand_path("fixtures/metadata.json", __dir__)
-    base_path = '/foobang'
+    fixture_file = File.expand_path("fixtures/metadata.csv", __dir__)
+    base_path = '/a_base_path'
     test_index_name = 'test-index'
 
     mock_index = double("index")
@@ -12,7 +12,46 @@ RSpec.describe Indexer::MetadataTagger do
     expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
       .and_return('real_index_name' => test_index_name)
 
-    expect(mock_index).to receive(:amend).with(base_path, "aircraft_category" => "big")
+    metadata = {
+      "sector_business_area" => %w(aerospace agriculture),
+      "employ_eu_citizens" => %w(yes),
+      "appear_in_find_eu_exit_guidance_business_finder" => "yes"
+    }
+
+    expect(mock_index).to receive(:amend).with(base_path, metadata)
+    expect_any_instance_of(SearchIndices::SearchServer).to receive(:index)
+      .with(test_index_name)
+      .and_return(mock_index)
+
+    described_class.amend_indexes_for_file(fixture_file)
+  end
+
+  it "amends with everything" do
+    # the second field in our csv indicates whether or not our base path should be
+    # tagged to every value of every facet. When this field is "yes", we should
+    # tag to everything
+    fixture_file = File.expand_path("fixtures/metadata_for_all.csv", __dir__)
+    test_index_name = 'test-index'
+    base_path = '/a_base_path'
+
+    mock_index = double("index")
+
+    expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
+      .and_return('real_index_name' => test_index_name)
+
+    metadata = {
+      "sector_business_area" => ["accommodation-restaurants-and-catering-services", "aerospace", "agriculture", "air-transport-aviation", "ancillary-services", "animal-health", "automotive", "banking-market-infrastructure", "broadcasting", "chemicals", "computer-services", "construction-contracting", "education", "electricity", "electronics", "environmental-services", "fisheries", "food-and-drink", "furniture-and-other-manufacturing", "gas-markets", "goods-sectors-each-0-4-of-gva", "imports", "imputed-rent", "insurance", "land-transport-excl-rail", "medical-services", "motor-trades", "network-industries-0-3-of-gva", "oil-and-gas-production", "other-personal-services", "parts-and-machinery", "pharmaceuticals", "post", "professional-and-business-services", "public-administration-and-defence", "rail", "real-estate-excl-imputed-rent", "retail", "service-sectors-each-1-of-gva", "social-work", "steel-and-other-metals-commodities", "telecoms", "textiles-and-clothing", "top-ten-trade-partners-by-value", "warehousing-and-support-for-transportation", "water-transport-maritime-ports", "wholesale-excl-motor-vehicles"],
+      "employ_eu_citizens" => ["yes", "no", "dont-know"],
+      "doing_business_in_the_eu" => ["do-business-in-the-eu", "buying", "selling", "transporting", "other-eu", "other-rest-of-the-world"],
+      "regulations_and_standards" => ["products-or-goods"],
+      "personal_data" => ["processing-personal-data", "interacting-with-eea-website", "digital-service-provider"],
+      "intellectual_property" => ["have-intellectual-property", "copyright", "trademarks", "designs", "patents", "exhaustion-of-rights"],
+      "receiving_eu_funding" => ["horizon-2020", "cosme", "european-investment-bank-eib", "european-structural-fund-esf", "eurdf", "etcf", "esc", "ecp", "etf"],
+      "public_sector_procurement" => ["civil-government-contracts", "defence-contracts"],
+      "appear_in_find_eu_exit_guidance_business_finder" => "yes"
+    }
+
+    expect(mock_index).to receive(:amend).with(base_path, metadata)
     expect_any_instance_of(SearchIndices::SearchServer).to receive(:index)
       .with(test_index_name)
       .and_return(mock_index)


### PR DESCRIPTION
We have decided that content to be tagged will be provided in a csv.
The format will be:

```
base_path, all, sector_business_area, employ_eu_citizens,....
```

Individual items in the facet columns will be comma delimited facet
values in a sluggified format.

When `all` is populated with "yes", we want to tag to every facet, every
value.

[Trello](https://trello.com/c/9je6KiA9/66-update-rummager-rake-import-task-to-use-csv)