### PR TITLE
Add summary to business readiness finder

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -13,6 +13,7 @@ details:
   beta: false
   document_noun: publication
   subscription_list_title_prefix: 'Find EU Exit guidance for your business '
+  summary: 'This is the information that has been published so far for your business to prepare for EU exit. You can change what information you get using the checkboxes. Come back to this page regularly or sign up to receive emails when new information is published.'
   filter:
     appear_in_find_eu_exit_guidance_business_finder: "yes"
   email_filter_facets:

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -99,7 +99,7 @@ class FinderEmailSignupContentItemPresenter
     details.merge(
       "subscription_list_title_prefix" => details.fetch("subscription_list_title_prefix", {}),
       "email_filter_facets" => details.fetch("email_filter_facets", []),
-    ).except("document_noun", "facets", "filter", "reject")
+    ).except("document_noun", "facets", "filter", "reject", "summary")
   end
 
   def present


### PR DESCRIPTION
https://trello.com/c/yn9nOcs4/62-description-text-for-the-top-of-the-finder-view

The top level description field is not displayed on the finder, should be the `details["summary"]` field.