### PR TITLE
Allow release timestamp as a sort field

### DIFF
--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -24,6 +24,7 @@ class BaseParameterParser
     start_date
     assessment_date
     popularity
+    release_timestamp
   ).freeze
 
   SORT_MAPPINGS = {


### PR DESCRIPTION
This allows the release_timestamp field to be a sort option.