### PR TITLE
Set the operator between facets to or

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -21,6 +21,7 @@ details:
   summary: 'This is the information that has been published so far for your business to prepare for EU exit. You can change what information you get using the checkboxes. Come back to this page regularly or sign up to receive emails when new information is published.'
   filter:
     appear_in_find_eu_exit_guidance_business_finder: "yes"
+  operator_between_facets: or
   facets:
   - allowed_values:
     - label: Accommodation, restaurants and catering services

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -99,7 +99,7 @@ class FinderEmailSignupContentItemPresenter
     details.merge(
       "subscription_list_title_prefix" => details.fetch("subscription_list_title_prefix", {}),
       "email_filter_facets" => email_filter_facets,
-    ).except("document_noun", "facets", "filter", "generic_description", "reject", "summary")
+    ).except("operator_between_facets", "document_noun", "facets", "filter", "generic_description", "reject", "summary")
   end
 
   def present


### PR DESCRIPTION
This changes the find-eu-exit-guidance-business finder to set the operator between the facets to or meaning that ticking boxes will show up more content rather than and where the content filters down.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/847

[Trello Card](https://trello.com/c/HoWR8kQM/150-or-between-and-in-facets-in-the-finder)