### PR TITLE
Add a common transliteration

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -1111,3 +1111,6 @@
 
 # Common misspellings of key people, in both publishing and searching
 - both: asad, assad
+
+# Common transliterations
+- search: hezbollah, hizballah, hizbullah


### PR DESCRIPTION
Common transliterations of the same word should be treated as equivalent.

Currently a GOV.UK search for [Hezbollah](https://www.gov.uk/search?q=Hezbollah) returns 33 results, [Hizballah](https://www.gov.uk/search?q=Hizballah) 19 results, and [Hizbullah](https://www.gov.uk/search?q=Hizbullah) 4 results.
