### PR TITLE
Allow publishing of the news and comms finder

### DIFF
--- a/config/finders/news_and_communications.yml.erb
+++ b/config/finders/news_and_communications.yml.erb
@@ -1,0 +1,81 @@
+---
+base_path: "/news-and-communications"
+content_id: 622e9691-4b4f-4e9c-bce1-098b0c4f5ee2
+document_type: finder
+locale: en
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder
+title: News and communications
+description: Find news and communications from government
+details:
+  document_noun: result
+  filter:
+    content_purpose_supergroup:
+    - news_and_communications
+  format_name: News or communications
+  show_summaries: true
+  sort:
+  - name: Most viewed
+    key: "-popularity"
+  - name: Relevance
+    key: "-relevance"
+  - name: Updated (newest)
+    key: "-public_timestamp"
+    default: true
+  - name: Updated (oldest)
+    key: public_timestamp
+  facets:
+  - key: related_to_brexit
+    filter_key: all_part_of_taxonomy_tree
+    filter_value: d6c2de5d-ef90-45d1-82d4-5f2438369eea
+    name: Show only Brexit results
+    short_name: Brexit
+    type: checkbox
+    display_as_result_metadata: false
+    filterable: true
+    preposition: about
+  - key: "_unused"
+    filter_key: all_part_of_taxonomy_tree
+    keys:
+    - level_one_taxon
+    - level_two_taxon
+    name: topic
+    short_name: topic
+    type: taxon
+    display_as_result_metadata: false
+    filterable: true
+    preposition: about
+  - key: people
+    name: Person
+    preposition: from
+    type: text
+    display_as_result_metadata: false
+    filterable: true
+  - key: organisations
+    name: Organisation
+    short_name: From
+    preposition: from
+    type: text
+    display_as_result_metadata: true
+    filterable: true
+  - key: world_locations
+    name: World location
+    preposition: in
+    type: text
+    display_as_result_metadata: true
+    filterable: true
+  - key: public_timestamp
+    short_name: Updated
+    name: Updated
+    type: date
+    display_as_result_metadata: true
+    filterable: true
+  default_documents_per_page: 20
+routes:
+- path: "/news-and-communications"
+  type: exact
+- path: "/news-and-communications.atom"
+  type: exact
+- path: "/news-and-communications.json"
+  type: exact


### PR DESCRIPTION
This allows the [news and comms finder](https://finder-frontend.herokuapp.com/news-and-communications) to be published and therefore visible on GOV.UK.

To actually publish this, you need to run:
`bundle exec rake publishing_api:publish_document_finder DOCUMENT_FINDER_CONFIG=finders/news_and_communications.yml`

This needs https://github.com/alphagov/finder-frontend/pull/837 and https://github.com/alphagov/govuk-content-schemas/pull/857 to be merged before this will work.

(This doesn't include the email signup page yet)

https://trello.com/c/oE1sdBdt/278-add-ability-to-publish-news-and-communications-finder-from-rummager