### PR TITLE
Allow finders to have `sort` under `details`

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -100,7 +100,9 @@ class FinderEmailSignupContentItemPresenter
     details.merge(
       "subscription_list_title_prefix" => details.fetch("subscription_list_title_prefix", {}),
       "email_filter_facets" => email_filter_facets,
-    ).except("canonical_link", "document_noun", "facets", "filter", "generic_description", "reject", "summary")
+    ).except("canonical_link", "document_noun",
+      "facets", "filter", "generic_description",
+      "reject", "summary", "sort")
   end
 
   def present


### PR DESCRIPTION
Previously publishing the latest find-eu-exit-guidance-business.yml
causes a crash when publishing the finder.

This was because it was sending `sort` to the content store for
the finder_email_signup.

This commit filters out `sort` from the json sent to the publishing api for
find-eu-exit-guidance-business/email-signup

Trello: https://trello.com/c/JgohmaDW/3-add-sort-order-to-the-business-finder-results-page