### PR TITLE
Query by facets as links

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -8,6 +8,7 @@
     "content_store_document_type",
     "description",
     "email_document_supertype",
+    "facet_values",
     "format",
     "government_document_supertype",
     "indexable_content",

--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -8,6 +8,7 @@
     "content_store_document_type",
     "description",
     "email_document_supertype",
+    "facet_groups",
     "facet_values",
     "format",
     "government_document_supertype",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -149,6 +149,11 @@
     "type": "identifiers"
   },
 
+  "facet_values": {
+      "description": "Facet values associated the the documents. Used for modelling facets in finders",
+      "type": "identifiers"
+  },
+
   "updated_at": {
     "description": "When the page was last updated. This field is unreliable and may be deprecated in a future version.",
     "type": "date"

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -149,6 +149,11 @@
     "type": "identifiers"
   },
 
+  "facet_groups": {
+      "description": "Facet groups associated the the documents. Used for tagging documents to finders",
+      "type": "identifiers"
+  },
+
   "facet_values": {
       "description": "Facet values associated the the documents. Used for modelling facets in finders",
       "type": "identifiers"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -43,6 +43,7 @@ module GovukIndex
         dfid_theme:                          specialist.dfid_theme,
         eligible_entities:                   specialist.eligible_entities,
         email_document_supertype:            common_fields.email_document_supertype,
+        facet_values:                        expanded_links.facet_values,
         first_published_at:                  specialist.first_published_at,
         format:                              common_fields.format,
         fund_state:                          specialist.fund_state,

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -44,6 +44,7 @@ module GovukIndex
         eligible_entities:                   specialist.eligible_entities,
         email_document_supertype:            common_fields.email_document_supertype,
         facet_values:                        expanded_links.facet_values,
+        facet_groups:                        expanded_links.facet_groups,
         first_published_at:                  specialist.first_published_at,
         format:                              common_fields.format,
         fund_state:                          specialist.fund_state,

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -32,6 +32,10 @@ module GovukIndex
       content_ids("taxons")
     end
 
+    def facet_values
+      content_ids("facet_values")
+    end
+
     def topic_content_ids
       content_ids("topics")
     end

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -32,6 +32,10 @@ module GovukIndex
       content_ids("taxons")
     end
 
+    def facet_groups
+      content_ids("facet_groups")
+    end
+
     def facet_values
       content_ids("facet_values")
     end

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -141,6 +141,7 @@ module Indexer
         'topic_content_ids' => content_ids_for(links, 'topics'),
         'mainstream_browse_page_content_ids' => content_ids_for(links, 'mainstream_browse_pages'),
         'organisation_content_ids' => content_ids_for(links, 'organisations'),
+        'facet_values' => content_ids_for(links, 'facet_values'),
         'part_of_taxonomy_tree' => parts_of_taxonomy_for_all_taxons(links)
       }
     end

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -141,6 +141,7 @@ module Indexer
         'topic_content_ids' => content_ids_for(links, 'topics'),
         'mainstream_browse_page_content_ids' => content_ids_for(links, 'mainstream_browse_pages'),
         'organisation_content_ids' => content_ids_for(links, 'organisations'),
+        'facet_groups' => content_ids_for(links, 'facet_groups'),
         'facet_values' => content_ids_for(links, 'facet_values'),
         'part_of_taxonomy_tree' => parts_of_taxonomy_for_all_taxons(links)
       }

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -76,6 +76,10 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
             "base_path" => "/alpha-taxonomy/my-taxon-1"
           }
         ],
+        facet_values: [
+          { "content_id" => "TAG-1" },
+          { "content_id" => "TAG-2" }
+        ]
       }
     )
 
@@ -95,6 +99,7 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
         "topic_content_ids" => ["TOPIC-CONTENT-ID-1", "TOPIC-CONTENT-ID-2"],
         "mainstream_browse_page_content_ids" => ["BROWSE-1"],
         "organisation_content_ids" => ["ORG-1", "ORG-2"],
+        "facet_values" => ["TAG-1", "TAG-2"]
       },
       index: "government_test",
     )

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
         facet_values: [
           { "content_id" => "TAG-1" },
           { "content_id" => "TAG-2" }
+        ],
+        facet_groups: [
+          { "content_id" => "TGRP-1" },
+          { "content_id" => "TGRP-2" }
         ]
       }
     )
@@ -99,6 +103,7 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
         "topic_content_ids" => ["TOPIC-CONTENT-ID-1", "TOPIC-CONTENT-ID-2"],
         "mainstream_browse_page_content_ids" => ["BROWSE-1"],
         "organisation_content_ids" => ["ORG-1", "ORG-2"],
