### PR TITLE
Lookup facet config from finder definition

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -2,9 +2,9 @@ require 'csv'
 
 module Indexer
   class MetadataTagger
-    def self.initialise(metadata_file_path)
+    def self.initialise(metadata_file_path, facet_config_file_path)
       @metadata = {}
-      @config = YAML.load_file(File.join(Dir.pwd, 'config/find-eu-exit-guidance-business.yml'))
+      @config = YAML.load_file(facet_config_file_path)
 
       CSV.foreach(file_name, converters: lambda { |v| v || "" }) do |row|
         base_path = row[0]

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -6,7 +6,7 @@ module Indexer
       @metadata = {}
       @config = YAML.load_file(facet_config_file_path)
 
-      CSV.foreach(file_name, converters: lambda { |v| v || "" }) do |row|
+      CSV.foreach(metadata_file_path, converters: lambda { |v| v || "" }) do |row|
         base_path = row[0]
 
         if row[1] == "yes"

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -2,8 +2,9 @@ require 'csv'
 
 module Indexer
   class MetadataTagger
-    def self.initialise(file_name)
+    def self.initialise(metadata_file_path)
       @metadata = {}
+      @config = YAML.load_file(File.join(Dir.pwd, 'config/find-eu-exit-guidance-business.yml'))
 
       CSV.foreach(file_name, converters: lambda { |v| v || "" }) do |row|
         base_path = row[0]
@@ -18,6 +19,10 @@ module Indexer
 
         @metadata[base_path] = metadata_for_path
       end
+    end
+
+    def self.facets_from_finder_config
+      @config["details"]["facets"]
     end
 
     def self.amend_all_metadata
@@ -35,142 +40,22 @@ module Indexer
     end
 
     def self.create_all_metadata
-      {
-        "sector_business_area" => all_sector_business_area,
-        "employ_eu_citizens" => all_employ_eu_citizens,
-        "doing_business_in_the_eu" => all_doing_business_in_the_eu,
-        "regulations_and_standards" => all_regulations_and_standards,
-        "personal_data" => all_personal_data,
-        "intellectual_property" => all_intellectual_property,
-        "receiving_eu_funding" => all_receiving_eu_funding,
-        "public_sector_procurement" => all_public_sector_procurement
-      }
+      all_metadata = {}
+      facets_from_finder_config.each do |facet|
+        all_metadata[facet["key"]] = facet["allowed_values"].map { |f| f["value"] }
+      end
+      all_metadata
     end
 
     def self.specific_metadata(row)
-      {
-        "sector_business_area" => row.fetch(2, "").split(","),
-        "employ_eu_citizens" => row.fetch(3, "").split(","),
-        "doing_business_in_the_eu" => row.fetch(4, "").split(","),
-        "regulations_and_standards" => row.fetch(5, "").split(","),
-        "personal_data" => row.fetch(6, "").split(","),
-        "intellectual_property" => row.fetch(7, "").split(","),
-        "receiving_eu_funding" => row.fetch(8, "").split(","),
-        "public_sector_procurement" => row.fetch(9, "").split(",")
-      }.reject do |_, value|
+      metadata = {}
+      facets_from_finder_config.each_with_index do |facet, index|
+        row_index = index + 2
+        metadata[facet["key"]] = row.fetch(row_index, "").split(",")
+      end
+      metadata.reject do |_, value|
         value == []
       end
