### PR TITLE
Include travel advice index page in citizen finder

### DIFF
--- a/config/prepare-eu-exit.yml.erb
+++ b/config/prepare-eu-exit.yml.erb
@@ -25,6 +25,8 @@ details:
     content_purpose_supergroup:
       - services
       - guidance_and_regulation
+    content_store_document_type:
+      - travel_advice_index
   subscription_list_title_prefix: "<%= config[:topic_name] %> – EU Exit guidance"
   summary:
 routes:

--- a/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
+++ b/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe PrepareEuExitFinderPublisher do
           "facets" => [],
           "filter" => {
             "all_part_of_taxonomy_tree" => ["d7bdaee2-8ea5-460e-b00d-6e9382eb6b61", "seaside-seaside-seaside"],
-            "content_purpose_supergroup" => %w(services guidance_and_regulation)
+            "content_purpose_supergroup" => %w(services guidance_and_regulation),
+            "content_store_document_type" => %w(travel_advice_index)
           },
           "summary" => nil
         },


### PR DESCRIPTION
We can do this now that https://github.com/alphagov/govuk-content-schemas/pull/849
has been merged.

The supergroups should get expanded to document types and merged with the supplied content store document types since https://github.com/alphagov/finder-frontend/pull/738 was merged.

https://trello.com/c/UDfCG0jA/184-add-foreign-travel-advice-index-to-going-abroad-finder