### PR TITLE
Send notifications of new EU Exit finder documents to email-alert-api

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -85,5 +85,36 @@ module Indexer
         "count" => %w(500)
       )
     end
+
+    def self.email_alert_api_payload(document, metadata)
+      {
+        title: document["title"],
+        description: document["description"],
+        change_note: "EU Exit guidance for business published",
+        subject: document["title"],
+        tags: metadata,
+        links: {
+          content_id: document["content_id"],
+          organisations: document["organisation_content_ids"],
+          taxons: document["taxons"],
+        },
+        urgent: true,
+        document_type: document["content_store_document_type"],
+        email_document_supertype: "other",
+        government_document_supertype: "other",
+        content_id: document["content_id"],
+        public_updated_at: document["public_timestamp"],
+        publishing_app: document["publishing_app"],
+        base_path: document["link"],
+        priority: "high",
+      }
+    end
+
+    def self.email_alert_api
+      @email_alert_api ||= GdsApi::EmailAlertApi.new(
+        Plek.current.find('email-alert-api'),
+        bearer_token: ENV['EMAIL_ALERT_API_BEARER_TOKEN'] || 'example123'
+      )
+    end
   end
 end

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -1,5 +1,5 @@
 require 'csv'
-require 'gds_api/email_alert_api'
+require 'indexer/workers/metadata_tagger_notification_worker'
 
 module Indexer
   class MetadataTagger
@@ -32,7 +32,7 @@ module Indexer
           Indexer::AmendWorker.new.perform(index_to_update, base_path, metadata)
 
           unless base_paths.empty? || base_paths.include?(base_path)
-            send_notification(item_in_search["_source"], metadata)
+            Indexer::MetadataTaggerNotificationWorker.perform_async(item_in_search, metadata)
           end
         end
       end
@@ -93,48 +93,6 @@ module Indexer
 
     def self.all_indexed_eu_exit_guidance_paths
       find_all_eu_exit_guidance[:results].collect { |r| r["link"] }
-    end
-
-    def self.send_notification(document, metadata)
-      payload = email_alert_api_payload(document, metadata)
-
-      begin
-        email_alert_api.send_alert(payload)
-        puts "notification sent for #{payload}"
-      rescue GdsApi::HTTPConflict
-        puts "email-alert-api returned 409 conflict for #{payload}"
-      end
-    end
-
-    def self.email_alert_api_payload(document, metadata)
-      {
-        title: document["title"],
-        description: document["description"],
-        change_note: "This publication has just been added to the EU Exit business guidance finder on GOV.UK.",
-        subject: document["title"],
-        tags: metadata,
-        links: {
-          content_id: document["content_id"],
-          organisations: document["organisation_content_ids"],
-          taxons: document["taxons"],
-        },
-        urgent: true,
-        document_type: document["content_store_document_type"],
-        email_document_supertype: "other",
-        government_document_supertype: "other",
-        content_id: document["content_id"],
-        public_updated_at: document["public_timestamp"],
-        publishing_app: document.fetch("publishing_app", "rummager"),
-        base_path: document["link"],
-        priority: "high",
-      }
-    end
-
-    def self.email_alert_api
-      @email_alert_api ||= GdsApi::EmailAlertApi.new(
-        Plek.current.find('email-alert-api'),
-        bearer_token: ENV['EMAIL_ALERT_API_BEARER_TOKEN'] || 'example123'
-      )
     end
   end
 end

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -119,7 +119,7 @@ module Indexer
         government_document_supertype: "other",
         content_id: document["content_id"],
         public_updated_at: document["public_timestamp"],
-        publishing_app: document["publishing_app"],
+        publishing_app: document.fetch("publishing_app", "rummager"),
         base_path: document["link"],
         priority: "high",
       }

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -23,7 +23,7 @@ module Indexer
     end
 
     def self.amend_all_metadata
-      base_paths = all_indexed_eu_exit_guidance_paths.map { |p| "/#{p}" }
+      base_paths = all_indexed_eu_exit_guidance_paths
 
       @metadata.each do |base_path, metadata|
         item_in_search = SearchConfig.instance.content_index.get_document_by_link(base_path)
