### PR TITLE
Add ordered related items to finder links presentation

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -76,6 +76,7 @@ class FinderContentItemPresenter
     links = {}
     links["email_alert_signup"] = [schema["signup_content_id"]] if schema.key?("signup_content_id")
     links["parent"] = Array(schema["parent"]) if schema.key?("parent")
+    links["ordered_related_items"] = Array(schema["ordered_related_items"]) if schema.key?("ordered_related_items")
 
     { content_id: content_id, links: links }
   end


### PR DESCRIPTION
https://trello.com/c/vgbMOK0e/62-a-content-item-can-be-pinned-to-the-top-of-a-sector-list-when-finder-results-are-organised-by-topic

We'll 'pin' items by including them in the ordered related items links array so make sure these can be presented when publishing a finder.

![screenshot from 2019-01-28 10-26-31](https://user-images.githubusercontent.com/93511/51830470-d81bc880-22e7-11e9-9b84-5a346a055ba7.png)