### PR TITLE
Stop filtering 'other' supergroup in all-content finder

### DIFF
--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -13,9 +13,6 @@ details:
   default_documents_per_page: 20
   document_noun: result
   format_name: Documents
-  reject:
-    content_purpose_supergroup:
-    - other
   facets:
   - key: "_unused"
     display_as_result_metadata: false

--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -8,7 +8,6 @@ rendering_app: finder-frontend
 schema_name: finder
 title: All content
 description: Find content from government
-signup_content_id: 49838f97-5d2e-407a-8876-30c4abe2a6bc
 details:
   default_documents_per_page: 20
   document_noun: result
@@ -63,8 +62,4 @@ details:
     name: Updated (oldest)
 routes:
 - path: "/all-content"
-  type: exact
-- path: "/all-content.atom"
-  type: exact
-- path: "/all-content.json"
   type: exact

--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -51,12 +51,12 @@ details:
     type: date
   show_summaries: true
   sort:
-  - key: "-popularity"
+  - default: true
+    key: "-popularity"
     name: Most viewed
   - key: "-relevance"
     name: Relevance
-  - default: true
-    key: "-public_timestamp"
+  - key: "-public_timestamp"
     name: Updated (newest)
   - key: public_timestamp
     name: Updated (oldest)


### PR DESCRIPTION
Some small changes to the all-content finder

- include the 'other' content purpose supergroup.
- relevance as the default sort order
- remove email and atom feed link

Trello: https://trello.com/c/ftI0xd67/459-make-post-review-changes-to-all-content-finder