### PR TITLE
Add policy and consultations email alert signup

### DIFF
--- a/config/finders/policy_and_engagement.yml
+++ b/config/finders/policy_and_engagement.yml
@@ -1,0 +1,90 @@
+---
+base_path: "/policy-papers-and-consultations"
+content_id: 45bb9f22-096a-4e4c-a39e-04a65ff82da7
+document_type: finder
+locale: en
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder
+title: Policy papers and consultations
+description: Find policy papers and consultations from government
+signup_content_id: 5a4dc517-57cf-4dd6-873f-f1d29f6d540c
+details:
+  document_noun: result
+  filter:
+    content_purpose_supergroup:
+    - policy_and_engagement
+  format_name: document
+  show_summaries: true
+  sort:
+  - name: Most viewed
+    key: "-popularity"
+  - name: Relevance
+    key: "-relevance"
+  - name: Updated (newest)
+    key: "-public_timestamp"
+    default: true
+  - name: Updated (oldest)
+    key: public_timestamp
+  facets:
+  - key: "_unused"
+    filter_key: all_part_of_taxonomy_tree
+    keys:
+    - level_one_taxon
+    - level_two_taxon
+    name: topic
+    short_name: topic
+    type: taxon
+    display_as_result_metadata: false
+    filterable: true
+    preposition: about
+  - key: content_store_document_type
+    name: Document type
+    preposition: with document type
+    type: text
+    display_as_result_metadata: true
+    filterable: true
+    option_lookup:
+      policy_papers:
+      - impact_assessment
+      - case_study
+      - policy_paper
+      open_consultations:
+      - open_consultation
+      closed_consultations:
+      - closed_consultation
+      - consultation_outcome
+    allowed_values:
+    - label: Policy papers
+      value: policy_papers
+    - label: Consultations (open)
+      value: open_consultations
+    - label: Consultations (closed)
+      value: closed_consultations
+  - key: organisations
+    name: Organisation
+    short_name: From
+    preposition: from
+    type: text
+    display_as_result_metadata: true
+    filterable: true
+  - key: world_locations
+    name: World location
+    preposition: in
+    type: text
+    display_as_result_metadata: true
+    filterable: true
+  - key: public_timestamp
+    short_name: Updated
+    name: Updated
+    type: date
+    display_as_result_metadata: true
+    filterable: true
+  default_documents_per_page: 20
+routes:
+- path: "/policy-papers-and-consultations"
+  type: exact
+- path: "/policy-papers-and-consultations.atom"
+  type: exact
+- path: "/policy-papers-and-consultations.json"
+  type: exact

--- a/config/finders/policy_and_engagement_email_signup.yml
+++ b/config/finders/policy_and_engagement_email_signup.yml
@@ -1,0 +1,44 @@
+---
+base_path: "/policy-papers-and-consultations/email-signup"
+content_id: 5a4dc517-57cf-4dd6-873f-f1d29f6d540c
+document_type: finder_email_signup
+locale: en
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder_email_signup
+title: Policy papers and consultations
+description: You'll get an email each time policy papers and consultations are published.
+details:
+  email_filter_by:
+  email_filter_name:
+  subscription_list_title_prefix: Policy papers and consultations
+  filter:
+    content_purpose_supergroup: policy_and_engagement
+  email_filter_facets:
+  - facet_id: people
+    facet_name: people
+  - facet_id: organisations
+    facet_name: organisations
+  - facet_id: content_store_document_type
+    facet_name: document types
+    option_lookup:
+      policy_papers:
+      - impact_assessment
+      - case_study
+      - policy_paper
+      open_consultations:
+      - open_consultation
+      closed_consultations:
+      - closed_consultation
+      - consultation_outcome
+  - facet_id: world_locations
+    facet_name: world locations
+  - facet_id: level_one_taxon
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
+  - facet_id: level_two_taxon
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
+routes:
+- path: "/policy-papers-and-consultations/email-signup"
+  type: exact

--- a/spec/unit/content_item_publisher/finder_email_signup_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_presenter_spec.rb
@@ -5,8 +5,11 @@ RSpec.describe ContentItemPublisher::FinderEmailSignupPresenter do
   include GovukSchemas::RSpecMatchers
 
   %w(
+    finders/policy_and_engagement_email_signup.yml
     finders/news_and_communications_email_signup.yml
     finders/all_content_email_signup.yml
+    finders/guidance_and_regulation_email_signup.yml
+    finders/transparency_email_signup.yml
   ).each do |config_file|
 
     subject(:instance) { described_class.new(finder, timestamp) }

--- a/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
@@ -2,8 +2,11 @@ require "spec_helper"
 
 RSpec.describe ContentItemPublisher::FinderEmailSignupPublisher do
   %w(
-    finders/news_and_communications.yml
-    finders/all_content.yml
+    finders/policy_and_engagement_email_signup.yml
+    finders/news_and_communications_email_signup.yml
+    finders/guidance_and_regulation_email_signup.yml
+    finders/transparency_email_signup.yml
+    finders/all_content_email_signup.yml
   ).each do |config_file|
 
     subject(:instance) { described_class.new(finder, timestamp) }

--- a/spec/unit/content_item_publisher/finder_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_presenter_spec.rb
@@ -4,40 +4,48 @@ require "govuk_schemas/rspec_matchers"
 RSpec.describe ContentItemPublisher::FinderPresenter do
   include GovukSchemas::RSpecMatchers
 
-  subject(:instance) { described_class.new(finder, timestamp) }
+  %w(
+    finders/policy_and_engagement.yml
+    finders/news_and_communications.yml
+    finders/all_content.yml
+    finders/guidance_and_regulation.yml
+    finders/transparency.yml
+  ).each do |config_file|
 
