### PR TITLE
Add Sweden to the export health certificate (EHC) finder

### DIFF
--- a/config/schema/elasticsearch_types/export_health_certificate.json
+++ b/config/schema/elasticsearch_types/export_health_certificate.json
@@ -222,6 +222,7 @@
       {"label": "Sudan", "value": "sudan"},
       {"label": "Suriname", "value": "suriname"},
       {"label": "Swaziland (now Eswatini)", "value": "swaziland-now-eswatini"},
+      {"label": "Sweden", "value": "sweden"},
       {"label": "Switzerland", "value": "switzerland"},
       {"label": "Syria", "value": "syria"},
       {"label": "Taiwan", "value": "taiwan"},


### PR DESCRIPTION
Adds 'Sweden' as a destination country because it was missing from the export health certificate (EHC) finder.

[Trello card](https://trello.com/c/dZIPRphR/826-add-sweden-and-remove-northern-ireland-exception-copy-from-the-exports-form-finder)