@@ -32,6 +32,7 @@ module Indexer
           Indexer::AmendWorker.new.perform(index_to_update, base_path, metadata)
 
           unless base_paths.empty? || base_paths.include?(base_path)
+            puts "Enqueuing notification for update to #{base_path}"
             Indexer::MetadataTaggerNotificationWorker.perform_async(item_in_search, metadata)
           end
         end

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -31,7 +31,7 @@ module Indexer
           index_to_update = item_in_search["real_index_name"]
           Indexer::AmendWorker.new.perform(index_to_update, base_path, metadata)
 
-          unless base_paths.empty? || base_paths.include?(base_path)
+          unless base_paths.include?(base_path) || item_in_search["_source"]["is_withdrawn"]
             puts "Enqueuing notification for update to #{base_path}"
             Indexer::MetadataTaggerNotificationWorker.perform_async(item_in_search, metadata)
           end

--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -98,7 +98,12 @@ module Indexer
     def self.send_notification(document, metadata)
       payload = email_alert_api_payload(document, metadata)
 
-      email_alert_api.send_alert(payload)
+      begin
+        email_alert_api.send_alert(payload)
+        puts "notification sent for #{payload}"
+      rescue GdsApi::HTTPConflict
+        puts "email-alert-api returned 409 conflict for #{payload}"
+      end
     end
 
     def self.email_alert_api_payload(document, metadata)

--- a/lib/indexer/workers/metadata_tagger_notification_worker.rb
+++ b/lib/indexer/workers/metadata_tagger_notification_worker.rb
@@ -1,0 +1,53 @@
+require 'gds_api/email_alert_api'
+
+module Indexer
+  class MetadataTaggerNotificationWorker < BaseWorker
+    notify_of_failures
+
+    def perform(item_in_search, metadata)
+      send_notification(item_in_search["_source"], metadata)
+    end
+
+    def send_notification(document, metadata)
+      payload = email_alert_api_payload(document, metadata)
+
+      begin
+        self.class.email_alert_api.send_alert(payload)
+        logger.info "Notification sent for #{payload}"
+      rescue GdsApi::HTTPConflict
+        logger.info "Email alert API returned 409 conflict for #{payload}"
+      end
+    end
+
+    def email_alert_api_payload(document, metadata)
+      {
+        title: document["title"],
+        description: document["description"],
+        change_note: "This publication has just been added to the EU Exit business guidance finder on GOV.UK.",
+        subject: document["title"],
+        tags: metadata,
+        links: {
+          content_id: document["content_id"],
+          organisations: document["organisation_content_ids"],
+          taxons: document["taxons"],
+        },
+        urgent: true,
+        document_type: document["content_store_document_type"],
+        email_document_supertype: "other",
+        government_document_supertype: "other",
+        content_id: document["content_id"],
+        public_updated_at: document["public_timestamp"],
+        publishing_app: document.fetch("publishing_app", "rummager"),
+        base_path: document["link"],
+        priority: "high",
+      }
+    end
+
+    def self.email_alert_api
+      @email_alert_api ||= GdsApi::EmailAlertApi.new(
+        Plek.current.find('email-alert-api'),
+        bearer_token: ENV['EMAIL_ALERT_API_BEARER_TOKEN'] || 'example123'
+      )
+    end
+  end
+end

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Indexer::MetadataTagger do
         {
           results:
             [
-              { "link" => "a_base_path", item: "one" },
-              { "link" => "another_base_path", item: "two" }
+              { "link" => "/a_base_path", item: "one" },
+              { "link" => "/another_base_path", item: "two" }
             ]
         }
     )
@@ -70,8 +70,8 @@ RSpec.describe Indexer::MetadataTagger do
         {
           results:
             [
-              { "link" => "differnt_base_path", item: "one" },
-              { "link" => "another_base_path", item: "two" }
+              { "link" => "/differnt_base_path", item: "one" },
+              { "link" => "/another_base_path", item: "two" }
             ]
         }
     )
