### PR TITLE
Hide organisation metadata in Services and All content finders

### DIFF
--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -24,7 +24,7 @@ details:
     preposition: about
     short_name: topic
     type: taxon
-  - display_as_result_metadata: true
+  - display_as_result_metadata: false
     filterable: true
     key: organisations
     name: Organisation

--- a/config/finders/services.yml
+++ b/config/finders/services.yml
@@ -17,7 +17,7 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
-  - display_as_result_metadata: true
+  - display_as_result_metadata: false
     filterable: true
     key: organisations
     name: Organisation


### PR DESCRIPTION
Rummager: https://trello.com/c/GlohunbM/519-remove-org-metadata-from-mainstream-results-in-all-content-and-services-finders