### PR TITLE
Add Brexit topic page to govuk index

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -59,6 +59,7 @@ migrated:
 - step_by_step_nav
 - task_list
 - taxon:
+  - /government/brexit
   - /world/afghanistan
   - /world/albania
   - /world/algeria


### PR DESCRIPTION
We'd like to index this particular topic page in search to make it easier for users to find relevant guidance and information.