@@ -148,15 +148,15 @@ RSpec.describe Indexer::MetadataTagger do
           {
             results:
               [
-                { "link" => "a_base_path", item: "one" },
-                { "link" => "another_base_path", item: "two" }
+                { "link" => "/a_base_path", item: "one" },
+                { "link" => "/another_base_path", item: "two" }
               ]
           }
       )
 
       expect(described_class)
         .to receive(:remove_all_metadata_for_base_paths)
-        .with(%w(a_base_path another_base_path))
+        .with(%w(/a_base_path /another_base_path))
 
       described_class.initialise(fixture_file, facet_config_file)
       described_class.destroy_all_eu_exit_guidance!

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'gds_api/email_alert_api'
+require 'indexer/workers/metadata_tagger_notification_worker'
 
 RSpec.describe Indexer::MetadataTagger do
   let(:facet_config_file) { File.expand_path("fixtures/facet_config.yml", __dir__) }
@@ -47,7 +47,6 @@ RSpec.describe Indexer::MetadataTagger do
     test_index_name = 'test-index'
 
     mock_index = double("index")
-    mock_email_alert_api = double("email_alert_api")
 
     expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
       .and_return(
@@ -58,8 +57,6 @@ RSpec.describe Indexer::MetadataTagger do
           "tags" => {}
         }
       )
