### PR TITLE
Add missing and facet value code

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -44,6 +44,7 @@ module GovukIndex
         eligible_entities:                   specialist.eligible_entities,
         email_document_supertype:            common_fields.email_document_supertype,
         facet_values:                        expanded_links.facet_values,
+        and_facet_values:                    expanded_links.facet_values,
         facet_groups:                        expanded_links.facet_groups,
         first_published_at:                  specialist.first_published_at,
         format:                              common_fields.format,

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -41,7 +41,7 @@ module GovukIndex
     end
 
     def and_facet_values
-      content_ids("and_facet_values")
+      content_ids("facet_values")
     end
 
     def topic_content_ids

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -40,10 +40,6 @@ module GovukIndex
       content_ids("facet_values")
     end
 
-    def and_facet_values
-      content_ids("facet_values")
-    end
-
     def topic_content_ids
       content_ids("topics")
     end

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -137,6 +137,12 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
         facet_values: ["4577e252-45c3-4c91-a040-c9f8568d0150", "5e326667-0d05-4453-b3a0-a1c6e797171e"]
       )
     end
+
+    it 'returns and_facet_values' do
+      expect(presenter.document).to include(
+        and_facet_values: ["4577e252-45c3-4c91-a040-c9f8568d0150", "5e326667-0d05-4453-b3a0-a1c6e797171e"]
+      )
+    end
   end
 
   def elasticsearch_presenter(payload, type = "aaib_report")

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
 
   it 'and_facet_values' do
     expanded_links = {
-      'and_facet_values' => [
+      'facet_values' => [
         { 'content_id' => 'ec58ec61-71a6-475a-8df5-da5f866990b5' },
         { 'content_id' => 'dd71726f-3fe5-4e5f-8d29-8f668e32a659' }
       ]

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -203,20 +203,6 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.facet_values).to eq(expected_facet_values)
   end
 
-  it 'and_facet_values' do
-    expanded_links = {
-      'facet_values' => [
-        { 'content_id' => 'ec58ec61-71a6-475a-8df5-da5f866990b5' },
-        { 'content_id' => 'dd71726f-3fe5-4e5f-8d29-8f668e32a659' }
-      ]
-    }
-
-    presenter = expanded_links_presenter(expanded_links)
-    expected_facet_values = ['ec58ec61-71a6-475a-8df5-da5f866990b5', 'dd71726f-3fe5-4e5f-8d29-8f668e32a659']
-
-    expect(presenter.and_facet_values).to eq(expected_facet_values)
-  end
-
   it 'facet_groups' do
     expanded_links = {
       'facet_groups' => [


### PR DESCRIPTION
# What

* Add missing spec for ElasticsearchPresenter.  …
  Managed to miss adding code to this class when trying to add
  `and_facet_values`.
  Realised this is because there are no tests around the #document
  method. This commit adds a spec to cover the code I added when
  implementing `facet_groups` and `facet_values`
* Add `and_facet_values` to ElasticsearchPresenter 
  This field was missing and therefore not getting indexed.
* Update spec I got wrong earlier.  …
  `and_facet_values` will never exist in expanded links for the documents.
  It should take it's data from `facet_values`.

* Remove redundant method ExpandedLinksPresenter#and_facet_values

Following on from https://github.com/alphagov/rummager/pull/1501

Trello: https://trello.com/c/ovMEU0aL/283-end-to-end-testing-on-integration-of-new-links-based-approach-for-tagging