### PR TITLE
Add finder and email signup for citizen readiness

### DIFF
--- a/config/finders/citizen_readiness.yml
+++ b/config/finders/citizen_readiness.yml
@@ -1,0 +1,65 @@
+---
+base_path: "/prepare-eu-exit/all"
+content_id: 3a6d9383-5341-47a8-aaee-860dabd7c4d8
+description: Detailed information about changes happening after Brexit.
+document_type: finder
+locale: en
+parent: ecb55f9d-0823-43bd-a116-dbfab2b76ef9 # /prepare-eu-exit
+publishing_app: rummager
+rendering_app: finder-frontend
+schema_name: finder
+signup_content_id: 6a46087b-737e-40c8-bcf2-afa580b7263e # /prepare-eu-exit/all/email-signup
+title: Detailed EU Exit guidance
+details:
+  default_documents_per_page: 20
+  document_noun: result
+  hide_facets_by_default: false
+  show_summaries: true
+  summary: "<p>Detailed information about changes happening after Brexit.</p>"
+  filter:
+    all_part_of_taxonomy_tree: d7bdaee2-8ea5-460e-b00d-6e9382eb6b61
+  facets:
+  - display_as_result_metadata: true
+    filterable: true
+    key: any_part_of_taxonomy_tree
+    name: Topic
+    preposition: about
+    short_name: About
+    type: text
+    show_option_select_filter: false
+    allowed_values:
+    - label: Business and industry
+      value: 495afdb6-47be-4df1-8b38-91c8adb1eefc
+    - label: Crime, justice and law
+      value: ba951b09-5146-43be-87af-44075eac3ae9
+    - label: Education, training and skills
+      value: c58fdadd-7743-46d6-9629-90bb3ccc4ef0
+    - label: Environment
+      value: 3cf97f69-84de-41ae-bc7b-7e2cc238fa58
+    - label: Going and being abroad
+      value: 9597c30a-605a-4e36-8bc1-47e5cdae41b3
+    - label: Health and social care
+      value: 8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8
+    - label: Parenting, childcare and children's services
+      value: 206b7f3a-49b5-476f-af0f-fd27e2a68473
+    - label: Transport
+      value: a4038b29-b332-4f13-98b1-1c9709e216bc
+    - label: Work
+      value: d0f1e5a3-c8f4-4780-8678-994f19104b21
+  sort:
+  - key: "-popularity"
+    name: Most viewed
+  - key: "-relevance"
+    name: Relevance
+  - default: true
+    key: "-public_timestamp"
+    name: Updated (newest)
+  - key: public_timestamp
+    name: Updated (oldest)
+routes:
+- path: "/prepare-eu-exit/all"
+  type: exact
+- path: "/prepare-eu-exit/all.atom"
+  type: exact
+- path: "/prepare-eu-exit/all.json"
+  type: exact

--- a/config/finders/citizen_readiness_email_signup.yml
+++ b/config/finders/citizen_readiness_email_signup.yml
@@ -1,0 +1,18 @@
+---
+base_path: "/prepare-eu-exit/all/email-signup"
+content_id: 6a46087b-737e-40c8-bcf2-afa580b7263e
+description: You'll get an email each time content is published.
+document_type: finder_email_signup
+title: Detailed EU Exit guidance
+details:
+  filter:
+    all_part_of_taxonomy_tree: d7bdaee2-8ea5-460e-b00d-6e9382eb6b61
+  email_filter_by:
+  email_filter_name:
+  subscription_list_title_prefix: 'Detailed EU Exit guidance'
+  email_filter_facets:
+  - facet_id: any_part_of_taxonomy_tree
+    facet_name: topics
+routes:
+- path: "/prepare-eu-exit/all/email-signup"
+  type: exact


### PR DESCRIPTION
The development finder can be viewed at http://finder-frontend-pr-989.herokuapp.com/prepare-eu-exit/all (PR here: https://github.com/alphagov/finder-frontend/pull/989)

This is a single finder that shows content tagged to the citizen readiness topic (d7bdaee2-8ea5-460e-b00d-6e9382eb6b61).  It will replace all the finders that we produced for each taxon.

The facet lists the topics that we showed on /prepare-eu-exit.  These should be combined using an "OR" with each other, and then "AND" with the citizen readiness topic, hence the use of `all_part_of_taxonomy_tree` and `any_part_of_taxonomy_tree` in this combination.

The parent is set to the /prepare-eu-exit page, so the breadcrumb is set up.

The email alert link is set to the content id of the signup page.

The email alert signup page doesn't show breadcrumbs at present, so we don't need to set this up on this page.

https://trello.com/c/bapIIB9X/155-spin-up-a-finder-for-content-tagged-to-brexit-guidance-for-uk-citizens-taxon
