### PR TITLE
Remove document type from prepare brexit finder

### DIFF
--- a/config/prepare-eu-exit.yml.erb
+++ b/config/prepare-eu-exit.yml.erb
@@ -28,8 +28,6 @@ details:
     content_purpose_supergroup:
       - services
       - guidance_and_regulation
-    content_store_document_type:
-      - travel_advice_index
   subscription_list_title_prefix: <%= title %>
   show_summaries: true
   summary:  <%= config[:topic_summary] %>

--- a/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
+++ b/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe PrepareEuExitFinderPublisher do
           "facets" => [],
           "filter" => {
             "all_part_of_taxonomy_tree" => ["d7bdaee2-8ea5-460e-b00d-6e9382eb6b61", "seaside-seaside-seaside"],
-            "content_purpose_supergroup" => %w(services guidance_and_regulation),
-            "content_store_document_type" => %w(travel_advice_index)
+            "content_purpose_supergroup" => %w(services guidance_and_regulation)
           },
           "show_summaries" => true,
           "summary" => "Something"


### PR DESCRIPTION
This doesn't appear in the search results as the citizen topic isn't live (currently `alpha`). It's misleading to include this in the query, so we should remove it.  There's a link to the foreign travel advice page on the [going and being abroad finder](https://www.gov.uk/prepare-eu-exit/going-and-being-abroad) anyway.

If we want non-whitehall content to appear in the finders, we need to set the topic to `live` in [content tagger](https://content-tagger.publishing.service.gov.uk/taxons/d7bdaee2-8ea5-460e-b00d-6e9382eb6b61)

There's been some resistance to doing this at present because it makes it available for publishers to tag to in Whitehall.