### PR TITLE
Enable publication of all content finder

### DIFF
--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -1,0 +1,73 @@
+---
+base_path: "/all-content"
+content_id: dd395436-9b40-41f3-8157-740a453ac972
+document_type: finder
+locale: en
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder
+title: All content
+description: Find content from government
+signup_content_id: 49838f97-5d2e-407a-8876-30c4abe2a6bc
+details:
+  default_documents_per_page: 20
+  document_noun: result
+  format_name: Documents
+  reject:
+    content_purpose_supergroup:
+    - other
+  facets:
+  - key: "_unused"
+    display_as_result_metadata: false
+    filter_key: all_part_of_taxonomy_tree
+    filterable: true
+    keys:
+    - level_one_taxon
+    - level_two_taxon
+    name: topic
+    preposition: about
+    short_name: topic
+    type: taxon
+  - display_as_result_metadata: true
+    filterable: true
+    key: organisations
+    name: Organisation
+    preposition: from
+    short_name: From
+    type: text
+  - display_as_result_metadata: false
+    filterable: true
+    key: people
+    name: Person
+    preposition: from
+    type: text
+  - display_as_result_metadata: true
+    filterable: true
+    key: world_locations
+    name: World location
+    preposition: in
+    type: text
+  - display_as_result_metadata: true
+    filterable: true
+    key: public_timestamp
+    name: Updated
+    short_name: Updated
+    type: date
+  show_summaries: true
+  sort:
+  - key: "-popularity"
+    name: Most viewed
+  - key: "-relevance"
+    name: Relevance
+  - default: true
+    key: "-public_timestamp"
+    name: Updated (newest)
+  - key: public_timestamp
+    name: Updated (oldest)
+routes:
+- path: "/all-content"
+  type: exact
+- path: "/all-content.atom"
+  type: exact
+- path: "/all-content.json"
+  type: exact

--- a/config/finders/all_content_email_signup.yml
+++ b/config/finders/all_content_email_signup.yml
@@ -1,0 +1,32 @@
+---
+base_path: "/all-content/email-signup"
+content_id: 49838f97-5d2e-407a-8876-30c4abe2a6bc
+document_type: finder_email_signup
+locale: en
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder_email_signup
+title: All content
+description: You'll get an email when content is published.
+details:
+  email_filter_by:
+  email_filter_name:
+  subscription_list_title_prefix: 'All content'
+  reject:
+    content_purpose_supergroup: other
+  email_filter_facets:
+  - facet_id: people
+    facet_name: people
+  - facet_id: organisations
+    facet_name: organisations
+  - facet_id: world_locations
+    facet_name: world locations
+  - facet_id: level_one_taxon
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
+  - facet_id: level_two_taxon
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
+routes:
+- path: "/all-content/email-signup"
+  type: exact

--- a/spec/unit/content_item_publisher/finder_email_signup_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_presenter_spec.rb
@@ -4,29 +4,34 @@ require "govuk_schemas/rspec_matchers"
 RSpec.describe ContentItemPublisher::FinderEmailSignupPresenter do
   include GovukSchemas::RSpecMatchers
 
-  subject(:instance) { described_class.new(finder, timestamp) }
+  %w(
+    finders/news_and_communications_email_signup.yml
+    finders/all_content_email_signup.yml
+  ).each do |config_file|
 
-  let(:config_file) { "finders/news_and_communications_email_signup.yml" }
-  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
-  let(:content_id) { finder["content_id"] }
-  let(:timestamp) { Time.now.iso8601 }
+    subject(:instance) { described_class.new(finder, timestamp) }
 
-  before do
-    GovukContentSchemaTestHelpers.configure do |config|
-      config.schema_type = 'publisher_v2'
-      config.project_root = File.expand_path(Dir.pwd)
+    let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+    let(:content_id) { finder["content_id"] }
+    let(:timestamp) { Time.now.iso8601 }
+
+    before do
+      GovukContentSchemaTestHelpers.configure do |config|
+        config.schema_type = 'publisher_v2'
+        config.project_root = File.expand_path(Dir.pwd)
+      end
     end
-  end
 
