### PR TITLE
Allow specific facets to use the new checkbox filter feature

### DIFF
--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -35,6 +35,7 @@ details:
     preposition: from
     short_name: From
     type: text
+    show_option_select_filter: true
   - display_as_result_metadata: false
     filterable: true
     key: people

--- a/config/finders/guidance_and_regulation.yml
+++ b/config/finders/guidance_and_regulation.yml
@@ -45,12 +45,14 @@ details:
     type: text
     display_as_result_metadata: true
     filterable: true
+    show_option_select_filter: true
   - key: world_locations
     name: World location
     preposition: in
     type: text
     display_as_result_metadata: true
     filterable: true
+    show_option_select_filter: true
   - key: public_timestamp
     short_name: Updated
     name: Updated

--- a/config/finders/news_and_communications.yml
+++ b/config/finders/news_and_communications.yml
@@ -54,6 +54,7 @@ details:
     type: text
     display_as_result_metadata: true
     filterable: true
+    show_option_select_filter: true
   - key: people
     name: Person
     preposition: from
@@ -66,6 +67,7 @@ details:
     type: text
     display_as_result_metadata: true
     filterable: true
+    show_option_select_filter: true
   - key: public_timestamp
     short_name: Updated
     name: Updated

--- a/config/finders/services.yml
+++ b/config/finders/services.yml
@@ -25,6 +25,7 @@ details:
     preposition: from
     short_name: From
     type: text
+    show_option_select_filter: true
   filter:
     content_purpose_supergroup:
     - services

--- a/config/finders/transparency.yml
+++ b/config/finders/transparency.yml
@@ -25,12 +25,14 @@ details:
     preposition: from
     short_name: From
     type: text
+    show_option_select_filter: true
   - display_as_result_metadata: true
     filterable: true
     key: world_locations
     name: World location
     preposition: in
     type: text
+    show_option_select_filter: true
   - display_as_result_metadata: true
     filterable: true
     key: public_timestamp


### PR DESCRIPTION
The new key added to the facets will control whether user see a filter textfield as shown in image below 

![image](https://user-images.githubusercontent.com/3441519/53946309-63446700-40bb-11e9-9ee1-36b9076e978b.png)

Ticket: https://trello.com/c/sEGGP7dF/470-turn-on-option-select-filters-for-finders