### PR TITLE
Export email signup content id in links when supplied

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -73,7 +73,10 @@ class FinderContentItemPresenter
   end
 
   def present_links
-    { content_id: content_id, links: {} }
+    links = {}
+    links["email_alert_signup"] = schema["signup_content_id"] if schema.key?("signup_content_id")
+
+    { content_id: content_id, links: links }
   end
 
   def details

--- a/spec/unit/publishing_api_finder_publisher_spec.rb
+++ b/spec/unit/publishing_api_finder_publisher_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe PublishingApiFinderPublisher do
 
       it "patches links for the finder" do
         expect(publishing_api).to have_received(:patch_links)
-          .with(content_id, { content_id: content_id, links: {} })
+          .with(content_id, { content_id: content_id, links: anything })
       end
 
       it "publishes the finder to the Publishing API" do


### PR DESCRIPTION
Adds signup content id to links hash so that finder frontend can render the email signup link.

See example here:
https://github.com/alphagov/govuk-content-schemas/blob/d9a5dcc8848239832b4c9a8dbdae88a1966c8107/examples/finder/publisher_v2/finder_links.json#L9-L11