### PR TITLE
Enclose search count in array

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -82,7 +82,7 @@ module Indexer
       # hard code 500 items - it should be enough for now
       SearchConfig.new.run_search(
         "filter_appear_in_find_eu_exit_guidance_business_finder" => "yes",
-        "count" => "500"
+        "count" => %w(500)
       )
     end
   end


### PR DESCRIPTION
Searching for all eu exit guidance is erroring because the value of
"count" is expected to be an array.