### PR TITLE
Ignore /prepare-business-uk-leaving-eu

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -302,6 +302,7 @@ non_indexable:
   - '/tour'
   - '/help/ab-testing'
   - '/help.json'
+  - '/prepare-business-uk-leaving-eu'
   - '/random'
   # from whitehall
   - "/BingSiteAuth.xml"


### PR DESCRIPTION
This commit adds `/prepare-business-uk-leaving-eu` to the list of special routes to be ignored.