### PR TITLE
Wipe all metadata for eu exit guidance

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -69,5 +69,21 @@ module Indexer
         end
       end
     end
+
+    def self.destroy_all_eu_exit_guidance!
+      base_paths = find_all_eu_exit_guidance[:results].collect do |result|
+        result["link"]
+      end
+
+      remove_all_metadata_for_base_paths(base_paths) if base_paths
+    end
+
+    def self.find_all_eu_exit_guidance
+      # hard code 500 items - it should be enough for now
+      SearchConfig.new.run_search(
+        "filter_appear_in_find_eu_exit_guidance_business_finder" => "yes",
+        "count" => "500"
+      )
+    end
   end
 end

--- a/lib/tasks/metadata_tagger.rake
+++ b/lib/tasks/metadata_tagger.rake
@@ -13,3 +13,8 @@ task :destroy_metadata_for_base_paths, [:base_paths] do |_, args|
   base_paths = args[:base_paths].split
   Indexer::MetadataTagger.remove_all_metadata_for_base_paths(base_paths)
 end
+
+desc "Destroy metadata for all eu exit guidance"
+task :destroy_metadata_for_eu_exit_guidance do
+  Indexer::MetadataTagger.destroy_all_eu_exit_guidance!
+end

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -61,6 +61,29 @@ RSpec.describe Indexer::MetadataTagger do
       described_class.initialise(fixture_file, facet_config_file)
       described_class.remove_all_metadata_for_base_paths(base_path)
     end
+
+    it "clears all eu exit guidance metadat" do
+      fixture_file = File.expand_path("fixtures/metadata.csv", __dir__)
+
+      allow(described_class)
+        .to receive(:find_all_eu_exit_guidance)
+        .and_return(
+          {
+            results:
+              [
+                { "link" => "a_base_path", item: "one" },
+                { "link" => "another_base_path", item: "two" }
+              ]
+          }
+      )
+
+      expect(described_class)
+        .to receive(:remove_all_metadata_for_base_paths)
+        .with(%w(a_base_path another_base_path))
+
+      described_class.initialise(fixture_file, facet_config_file)
+      described_class.destroy_all_eu_exit_guidance!
+    end
   end
   # rubocop:enable RSpec/VerifiedDoubles, RSpec/AnyInstance, RSpec/MessageSpies
 end


### PR DESCRIPTION
Add rake task and supporting methods to destroy all metadata for eu exit guidance.
This will execute a search to find all associated documents and then use `#remove_all_metadata_for_base_paths` to remove all the metadata.

I've hardcoded the number of search results to 500 - we currently have about 300 identified pieces of content, so this gives us some room for growth. We should, at some point, page the search properly.