### PR TITLE
Don't attempt to add generic_description field to email signup content item

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -99,7 +99,7 @@ class FinderEmailSignupContentItemPresenter
     details.merge(
       "subscription_list_title_prefix" => details.fetch("subscription_list_title_prefix", {}),
       "email_filter_facets" => email_filter_facets,
-    ).except("document_noun", "facets", "filter", "reject", "summary")
+    ).except("document_noun", "facets", "filter", "generic_description", "reject", "summary")
   end
 
   def present


### PR DESCRIPTION
This field is only applicable to the finder and not the email signup page.