-    end
-
-    def self.all_sector_business_area
-      [
-        "accommodation-restaurants-and-catering-services",
-        "aerospace",
-        "agriculture",
-        "air-transport-aviation",
-        "ancillary-services",
-        "animal-health",
-        "automotive",
-        "banking-market-infrastructure",
-        "broadcasting",
-        "chemicals",
-        "computer-services",
-        "construction-contracting",
-        "education",
-        "electricity",
-        "electronics",
-        "environmental-services",
-        "fisheries",
-        "food-and-drink",
-        "furniture-and-other-manufacturing",
-        "gas-markets",
-        "goods-sectors-each-0-4-of-gva",
-        "imports",
-        "imputed-rent",
-        "insurance",
-        "land-transport-excl-rail",
-        "medical-services",
-        "motor-trades",
-        "network-industries-0-3-of-gva",
-        "oil-and-gas-production",
-        "other-personal-services",
-        "parts-and-machinery",
-        "pharmaceuticals",
-        "post",
-        "professional-and-business-services",
-        "public-administration-and-defence",
-        "rail",
-        "real-estate-excl-imputed-rent",
-        "retail",
-        "service-sectors-each-1-of-gva",
-        "social-work",
-        "steel-and-other-metals-commodities",
-        "telecoms",
-        "textiles-and-clothing",
-        "top-ten-trade-partners-by-value",
-        "warehousing-and-support-for-transportation",
-        "water-transport-maritime-ports",
-        "wholesale-excl-motor-vehicles"
-      ]
-    end
-
-    def self.all_employ_eu_citizens
-      %w(yes no dont-know)
-    end
-
-    def self.all_doing_business_in_the_eu
-      [
-        "do-business-in-the-eu",
-        "buying",
-        "selling",
-        "transporting",
-        "other-eu",
-        "other-rest-of-the-world"
-      ]
-    end
-
-    def self.all_regulations_and_standards
-      %w(products-or-goods)
-    end
-
-    def self.all_personal_data
-      [
-        "processing-personal-data",
-        "interacting-with-eea-website",
-        "digital-service-provider"
-      ]
-    end
-
-    def self.all_intellectual_property
-      [
-        "have-intellectual-property",
-        "copyright",
-        "trademarks",
-        "designs",
-        "patents",
-        "exhaustion-of-rights"
-      ]
-    end
-
-    def self.all_receiving_eu_funding
-      [
-        "horizon-2020",
-        "cosme",
-        "european-investment-bank-eib",
-        "european-structural-fund-esf",
-        "eurdf",
-        "etcf",
-        "esc",
-        "ecp",
-        "etf"
-      ]
-    end
-
-    def self.all_public_sector_procurement
-      [
-        "civil-government-contracts",
-        "defence-contracts"
-      ]
     end
   end
 end

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -166,4 +166,5 @@ require 'sitemap/sitemap_presenter'
 require 'sitemap/sitemap_writer'
 
 metadata_file_path = File.join(settings.root, '../../config/business_readiness.csv')
-Indexer::MetadataTagger.initialise(metadata_file_path)
+facet_config_file_path = File.join(settings.root, '../../config/find-eu-exit-guidance-business.yml')
+Indexer::MetadataTagger.initialise(metadata_file_path, facet_config_file_path)

