### PR TITLE
Add services finder and email signup

### DIFF
--- a/config/finders/services.yml
+++ b/config/finders/services.yml
@@ -1,0 +1,52 @@
+---
+base_path: "/services"
+content_id: f6d779ac-5f78-413d-a1ff-da391944e6ec
+description: Find services from government
+signup_content_id: e72eda7d-8fff-498f-b0f4-c07d8cd8ceb5
+details:
+  default_documents_per_page: 20
+  document_noun: service
+  facets:
+  - key: "_unused"
+    filter_key: all_part_of_taxonomy_tree
+    keys:
+    - level_one_taxon
+    - level_two_taxon
+    name: topic
+    short_name: topic
+    type: taxon
+    display_as_result_metadata: false
+    filterable: true
+    preposition: about
+  - display_as_result_metadata: true
+    filterable: true
+    key: organisations
+    name: Organisation
+    preposition: from
+    short_name: From
+    type: text
+  filter:
+    content_purpose_supergroup:
+    - services
+  show_summaries: true
+  sort:
+  - key: title
+    name: A-Z
+  - default: true
+    key: "-popularity"
+    name: Most viewed
+  - key: "-relevance"
+    name: Relevance
+document_type: finder
+locale: en
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder
+title: Services
+routes:
+- path: "/services"
+  type: exact
+- path: "/services.atom"
+  type: exact
+- path: "/services.json"
+  type: exact

--- a/config/finders/services_email_signup.yml
+++ b/config/finders/services_email_signup.yml
@@ -1,0 +1,28 @@
+---
+base_path: "/services/email-signup"
+content_id: e72eda7d-8fff-498f-b0f4-c07d8cd8ceb5
+document_type: finder_email_signup
+locale: en
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder_email_signup
+title: Services
+description: You'll get an email when services are published.
+details:
+  email_filter_by:
+  email_filter_name:
+  subscription_list_title_prefix: 'Services'
+  filter:
+    content_purpose_supergroup: services
+  email_filter_facets:
+  - facet_id: organisations
+    facet_name: organisations
+  - facet_id: level_one_taxon
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
+  - facet_id: level_two_taxon
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
+routes:
+- path: "/services/email-signup"
+  type: exact


### PR DESCRIPTION
https://trello.com/c/e53rC9Ee/287-publish-services-finder-from-rummager

This can be published with the following rake task:

```
publishing_api:publish_finder FINDER_CONFIG=services.yml EMAIL_SIGNUP_CONFIG=services_email_signup.yml
```