### PR TITLE
Add sort option to prepare EU Exit finders

### DIFF
--- a/config/prepare-eu-exit.yml.erb
+++ b/config/prepare-eu-exit.yml.erb
@@ -30,6 +30,16 @@ details:
       - guidance_and_regulation
   subscription_list_title_prefix: <%= title %>
   show_summaries: true
+  sort:
+  - default: true
+    key: "-popularity"
+    name: Most viewed
+  - key: "-relevance"
+    name: Relevance
+  - key: "-public_timestamp"
+    name: Updated (newest)
+  - key: public_timestamp
+    name: Updated (oldest)
   summary:  <%= config[:topic_summary] %>
 routes:
 - path: <%= base_path %>

--- a/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
+++ b/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe PrepareEuExitFinderPublisher do
             "content_purpose_supergroup" => %w(services guidance_and_regulation)
           },
           "show_summaries" => true,
+          "sort" => [
+            { "default" => true, "key" => "-popularity", "name" => "Most viewed" },
+            { "key" => "-relevance", "name" => "Relevance" },
+            { "key" => "-public_timestamp", "name" => "Updated (newest)" },
+            { "key" => "public_timestamp", "name" => "Updated (oldest)" }
+          ],
           "summary" => "Something"
         },
         "document_type" => "finder",


### PR DESCRIPTION
https://trello.com/c/C9rx0dwK/401-add-a-sort-facet-to-the-citizen-readiness-finders

This will enable users of the Prepare EU Exit finders to sort results. It will default to showing the most
popular results first.

I ran [the rake task](https://www-origin.integration.publishing.service.gov.uk/prepare-eu-exit/going-and-being-abroad?parent=&keywords=brexit&order=relevance) that publishes these finders on integration and it worked.

Example:
https://www-origin.integration.publishing.service.gov.uk/prepare-eu-exit/going-and-being-abroad