### PR TITLE
Expose image_url for any document type

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -12,6 +12,7 @@
     "government_document_supertype",
     "indexable_content",
     "navigation_document_supertype",
+    "image_url",
     "is_withdrawn",
     "latest_change_note",
     "licence_identifier",

--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -18,7 +18,6 @@
     "has_command_paper",
     "has_official_document",
     "id",
-    "image_url",
     "important_to_policy",
     "intellectual_property",
     "is_historic",


### PR DESCRIPTION
Since https://github.com/alphagov/rummager/pull/1354 lots more things are able to have an image.

We need to make this change so that rummager can expose the information. For example https://www.gov.uk/api/search.json?filter_link=/guidance/the-highway-code now has an image_url.  When this document is retrieved and includes the `image_url` field an [error is raised](https://sentry.io/govuk/app-rummager/issues/790236958/?query=is:unresolved) because the schema that defines the-highway-code is not `edition.json`.

By adding the field to the base_elasticsearch type, this error should be resolved.