### PR TITLE
Add irb as an explicit Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "gds-api-adapters", "~> 57.4"
 gem "govuk_app_config", "~> 1.11.3"
 gem "govuk_document_types", "~> 0.9.0"
 gem "govuk-lint", "~> 3.11.0"
+gem "irb", "~> 1.0", require: false
 gem "logging", "~> 2.2.2"
 gem "govuk_sidekiq", "~> 3.0.2"
 gem "loofah"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
+    irb (1.0.0)
     jaro_winkler (1.5.2)
     json (2.1.0)
     json-schema (2.8.0)
@@ -264,6 +265,7 @@ DEPENDENCIES
   govuk_message_queue_consumer (~> 3.2.1)
   govuk_schemas (~> 3.2.0)
   govuk_sidekiq (~> 3.0.2)
+  irb (~> 1.0)
   logging (~> 2.2.2)
   loofah
   mr-sparkle (= 0.3.0)
@@ -290,4 +292,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
Since Ruby 2.6 irb doesn't come with Ruby and needs to be installed as a separate Gem. This means it's not possible to run the `./console` command currently as Bundle fails with an error saying it's can't find irb.

See https://github.com/bundler/bundler/issues/6929 for some more background.