### PR TITLE
Add custom conversion for nil to empty string

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -5,7 +5,7 @@ module Indexer
     def self.initialise(file_name)
       @metadata = {}
 
-      CSV.foreach(file_name) do |row|
+      CSV.foreach(file_name, converters: lambda { |v| v || "" }) do |row|
         base_path = row[0]
 
         if row[1] == "yes"

--- a/spec/unit/indexer/fixtures/metadata.csv
+++ b/spec/unit/indexer/fixtures/metadata.csv
@@ -1,1 +1,1 @@
-/a_base_path,,"aerospace,agriculture",yes
+/a_base_path,,"aerospace,agriculture",yes,,


### PR DESCRIPTION
We don't want nils. They tend to break our String#split methods.
This adds a custom converter that turns nil values into empty strings.