### PR TITLE
Change finder paths to have '/search' prefix

### DIFF
--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/all-content"
+base_path: "/search/all"
 content_id: dd395436-9b40-41f3-8157-740a453ac972
 document_type: finder
 locale: en
@@ -64,5 +64,7 @@ details:
   - key: public_timestamp
     name: Updated (oldest)
 routes:
-- path: "/all-content"
+- path: "/search/all"
+  type: exact
+- path: "/search/all.json"
   type: exact

--- a/config/finders/all_content_email_signup.yml
+++ b/config/finders/all_content_email_signup.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/all-content/email-signup"
+base_path: "/search/all/email-signup"
 content_id: 49838f97-5d2e-407a-8876-30c4abe2a6bc
 document_type: finder_email_signup
 locale: en
@@ -28,5 +28,5 @@ details:
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics
 routes:
-- path: "/all-content/email-signup"
+- path: "/search/all/email-signup"
   type: exact

--- a/config/finders/guidance_and_regulation.yml
+++ b/config/finders/guidance_and_regulation.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/guidance-and-regulation"
+base_path: "/search/guidance-and-regulation"
 content_id: b8507038-e3b5-422c-bc51-28ff1ed12370
 signup_content_id: 30974a3c-b86d-4f12-883d-783e97055690
 document_type: finder
@@ -61,9 +61,9 @@ details:
     filterable: true
   default_documents_per_page: 20
 routes:
-- path: "/guidance-and-regulation"
+- path: "/search/guidance-and-regulation"
   type: exact
-- path: "/guidance-and-regulation.atom"
+- path: "/search/guidance-and-regulation.atom"
   type: exact
-- path: "/guidance-and-regulation.json"
+- path: "/search/guidance-and-regulation.json"
   type: exact

--- a/config/finders/guidance_and_regulation_email_signup.yml
+++ b/config/finders/guidance_and_regulation_email_signup.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/guidance-and-regulation/email-signup"
+base_path: "/search/guidance-and-regulation/email-signup"
 content_id: 30974a3c-b86d-4f12-883d-783e97055690
 document_type: finder_email_signup
 locale: en
@@ -26,5 +26,5 @@ details:
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics
 routes:
-- path: "/guidance-and-regulation/email-signup"
+- path: "/search/guidance-and-regulation/email-signup"
   type: exact

--- a/config/finders/news_and_communications.yml
+++ b/config/finders/news_and_communications.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/news-and-communications"
+base_path: "/search/news-and-communications"
 content_id: 622e9691-4b4f-4e9c-bce1-098b0c4f5ee2
 document_type: finder
 locale: en
@@ -76,9 +76,9 @@ details:
     filterable: true
   default_documents_per_page: 20
 routes:
-- path: "/news-and-communications"
+- path: "/search/news-and-communications"
   type: exact
-- path: "/news-and-communications.atom"
+- path: "/search/news-and-communications.atom"
   type: exact
-- path: "/news-and-communications.json"
+- path: "/search/news-and-communications.json"
   type: exact

--- a/config/finders/news_and_communications_email_signup.yml
+++ b/config/finders/news_and_communications_email_signup.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/news-and-communications/email-signup"
+base_path: "/search/news-and-communications/email-signup"
 content_id: 54fa4dca-4dfb-40a5-b860-127716f02e75
 document_type: finder_email_signup
 locale: en
@@ -32,5 +32,5 @@ details:
     filter_value: d6c2de5d-ef90-45d1-82d4-5f2438369eea
     facet_name: topics
 routes:
-- path: "/news-and-communications/email-signup"
+- path: "/search/news-and-communications/email-signup"
   type: exact

--- a/config/finders/policy_and_engagement.yml
+++ b/config/finders/policy_and_engagement.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/policy-papers-and-consultations"
+base_path: "/search/policy-papers-and-consultations"
 content_id: 45bb9f22-096a-4e4c-a39e-04a65ff82da7
 document_type: finder
 locale: en
@@ -82,9 +82,9 @@ details:
     filterable: true
   default_documents_per_page: 20
 routes:
-- path: "/policy-papers-and-consultations"
+- path: "/search/policy-papers-and-consultations"
   type: exact
-- path: "/policy-papers-and-consultations.atom"
+- path: "/search/policy-papers-and-consultations.atom"
   type: exact
-- path: "/policy-papers-and-consultations.json"
+- path: "/search/policy-papers-and-consultations.json"
   type: exact

--- a/config/finders/policy_and_engagement_email_signup.yml
+++ b/config/finders/policy_and_engagement_email_signup.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/policy-papers-and-consultations/email-signup"
+base_path: "/search/policy-papers-and-consultations/email-signup"
 content_id: 5a4dc517-57cf-4dd6-873f-f1d29f6d540c
 document_type: finder_email_signup
 locale: en
@@ -40,5 +40,5 @@ details:
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics
 routes:
-- path: "/policy-papers-and-consultations/email-signup"
+- path: "/search/policy-papers-and-consultations/email-signup"
   type: exact

--- a/config/finders/services.yml
+++ b/config/finders/services.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/services"
+base_path: "/search/services"
 content_id: f6d779ac-5f78-413d-a1ff-da391944e6ec
 description: Find services from government
 details:
@@ -44,9 +44,9 @@ rendering_app: finder-frontend
 schema_name: finder
 title: Services
 routes:
-- path: "/services"
+- path: "/search/services"
   type: exact
-- path: "/services.atom"
+- path: "/search/services.atom"
   type: exact
-- path: "/services.json"
+- path: "/search/services.json"
   type: exact

--- a/config/finders/transparency.yml
+++ b/config/finders/transparency.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/transparency-and-freedom-of-information-releases"
+base_path: "/search/transparency-and-freedom-of-information-releases"
 content_id: 9d21cee6-990b-4e87-b254-cada0e2ec4db
 description: Find transparency and freedom of information releases from government
 signup_content_id: 92f7eb26-030b-4a41-962e-d8e0f8814654
@@ -60,9 +60,9 @@ rendering_app: finder-frontend
 schema_name: finder
 title: Transparency and freedom of information releases
 routes:
-- path: "/transparency-and-freedom-of-information-releases"
+- path: "/search/transparency-and-freedom-of-information-releases"
   type: exact
-- path: "/transparency-and-freedom-of-information-releases.atom"
+- path: "/search/transparency-and-freedom-of-information-releases.atom"
   type: exact
-- path: "/transparency-and-freedom-of-information-releases.json"
+- path: "/search/transparency-and-freedom-of-information-releases.json"
   type: exact

--- a/config/finders/transparency_email_signup.yml
+++ b/config/finders/transparency_email_signup.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/transparency-and-freedom-of-information-releases/email-signup"
+base_path: "/search/transparency-and-freedom-of-information-releases/email-signup"
 content_id: 92f7eb26-030b-4a41-962e-d8e0f8814654
 document_type: finder_email_signup
 locale: en
@@ -28,5 +28,5 @@ details:
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics
 routes:
-- path: "/transparency-and-freedom-of-information-releases/email-signup"
+- path: "/search/transparency-and-freedom-of-information-releases/email-signup"
   type: exact


### PR DESCRIPTION
https://trello.com/c/SjudMnoT/499-update-urls-across-all-7-finders

We will need to republish all of these finders and email signup pages. I removed a commit that added a rake task to redirect finders paths, as it wasn't necessary. This will create redirects automatically (see Simon's comment below).