-
-    expect(GdsApi::EmailAlertApi).to receive(:new).and_return(mock_email_alert_api)
 
     metadata = {
       "sector_business_area" => %w(aerospace agriculture),
@@ -84,23 +81,29 @@ RSpec.describe Indexer::MetadataTagger do
       .with(test_index_name)
       .and_return(mock_index)
 
-    expect(mock_email_alert_api).to receive(:send_alert).with(
-      a_hash_including(
-        base_path: "/a_base_path",
-        content_id: "f2b1e88f-fdb3-4338-80c3-c36ac9b385ac",
-        tags: {
-          "appear_in_find_eu_exit_guidance_business_finder" => "yes",
-          "business_activity" => %W(yes),
-          "sector_business_area" => %W(aerospace agriculture),
+
+    mock_worker = double(:worker)
+    allow(Indexer::MetadataTaggerNotificationWorker).to receive(:new).and_return(mock_worker)
+    allow(mock_worker).to receive(:jid=)
+    expect(mock_worker).to receive(:perform).with(
+      {
+        "_source" => {
+          "link" => "/a_base_path",
+          "content_id" => "f2b1e88f-fdb3-4338-80c3-c36ac9b385ac",
+          "tags" => {},
         },
-      )
+        "real_index_name" => "test-index",
+      },
+      {
+        "appear_in_find_eu_exit_guidance_business_finder" => "yes",
+        "business_activity" => %W(yes),
+        "sector_business_area" => %W(aerospace agriculture),
+      }
     )
 
     described_class.initialise(fixture_file, facet_config_file)
     described_class.amend_all_metadata
   end
-
-
 
   context "when removing metadata" do
     def nil_metadata_hash
@@ -157,60 +160,6 @@ RSpec.describe Indexer::MetadataTagger do
 
       described_class.initialise(fixture_file, facet_config_file)
       described_class.destroy_all_eu_exit_guidance!
-    end
-  end
-
-  describe "email_alert_api_payload" do
-    let(:document) {
-      {
-        "content_id" => "9d58f37a-7ebe-436a-b7fc-bdb5e287a2b3",
-        "title" => "Operating in the EU after Brexit",
-        "description" => "When the UK leaves the EU, the way businesses both offer services in the EU and operate will change.",
-        "publishing_app" => "whitehall",
-        "content_store_document_type" => "detailed_guide",
-        "public_timestamp" => "2018-01-02 10:10:20.002",
-        "link" => "/guidance/operating-in-the-eu-after-brexit",
-        "taxons" => { a: 'a', b: 'b' },
-        "organisation_content_ids" => ["16f03199-c4f4-408f-844c-bd8489b0a06b"],
-      }
-    }
-    let(:metadata) {
-      {
-        "sector_business_area" => %w(aerospace agriculture),
-        "business_activity" => %w(yes),
-        "appear_in_find_eu_exit_guidance_business_finder" => "yes"
-      }
-    }
-    let(:payload) {
-      described_class.email_alert_api_payload(document, metadata)
-    }
-
-    it "presents metadata as tags" do
-      expect(payload[:tags]).to eq(metadata)
-    end
-
-    it "presents common document attributes" do
-      %i[content_id title description publishing_app].each do |key|
-        expect(payload[key]).to eq(document[key.to_s])
-      end
-    end
-
-    it "presents urgency and priority fields" do
-      expect(payload[:urgent]).to be true
-      expect(payload[:priority]).to eq("high")
-    end
-
-    it "presents fields mapped to appropriate keys" do
-      expect(payload[:base_path]).to eq(document["link"])
-      expect(payload[:document_type]).to eq(document["content_store_document_type"])
-      expect(payload[:public_updated_at]).to eq(document["public_timestamp"])
-    end
-
-    it "presents links" do
-      links = payload[:links]
-      expect(links[:content_id]).to eq(document["content_id"])
-      expect(links[:organisations]).to eq(document["organisation_content_ids"])
-      expect(links[:taxons]).to eq(document["taxons"])
     end
   end
   # rubocop:enable RSpec/VerifiedDoubles, RSpec/AnyInstance, RSpec/MessageSpies

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -2,23 +2,23 @@ require 'spec_helper'
 require 'indexer/workers/metadata_tagger_notification_worker'
 
 RSpec.describe Indexer::MetadataTagger do
-  let(:facet_config_file) { File.expand_path("fixtures/facet_config.yml", __dir__) }
   # rubocop:disable RSpec/VerifiedDoubles, RSpec/AnyInstance, RSpec/MessageSpies
-  it "amends documents" do
-    fixture_file = File.expand_path("fixtures/metadata.csv", __dir__)
-    base_path = '/a_base_path'
-    test_index_name = 'test-index'
-
-    mock_index = double("index")
-
-    expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
-      .and_return('real_index_name' => test_index_name)
-
-    metadata = {
+  let(:base_path) { "/a_base_path" }
+  let(:facet_config_file) { File.expand_path("fixtures/facet_config.yml", __dir__) }
+  let(:fixture_file) { File.expand_path("fixtures/metadata.csv", __dir__) }
+  let(:metadata) {
+    {
       "sector_business_area" => %w(aerospace agriculture),
       "business_activity" => %w(yes),
       "appear_in_find_eu_exit_guidance_business_finder" => "yes"
     }
+  }
+  let(:mock_index) { double(:index) }
+  let(:test_index_name) { "test-index" }
+
+  it "amends documents" do
+    expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
+      .and_return('real_index_name' => test_index_name)
 
     allow(described_class)
       .to receive(:find_all_eu_exit_guidance)
@@ -41,68 +41,87 @@ RSpec.describe Indexer::MetadataTagger do
     described_class.amend_all_metadata
   end
 
-  it "notifies for new documents" do
-    fixture_file = File.expand_path("fixtures/metadata.csv", __dir__)
-    base_path = '/a_base_path'
-    test_index_name = 'test-index'
+  context "when a document is indexed but has not been tagged" do
+    it "notifies users via a worker" do
+      expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
+        .and_return(
+          'real_index_name' => test_index_name,
+          '_source' => {
+            "link" => "/a_base_path",
+            "content_id" => "f2b1e88f-fdb3-4338-80c3-c36ac9b385ac",
+            "tags" => {}
+          }
+        )
 
-    mock_index = double("index")
+      allow(described_class)
+        .to receive(:find_all_eu_exit_guidance)
+        .and_return(
+          {
+            results:
+              [
+                { "link" => "/differnt_base_path", item: "one" },
+                { "link" => "/another_base_path", item: "two" },
+              ]
+          }
+      )
 
-    expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
-      .and_return(
-        'real_index_name' => test_index_name,
-        '_source' => {
-          "link" => "/a_base_path",
-          "content_id" => "f2b1e88f-fdb3-4338-80c3-c36ac9b385ac",
-          "tags" => {}
+      expect(mock_index).to receive(:amend).with(base_path, metadata)
+      expect_any_instance_of(SearchIndices::SearchServer).to receive(:index)
+        .with(test_index_name)
+        .and_return(mock_index)
+
+
+      mock_worker = double(:worker)
+      allow(Indexer::MetadataTaggerNotificationWorker).to receive(:new).and_return(mock_worker)
+      allow(mock_worker).to receive(:jid=)
+      expect(mock_worker).to receive(:perform).with(
+        {
+          "_source" => {
+            "link" => "/a_base_path",
+            "content_id" => "f2b1e88f-fdb3-4338-80c3-c36ac9b385ac",
+            "tags" => {},
+          },
+          "real_index_name" => "test-index",
+        },
+        {
+          "appear_in_find_eu_exit_guidance_business_finder" => "yes",
+          "business_activity" => %W(yes),
+          "sector_business_area" => %W(aerospace agriculture),
         }
       )
 
-    metadata = {
-      "sector_business_area" => %w(aerospace agriculture),
-      "business_activity" => %w(yes),
-      "appear_in_find_eu_exit_guidance_business_finder" => "yes"
-    }
+      described_class.initialise(fixture_file, facet_config_file)
+      described_class.amend_all_metadata
+    end
+  end
 
-    allow(described_class)
-      .to receive(:find_all_eu_exit_guidance)
-      .and_return(
-        {
-          results:
-            [
-              { "link" => "/differnt_base_path", item: "one" },
-              { "link" => "/another_base_path", item: "two" }
-            ]
-        }
-    )
+  context "when an item has been withdrawn" do
+    it "does not attempt to send a notification" do
+      expect_any_instance_of(LegacyClient::IndexForSearch).to receive(:get_document_by_link)
+        .and_return(
+          'real_index_name' => test_index_name,
+          '_source' => {
+            "link" => "/a_base_path",
+            "content_id" => "f2b1e88f-fdb3-4338-80c3-c36ac9b385ac",
+            "tags" => {},
+            "is_withdrawn" => true,
+          }
+        )
 
-    expect(mock_index).to receive(:amend).with(base_path, metadata)
-    expect_any_instance_of(SearchIndices::SearchServer).to receive(:index)
-      .with(test_index_name)
-      .and_return(mock_index)
+      allow(described_class)
+        .to receive(:find_all_eu_exit_guidance)
+        .and_return({ results: [{ "link" => "/something-else", item: "one" }] })
 
+      expect(mock_index).to receive(:amend).with(base_path, metadata)
+      expect_any_instance_of(SearchIndices::SearchServer).to receive(:index)
+        .with(test_index_name)
+        .and_return(mock_index)
 
-    mock_worker = double(:worker)
-    allow(Indexer::MetadataTaggerNotificationWorker).to receive(:new).and_return(mock_worker)
-    allow(mock_worker).to receive(:jid=)
-    expect(mock_worker).to receive(:perform).with(
-      {
-        "_source" => {
-          "link" => "/a_base_path",
-          "content_id" => "f2b1e88f-fdb3-4338-80c3-c36ac9b385ac",
-          "tags" => {},
-        },
-        "real_index_name" => "test-index",
-      },
-      {
-        "appear_in_find_eu_exit_guidance_business_finder" => "yes",
-        "business_activity" => %W(yes),
-        "sector_business_area" => %W(aerospace agriculture),
-      }
-    )
+      expect(Indexer::MetadataTaggerNotificationWorker).not_to receive(:perform_async)
 
-    described_class.initialise(fixture_file, facet_config_file)
-    described_class.amend_all_metadata
+      described_class.initialise(fixture_file, facet_config_file)
+      described_class.amend_all_metadata
+    end
   end
 
   context "when removing metadata" do

--- a/spec/unit/indexer/workers/metadata_tagger_notification_worker_spec.rb
+++ b/spec/unit/indexer/workers/metadata_tagger_notification_worker_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'gds_api/email_alert_api'
+
+# rubocop:disable RSpec/FilePath, RSpec/VerifiedDoubles
+RSpec.describe Indexer::MetadataTaggerNotificationWorker do
+  subject(:instance) { described_class.new }
+
+  let(:metadata) {
+    {
+      "sector_business_area" => %w(aerospace agriculture),
+      "business_activity" => %w(yes),
+      "appear_in_find_eu_exit_guidance_business_finder" => "yes"
+    }
+  }
+
+  let(:document) do
+    {
+      "content_id" => "9d58f37a-7ebe-436a-b7fc-bdb5e287a2b3",
+      "title" => "Operating in the EU after Brexit",
+      "description" => "When the UK leaves the EU, the way businesses both offer services in the EU and operate will change.",
+      "publishing_app" => "whitehall",
+      "content_store_document_type" => "detailed_guide",
+      "public_timestamp" => "2018-01-02 10:10:20.002",
+      "link" => "/guidance/operating-in-the-eu-after-brexit",
+      "taxons" => { a: 'a', b: 'b' },
+      "organisation_content_ids" => ["16f03199-c4f4-408f-844c-bd8489b0a06b"],
+    }
+  end
+
+  let(:payload) { instance.email_alert_api_payload(document, metadata) }
+
+  describe "#email_alert_api_payload" do
+    it "presents metadata as tags" do
+      expect(payload[:tags]).to eq(metadata)
+    end
+
+    it "presents common document attributes" do
+      %i[content_id title description publishing_app].each do |key|
+        expect(payload[key]).to eq(document[key.to_s])
+      end
+    end
+
+    it "presents urgency and priority fields" do
+      expect(payload[:urgent]).to be true
+      expect(payload[:priority]).to eq("high")
+    end
+
+    it "presents fields mapped to appropriate keys" do
+      expect(payload[:base_path]).to eq(document["link"])
+      expect(payload[:document_type]).to eq(document["content_store_document_type"])
+      expect(payload[:public_updated_at]).to eq(document["public_timestamp"])
+    end
+
+    it "presents links" do
+      links = payload[:links]
+      expect(links[:content_id]).to eq(document["content_id"])
+      expect(links[:organisations]).to eq(document["organisation_content_ids"])
+      expect(links[:taxons]).to eq(document["taxons"])
+    end
+  end
+
+  describe "#perform" do
+    let(:item_in_search) { { "_source" => document } }
+    let(:mock_email_alert_api) { instance_double(GdsApi::EmailAlertApi, send_alert: :sent!) }
+
+    before do
+      allow(GdsApi::EmailAlertApi).to receive(:new).and_return(mock_email_alert_api)
+    end
+
+    it "sends an appropriate payload to email-alert-api" do
+      instance.perform(item_in_search, metadata)
+
+      expect(mock_email_alert_api).to have_received(:send_alert).with(payload)
+    end
+  end
+
+  describe "#perform when email-alert-api returns a conflict" do
+    let(:item_in_search) { { "_source" => document } }
+    let(:conflicting_email_alert_api) { double(:email_alert_api) }
+
+    before do
+      allow(described_class).to receive(:email_alert_api).and_return(conflicting_email_alert_api)
+      allow(conflicting_email_alert_api).to receive(:send_alert).and_return(GdsApi::HTTPConflict.new("nope"))
+    end
+
+    it "rescues the error" do
+      expect { instance.perform(item_in_search, metadata) }.not_to raise_error
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath, RSpec/VerifiedDoubles


### PR DESCRIPTION
https://trello.com/c/NjLjpkb3/14-email-alerts-on-business-readiness-finder

The metadata tagging class needs to send notifications of new content
being added to the EU Exit guidance finder, so add a way to build a
suitable email-alert-api payload.