### PR TITLE
Remove unset metadata values from documents amended by MetadataTagger

### DIFF
--- a/lib/indexer/metadata_tagger.rb
+++ b/lib/indexer/metadata_tagger.rb
@@ -49,9 +49,7 @@ module Indexer
         row_index = index + 1
         metadata[facet["key"]] = row.fetch(row_index, "").split(",").map(&:strip)
       end
-      metadata.reject do |_, value|
-        value == []
-      end
+      metadata
     end
 
     def self.all_nil_metadata_hash

--- a/spec/unit/indexer/metadata_tagger_spec.rb
+++ b/spec/unit/indexer/metadata_tagger_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe Indexer::MetadataTagger do
     {
       "sector_business_area" => %w(aerospace agriculture),
       "business_activity" => %w(yes),
-      "appear_in_find_eu_exit_guidance_business_finder" => "yes"
+      "appear_in_find_eu_exit_guidance_business_finder" => "yes",
+      "employ_eu_citizens" => [],
+      "eu_uk_government_funding" => [],
+      "intellectual_property" => [],
+      "personal_data" => [],
+      "public_sector_procurement" => [],
+      "regulations_and_standards" => [],
     }
   }
   let(:mock_index) { double(:index) }
@@ -87,6 +93,12 @@ RSpec.describe Indexer::MetadataTagger do
           "appear_in_find_eu_exit_guidance_business_finder" => "yes",
           "business_activity" => %W(yes),
           "sector_business_area" => %W(aerospace agriculture),
+          "employ_eu_citizens" => [],
+          "eu_uk_government_funding" => [],
+          "intellectual_property" => [],
+          "personal_data" => [],
+          "public_sector_procurement" => [],
+          "regulations_and_standards" => [],
         }
       )
 


### PR DESCRIPTION
Currently it is not possible to remove a metadata value by leaving a field
unset in the metadata CSV when running the rake task metadata_tagger:tag_metadata.

This will set an empty array for the fields which don't have a value set.