### PR TITLE
Add 'Great Britain' to the export health certificate (EHC) finder

### DIFF
--- a/config/schema/elasticsearch_types/export_health_certificate.json
+++ b/config/schema/elasticsearch_types/export_health_certificate.json
@@ -107,6 +107,7 @@
       {"label": "Germany", "value": "germany"},
       {"label": "Ghana", "value": "ghana"},
       {"label": "Gibraltar", "value": "gibraltar"},
+      {"label": "Great Britain", "value": "great-britain"},
       {"label": "Greece", "value": "greece"},
       {"label": "Grenada", "value": "grenada"},
       {"label": "Guam", "value": "guam"},


### PR DESCRIPTION
Add 'Great Britain' as a destination country because it was missing from the export health certificate (EHC) finder.

[Trello card](https://trello.com/c/dZIPRphR/826-add-sweden-and-remove-northern-ireland-exception-copy-from-the-exports-form-finder)