### PR TITLE
Remove usage of PublishingApiV1 adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 5.2.2"
 gem "elasticsearch", "~> 2"
-gem "gds-api-adapters", "~> 55.0"
+gem "gds-api-adapters", "~> 57.0"
 gem "govuk_app_config", "~> 1.11.2"
 gem "govuk_document_types", "~> 0.9.0"
 gem "govuk-lint", "~> 3.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
-    gds-api-adapters (55.0.2)
+    gds-api-adapters (57.0.0)
       addressable
       link_header
       null_logger
@@ -242,7 +242,7 @@ DEPENDENCIES
   activesupport (~> 5.2.2)
   bunny-mock (~> 1.7)
   elasticsearch (~> 2)
-  gds-api-adapters (~> 55.0)
+  gds-api-adapters (~> 57.0)
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk-lint (~> 3.10.0)
   govuk_app_config (~> 1.11.2)
@@ -273,4 +273,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -7,12 +7,12 @@ class SpecialRoutePublisher
   end
 
   def take_ownership_of_search_routes
-    publishing_api_v1 = GdsApi::PublishingApi.new(
+    publishing_api = GdsApi::PublishingApiV2.new(
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
     %w(/search /search.json /search/opensearch.xml).each do |path|
-      publishing_api_v1.put_path(
+      publishing_api.put_path(
         path,
         publishing_app: 'rummager',
         override_existing: true


### PR DESCRIPTION
This was removed from GDS API Adapters at version 56 and now the V2
adapter must be used. This same put_path method exists in the V2 adapter
as well.