### PR TITLE
Replace content_purpose_supergroup with document types

### DIFF
--- a/lib/duplicate_deleter.rb
+++ b/lib/duplicate_deleter.rb
@@ -9,7 +9,7 @@ class DuplicateDeleter
 
   def call(ids, id_type: 'content_id')
     ids.each do |id|
-      results = search_config.run_search("filter_#{id_type}" => id, 'fields' => ['content_id'])
+      results = search_config.run_search("filter_#{id_type}" => Array(id), 'fields' => %w[content_id])
 
       if results[:results].count < 2
         io.puts "Skipping #{id_type} #{id} as less than 2 results found"

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -81,7 +81,7 @@ module Indexer
     def self.find_all_eu_exit_guidance
       # hard code 500 items - it should be enough for now
       SearchConfig.new.run_search(
-        "filter_appear_in_find_eu_exit_guidance_business_finder" => "yes",
+        "filter_appear_in_find_eu_exit_guidance_business_finder" => %w[yes],
         "count" => %w(500)
       )
     end

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -167,16 +167,13 @@ class Rummager < Sinatra::Application
         parsed_searches_parameters[parts[0]][parts[1]] = values
       end
       searches = parsed_searches_parameters.values
-      results = []
       begin
-        results = SearchConfig.instance.run_batch_search(searches)
+        headers['Access-Control-Allow-Origin'] = '*'
+        { results: SearchConfig.instance.run_batch_search(searches) }.to_json
       rescue BaseParameterParser::ParseError => e
         status 422
-        return { error: e.error }.to_json
+        { error: e.error }.to_json
       end
-
-      headers['Access-Control-Allow-Origin'] = '*'
-      { results: results }.to_json
     end
   end
 

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -540,6 +540,29 @@ RSpec.describe 'SearchTest' do
     expect(last_response.body).to eq('Query must be less than 1024 words')
   end
 
+  describe 'substitute content_purpose_supergroup with document_types' do
+    before do
+      commit_ministry_of_magic_document('content_store_document_type' => "doc_type")
+      commit_treatment_of_dragons_document('content_store_document_type' => "other_doc_type")
+    end
+
+    it "Returns correct values for a valid document_supertype" do
+      allow(GovukDocumentTypes).to receive(:supergroup_document_types).
+          with('my_supergroup').
+          and_return(%w[doc_type])
+      get "/search?filter_content_purpose_supergroup=my_supergroup"
+      expect(result_titles).to eq(['Ministry of Magic'])
+    end
+
+    it "Returns no values for an invalid document_supertype" do
+      allow(GovukDocumentTypes).to receive(:supergroup_document_types).
+          with('invalid_supergroup').
+          and_return(%w[])
+      get "/search?filter_content_purpose_supergroup=invalid_supergroup"
+      expect(parsed_response).to eq({ "error" => '"invalid_supergroup" contains invalid content purpose supergroups' })
+    end
+  end
+
   private
 
   def first_result

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe SearchParameterParser do
     it "includes the type in return value of #parsed params" do
       params = {
         "filter_document_type" => ["cma_case"],
-        "filter_opened_date" => "from:2014-04-01 05:08,to:2014-04-02 17:43:12",
+        "filter_opened_date" => ["from:2014-04-01 05:08,to:2014-04-02 17:43:12"],
       }
 
       parser = described_class.new(params, @schema)
@@ -478,7 +478,7 @@ RSpec.describe SearchParameterParser do
     it "includes the whole day if time is omitted" do
       params = {
         "filter_document_type" => ["cma_case"],
-        "filter_public_timestamp" => "from:2017-06-05,to:2017-06-08",
+        "filter_public_timestamp" => ["from:2017-06-05,to:2017-06-08"],
       }
 
       parser = described_class.new(params, @schema)
@@ -499,7 +499,7 @@ RSpec.describe SearchParameterParser do
     it "does not filter on date if the date is invalid" do
       params = {
         "filter_document_type" => ["cma_case"],
-        "filter_opened_date" => "from:2014-bananas-01 00:00,to:2014-04-02 00:00",
+        "filter_opened_date" => ["from:2014-bananas-01 00:00,to:2014-04-02 00:00"],
       }
 
       parser = described_class.new(params, @schema)
@@ -513,7 +513,7 @@ RSpec.describe SearchParameterParser do
     it "does not filter on date if the filter parameter name is invalid" do
       params = {
         "filter_document_type" => ["cma_case"],
-        "filter_opened_date" => "some_invalid_parameter:2014-04-01",
+        "filter_opened_date" => ["some_invalid_parameter:2014-04-01"],
       }
 
       parser = described_class.new(params, @schema)


### PR DESCRIPTION
When filtering by content_purpose_supergroups elastic search is queried
using the equivalent content_types instead. This is because the
content_purpose_supergroup attribute is expected to be deprecated
in the content-store/elasticsearch soon.

https://trello.com/c/gVU3f7Xr/285-convert-supertypes-to-document-types-inside-rummager