### PR TITLE
change title for all content search to Search

### DIFF
--- a/config/finders/all_content.yml
+++ b/config/finders/all_content.yml
@@ -6,7 +6,7 @@ locale: en
 publishing_app: rummager
 rendering_app: finder-frontend
 schema_name: finder
-title: All content
+title: Search
 description: Find content from government
 details:
   default_documents_per_page: 20

--- a/config/finders/all_content_email_signup.yml
+++ b/config/finders/all_content_email_signup.yml
@@ -6,7 +6,7 @@ locale: en
 publishing_app: rummager
 rendering_app: finder-frontend
 schema_name: finder_email_signup
-title: All content
+title: Search
 description: You'll get an email when content is published.
 details:
   email_filter_by:


### PR DESCRIPTION
update to call All Content finder Search instead, in preparation for it replacing old site search