### PR TITLE
Add manuals field to all-content finder.

### DIFF
--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -27,6 +27,14 @@ details:
     type: taxon
   - display_as_result_metadata: true
     filterable: true
+    key: manual
+    name: Manual
+    preposition: in manual
+    short_name: in
+    type: text
+    show_option_select_filter: false
+  - display_as_result_metadata: false
+    filterable: true
     key: organisations
     name: Organisation
     preposition: from


### PR DESCRIPTION
Trello: https://trello.com/c/EXKGr1Uv/497-handle-scoped-manuals-filter-in-site-search