### PR TITLE
Prevent email signup content item attempting to add `canonical_link` field

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -16,6 +16,7 @@ publishing_app: rummager
 rendering_app: finder-frontend
 details:
   beta: false
+  canonical_link: true
   document_noun: publication
   subscription_list_title_prefix: 'Find EU Exit guidance for your business '
   summary: 'This is the information that has been published so far for your business to prepare for EU exit. You can change what information you get using the checkboxes. Come back to this page regularly or sign up to receive emails when new information is published.'

--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -100,7 +100,7 @@ class FinderEmailSignupContentItemPresenter
     details.merge(
       "subscription_list_title_prefix" => details.fetch("subscription_list_title_prefix", {}),
       "email_filter_facets" => email_filter_facets,
-    ).except("document_noun", "facets", "filter", "generic_description", "reject", "summary")
+    ).except("canonical_link", "document_noun", "facets", "filter", "generic_description", "reject", "summary")
   end
 
   def present


### PR DESCRIPTION
The Finder schema now has an optional `canonical_link` field. This commit
ensures we don't error by attempting to add the field to the email signup
content item.