+        "facet_groups" => ["TGRP-1", "TGRP-2"],
         "facet_values" => ["TAG-1", "TAG-2"]
       },
       index: "government_test",

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -548,6 +548,22 @@ RSpec.describe 'SearchTest' do
     })
   end
 
+  it "can filter by facet group" do
+    commit_ministry_of_magic_document({ "facet_groups" => ['fe2fc3b5-a71b-4063-9605-12c3e6e179d6'] })
+    commit_treatment_of_dragons_document({ "facet_groups" => ['e602eb34-a870-46ff-8ba4-de36689fb028'] })
+    get "/search?filter_facet_groups=fe2fc3b5-a71b-4063-9605-12c3e6e179d6"
+    expect(last_response).to be_ok
+    expect(parsed_response.fetch("total")).to eq(1)
+    expect_result_includes_ministry_of_magic_for_key(parsed_response, "results", {
+      "_id" => "/ministry-of-magic-site",
+      "document_type" => "edition",
+      "elasticsearch_type" => "edition",
+      "es_score" => nil,
+      "index" => "government_test",
+      "link" => "/ministry-of-magic-site"
+    })
+  end
+
   it "return 400 response for query term length too long" do
     terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
     get "/search.json?q=#{terms}"

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -532,6 +532,22 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response.fetch("total")).to eq(1)
   end
 
+  it "can filter by facet value" do
+    commit_ministry_of_magic_document({ "facet_values" => ['fe2fc3b5-a71b-4063-9605-12c3e6e179d6'] })
+    commit_treatment_of_dragons_document({ "facet_values" => ['e602eb34-a870-46ff-8ba4-de36689fb028'] })
+    get "/search?filter_facet_values=fe2fc3b5-a71b-4063-9605-12c3e6e179d6"
+    expect(last_response).to be_ok
+    expect(parsed_response.fetch("total")).to eq(1)
+    expect_result_includes_ministry_of_magic_for_key(parsed_response, "results", {
+      "_id" => "/ministry-of-magic-site",
+      "document_type" => "edition",
+      "elasticsearch_type" => "edition",
+      "es_score" => nil,
+      "index" => "government_test",
+      "link" => "/ministry-of-magic-site"
+    })
+  end
+
   it "return 400 response for query term length too long" do
     terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
     get "/search.json?q=#{terms}"

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -202,6 +202,20 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.facet_values).to eq(expected_facet_values)
   end
 
+  it 'facet_groups' do
+    expanded_links = {
+      'facet_groups' => [
+        { 'content_id' => 'ec58ec61-71a6-475a-8df5-da5f866990b5' },
+        { 'content_id' => 'dd71726f-3fe5-4e5f-8d29-8f668e32a659' }
+      ]
+    }
+
+    presenter = expanded_links_presenter(expanded_links)
+    expected_facet_groups = ['ec58ec61-71a6-475a-8df5-da5f866990b5', 'dd71726f-3fe5-4e5f-8d29-8f668e32a659']
+
+    expect(presenter.facet_groups).to eq(expected_facet_groups)
+  end
+
   it "topics" do
     expanded_links = {
       "topics" => [

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -188,6 +188,20 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.taxons).to eq(expected_taxons)
   end
 
+  it 'facet_values' do
+    expanded_links = {
+      'facet_values' => [
+        { 'content_id' => 'ec58ec61-71a6-475a-8df5-da5f866990b5' },
+        { 'content_id' => 'dd71726f-3fe5-4e5f-8d29-8f668e32a659' }
+      ]
+    }
+
+    presenter = expanded_links_presenter(expanded_links)
+    expected_facet_values = ['ec58ec61-71a6-475a-8df5-da5f866990b5', 'dd71726f-3fe5-4e5f-8d29-8f668e32a659']
+
+    expect(presenter.facet_values).to eq(expected_facet_values)
+  end
+
   it "topics" do
     expanded_links = {
       "topics" => [


### PR DESCRIPTION
# What
Allow rummager to index and query the following link types:

* facet_values
* facet_groups

As part of the work to address tech debt introduced by the [EU Exit business finder](https://www.gov.uk/find-eu-exit-guidance-business) and to [Improve the Business Finder tagging system](https://trello.com/c/zn5LBg3L/77-improve-the-business-finder-tagging-system).

We are introducing Facet Groups, Facets and FacetValues as content items.

Tagging to these things will then be done in `content-tagger` (similar to taxonomy) and implemented as links.

Trello: https://trello.com/c/RHl653OZ/245-rummager-query-on-facet-group-and-facet-value