### PR TITLE
Add tasks to unpublish business readiness and UK citizens in the EU

### DIFF
--- a/lib/tasks/document_finders.rake
+++ b/lib/tasks/document_finders.rake
@@ -16,6 +16,20 @@ namespace :publishing_api do
     PublishingApiFinderPublisher.new(finder, timestamp).call
   end
 
+  desc "Unpublish document finder."
+  task :unpublish_document_finder do
+    document_finder_config = ENV["DOCUMENT_FINDER_CONFIG"]
+
+    unless document_finder_config
+      raise "Please supply a valid finder config file name"
+    end
+
+    finder = YAML.load_file("config/#{document_finder_config}")
+
+    Services.publishing_api.unpublish(finder["content_id"], "gone")
+    Services.publishing_api.unpublish(finder["signup_content_id"], "gone")
+  end
+
   desc "Publish citizen topic finders"
   task :publish_citizen_finders do
     topic_config = YAML.load_file("config/topic_finders/finder_content_items.yml")

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -24,4 +24,12 @@ namespace :publishing_api do
       end
     end
   end
+
+  desc "Unpublish special routes"
+  task :unpublish_prepare_business_and_uk_nationals_special_routes do
+    content_ids = ["7a99da17-e9e1-410b-b67d-c3f6348c595d", "b9ef4434-761f-49ae-af97-dc7a248499c4"]
+    content_ids.each do |content_id|
+      Services.publishing_api.unpublish(content_id, type: "gone")
+    end
+  end
 end


### PR DESCRIPTION
Unpublish the special routes as well as the document finder and email signup route.