### PR TITLE
Allow and filter across facet values

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -10,6 +10,7 @@
     "email_document_supertype",
     "facet_groups",
     "facet_values",
+    "and_facet_values",
     "format",
     "government_document_supertype",
     "indexable_content",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -159,6 +159,11 @@
       "type": "identifiers"
   },
 
+  "and_facet_values": {
+      "description": "Facet values associated the the documents. Copy to allow for AND filters",
+      "type": "identifiers"
+  },
+
   "updated_at": {
     "description": "When the page was last updated. This field is unreliable and may be deprecated in a future version.",
     "type": "date"

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -40,6 +40,10 @@ module GovukIndex
       content_ids("facet_values")
     end
 
+    def and_facet_values
+      content_ids("and_facet_values")
+    end
+
     def topic_content_ids
       content_ids("topics")
     end

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -143,6 +143,7 @@ module Indexer
         'organisation_content_ids' => content_ids_for(links, 'organisations'),
         'facet_groups' => content_ids_for(links, 'facet_groups'),
         'facet_values' => content_ids_for(links, 'facet_values'),
+        'and_facet_values' => content_ids_for(links, 'and_facet_values'),
         'part_of_taxonomy_tree' => parts_of_taxonomy_for_all_taxons(links)
       }
     end

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
           { "content_id" => "TAG-1" },
           { "content_id" => "TAG-2" }
         ],
+        and_facet_values: [
+          { "content_id" => "TAG-1" },
+          { "content_id" => "TAG-2" }
+        ],
         facet_groups: [
           { "content_id" => "TGRP-1" },
           { "content_id" => "TGRP-2" }
@@ -104,7 +108,8 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
         "mainstream_browse_page_content_ids" => ["BROWSE-1"],
         "organisation_content_ids" => ["ORG-1", "ORG-2"],
         "facet_groups" => ["TGRP-1", "TGRP-2"],
-        "facet_values" => ["TAG-1", "TAG-2"]
+        "facet_values" => ["TAG-1", "TAG-2"],
+        "and_facet_values" => ["TAG-1", "TAG-2"]
       },
       index: "government_test",
     )

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -548,6 +548,31 @@ RSpec.describe 'SearchTest' do
     })
   end
 
+  it "can perform AND filter across facet values" do
+    commit_ministry_of_magic_document({
+      "facet_values" => ['fe2fc3b5-a71b-4063-9605-12c3e6e179d6', '40c0f604-9388-4dd8-b114-3f2ffbe16cce'],
+      "and_facet_values" => ['fe2fc3b5-a71b-4063-9605-12c3e6e179d6', '40c0f604-9388-4dd8-b114-3f2ffbe16cce']
+    })
+    commit_treatment_of_dragons_document({ "facet_values" => ['e602eb34-a870-46ff-8ba4-de36689fb028'] })
+    get "/search?filter_facet_values=fe2fc3b5-a71b-4063-9605-12c3e6e179d6&filter_and_facet_values=69c7ec42-fe51-4af0-93c3-c3ef7f93860d"
+    expect(last_response).to be_ok
+    expect(parsed_response.fetch("total")).to eq(0)
+    get "/search?filter_facet_values=248f13e2-c93d-4232-b44b-33cfe05b57e8&filter_and_facet_values=640c0f604-9388-4dd8-b114-3f2ffbe16cce"
+    expect(last_response).to be_ok
+    expect(parsed_response.fetch("total")).to eq(0)
+    get "/search?filter_facet_values=fe2fc3b5-a71b-4063-9605-12c3e6e179d6&filter_and_facet_values=40c0f604-9388-4dd8-b114-3f2ffbe16cce"
+    expect(last_response).to be_ok
+    expect(parsed_response.fetch("total")).to eq(1)
+    expect_result_includes_ministry_of_magic_for_key(parsed_response, "results", {
+      "_id" => "/ministry-of-magic-site",
+      "document_type" => "edition",
+      "elasticsearch_type" => "edition",
+      "es_score" => nil,
+      "index" => "government_test",
+      "link" => "/ministry-of-magic-site"
+    })
+  end
+
   it "can filter by facet group" do
     commit_ministry_of_magic_document({ "facet_groups" => ['fe2fc3b5-a71b-4063-9605-12c3e6e179d6'] })
     commit_treatment_of_dragons_document({ "facet_groups" => ['e602eb34-a870-46ff-8ba4-de36689fb028'] })

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'spec_helper'
 
 RSpec.describe GovukIndex::ExpandedLinksPresenter do
@@ -200,6 +201,20 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expected_facet_values = ['ec58ec61-71a6-475a-8df5-da5f866990b5', 'dd71726f-3fe5-4e5f-8d29-8f668e32a659']
 
     expect(presenter.facet_values).to eq(expected_facet_values)
+  end
+
+  it 'and_facet_values' do
+    expanded_links = {
+      'and_facet_values' => [
+        { 'content_id' => 'ec58ec61-71a6-475a-8df5-da5f866990b5' },
+        { 'content_id' => 'dd71726f-3fe5-4e5f-8d29-8f668e32a659' }
+      ]
+    }
+
+    presenter = expanded_links_presenter(expanded_links)
+    expected_facet_values = ['ec58ec61-71a6-475a-8df5-da5f866990b5', 'dd71726f-3fe5-4e5f-8d29-8f668e32a659']
+
+    expect(presenter.and_facet_values).to eq(expected_facet_values)
   end
 
   it 'facet_groups' do


### PR DESCRIPTION
The problem with moving to the new `facet_values`
type of query, instead of the existing metadata facets,
is that Rummager treats queries on the same column
as `OR` queries.

All of the existing facets are in different fields,
the `facet_values` approach makes this a single field.

This commit introduces a second copy of the `facet_values`
called `and_facet_values`

When populated with identical data this will allow queries like:

&filter_facet_values=uuid-from-first-facet[....]&filter_and_facet_values=uuid-from-different-facet[...]