### PR TITLE
Update guidance and regulation finder

### DIFF
--- a/config/finders/guidance_and_regulation.yml
+++ b/config/finders/guidance_and_regulation.yml
@@ -19,11 +19,11 @@ details:
   sort:
   - name: Most viewed
     key: "-popularity"
+    default: true
   - name: Relevance
     key: "-relevance"
   - name: Updated (newest)
     key: "-public_timestamp"
-    default: true
   - name: Updated (oldest)
     key: public_timestamp
   facets:


### PR DESCRIPTION
Make the 'Most Viewed' sort option the default

Trello: https://trello.com/c/RuTATHvz/479-make-post-review-changes-to-guidance-and-regulation-finder
