### PR TITLE
Publish news and comms finder email signup

### DIFF
--- a/config/finders/news_and_communications.yml
+++ b/config/finders/news_and_communications.yml
@@ -8,6 +8,7 @@ rendering_app: finder-frontend
 schema_name: finder
 title: News and communications
 description: Find news and communications from government
+signup_content_id: 54fa4dca-4dfb-40a5-b860-127716f02e75
 details:
   document_noun: result
   filter:

--- a/config/finders/news_and_communications_email_signup.yml
+++ b/config/finders/news_and_communications_email_signup.yml
@@ -1,0 +1,36 @@
+---
+base_path: "/news-and-communications/email-signup"
+content_id: 54fa4dca-4dfb-40a5-b860-127716f02e75
+document_type: finder_email_signup
+locale: en
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder_email_signup
+title: News and communications
+description: You'll get an email each time news or communications are published.
+details:
+  filter:
+    content_purpose_supergroup: news_and_communications
+  email_filter_by:
+  email_filter_name:
+  subscription_list_title_prefix: 'News and communications ' # whitespace intended
+  email_filter_facets:
+  - facet_id: people
+    facet_name: people
+  - facet_id: organisations
+    facet_name: organisations
+  - facet_id: world_locations
+    facet_name: world locations
+  - facet_id: level_one_taxon
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
+  - facet_id: level_two_taxon
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
+  - facet_id: related_to_brexit
+    filter_key: all_part_of_taxonomy_tree
+    filter_value: d6c2de5d-ef90-45d1-82d4-5f2438369eea
+    facet_name: topics
+routes:
+- path: "/news-and-communications/email-signup"
+  type: exact

--- a/doc/publishing-finders.md
+++ b/doc/publishing-finders.md
@@ -6,16 +6,23 @@ not fit the standard specialist document finder pattern. These are:
 - [Advanced search](advanced-search)
 - Find EU Exit guidance for business (currently in development)
 
-The configuration for these finders can be found in YAML files in 
+The configuration for these finders can be found in YAML files in
 the `config/` directory. These config files are a YAML representation
 of a content item.  
