### PR TITLE
Amend base filter with new metadata filter

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -13,8 +13,8 @@ details:
   beta: false
   document_noun: publication
   subscription_list_title_prefix: 'Find EU Exit guidance for your business '
-  reject:
-    sector_business_area: "_MISSING"
+  filter:
+    appear_in_find_eu_exit_guidance_business_finder: "yes"
   email_filter_facets:
   - facet_id: sector_business_area
     facet_name: Sector / Business Area

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -77,7 +77,7 @@ class FinderContentItemPresenter
   end
 
   def details
-    schema["details"].except("reject", "subscription_list_title_prefix", "email_filter_facets")
+    schema["details"].except("email_filter_facets", "subscription_list_title_prefix")
   end
 end
 
@@ -96,7 +96,7 @@ class FinderEmailSignupContentItemPresenter
     details.merge(
       "subscription_list_title_prefix" => details.fetch("subscription_list_title_prefix", {}),
       "email_filter_facets" => details.fetch("email_filter_facets", []),
-    ).except("document_noun", "facets", "reject")
+    ).except("document_noun", "facets", "filter", "reject")
   end
 
   def present


### PR DESCRIPTION
https://trello.com/c/2BGHlD7M/13-make-it-possible-to-publish-finder

We'd like to include any document tagged to a business readiness
filtering facet, so use an internal metadata value as the base
filter.

DNM until release_827 of govuk-content-schemas

Depends on https://github.com/alphagov/govuk-content-schemas/pull/838