-  it "presents a valid payload" do
-    expect(instance.present).to be_valid_against_schema("finder_email_signup")
-  end
+    it "presents a valid payload" do
+      expect(instance.present).to be_valid_against_schema("finder_email_signup")
+    end
 
-  it "exposes the content_id" do
-    expect(instance.content_id).to eq(content_id)
-  end
+    it "exposes the content_id" do
+      expect(instance.content_id).to eq(content_id)
+    end
 
-  it "sets the public_updated_at value" do
-    expect(instance.present[:public_updated_at]).to eq(timestamp)
+    it "sets the public_updated_at value" do
+      expect(instance.present[:public_updated_at]).to eq(timestamp)
+    end
   end
 end

--- a/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
@@ -1,44 +1,49 @@
 require "spec_helper"
 
 RSpec.describe ContentItemPublisher::FinderEmailSignupPublisher do
-  subject(:instance) { described_class.new(finder, timestamp) }
+  %w(
+    finders/news_and_communications.yml
+    finders/all_content.yml
+  ).each do |config_file|
 
-  let(:config_file) { "finders/news_and_communications_email_signup.yml" }
-  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
-  let(:content_id) { finder["content_id"] }
-  let(:timestamp) { Time.now.iso8601 }
-  let(:logger) { instance_double("Logger") }
+    subject(:instance) { described_class.new(finder, timestamp) }
 
-  before do
-    allow(Logger).to receive(:new).and_return(logger)
-  end
-
-  describe "#call" do
-    let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
-    let(:payload) {
-      ContentItemPublisher::FinderEmailSignupPresenter.new(finder, timestamp).present
-    }
+    let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+    let(:content_id) { finder["content_id"] }
+    let(:timestamp) { Time.now.iso8601 }
+    let(:logger) { instance_double("Logger") }
 
     before do
-      allow(logger).to receive(:info)
-      allow(Services.publishing_api).to receive(:put_content)
-      allow(Services.publishing_api).to receive(:patch_links)
-      allow(Services.publishing_api).to receive(:publish)
-
-      instance.call
+      allow(Logger).to receive(:new).and_return(logger)
     end
 
-    it "drafts the email signup page" do
-      expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
-    end
+    describe "#call" do
+      let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+      let(:payload) {
+        ContentItemPublisher::FinderEmailSignupPresenter.new(finder, timestamp).present
+      }
 
-    it "patches links for the email signup page" do
-      expect(Services.publishing_api).to have_received(:patch_links)
-        .with(content_id, { content_id: content_id, links: anything })
-    end
+      before do
+        allow(logger).to receive(:info)
+        allow(Services.publishing_api).to receive(:put_content)
+        allow(Services.publishing_api).to receive(:patch_links)
+        allow(Services.publishing_api).to receive(:publish)
 
-    it "publishes the email signup page to the Publishing API" do
-      expect(Services.publishing_api).to have_received(:publish).with(content_id)
+        instance.call
+      end
+
+      it "drafts the email signup page" do
+        expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
+      end
+
+      it "patches links for the email signup page" do
+        expect(Services.publishing_api).to have_received(:patch_links)
+          .with(content_id, { content_id: content_id, links: anything })
+      end
+
+      it "publishes the email signup page to the Publishing API" do
+        expect(Services.publishing_api).to have_received(:publish).with(content_id)
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/PGi2D6eV/291-publish-all-content-finder-from-rummager

This adds an all content finder and a corresponding email alert signup page

These can be published using the `publishing_api:publish_finder rake task`:

```
FINDER_CONFIG=all_content.yml EMAIL_SIGNUP_CONFIG=all_content_email_signup.yml publishing_api:publish_finder
```

Note: Nothing changed in the specs, but they now run for both all content and news and comms finders.

Blocked by:

- https://github.com/alphagov/govuk-content-schemas/pull/861
- https://github.com/alphagov/gds-api-adapters/pull/901
- https://github.com/alphagov/email-alert-api/pull/784
- https://github.com/alphagov/finder-frontend/pull/862

Once those are merged and deployed (govuk-content-schemas in particular) we can re-run the CI and then merge this in.