### PR TITLE
Refactor Prepare EU Exit Finder publisher

### DIFF
--- a/lib/prepare_eu_exit_finder_publisher.rb
+++ b/lib/prepare_eu_exit_finder_publisher.rb
@@ -3,6 +3,8 @@ require 'publishing_api_finder_publisher'
 class PrepareEuExitFinderPublisher
   TEMPLATE_PATH = "config/prepare-eu-exit.yml.erb".freeze
 
+  PrepareEuExitFinderValidationError = Class.new(StandardError)
+
   def initialize(topics, timestamp = Time.now.iso8601)
     @topics = validate(topics)
     @timestamp = timestamp
@@ -36,5 +38,3 @@ private
     finder_config
   end
 end
-
-class PrepareEuExitFinderValidationError < StandardError; end

--- a/lib/prepare_eu_exit_finder_publisher.rb
+++ b/lib/prepare_eu_exit_finder_publisher.rb
@@ -3,21 +3,21 @@ require 'publishing_api_finder_publisher'
 class PrepareEuExitFinderPublisher
   TEMPLATE_CONTENT_ITEM_PATH = "config/prepare-eu-exit.yml.erb".freeze
 
-  def initialize(finder_config, timestamp = Time.now.iso8601)
-    @finder_config = validate(finder_config)
+  def initialize(topics, timestamp = Time.now.iso8601)
+    @topics = validate(topics)
     @timestamp = timestamp
   end
 
   def call
     template_content_item = File.read(TEMPLATE_CONTENT_ITEM_PATH)
 
-    @finder_config.each do |item|
+    @topics.each do |topic|
       config = {
-        finder_content_id: item["finder_content_id"],
+        finder_content_id: topic["finder_content_id"],
         timestamp: @timestamp,
-        topic_content_id: item["topic_content_id"],
-        topic_name: item["title"],
-        topic_slug: item["slug"],
+        topic_content_id: topic["topic_content_id"],
+        topic_name: topic["title"],
+        topic_slug: topic["slug"],
       }
 
       finder = YAML.safe_load(ERB.new(template_content_item).result(binding))

--- a/lib/prepare_eu_exit_finder_publisher.rb
+++ b/lib/prepare_eu_exit_finder_publisher.rb
@@ -12,7 +12,7 @@ class PrepareEuExitFinderPublisher
     template = ERB.new(File.read(TEMPLATE_PATH))
 
     @topics.each do |topic|
-      config = {
+      schema_config = {
         finder_content_id: topic["finder_content_id"],
         timestamp: @timestamp,
         topic_content_id: topic["topic_content_id"],
@@ -20,9 +20,9 @@ class PrepareEuExitFinderPublisher
         topic_slug: topic["slug"],
       }
 
-      finder = YAML.safe_load(template.result(binding))
+      schema = YAML.safe_load(template.result_with_hash(config: schema_config))
 
-      PublishingApiFinderPublisher.new(finder, @timestamp).call
+      PublishingApiFinderPublisher.new(schema, @timestamp).call
     end
   end
 

--- a/lib/prepare_eu_exit_finder_publisher.rb
+++ b/lib/prepare_eu_exit_finder_publisher.rb
@@ -1,7 +1,7 @@
 require 'publishing_api_finder_publisher'
 
 class PrepareEuExitFinderPublisher
-  TEMPLATE_CONTENT_ITEM_PATH = "config/prepare-eu-exit.yml.erb".freeze
+  TEMPLATE_PATH = "config/prepare-eu-exit.yml.erb".freeze
 
   def initialize(topics, timestamp = Time.now.iso8601)
     @topics = validate(topics)
@@ -9,7 +9,7 @@ class PrepareEuExitFinderPublisher
   end
 
   def call
-    template_content_item = File.read(TEMPLATE_CONTENT_ITEM_PATH)
+    template = ERB.new(File.read(TEMPLATE_PATH))
 
     @topics.each do |topic|
       config = {
@@ -20,7 +20,7 @@ class PrepareEuExitFinderPublisher
         topic_slug: topic["slug"],
       }
 
-      finder = YAML.safe_load(ERB.new(template_content_item).result(binding))
+      finder = YAML.safe_load(template.result(binding))
 
       PublishingApiFinderPublisher.new(finder, @timestamp).call
     end


### PR DESCRIPTION
Hopefully makes things easier to follow by:

- Clearer naming of variables
- Only loading the ERB template once
- Removing the need for a binding for the ERB template