### PR TITLE
Fix manuals facet

### DIFF
--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -26,13 +26,14 @@ details:
     short_name: topic
     type: taxon
   - display_as_result_metadata: false
-    filterable: false
+    filterable: true
     key: manual
     name: Manual
     preposition: in manual
     short_name: in
-    type: text
+    type: hidden
     show_option_select_filter: false
+    allowed_values: []
   - display_as_result_metadata: true
     filterable: true
     key: organisations


### PR DESCRIPTION
We fixed this in production to do the right thing.  Now following through with a PR with the correct configuration.

We do actually need this to be filterable, but we don't want to show the facet.

https://trello.com/c/EXKGr1Uv/497-handle-scoped-manuals-filter-in-site-search