### PR TITLE
Ensure the public updated timestamp is current

### DIFF
--- a/lib/indexer/workers/metadata_tagger_notification_worker.rb
+++ b/lib/indexer/workers/metadata_tagger_notification_worker.rb
@@ -36,7 +36,7 @@ module Indexer
         email_document_supertype: "other",
         government_document_supertype: "other",
         content_id: document["content_id"],
-        public_updated_at: document["public_timestamp"],
+        public_updated_at: Time.now.iso8601,
         publishing_app: document.fetch("publishing_app", "rummager"),
         base_path: document["link"],
         priority: "high",

--- a/spec/unit/indexer/workers/metadata_tagger_notification_worker_spec.rb
+++ b/spec/unit/indexer/workers/metadata_tagger_notification_worker_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Indexer::MetadataTaggerNotificationWorker do
     it "presents fields mapped to appropriate keys" do
       expect(payload[:base_path]).to eq(document["link"])
       expect(payload[:document_type]).to eq(document["content_store_document_type"])
-      expect(payload[:public_updated_at]).to eq(document["public_timestamp"])
+      expect(payload[:public_updated_at]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
     end
 
     it "presents links" do


### PR DESCRIPTION
https://trello.com/c/NjLjpkb3/14-email-alerts-on-business-readiness-finder

The public updated timestamp on the email alert api payload needs to differ from the one
from the last publishing event for the given content. Otherwise the email alert api will see the notification as a duplicate.