### PR TITLE
Rename `receiving-eu-funding` key

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -224,7 +224,7 @@ details:
       value: etf
     display_as_result_metadata: false
     filterable: true
-    key: receiving_eu_funding
+    key: eu_uk_government_funding
     name: Receiving EU funding
     preposition: for businesses that receive funding from
     type: text

--- a/config/schema/elasticsearch_types/aaib_report.json
+++ b/config/schema/elasticsearch_types/aaib_report.json
@@ -10,7 +10,7 @@
     "location",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "registration",
     "regulations_and_standards",
     "report_type",

--- a/config/schema/elasticsearch_types/asylum_support_decision.json
+++ b/config/schema/elasticsearch_types/asylum_support_decision.json
@@ -6,7 +6,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "tribunal_decision_categories",

--- a/config/schema/elasticsearch_types/business_finance_support_scheme.json
+++ b/config/schema/elasticsearch_types/business_finance_support_scheme.json
@@ -9,7 +9,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regions",
     "regulations_and_standards",
     "sector_business_area",

--- a/config/schema/elasticsearch_types/cma_case.json
+++ b/config/schema/elasticsearch_types/cma_case.json
@@ -12,7 +12,7 @@
     "outcome_type",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area"
   ],

--- a/config/schema/elasticsearch_types/countryside_stewardship_grant.json
+++ b/config/schema/elasticsearch_types/countryside_stewardship_grant.json
@@ -9,7 +9,7 @@
     "land_use",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "tiers_or_standalone_items"

--- a/config/schema/elasticsearch_types/dfid_research_output.json
+++ b/config/schema/elasticsearch_types/dfid_research_output.json
@@ -12,7 +12,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area"
   ],

--- a/config/schema/elasticsearch_types/drug_safety_update.json
+++ b/config/schema/elasticsearch_types/drug_safety_update.json
@@ -7,7 +7,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "therapeutic_area"

--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -40,7 +40,7 @@
     "popularity",
     "public_sector_procurement",
     "public_timestamp",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "release_timestamp",
     "relevant_to_local_government",

--- a/config/schema/elasticsearch_types/employment_appeal_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/employment_appeal_tribunal_decision.json
@@ -6,7 +6,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "tribunal_decision_categories",

--- a/config/schema/elasticsearch_types/employment_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/employment_tribunal_decision.json
@@ -6,7 +6,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "tribunal_decision_categories",

--- a/config/schema/elasticsearch_types/european_structural_investment_fund.json
+++ b/config/schema/elasticsearch_types/european_structural_investment_fund.json
@@ -11,7 +11,7 @@
     "location",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area"
   ],

--- a/config/schema/elasticsearch_types/export_health_certificate.json
+++ b/config/schema/elasticsearch_types/export_health_certificate.json
@@ -9,7 +9,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area"
   ],

--- a/config/schema/elasticsearch_types/hmrc_manual.json
+++ b/config/schema/elasticsearch_types/hmrc_manual.json
@@ -7,7 +7,7 @@
     "personal_data",
     "public_sector_procurement",
     "regulations_and_standards",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "sector_business_area"
   ]
 }

--- a/config/schema/elasticsearch_types/hmrc_manual_section.json
+++ b/config/schema/elasticsearch_types/hmrc_manual_section.json
@@ -9,7 +9,7 @@
     "personal_data",
     "public_sector_procurement",
     "regulations_and_standards",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "sector_business_area"
   ]
 }

--- a/config/schema/elasticsearch_types/international_development_fund.json
+++ b/config/schema/elasticsearch_types/international_development_fund.json
@@ -10,7 +10,7 @@
     "location",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "value_of_funding"

--- a/config/schema/elasticsearch_types/maib_report.json
+++ b/config/schema/elasticsearch_types/maib_report.json
@@ -7,7 +7,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "report_type",
     "sector_business_area",

--- a/config/schema/elasticsearch_types/manual.json
+++ b/config/schema/elasticsearch_types/manual.json
@@ -7,7 +7,7 @@
     "personal_data",
     "public_sector_procurement",
     "regulations_and_standards",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "sector_business_area"
   ]
 }

--- a/config/schema/elasticsearch_types/manual_section.json
+++ b/config/schema/elasticsearch_types/manual_section.json
@@ -8,7 +8,7 @@
     "personal_data",
     "public_sector_procurement",
     "regulations_and_standards",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "sector_business_area"
   ]
 }

--- a/config/schema/elasticsearch_types/medical_safety_alert.json
+++ b/config/schema/elasticsearch_types/medical_safety_alert.json
@@ -9,7 +9,7 @@
     "medical_specialism",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area"
   ],

--- a/config/schema/elasticsearch_types/raib_report.json
+++ b/config/schema/elasticsearch_types/raib_report.json
@@ -8,7 +8,7 @@
     "personal_data",
     "public_sector_procurement",
     "railway_type",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "report_type",
     "sector_business_area"

--- a/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
@@ -6,7 +6,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "tribunal_decision_category",

--- a/config/schema/elasticsearch_types/service_standard_report.json
+++ b/config/schema/elasticsearch_types/service_standard_report.json
@@ -7,7 +7,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area"
   ]

--- a/config/schema/elasticsearch_types/statutory_instrument.json
+++ b/config/schema/elasticsearch_types/statutory_instrument.json
@@ -7,7 +7,7 @@
     "laid_date",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "sift_end_date",

--- a/config/schema/elasticsearch_types/tax_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/tax_tribunal_decision.json
@@ -6,7 +6,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "tribunal_decision_category",

--- a/config/schema/elasticsearch_types/utaac_decision.json
+++ b/config/schema/elasticsearch_types/utaac_decision.json
@@ -6,7 +6,7 @@
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "receiving_eu_funding",
+    "eu_uk_government_funding",
     "regulations_and_standards",
     "sector_business_area",
     "tribunal_decision_categories",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -752,7 +752,7 @@
     "type": "identifiers"
   },
 
-  "receiving_eu_funding": {
+  "eu_uk_government_funding": {
     "description": "The EU scheme from which the business receives its funding",
     "type": "identifiers"
   },

--- a/spec/unit/indexer/fixtures/facet_config.yml
+++ b/spec/unit/indexer/fixtures/facet_config.yml
@@ -205,7 +205,7 @@ details:
       value: etf
     display_as_result_metadata: false
     filterable: true
-    key: receiving_eu_funding
+    key: eu_uk_government_funding
     name: Receiving EU funding
     preposition: for businesses that receive funding from
     type: text

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Indexer::MetadataTagger do
       "regulations_and_standards" => %w(yes no),
       "personal_data" => ["processing-personal-data", "interacting-with-eea-website", "digital-service-provider"],
       "intellectual_property" => ["copyright", "trademarks", "designs", "patents", "exhaustion-of-rights"],
-      "receiving_eu_funding" => ["horizon-2020", "cosme", "european-investment-bank-eib", "european-structural-fund-esf", "eurdf", "etcf", "esc", "ecp", "etf"],
+      "eu_uk_government_funding" => ["horizon-2020", "cosme", "european-investment-bank-eib", "european-structural-fund-esf", "eurdf", "etcf", "esc", "ecp", "etf"],
       "public_sector_procurement" => ["civil-government-contracts", "defence-contracts"],
       "appear_in_find_eu_exit_guidance_business_finder" => "yes"
     }


### PR DESCRIPTION
This was changed to `eu_uk_government_funding` in
https://github.com/alphagov/govuk-app-deployment-secrets/pull/13