### PR TITLE
Pull first_published_at from metadata and top level

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -169,19 +169,19 @@ module GovukIndex
     end
 
     def common_fields
-      @_common_fields ||= CommonFieldsPresenter.new(payload)
+      @common_fields ||= CommonFieldsPresenter.new(payload)
     end
 
     def details
-      @_details ||= DetailsPresenter.new(details: payload["details"], format: common_fields.format)
+      @details ||= DetailsPresenter.new(details: payload["details"], format: common_fields.format)
     end
 
     def expanded_links
-      @_expanded_links ||= ExpandedLinksPresenter.new(payload["expanded_links"])
+      @expanded_links ||= ExpandedLinksPresenter.new(payload["expanded_links"])
     end
 
     def specialist
-      @_specialist ||= SpecialistPresenter.new(payload)
+      @specialist ||= SpecialistPresenter.new(payload)
     end
 
     def newslike?

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -181,7 +181,7 @@ module GovukIndex
     end
 
     def specialist
-      @_specialist ||= SpecialistPresenter.new(metadata: payload.dig("details", "metadata"))
+      @_specialist ||= SpecialistPresenter.new(payload)
     end
 
     def newslike?

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -26,7 +26,6 @@ module GovukIndex
     delegate_to_payload :dfid_review_status
     delegate_to_payload :dfid_theme
     delegate_to_payload :eligible_entities
-    delegate_to_payload :first_published_at
     delegate_to_payload :fund_state, convert_to_array: true
     delegate_to_payload :fund_type
     delegate_to_payload :funding_amount
@@ -66,8 +65,13 @@ module GovukIndex
     delegate_to_payload :will_continue_on
     delegate_to_payload :withdrawn_date
 
-    def initialize(metadata:)
-      @metadata = metadata || {}
+    def initialize(payload)
+      @payload = payload
+      @metadata = @payload.dig("details", "metadata") || {}
+    end
+
+    def first_published_at
+      metadata["first_published_at"] || @payload["first_published_at"]
     end
 
   private


### PR DESCRIPTION
This allows filtering by `first_published_at` without requiring an entry for it in the details hash.

## Drug safety updates

### Before
<img width="1034" alt="screen shot 2019-02-05 at 13 50 18" src="https://user-images.githubusercontent.com/109225/52278044-fae45780-294d-11e9-816a-4042334540d4.png">

### After
<img width="685" alt="screen shot 2019-02-05 at 13 57 44" src="https://user-images.githubusercontent.com/109225/52278078-13ed0880-294e-11e9-9bd7-83a7cbcb8cfc.png">

## DFID

### After
<img width="996" alt="screen shot 2019-02-05 at 13 58 31" src="https://user-images.githubusercontent.com/109225/52278123-2bc48c80-294e-11e9-839c-e8401b121e20.png">

## CMA

### After
<img width="1023" alt="screen shot 2019-02-05 at 13 59 03" src="https://user-images.githubusercontent.com/109225/52278144-3ed75c80-294e-11e9-89ec-42d3bf340c47.png">

https://trello.com/c/rM1I5XM6/750-finder-frontend-does-not-return-the-correct-results-for-drug-safety-update