### PR TITLE
Remove broken link to healthcheck doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,6 @@ These are used by [search admin](https://github.com/alphagov/search-admin/).
 
 - [New indexing process](doc/new-indexing-process.md): how to update a format to use the new indexing process
 - [Schemas](doc/schemas.md): how to work with schemas and the document types
-- [Health Check](doc/health-check.md): usage instructions for the Health Check
-	functionality.
 - [Popularity information](doc/popularity.md): Rummager uses Google Analytics
 	data to improve search results.
 - [Publishing advanced search](doc/advanced-search.md): Information about the advanced search finder


### PR DESCRIPTION
The healthcheck functionality was moved to search-performance-explorer in https://github.com/alphagov/rummager/commit/30479dabfb3189aebe70846c50e13c4036b3665e. This is mentioned elsewhere in this README.