--- a/spec/unit/indexer/fixtures/facet_config.yml
+++ b/spec/unit/indexer/fixtures/facet_config.yml
@@ -1,0 +1,212 @@
+---
+details:
+  facets:
+  - allowed_values:
+    - label: Accommodation, restaurants and catering services
+      value: accommodation-restaurants-and-catering-services
+    - label: Aerospace
+      value: aerospace
+    - label: Agriculture
+      value: agriculture
+    - label: Air transport (Aviation
+      value: air-transport-aviation
+    - label: Ancillary Services
+      value: ancillary-services
+    - label: Animal Health
+      value: animal-health
+    - label: Automotive
+      value: automotive
+    - label: Banking, market infrastructure
+      value: banking-market-infrastructure
+    - label: Broadcasting
+      value: broadcasting
+    - label: Chemicals
+      value: chemicals
+    - label: Computer Services
+      value: computer-services
+    - label: Construction Contracting
+      value: construction-contracting
+    - label: Education
+      value: education
+    - label: Electricity
+      value: electricity
+    - label: Electronics
+      value: electronics
+    - label: Environmental Services
+      value: environmental-services
+    - label: Fisheries
+      value: fisheries
+    - label: Food and Drink
+      value: food-and-drink
+    - label: Furniture and other manufacturing
+      value: furniture-and-other-manufacturing
+    - label: Gas markets
+      value: gas-markets
+    - label: Goods sectors each <0.4% of GVA
+      value: goods-sectors-each-0-4-of-gva
+    - label: Imports
+      value: imports
+    - label: Imputed Rent
+      value: imputed-rent
+    - label: Insurance
+      value: insurance
+    - label: Land transport (excl. rail)
+      value: land-transport-excl-rail
+    - label: Medical services
+      value: medical-services
+    - label: Motor Trades
+      value: motor-trades
+    - label: Network Industries <0.3% of GVA
+      value: network-industries-0-3-of-gva
+    - label: Oil and gas production
+      value: oil-and-gas-production
+    - label: Other personal services
+      value: other-personal-services
+    - label: Parts and machinery
+      value: parts-and-machinery
+    - label: Pharmaceuticals
+      value: pharmaceuticals
+    - label: Post
+      value: post
+    - label: Professional and Business services
+      value: professional-and-business-services
+    - label: Public Administration and Defence
+      value: public-administration-and-defence
+    - label: Rail
+      value: rail
+    - label: Real Estate (excl. Imputed Rent)
+      value: real-estate-excl-imputed-rent
+    - label: Retail
+      value: retail
+    - label: Service sectors each <1% of GVA
+      value: service-sectors-each-1-of-gva
+    - label: Social Work
+      value: social-work
+    - label: Steel and other metals/commodities
+      value: steel-and-other-metals-commodities
+    - label: Telecoms
+      value: telecoms
+    - label: Textiles and clothing
+      value: textiles-and-clothing
+    - label: Top Ten Trade Partners by Value
+      value: top-ten-trade-partners-by-value
+    - label: Warehousing and support for transportation
+      value: warehousing-and-support-for-transportation
+    - label: Water Transport (Maritime/ports)
+      value: water-transport-maritime-ports
+    - label: Wholesale (excl. Motor Vehicles)
+      value: wholesale-excl-motor-vehicles
+    display_as_result_metadata: false
+    filterable: true
+    key: sector_business_area
+    name: Sector / Business Area
+    preposition: for businesses in
+    type: text
+  - allowed_values:
+    - label: Do business in the EU
+      value: do-business-in-the-eu
+    - label: Buying
+      value: buying
+    - label: Selling
+      value: selling
+    - label: Transporting
+      value: transporting
+    - label: Other business in the EU
+      value: other-eu
+    display_as_result_metadata: false
+    filterable: true
+    key: doing_business_in_the_eu
+    name: Doing business in the EU
+    preposition: for businesses that
+    type: text
+  - allowed_values:
+    - label: "Yes"
+      value: "yes"
+    - label: "No"
+      value: "no"
+    - label: Don't know
+      value: dont-know
+    display_as_result_metadata: false
+    filterable: true
+    key: employ_eu_citizens
+    name: Employ EU citizens
+    preposition: for businesses that
+    type: text
+  - allowed_values:
+    - label: "Yes"
+      value: "yes"
+    - label: "No"
+      value: "no"
+    display_as_result_metadata: false
+    filterable: true
+    key: regulations_and_standards
+    name: Sell products and goods in the UK
+    preposition: for businesses that sell
+    type: text
+  - allowed_values:
+    - label: Processing personal data
+      value: processing-personal-data
+    - label: Visiting a website hosted in the EEA
+      value: interacting-with-eea-website
+    - label: Digital service provider
+      value: digital-service-provider
+    display_as_result_metadata: false
+    filterable: true
+    key: personal_data
+    name: Personal data
+    preposition: for businesses involved in
+    type: text
+  - allowed_values:
+    - label: Copyright
+      value: copyright
+    - label: Trade marks
+      value: trademarks
+    - label: Designs
+      value: designs
+    - label: Patents
+      value: patents
+    - label: Exhaustion of rights
+      value: exhaustion-of-rights
+    display_as_result_metadata: false
+    filterable: true
+    key: intellectual_property
+    name: Intellectual property
+    preposition: for businesses working with
+    type: text
+  - allowed_values:
+    - label: Civil government contracts
+      value: civil-government-contracts
+    - label: Defence contracts
+      value: defence-contracts
+    display_as_result_metadata: false
+    filterable: true
+    key: public_sector_procurement
+    name: Public sector procurement
+    preposition: businesses that work with
+    type: text
+  - allowed_values:
+    - label: Horizon 2020
+      value: horizon-2020
+    - label: COSME
+      value: cosme
+    - label: European Investment Bank (EIB)
+      value: european-investment-bank-eib
+    - label: European Structural Fund (ESF)
+      value: european-structural-fund-esf
+    - label: European Redevelopment Fund (EURDF)
+      value: eurdf
+    - label: European Territorial Cooperation Fund (ETCF)
+      value: etcf
+    - label: European Solidarity Corps (ESC)
+      value: esc
+    - label: ECP
+      value: ecp
+    - label: ETF
+      value: etf
+    display_as_result_metadata: false
+    filterable: true
+    key: receiving_eu_funding
+    name: Receiving EU funding
+    preposition: for businesses that receive funding from
+    type: text
+

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Indexer::MetadataTagger do
 
     metadata = {
       "sector_business_area" => %w(aerospace agriculture),
-      "employ_eu_citizens" => %w(yes),
+      "doing_business_in_the_eu" => %w(yes),
       "appear_in_find_eu_exit_guidance_business_finder" => "yes"
     }
 
@@ -43,10 +43,10 @@ RSpec.describe Indexer::MetadataTagger do
     metadata = {
       "sector_business_area" => ["accommodation-restaurants-and-catering-services", "aerospace", "agriculture", "air-transport-aviation", "ancillary-services", "animal-health", "automotive", "banking-market-infrastructure", "broadcasting", "chemicals", "computer-services", "construction-contracting", "education", "electricity", "electronics", "environmental-services", "fisheries", "food-and-drink", "furniture-and-other-manufacturing", "gas-markets", "goods-sectors-each-0-4-of-gva", "imports", "imputed-rent", "insurance", "land-transport-excl-rail", "medical-services", "motor-trades", "network-industries-0-3-of-gva", "oil-and-gas-production", "other-personal-services", "parts-and-machinery", "pharmaceuticals", "post", "professional-and-business-services", "public-administration-and-defence", "rail", "real-estate-excl-imputed-rent", "retail", "service-sectors-each-1-of-gva", "social-work", "steel-and-other-metals-commodities", "telecoms", "textiles-and-clothing", "top-ten-trade-partners-by-value", "warehousing-and-support-for-transportation", "water-transport-maritime-ports", "wholesale-excl-motor-vehicles"],
       "employ_eu_citizens" => ["yes", "no", "dont-know"],
-      "doing_business_in_the_eu" => ["do-business-in-the-eu", "buying", "selling", "transporting", "other-eu", "other-rest-of-the-world"],
-      "regulations_and_standards" => ["products-or-goods"],
+      "doing_business_in_the_eu" => ["do-business-in-the-eu", "buying", "selling", "transporting", "other-eu"],
+      "regulations_and_standards" => ["yes", "no"],
       "personal_data" => ["processing-personal-data", "interacting-with-eea-website", "digital-service-provider"],
-      "intellectual_property" => ["have-intellectual-property", "copyright", "trademarks", "designs", "patents", "exhaustion-of-rights"],
+      "intellectual_property" => ["copyright", "trademarks", "designs", "patents", "exhaustion-of-rights"],
       "receiving_eu_funding" => ["horizon-2020", "cosme", "european-investment-bank-eib", "european-structural-fund-esf", "eurdf", "etcf", "esc", "ecp", "etf"],
       "public_sector_procurement" => ["civil-government-contracts", "defence-contracts"],
       "appear_in_find_eu_exit_guidance_business_finder" => "yes"

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Indexer::MetadataTagger do
+  let(:facet_config_file) { File.join(Dir.pwd, "config", "find-eu-exit-guidance-business.yml") }
   # rubocop:disable RSpec/VerifiedDoubles, RSpec/AnyInstance, RSpec/MessageSpies
   it "amends documents" do
     fixture_file = File.expand_path("fixtures/metadata.csv", __dir__)
@@ -23,7 +24,7 @@ RSpec.describe Indexer::MetadataTagger do
       .with(test_index_name)
       .and_return(mock_index)
 
-    described_class.initialise(fixture_file)
+    described_class.initialise(fixture_file, facet_config_file)
     described_class.amend_all_metadata
   end
 
@@ -44,7 +45,7 @@ RSpec.describe Indexer::MetadataTagger do
       "sector_business_area" => ["accommodation-restaurants-and-catering-services", "aerospace", "agriculture", "air-transport-aviation", "ancillary-services", "animal-health", "automotive", "banking-market-infrastructure", "broadcasting", "chemicals", "computer-services", "construction-contracting", "education", "electricity", "electronics", "environmental-services", "fisheries", "food-and-drink", "furniture-and-other-manufacturing", "gas-markets", "goods-sectors-each-0-4-of-gva", "imports", "imputed-rent", "insurance", "land-transport-excl-rail", "medical-services", "motor-trades", "network-industries-0-3-of-gva", "oil-and-gas-production", "other-personal-services", "parts-and-machinery", "pharmaceuticals", "post", "professional-and-business-services", "public-administration-and-defence", "rail", "real-estate-excl-imputed-rent", "retail", "service-sectors-each-1-of-gva", "social-work", "steel-and-other-metals-commodities", "telecoms", "textiles-and-clothing", "top-ten-trade-partners-by-value", "warehousing-and-support-for-transportation", "water-transport-maritime-ports", "wholesale-excl-motor-vehicles"],
       "employ_eu_citizens" => ["yes", "no", "dont-know"],
       "doing_business_in_the_eu" => ["do-business-in-the-eu", "buying", "selling", "transporting", "other-eu"],
-      "regulations_and_standards" => ["yes", "no"],
+      "regulations_and_standards" => %w(yes no),
       "personal_data" => ["processing-personal-data", "interacting-with-eea-website", "digital-service-provider"],
       "intellectual_property" => ["copyright", "trademarks", "designs", "patents", "exhaustion-of-rights"],
       "receiving_eu_funding" => ["horizon-2020", "cosme", "european-investment-bank-eib", "european-structural-fund-esf", "eurdf", "etcf", "esc", "ecp", "etf"],
@@ -57,7 +58,7 @@ RSpec.describe Indexer::MetadataTagger do
       .with(test_index_name)
       .and_return(mock_index)
 
-    described_class.initialise(fixture_file)
+    described_class.initialise(fixture_file, facet_config_file)
     described_class.amend_all_metadata
   end
   # rubocop:enable RSpec/VerifiedDoubles, RSpec/AnyInstance, RSpec/MessageSpies

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Indexer::MetadataTagger do
-  let(:facet_config_file) { File.join(Dir.pwd, "config", "find-eu-exit-guidance-business.yml") }
+  let(:facet_config_file) { File.expand_path("fixtures/facet_config.yml", __dir__) }
   # rubocop:disable RSpec/VerifiedDoubles, RSpec/AnyInstance, RSpec/MessageSpies
   it "amends documents" do
     fixture_file = File.expand_path("fixtures/metadata.csv", __dir__)


### PR DESCRIPTION
https://trello.com/c/UhV3PPfO/87-metadata-tagger-should-use-finder-facet-definitions

Facet config is stored in YAML in this project and should be
treated as the single definition of the facets and values we
tag with. This should reduce the impact of changes to metadata
values and names.