### PR TITLE
Revert "Lookup organisation's default news image when setting image URL"

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -53,7 +53,7 @@ module GovukIndex
         grant_type:                          specialist.grant_type,
         hidden_indexable_content:            specialist.hidden_indexable_content,
         hmrc_manual_section_id:              common_fields.section_id,
-        image_url:                           image_url,
+        image_url:                           details.image_url,
         indexable_content:                   indexable.indexable_content,
         industries:                          specialist.industries,
         regions:                             specialist.regions,
@@ -140,10 +140,6 @@ module GovukIndex
       else
         base_path || raise(NotIdentifiable, "base_path missing from payload")
       end
-    end
-
-    def image_url
-      details.image_url || expanded_links.default_news_image
     end
 
   private

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -60,11 +60,6 @@ module GovukIndex
       end
     end
 
-    def default_news_image
-      organisation = expanded_links.fetch("primary_publishing_organisation", [])
-      organisation[0].dig("details", "default_news_image", "url") unless organisation.empty?
-    end
-
   private
 
     attr_reader :expanded_links

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -63,34 +63,6 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     end
   end
 
-  describe "#image_url" do
-    let(:default_news_image_url) { "https://www.test.gov.uk/default_news_image.jpg" }
-    let(:expanded_links) do
-      { "primary_publishing_organisation" => [{
-        "details" => { "default_news_image" => { "url" => default_news_image_url } }
-      }] }
-    end
-
-    it "returns a document's organisation's default news image if it does not have an image" do
-      payload = generate_random_example(payload: { payload_version: 1 })
-      payload["details"].delete("image")
-      payload["expanded_links"] = expanded_links
-
-      presenter = elasticsearch_presenter(payload, payload["document_type"])
-      expect(presenter.image_url).to eq(default_news_image_url)
-    end
-
-    it "returns a document's image when it and organisation's default news image are present " do
-      image_url = "https://www.test.gov.uk/image.jpg"
-      payload = generate_random_example(payload: { payload_version: 1 })
-      payload["expanded_links"] = expanded_links
-      payload["details"]["image"] = { "url" => image_url }
-
-      presenter = elasticsearch_presenter(payload, payload["document_type"])
-      expect(presenter.image_url).to eq(image_url)
-    end
-  end
-
   def elasticsearch_presenter(payload, type = "aaib_report")
     type_mapper = GovukIndex::DocumentTypeMapper.new(payload)
     allow(type_mapper).to receive(:type).and_return(type)

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -243,23 +243,6 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.policy_groups).to eq(["micropig-advisory-group"])
   end
 
-  it "default_news_image" do
-    default_news_image_url = "https://www.test.gov.uk/default_news_image.jpg"
-    expanded_links = {
-      "primary_publishing_organisation" => [
-        {
-          "details" => {
-            "default_news_image" => { "url" => default_news_image_url }
-          }
-        }
-      ]
-    }
-
-    presenter = expanded_links_presenter(expanded_links)
-
-    expect(presenter.default_news_image).to eq(default_news_image_url)
-  end
-
   def expanded_links_presenter(expanded_links)
     described_class.new(expanded_links)
   end


### PR DESCRIPTION
Reverts alphagov/rummager#1354