### PR TITLE
Remove leading space from business readiness data

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -51,7 +51,7 @@ module Indexer
       metadata = {}
       facets_from_finder_config.each_with_index do |facet, index|
         row_index = index + 2
-        metadata[facet["key"]] = row.fetch(row_index, "").split(",")
+        metadata[facet["key"]] = row.fetch(row_index, "").split(",").map(&:lstrip)
       end
       metadata.reject do |_, value|
         value == []

--- a/spec/unit/indexer/fixtures/metadata.csv
+++ b/spec/unit/indexer/fixtures/metadata.csv
@@ -1,1 +1,1 @@
-/a_base_path,,"aerospace,agriculture",yes,,
+/a_base_path,,"aerospace,agriculture", yes,,


### PR DESCRIPTION
We do not want leading spaces in our data.