### PR TITLE
Strip spaces from business readiness csv data

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -9,7 +9,7 @@ module Indexer
       CSV.foreach(metadata_file_path, converters: lambda { |v| v || "" }) do |row|
         base_path = row[0]
 
-        if row[1] == "yes"
+        if row[1].strip == "yes"
           metadata_for_path = create_all_metadata
         else
           metadata_for_path = specific_metadata(row)
@@ -51,7 +51,7 @@ module Indexer
       metadata = {}
       facets_from_finder_config.each_with_index do |facet, index|
         row_index = index + 2
-        metadata[facet["key"]] = row.fetch(row_index, "").split(",")
+        metadata[facet["key"]] = row.fetch(row_index, "").split(",").map(&:strip)
       end
       metadata.reject do |_, value|
         value == []

--- a/spec/unit/indexer/fixtures/metadata.csv
+++ b/spec/unit/indexer/fixtures/metadata.csv
@@ -1,1 +1,1 @@
-/a_base_path,,"aerospace,agriculture",yes,,
+/a_base_path,,"aerospace,agriculture", yes,,

--- a/spec/unit/indexer/fixtures/metadata_for_all.csv
+++ b/spec/unit/indexer/fixtures/metadata_for_all.csv
@@ -1,1 +1,1 @@
-/a_base_path,yes
+/a_base_path, yes ,


### PR DESCRIPTION
CSV file can present with leading and trailing spaces. We should strip
these before using them in the business readiness loader. Apply
String#strip to facet values and also introduce some leading and
trailing space to the test fixtures.

Related [Email Alert Api PR](https://github.com/alphagov/email-alert-api/pull/733)
[Trello](https://trello.com/c/BhQuSYao/92-strip-spaces-from-csv-values)