### PR TITLE
Add metadata destroyer

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -45,5 +45,29 @@ module Indexer
         value == []
       end
     end
+
+    def self.all_nil_metadata_hash
+      metadata = {}
+
+      facets_from_finder_config.each do |facet|
+        metadata[facet["key"]] = nil
+      end
+
+      metadata
+    end
+
+    def self.remove_all_metadata_for_base_paths(base_paths)
+      base_paths = Array(base_paths)
+
+      base_paths.each do |base_path|
+        item_in_search = SearchConfig.instance.content_index.get_document_by_link(base_path)
+        if item_in_search
+          index_to_update = item_in_search["real_index_name"]
+          metadata_for_path = all_nil_metadata_hash
+          metadata_for_path["appear_in_find_eu_exit_guidance_business_finder"] = nil
+          Indexer::AmendWorker.new.perform(index_to_update, base_path, metadata_for_path)
+        end
+      end
+    end
   end
 end

--- a/lib/tasks/metadata_tagger.rake
+++ b/lib/tasks/metadata_tagger.rake
@@ -4,3 +4,12 @@ desc "Apply metadata from the json file"
 task :tag_metadata do
   Indexer::MetadataTagger.amend_all_metadata
 end
+
+desc "Destroy metadata for a path"
+task :destroy_metadata_for_base_paths, [:base_paths] do |_, args|
+  USAGE_MESSAGE = "usage: rake destroy_metadata_for_base_paths[<base_paths>]".freeze
+  abort USAGE_MESSAGE unless args[:base_paths]
+
+  base_paths = args[:base_paths].split
+  Indexer::MetadataTagger.remove_all_metadata_for_base_paths(base_paths)
+end

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -27,5 +27,40 @@ RSpec.describe Indexer::MetadataTagger do
     described_class.initialise(fixture_file, facet_config_file)
     described_class.amend_all_metadata
   end
+
+  context "when removing metadata" do
+    def nil_metadata_hash
+      {
+        "business_activity" => nil,
+        "employ_eu_citizens" => nil,
+        "eu_uk_government_funding" => nil,
+        "regulations_and_standards" => nil,
+        "personal_data" => nil,
+        "intellectual_property" => nil,
+        "public_sector_procurement" => nil,
+        "sector_business_area" => nil,
+        "appear_in_find_eu_exit_guidance_business_finder" => nil
+      }
+    end
+
+    it "nils out all metadatad for a base path" do
+      fixture_file = File.expand_path("fixtures/metadata.csv", __dir__)
+      base_path = "/a_base_path"
+      test_index = "test_index"
+
+      mock_index = double("index")
+
+      expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
+        .and_return("real_index_name" => test_index)
+
+      expect(mock_index).to receive(:amend).with(base_path, nil_metadata_hash)
+      expect_any_instance_of(SearchIndices::SearchServer).to receive(:index)
+        .with(test_index)
+        .and_return(mock_index)
+
+      described_class.initialise(fixture_file, facet_config_file)
+      described_class.remove_all_metadata_for_base_paths(base_path)
+    end
+  end
   # rubocop:enable RSpec/VerifiedDoubles, RSpec/AnyInstance, RSpec/MessageSpies
 end


### PR DESCRIPTION
This exposes a rake task to which we can pass a `base_path` or set of `base_paths` whose business readiness metadata we want cleared. There's a corresponding method in `MetadataTagger`.