### PR TITLE
Fix news and comms facet order

### DIFF
--- a/config/finders/news_and_communications.yml
+++ b/config/finders/news_and_communications.yml
@@ -47,18 +47,18 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
-  - key: people
-    name: Person
-    preposition: from
-    type: text
-    display_as_result_metadata: false
-    filterable: true
   - key: organisations
     name: Organisation
     short_name: From
     preposition: from
     type: text
     display_as_result_metadata: true
+    filterable: true
+  - key: people
+    name: Person
+    preposition: from
+    type: text
+    display_as_result_metadata: false
     filterable: true
   - key: world_locations
     name: World location


### PR DESCRIPTION
The [news and comms finder][1] facets are in a different order to those in the [all content finder][2].  [The facet definition story][3] put the person facet below the org facet, so we should do that.

[1]: https://www.gov.uk/news-and-communications
[2]: https://www.gov.uk/all-content
[3]: https://trello.com/c/r02HDvi6/5-define-facets-for-each-finder