### PR TITLE
Add a link to finder email signup pages

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -73,7 +73,12 @@ class FinderContentItemPresenter
   end
 
   def present_links
-    { content_id: content_id, links: {} }
+    {
+      content_id: content_id,
+      links: {
+        email_alert_signup: [schema["signup_content_id"]].compact
+      }
+    }
   end
 
   def details


### PR DESCRIPTION
This allows for a button to appear on the finder allowing users to subscriber to emails.