### PR TITLE
Fix bug in patching links in FinderPresenter

### DIFF
--- a/lib/content_item_publisher/finder_presenter.rb
+++ b/lib/content_item_publisher/finder_presenter.rb
@@ -1,25 +1,15 @@
 module ContentItemPublisher
   class FinderPresenter < ContentItemPresenter
     def present_links
-      links = {}
-      links["email_alert_signup"] = email_alert_signup if email_alert_signup?
-      links["parent"] = content_item_parent if content_item_parent?
+      links = { "email_alert_signup" => email_alert_signup,
+               "parent" => content_item_parent }
 
       { content_id: content_id, links: links }
     end
 
   private
-
-    def email_alert_signup?
-      content_item.key?("signup_content_id")
-    end
-
     def email_alert_signup
-      [content_item["signup_content_id"]]
-    end
-
-    def content_item_parent?
-      content_item.key?("parent")
+      Array(content_item["signup_content_id"])
     end
 
     def content_item_parent

--- a/spec/unit/content_item_publisher/finder_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_presenter_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe ContentItemPublisher::FinderPresenter do
   it "sets the public_updated_at value" do
     expect(instance.present[:public_updated_at]).to eq(timestamp)
   end
+
+  it "sets the links hash" do
+    expect(instance.present_links[:links]).to eq({ "email_alert_signup" => ["54fa4dca-4dfb-40a5-b860-127716f02e75"],
+                                                   "parent" => [] })
+  end
+
+  it "uses empty arrays to remove links" do
+    finder.except!("signup_content_id")
+    expect(instance.present_links[:links]).to eq({ "email_alert_signup" => [],
+                                                   "parent" => [] })
+  end
 end


### PR DESCRIPTION
The publish_document_finder rake task publishes a given content item
and then performs a patch links api call to to the publishing api to update 
links in the content item.

Removing links from an existing content item requires a call to
patch links containing the relevant key and an empty array. Omitting
the key will leave the link in place.

This fix ensures that removing either email_alert_signup or parent links
works properly.