### PR TITLE
Revert "Bump gds-api-adapters from 55.0.2 to 57.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 5.2.2"
 gem "elasticsearch", "~> 2"
-gem "gds-api-adapters", "~> 57.0"
+gem "gds-api-adapters", "~> 55.0"
 gem "govuk_app_config", "~> 1.11.2"
 gem "govuk_document_types", "~> 0.9.0"
 gem "govuk-lint", "~> 3.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
-    gds-api-adapters (57.0.0)
+    gds-api-adapters (55.0.2)
       addressable
       link_header
       null_logger
@@ -242,7 +242,7 @@ DEPENDENCIES
   activesupport (~> 5.2.2)
   bunny-mock (~> 1.7)
   elasticsearch (~> 2)
-  gds-api-adapters (~> 57.0)
+  gds-api-adapters (~> 55.0)
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk-lint (~> 3.10.0)
   govuk_app_config (~> 1.11.2)


### PR DESCRIPTION
Reverts alphagov/rummager#1395 as Rummager relies on put_path in gds-api-adapters which was removed in gds-api-adapters version 57 and it was causing end to end tests to fail