### PR TITLE
Add result summaries to citizen finders

### DIFF
--- a/config/prepare-eu-exit.yml.erb
+++ b/config/prepare-eu-exit.yml.erb
@@ -28,6 +28,7 @@ details:
     content_store_document_type:
       - travel_advice_index
   subscription_list_title_prefix: "<%= config[:topic_name] %> – EU Exit guidance"
+  show_summaries: true
   summary:
 routes:
 - path: "/prepare-eu-exit/<%= config[:topic_slug] %>"

--- a/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
+++ b/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe PrepareEuExitFinderPublisher do
             "content_purpose_supergroup" => %w(services guidance_and_regulation),
             "content_store_document_type" => %w(travel_advice_index)
           },
+          "show_summaries" => true,
           "summary" => nil
         },
         "document_type" => "finder",


### PR DESCRIPTION
This renders a summary underneath each result in the finders.  It's a common pattern in many finders on GOV.UK