### PR TITLE
Have Rummager wait while updating the popularity

### DIFF
--- a/lib/govuk_index/popularity_updater.rb
+++ b/lib/govuk_index/popularity_updater.rb
@@ -6,6 +6,8 @@ module GovukIndex
         destination_index: index_name,
         process_all: process_all,
       ).run
+
+      worker.wait_until_processed
     end
 
     def self.worker

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -88,7 +88,8 @@ correctly
   desc "Update popularity data in indices.
 
 Update all data in the index inplace (without locks) with the new popularity
-data using sidekiq workers.
+data using sidekiq workers. The Rake task will exit when the workers
+have finished.
 
 This does not update the schema.
 "


### PR DESCRIPTION
Currently updating the popularity values involves putting the
documents in the index on to the Sidekiq queue, so that they can be
sent back to Elasticsearch with the updated popularity value.

This uses lots of memory, and recently, enough memory to cause Redis
to run out.

I've attempted to switch this to use the update, rather than index
action, but this doesn't work due to the use of `external_gte`
versioning, as the update increments the version, which could cause a
problem with processing messages from the Publishing API. ADR 002
describes one way to workaround this issue "External versioning with
multiplier", but changing the versioning scheme seems like a big
change to me.

Instead, this commit changes the popularity updating Rake task to
block while the jobs are being processed. As the nightly search
analytics job updated 3 indexes, I'm hoping that this will reduce the
peak Redis memory usage.