### PR TITLE
Tag metadata on change notification messages

### DIFF
--- a/lib/indexer/change_notification_processor.rb
+++ b/lib/indexer/change_notification_processor.rb
@@ -13,7 +13,8 @@ module Indexer
       return :rejected unless document
       index_name = document['real_index_name']
       document_id = document['_id']
-      updates = {}
+      base_path = content_item['base_path']
+      updates = {}.merge(Indexer::MetadataTagger.metadata_for_base_path(base_path))
       Indexer::AmendWorker.perform_async(index_name, document_id, updates)
       :accepted
     end


### PR DESCRIPTION
https://trello.com/c/spSQHcZ9/34-bug-some-items-of-content-are-disappearing-from-finder

Change notification messages for links updates were causing
the `DocumentPreparer` to [return a version of the document without
additional metadata](https://github.com/alphagov/rummager/blob/93e6e9274db913a5d8adcb1422b415384e2c97d3/lib/indexer/amender.rb#L23) normally augmented by the `Indexer::MetadataTagger`.
This meant that the tagging process and `PublishingEventWorker` updates [would
correctly assign the metadata](https://github.com/alphagov/rummager/blob/0b0229df6ae62e61e5f951564e64b6bbf193c21c/lib/rummager/app.rb#L230-L231) but a change notification from link
updates would rewrite the document back to the default unaugmented state. 

Arguably this means we should make the default state consistent
with the results of tagging with metadata but we've yet to decide on
the correct strategy for tagging the documents in question. So
for now fix this code-path to be consistent with `PublishingEventWorker`.