### PR TITLE
Change path of stats finder

### DIFF
--- a/config/finders/statistics.yml
+++ b/config/finders/statistics.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/search/statistics"
+base_path: "/search/research-and-statistics"
 content_id: 8f827d53-9ad1-4b90-b6ae-2301c1ecdf02
 description: Find statistics from government
 document_type: finder
@@ -120,9 +120,9 @@ details:
     filterable: true
   default_documents_per_page: 20
 routes:
-- path: "/search/statistics"
+- path: "/search/research-and-statistics"
   type: exact
-- path: "/search/statistics.atom"
+- path: "/search/research-and-statistics.atom"
   type: exact
-- path: "/search/statistics.json"
+- path: "/search/research-and-statistics.json"
   type: exact

--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/search/statistics/email-signup"
+base_path: "/search/research-and-statistics/email-signup"
 content_id: 119db584-0ae7-45e4-8f3a-fd79316c6921
 document_type: finder_email_signup
 locale: en
@@ -41,5 +41,5 @@ details:
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics
 routes:
-- path: "/search/statistics/email-signup"
+- path: "/search/research-and-statistics/email-signup"
   type: exact


### PR DESCRIPTION
https://trello.com/c/VMPLPT1X/538-change-stats-finder-url

We will need to run publishing_api:publish_finder once this is deployed.