### PR TITLE
Add additional specs for batch search by new facets

### DIFF
--- a/spec/integration/search/batch_search_spec.rb
+++ b/spec/integration/search/batch_search_spec.rb
@@ -483,6 +483,40 @@ RSpec.describe 'BatchSearchTest' do
     expect_results_includes_ministry_of_magic(results, 1, 0)
   end
 
+  it "can filter by facet groups" do
+    commit_treatment_of_dragons_document
+    commit_ministry_of_magic_document(
+      {
+        "facet_groups" => %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
+      }
+    )
+
+    get build_get_url([{ filter_facet_groups: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"] }, { filter_facet_groups: ["aa2093ef-778c-4105-9f33-9aa03d14bc5c"] }])
+    results = parsed_response['results']
+
+    expect_search_has_result_count(results[0], 1)
+    expect_results_includes_ministry_of_magic(results, 0, 0)
+    expect_search_has_result_count(results[1], 1)
+    expect_results_includes_ministry_of_magic(results, 1, 0)
+  end
+
+  it "can filter by facet values" do
+    commit_treatment_of_dragons_document
+    commit_ministry_of_magic_document(
+      {
+        "facet_values" => %w(eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c)
+      }
+    )
+
+    get build_get_url([{ filter_facet_values: ["eb2093ef-778c-4105-9f33-9aa03d14bc5c"] }, { filter_facet_values: ["aa2093ef-778c-4105-9f33-9aa03d14bc5c"] }])
+    results = parsed_response['results']
+
+    expect_search_has_result_count(results[0], 1)
+    expect_results_includes_ministry_of_magic(results, 0, 0)
+    expect_search_has_result_count(results[1], 1)
+    expect_results_includes_ministry_of_magic(results, 1, 0)
+  end
+
   it "return 400 response for query term length too long" do
     terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
     get build_get_url([{ q: terms }, { q: "Minstry of Magic" }])


### PR DESCRIPTION
Forgot the batch search spec when developing this.

Added a spec to cover the new behaviour.

Trello: https://trello.com/c/RHl653OZ/245-rummager-query-on-facet-group-and-facet-value