### PR TITLE
Fix running the integration tests with any base URI

### DIFF
--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -50,7 +50,7 @@ module IntegrationSpecHelper
     allowed_paths << '_search/scroll'
     allowed_paths << '_tasks'
 
-    allow_urls = %r{http://localhost:9200/(#{allowed_paths.join('|')})}
+    allow_urls = %r{#{SearchConfig.instance.base_uri}/(#{allowed_paths.join('|')})}
     WebMock.disable_net_connect!(allow: allow_urls)
     yield
   ensure


### PR DESCRIPTION
Previously, you could attempt to run the integration tests with any
base URI, but they would fail if it didn't match this allow_urls
value, as the test indices would fail to be created.

This uses the actual configured value, making the configuration
consistent.