-  let(:config_file) { "finders/news_and_communications.yml" }
-  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
-  let(:content_id) { finder["content_id"] }
-  let(:timestamp) { Time.now.iso8601 }
+    subject(:instance) { described_class.new(finder, timestamp) }
 
-  before do
-    GovukContentSchemaTestHelpers.configure do |config|
-      config.schema_type = 'publisher_v2'
-      config.project_root = File.expand_path(Dir.pwd)
+    let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+    let(:content_id) { finder["content_id"] }
+    let(:timestamp) { Time.now.iso8601 }
+
+    before do
+      GovukContentSchemaTestHelpers.configure do |config|
+        config.schema_type = 'publisher_v2'
+        config.project_root = File.expand_path(Dir.pwd)
+      end
     end
-  end
 
-  it "presents a valid payload" do
-    expect(instance.present).to be_valid_against_schema("finder")
-  end
+    it "presents a valid payload" do
+      expect(instance.present).to be_valid_against_schema("finder")
+    end
 
-  it "exposes the content_id" do
-    expect(instance.content_id).to eq(content_id)
-  end
+    it "exposes the content_id" do
+      expect(instance.content_id).to eq(content_id)
+    end
 
-  it "sets the public_updated_at value" do
-    expect(instance.present[:public_updated_at]).to eq(timestamp)
-  end
+    it "sets the public_updated_at value" do
+      expect(instance.present[:public_updated_at]).to eq(timestamp)
+    end
 
-  it "sets the links hash" do
-    expect(instance.present_links[:links]).to eq({ "email_alert_signup" => ["54fa4dca-4dfb-40a5-b860-127716f02e75"],
-                                                   "parent" => [] })
-  end
+    it "sets the links hash" do
+      expect(instance.present_links[:links]).to eq({ "email_alert_signup" => [finder['signup_content_id']],
+                                                     "parent" => [] })
+    end
 
-  it "uses empty arrays to remove links" do
-    finder.except!("signup_content_id")
-    expect(instance.present_links[:links]).to eq({ "email_alert_signup" => [],
-                                                   "parent" => [] })
+    it "uses empty arrays to remove links" do
+      finder.except!("signup_content_id")
+      expect(instance.present_links[:links]).to eq({ "email_alert_signup" => [],
+                                                     "parent" => [] })
+    end
   end
 end

--- a/spec/unit/content_item_publisher/finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_publisher_spec.rb
@@ -1,44 +1,52 @@
 require "spec_helper"
 
 RSpec.describe ContentItemPublisher::FinderPublisher do
-  subject(:instance) { described_class.new(finder, timestamp) }
+  %w(
+    finders/policy_and_engagement_email_signup.yml
+    finders/news_and_communications_email_signup.yml
+    finders/guidance_and_regulation_email_signup.yml
+    finders/transparency_email_signup.yml
+    finders/all_content_email_signup.yml
+  ).each do |config_file|
 
-  let(:config_file) { "finders/news_and_communications.yml" }
-  let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
-  let(:content_id) { finder["content_id"] }
-  let(:timestamp) { Time.now.iso8601 }
-  let(:logger) { instance_double("Logger") }
+    subject(:instance) { described_class.new(finder, timestamp) }
 
-  before do
-    allow(Logger).to receive(:new).and_return(logger)
-  end
-
-  describe "#call" do
-    let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
-    let(:payload) {
-      ContentItemPublisher::FinderPresenter.new(finder, timestamp).present
-    }
+    let(:finder) { YAML.load_file(File.join(Dir.pwd, "config", config_file)) }
+    let(:content_id) { finder["content_id"] }
+    let(:timestamp) { Time.now.iso8601 }
+    let(:logger) { instance_double("Logger") }
 
     before do
-      allow(logger).to receive(:info)
-      allow(Services.publishing_api).to receive(:put_content)
-      allow(Services.publishing_api).to receive(:patch_links)
-      allow(Services.publishing_api).to receive(:publish)
-
-      instance.call
+      allow(Logger).to receive(:new).and_return(logger)
     end
 
-    it "drafts the finder" do
-      expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
-    end
+    describe "#call" do
+      let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+      let(:payload) {
+        ContentItemPublisher::FinderPresenter.new(finder, timestamp).present
+      }
 
-    it "patches links for the finder" do
-      expect(Services.publishing_api).to have_received(:patch_links)
-        .with(content_id, { content_id: content_id, links: anything })
-    end
+      before do
+        allow(logger).to receive(:info)
+        allow(Services.publishing_api).to receive(:put_content)
+        allow(Services.publishing_api).to receive(:patch_links)
+        allow(Services.publishing_api).to receive(:publish)
 
-    it "publishes the finder to the Publishing API" do
-      expect(Services.publishing_api).to have_received(:publish).with(content_id)
+        instance.call
+      end
+
+      it "drafts the finder" do
+        expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
+      end
+
+      it "patches links for the finder" do
+        expect(Services.publishing_api).to have_received(:patch_links)
+          .with(content_id, { content_id: content_id, links: anything })
+      end
+
+      it "publishes the finder to the Publishing API" do
+        expect(Services.publishing_api).to have_received(:publish).with(content_id)
+      end
     end
   end
 end


### PR DESCRIPTION
This will enable us to publish the email signup page
for the policy and consultation finder.

It can be published with:

```
FINDER_CONFIG=policy_and_engagement.yml EMAIL_SIGNUP_CONFIG=policy_and_engagement_email_signup.yml publishing_api:publish_finder
```
Publication will need to wait for these two PRs:
https://github.com/alphagov/govuk-content-schemas/pull/868
https://github.com/alphagov/finder-frontend/pull/936

Trello: https://trello.com/c/QYU40Ezk/286-publish-consultations-finder-from-rummager-s