### PR TITLE
Prepare rummager to directly serve API paths

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -137,7 +137,7 @@ class Rummager < Sinatra::Application
   # Return results for the GOV.UK site search
   #
   # For details, see doc/search-api.md
-  ["/search.?:request_format?"].each do |path|
+  ["/search.?:request_format?", "/api/search.?:request_format?"].each do |path|
     get path do
       json_only
 
@@ -150,12 +150,13 @@ class Rummager < Sinatra::Application
         return { error: e.error }.to_json
       end
 
+      headers['Access-Control-Allow-Origin'] = '*'
       results.to_json
     end
   end
 
   # Batch return results for the GOV.UK site search
-  ["/batch_search.?:request_format?"].each do |path|
+  ["/batch_search.?:request_format?", "/api/batch_search.?:request_format?"].each do |path|
     get path do
       json_only
 
@@ -174,6 +175,7 @@ class Rummager < Sinatra::Application
         return { error: e.error }.to_json
       end
 
+      headers['Access-Control-Allow-Origin'] = '*'
       { results: results }.to_json
     end
   end

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -60,6 +60,22 @@ class SpecialRoutePublisher
       },
       {
         rendering_app: "rummager",
+        content_id: "0818867d-8026-482c-b797-306fb74f5a2d",
+        base_path: "/api/search.json",
+        title: "GOV.UK search results API",
+        description: "Sitewide search results are displayed in JSON format here.",
+        type: "exact",
+      },
+      {
+        rendering_app: "rummager",
+        content_id: "5edd25bd-987f-45d3-8eca-5fb35cbf2978",
+        base_path: "/api/batch_search.json",
+        title: "GOV.UK batch search results API",
+        description: "Sitewide batch search results are displayed in JSON format here.",
+        type: "exact",
+      },
+      {
+        rendering_app: "rummager",
         base_path: "/sitemap.xml",
         content_id: "fee32a90-397a-4761-9f98-b06e47d2b798",
         title: "GOV.UK sitemap index",

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -349,6 +349,19 @@ RSpec.describe 'SearchTest' do
     )
   end
 
+  it "also works with the /api prefix" do
+    commit_treatment_of_dragons_document({ "organisations" => ['/ministry-of-magic'] })
+    commit_ministry_of_magic_document({ "format" => 'organisation' })
+
+    get "/api/search.json?q=dragons"
+
+    expect(first_result['organisations']).to eq(
+      [{ "slug" => "/ministry-of-magic",
+      "link" => "/ministry-of-magic-site",
+      "title" => "Ministry of Magic" }]
+    )
+  end
+
   it "expands organisations via content_id" do
     commit_treatment_of_dragons_document({ "organisation_content_ids" => ['organisation-content-id'] })
     commit_ministry_of_magic_document({ "content_id" => 'organisation-content-id', "format" => 'organisation' })


### PR DESCRIPTION
This PR makes three changes to rummager to allow it to directly serve public API endpoints without publicapi:

* `search.json` and `batch_search.json` are now also accessible via an `/api` prefix since this is how they will be accessed when going via `www.gov.uk/api/search.json`.
* Both endpoints also set the `Access-Control-Allow-Origin` HTTP header to `*` to allow third-party clients to easily use the API.
* Special routes are published for `/api/search.json` and `/api/batch_search.json`.

Trello: https://trello.com/c/C2DS0GbF/46-some-routing-info-is-in-nginx-config