-The rake task 
+
+This rake task is used to present the finders to the publishing API:
 
 ```
 DOCUMENT_FINDER_CONFIG=<finder-config-file-path> publishing_api:publish_document_finder
-``` 
+```
 
-is used to present the finders to the publishing API.  
+**Note:** The rake task `publishing_api:publish_document_finder` is to be deprecated.
+
+For new finder content items, use the rake task `publishing_api:publish_finder`. For example:
+
+```
+FINDER_CONFIG=news_and_communications.yml EMAIL_SIGNUP_CONFIG=news_and_communications_email_signup.yml publishing_api:publish_finder
+```
 
 **NOTE:** The `find-eu-exit-guidance-business` finder config is overwritten by a
 [shared definition in the govuk-app-deployment-secrets repo](https://github.com/alphagov/govuk-app-deployment-secrets/blob/master/shared_config/find-eu-exit-guidance-business.yml), the file committed to the

--- a/lib/content_item_publisher/content_item_presenter.rb
+++ b/lib/content_item_publisher/content_item_presenter.rb
@@ -1,0 +1,37 @@
+module ContentItemPublisher
+  class ContentItemPresenter
+    attr_reader :content_id, :content_item, :timestamp
+
+    def initialize(content_item, timestamp)
+      @content_item = content_item
+      @content_id = content_item["content_id"]
+      @timestamp = timestamp
+    end
+
+    def present
+      {
+        base_path: content_item["base_path"],
+        description: content_item["description"],
+        details: content_item["details"],
+        document_type: content_item["document_type"],
+        locale: "en",
+        phase: "live",
+        public_updated_at: timestamp,
+        publishing_app: "rummager",
+        rendering_app: "finder-frontend",
+        routes: content_item["routes"],
+        schema_name: content_item["schema_name"],
+        title: content_item["title"],
+        update_type: "minor",
+      }
+    end
+
+    def present_links
+      { content_id: content_id, links: {} }
+    end
+
+    def description
+      "#{present[:title]} (a #{present[:schema_name]} content item)"
+    end
+  end
+end

--- a/lib/content_item_publisher/finder_email_signup_presenter.rb
+++ b/lib/content_item_publisher/finder_email_signup_presenter.rb
@@ -1,0 +1,4 @@
+module ContentItemPublisher
+  class FinderEmailSignupPresenter < ContentItemPresenter
+  end
+end

--- a/lib/content_item_publisher/finder_email_signup_publisher.rb
+++ b/lib/content_item_publisher/finder_email_signup_publisher.rb
@@ -1,0 +1,9 @@
+module ContentItemPublisher
+  class FinderEmailSignupPublisher < Publisher
+  private
+
+    def content_item_presenter
+      FinderEmailSignupPresenter
+    end
+  end
+end

--- a/lib/content_item_publisher/finder_presenter.rb
+++ b/lib/content_item_publisher/finder_presenter.rb
@@ -1,0 +1,21 @@
+module ContentItemPublisher
+  class FinderPresenter < ContentItemPresenter
+    def present_links
+      links = {}
+      links["email_alert_signup"] = email_alert_signup if email_alert_signup?
+      links["parent"] = Array(content_item["parent"]) if content_item.key?("parent")
+
+      { content_id: content_id, links: links }
+    end
+
+  private
+
+    def email_alert_signup?
+      content_item.key?("signup_content_id")
+    end
+
+    def email_alert_signup
+      [content_item["signup_content_id"]]
+    end
+  end
+end

--- a/lib/content_item_publisher/finder_presenter.rb
+++ b/lib/content_item_publisher/finder_presenter.rb
@@ -3,7 +3,7 @@ module ContentItemPublisher
     def present_links
       links = {}
       links["email_alert_signup"] = email_alert_signup if email_alert_signup?
-      links["parent"] = Array(content_item["parent"]) if content_item.key?("parent")
+      links["parent"] = content_item_parent if content_item_parent?
 
       { content_id: content_id, links: links }
     end
@@ -16,6 +16,14 @@ module ContentItemPublisher
 
     def email_alert_signup
       [content_item["signup_content_id"]]
+    end
+
+    def content_item_parent?
+      content_item.key?("parent")
+    end
+
+    def content_item_parent
+      Array(content_item["parent"])
     end
   end
 end

--- a/lib/content_item_publisher/finder_publisher.rb
+++ b/lib/content_item_publisher/finder_publisher.rb
@@ -1,0 +1,9 @@
+module ContentItemPublisher
+  class FinderPublisher < Publisher
+  private
+
+    def content_item_presenter
+      FinderPresenter
+    end
+  end
+end

--- a/lib/content_item_publisher/publisher.rb
+++ b/lib/content_item_publisher/publisher.rb
@@ -18,14 +18,6 @@ module ContentItemPublisher
 
     attr_reader :content_item, :logger, :timestamp
 
-    def publishing_api
-      @publishing_api ||= GdsApi::PublishingApiV2.new(
-        Plek.new.find('publishing-api'),
-        bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
-        timeout: 10,
-      )
-    end
-
     def content_item_presenter
       raise NotImplementedError
     end
@@ -35,9 +27,9 @@ module ContentItemPublisher
 
       logger.info("Publishing #{presenter.description}")
 
-      publishing_api.put_content(presenter.content_id, presenter.present)
-      publishing_api.patch_links(presenter.content_id, presenter.present_links)
-      publishing_api.publish(presenter.content_id)
+      Services.publishing_api.put_content(presenter.content_id, presenter.present)
+      Services.publishing_api.patch_links(presenter.content_id, presenter.present_links)
+      Services.publishing_api.publish(presenter.content_id)
     end
   end
 end

--- a/lib/content_item_publisher/publisher.rb
+++ b/lib/content_item_publisher/publisher.rb
@@ -1,0 +1,43 @@
+require "gds_api/publishing_api_v2"
+
+# ContentItemPublisher is responsible for publishing content items related
+# to search, such as finders and finder email signup pages.
+module ContentItemPublisher
+  class Publisher
+    def initialize(content_item, timestamp = Time.now.iso8601, logger = Logger.new(STDOUT))
+      @content_item = content_item
+      @logger = logger
+      @timestamp = timestamp
+    end
+
+    def call
+      publish(content_item)
+    end
+
+  private
+
+    attr_reader :content_item, :logger, :timestamp
+
+    def publishing_api
+      @publishing_api ||= GdsApi::PublishingApiV2.new(
+        Plek.new.find('publishing-api'),
+        bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+        timeout: 10,
+      )
+    end
+
+    def content_item_presenter
+      raise NotImplementedError
+    end
+
+    def publish(content_item)
+      presenter = content_item_presenter.new(content_item, timestamp)
+
+      logger.info("Publishing #{presenter.description}")
+
+      publishing_api.put_content(presenter.content_id, presenter.present)
+      publishing_api.patch_links(presenter.content_id, presenter.present_links)
+      publishing_api.publish(presenter.content_id)
+    end
+  end
+end

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -49,6 +49,13 @@ require 'special_route_publisher'
 require 'auth/gds_sso'
 require 'auth/mock_strategy'
 
+require 'content_item_publisher/publisher'
+require 'content_item_publisher/content_item_presenter'
+require 'content_item_publisher/finder_publisher'
+require 'content_item_publisher/finder_presenter'
+require 'content_item_publisher/finder_email_signup_publisher'
+require 'content_item_publisher/finder_email_signup_presenter'
+
 require 'indexer'
 require 'indexer/amender'
 require 'indexer/bulk_payload_generator'

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -50,6 +50,29 @@ namespace :publishing_api do
     PublishingApiFinderPublisher.new(finder, timestamp).call
   end
 
+  desc "
+    Publish finder and email signup content items
+
+    Usage:
+    FINDER_CONFIG=news_and_communications.yml EMAIL_SIGNUP_CONFIG=news_and_communications_email_signup.yml rake publishing_api:publish_finder
+  "
+  task :publish_finder do
+    finder_config = ENV["FINDER_CONFIG"]
+    email_signup_config = ENV["EMAIL_SIGNUP_CONFIG"]
+
+    unless finder_config || email_signup_finder_config
+      raise "Please supply a valid config file name, e.g. FINDER_CONFIG=news_and_communications.yml and/or EMAIL_SIGNUP_CONFIG=news_and_communications_email_signup.yml"
+    end
+
+    finder = YAML.load_file("config/finders/#{finder_config}")
+    email_signup = YAML.load_file("config/finders/#{email_signup_config}")
+    timestamp = Time.now.iso8601
+
+    ContentItemPublisher::FinderEmailSignupPublisher.new(email_signup, timestamp).call if email_signup
+    ContentItemPublisher::FinderPublisher.new(finder, timestamp).call if finder
+    puts "FINISHED"
+  end
+
   desc "Unpublish document finder."
   task :unpublish_document_finder do
     document_finder_config = ENV["DOCUMENT_FINDER_CONFIG"]

--- a/spec/unit/content_item_publisher/finder_email_signup_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_presenter_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "govuk_schemas/rspec_matchers"
+
+RSpec.describe ContentItemPublisher::FinderEmailSignupPresenter do
+  include GovukSchemas::RSpecMatchers
+
+  subject(:instance) { described_class.new(finder, timestamp) }
+
+  let(:config_file) { "finders/news_and_communications_email_signup.yml" }
+  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+  let(:content_id) { finder["content_id"] }
+  let(:timestamp) { Time.now.iso8601 }
+
+  before do
+    GovukContentSchemaTestHelpers.configure do |config|
+      config.schema_type = 'publisher_v2'
+      config.project_root = File.expand_path(Dir.pwd)
+    end
+  end
+
+  it "presents a valid payload" do
+    expect(instance.present).to be_valid_against_schema("finder_email_signup")
+  end
+
+  it "exposes the content_id" do
+    expect(instance.content_id).to eq(content_id)
+  end
+
+  it "sets the public_updated_at value" do
+    expect(instance.present[:public_updated_at]).to eq(timestamp)
+  end
+end

--- a/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
@@ -21,25 +21,24 @@ RSpec.describe ContentItemPublisher::FinderEmailSignupPublisher do
 
     before do
       allow(logger).to receive(:info)
-      allow(GdsApi::PublishingApiV2).to receive(:new).and_return(publishing_api)
-      allow(publishing_api).to receive(:put_content)
-      allow(publishing_api).to receive(:patch_links)
-      allow(publishing_api).to receive(:publish)
+      allow(Services.publishing_api).to receive(:put_content)
+      allow(Services.publishing_api).to receive(:patch_links)
+      allow(Services.publishing_api).to receive(:publish)
 
       instance.call
     end
 
     it "drafts the email signup page" do
-      expect(publishing_api).to have_received(:put_content).with(content_id, payload)
+      expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
     end
 
     it "patches links for the email signup page" do
-      expect(publishing_api).to have_received(:patch_links)
+      expect(Services.publishing_api).to have_received(:patch_links)
         .with(content_id, { content_id: content_id, links: anything })
     end
 
     it "publishes the email signup page to the Publishing API" do
-      expect(publishing_api).to have_received(:publish).with(content_id)
+      expect(Services.publishing_api).to have_received(:publish).with(content_id)
     end
   end
 end

--- a/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe ContentItemPublisher::FinderEmailSignupPublisher do
+  subject(:instance) { described_class.new(finder, timestamp) }
+
+  let(:config_file) { "finders/news_and_communications_email_signup.yml" }
+  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+  let(:content_id) { finder["content_id"] }
+  let(:timestamp) { Time.now.iso8601 }
+  let(:logger) { instance_double("Logger") }
+
+  before do
+    allow(Logger).to receive(:new).and_return(logger)
+  end
+
+  describe "#call" do
+    let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+    let(:payload) {
+      ContentItemPublisher::FinderEmailSignupPresenter.new(finder, timestamp).present
+    }
+
+    before do
+      allow(logger).to receive(:info)
+      allow(GdsApi::PublishingApiV2).to receive(:new).and_return(publishing_api)
+      allow(publishing_api).to receive(:put_content)
+      allow(publishing_api).to receive(:patch_links)
+      allow(publishing_api).to receive(:publish)
+
+      instance.call
+    end
+
+    it "drafts the email signup page" do
+      expect(publishing_api).to have_received(:put_content).with(content_id, payload)
+    end
+
+    it "patches links for the email signup page" do
+      expect(publishing_api).to have_received(:patch_links)
+        .with(content_id, { content_id: content_id, links: anything })
+    end
+
+    it "publishes the email signup page to the Publishing API" do
+      expect(publishing_api).to have_received(:publish).with(content_id)
+    end
+  end
+end

--- a/spec/unit/content_item_publisher/finder_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_presenter_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "govuk_schemas/rspec_matchers"
+
+RSpec.describe ContentItemPublisher::FinderPresenter do
+  include GovukSchemas::RSpecMatchers
+
+  subject(:instance) { described_class.new(finder, timestamp) }
+
+  let(:config_file) { "finders/news_and_communications.yml" }
+  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+  let(:content_id) { finder["content_id"] }
+  let(:timestamp) { Time.now.iso8601 }
+
+  before do
+    GovukContentSchemaTestHelpers.configure do |config|
+      config.schema_type = 'publisher_v2'
+      config.project_root = File.expand_path(Dir.pwd)
+    end
+  end
+
+  it "presents a valid payload" do
+    expect(instance.present).to be_valid_against_schema("finder")
+  end
+
+  it "exposes the content_id" do
+    expect(instance.content_id).to eq(content_id)
+  end
+
+  it "sets the public_updated_at value" do
+    expect(instance.present[:public_updated_at]).to eq(timestamp)
+  end
+end

--- a/spec/unit/content_item_publisher/finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_publisher_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe ContentItemPublisher::FinderPublisher do
+  subject(:instance) { described_class.new(finder, timestamp) }
+
+  let(:config_file) { "finders/news_and_communications.yml" }
+  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+  let(:content_id) { finder["content_id"] }
+  let(:timestamp) { Time.now.iso8601 }
+  let(:logger) { instance_double("Logger") }
+
+  before do
+    allow(Logger).to receive(:new).and_return(logger)
+  end
+
+  describe "#call" do
+    let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+    let(:payload) {
+      ContentItemPublisher::FinderPresenter.new(finder, timestamp).present
+    }
+
+    before do
+      allow(logger).to receive(:info)
+      allow(GdsApi::PublishingApiV2).to receive(:new).and_return(publishing_api)
+      allow(publishing_api).to receive(:put_content)
+      allow(publishing_api).to receive(:patch_links)
+      allow(publishing_api).to receive(:publish)
+
+      instance.call
+    end
+
+    it "drafts the finder" do
+      expect(publishing_api).to have_received(:put_content).with(content_id, payload)
+    end
+
+    it "patches links for the finder" do
+      expect(publishing_api).to have_received(:patch_links)
+        .with(content_id, { content_id: content_id, links: anything })
+    end
+
+    it "publishes the finder to the Publishing API" do
+      expect(publishing_api).to have_received(:publish).with(content_id)
+    end
+  end
+end

--- a/spec/unit/content_item_publisher/finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_publisher_spec.rb
@@ -21,25 +21,24 @@ RSpec.describe ContentItemPublisher::FinderPublisher do
 
     before do
       allow(logger).to receive(:info)
-      allow(GdsApi::PublishingApiV2).to receive(:new).and_return(publishing_api)
-      allow(publishing_api).to receive(:put_content)
-      allow(publishing_api).to receive(:patch_links)
-      allow(publishing_api).to receive(:publish)
+      allow(Services.publishing_api).to receive(:put_content)
+      allow(Services.publishing_api).to receive(:patch_links)
+      allow(Services.publishing_api).to receive(:publish)
 
       instance.call
     end
 
     it "drafts the finder" do
-      expect(publishing_api).to have_received(:put_content).with(content_id, payload)
+      expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
     end
 
     it "patches links for the finder" do
-      expect(publishing_api).to have_received(:patch_links)
+      expect(Services.publishing_api).to have_received(:patch_links)
         .with(content_id, { content_id: content_id, links: anything })
     end
 
     it "publishes the finder to the Publishing API" do
-      expect(publishing_api).to have_received(:publish).with(content_id)
+      expect(Services.publishing_api).to have_received(:publish).with(content_id)
     end
   end
 end

--- a/spec/unit/content_item_publisher/publisher_spec.rb
+++ b/spec/unit/content_item_publisher/publisher_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe ContentItemPublisher::Publisher do
+  subject(:instance) { described_class.new(finder, timestamp) }
+
+  let(:config_file) { "finders/news_and_communications.yml" }
+  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+  let(:timestamp) { Time.now.iso8601 }
+  let(:logger) { instance_double("Logger") }
+
+  before do
+    allow(Logger).to receive(:new).and_return(logger)
+  end
+
+  describe "#call" do
+    it "throws an error" do
+      # See finder_publisher_spec for more extensive tests
+      expect {
+        instance.call
+      }.to raise_error NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/HZHHKXc8/311-make-it-possible-to-publish-news-and-communications-email-alert-content-item-from-rummager

**Note:** this will need to be merged after https://github.com/alphagov/govuk-content-schemas/pull/860 is merged and the latest version of the gem is used by rummager. The tests wont pass until this is done.

This adds `ContentItemPublisher` to handle the publication of finders and their email signup pages from rummager. Additionally it adds a rake task to publish the content items.