### PR TITLE
Add filter option to people facet on news & comms finder

### DIFF
--- a/config/finders/news_and_communications.yml
+++ b/config/finders/news_and_communications.yml
@@ -61,6 +61,7 @@ details:
     type: text
     display_as_result_metadata: false
     filterable: true
+    show_option_select_filter: true
   - key: world_locations
     name: World location
     preposition: in


### PR DESCRIPTION
People facet `show_option_select_filter` key was missed off the original
PR #1452