### PR TITLE
Run end-to-end tests as part of Rummager build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@
 library("govuk")
 
 node('elasticsearch-2.4') {
-  govuk.buildProject()
+  govuk.buildProject(publishingE2ETests: true)
 }


### PR DESCRIPTION
As rummager is part of end-to-end tests changes to it can break the
suite of tests.