### PR TITLE
Lookup default news image if newslike content

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -185,6 +185,7 @@ module GovukIndex
     end
 
     def newslike?
+      return false if common_fields.content_store_document_type == "fatality_notice"
       common_fields.content_purpose_subgroup == "news" ||
         common_fields.content_purpose_subgroup == "speeches_and_statements"
     end

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -143,7 +143,7 @@ module GovukIndex
     end
 
     def image_url
-      details.image_url || expanded_links.default_news_image
+      details.image_url || (expanded_links.default_news_image if newslike?)
     end
 
   private
@@ -182,6 +182,11 @@ module GovukIndex
 
     def specialist
       @_specialist ||= SpecialistPresenter.new(metadata: payload.dig("details", "metadata"))
+    end
+
+    def newslike?
+      common_fields.content_purpose_subgroup == "news" ||
+        common_fields.content_purpose_subgroup == "speeches_and_statements"
     end
   end
 end

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -71,8 +71,12 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
       }] }
     end
 
-    it "returns a document's organisation's default news image if it does not have an image" do
-      payload = generate_random_example(payload: { payload_version: 1 })
+    it "returns a newslike document's organisation's default news image if it does not have an image" do
+      payload = generate_random_example(schema: "news_article", payload: {
+        payload_version: 1,
+        document_type: "news_story",
+        content_purpose_subgroup: "news",
+      })
       payload["details"].delete("image")
       payload["expanded_links"] = expanded_links
 
@@ -88,6 +92,14 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
 
       presenter = elasticsearch_presenter(payload, payload["document_type"])
       expect(presenter.image_url).to eq(image_url)
+    end
+
+    it "returns nil if a document has no image and is not a newslike document" do
+      payload = generate_random_example(payload: { payload_version: 1 })
+      payload["details"].delete("image")
+
+      presenter = elasticsearch_presenter(payload, payload["document_type"])
+      expect(presenter.image_url).to be nil
     end
   end
 


### PR DESCRIPTION
We should only provide a default news image if the content belongs to the
`news` subgroup.