### PR TITLE
Fix incorrect links lookup for `and_facet_values`

### DIFF
--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -143,7 +143,7 @@ module Indexer
         'organisation_content_ids' => content_ids_for(links, 'organisations'),
         'facet_groups' => content_ids_for(links, 'facet_groups'),
         'facet_values' => content_ids_for(links, 'facet_values'),
-        'and_facet_values' => content_ids_for(links, 'and_facet_values'),
+        'and_facet_values' => content_ids_for(links, 'facet_values'),
         'part_of_taxonomy_tree' => parts_of_taxonomy_for_all_taxons(links)
       }
     end

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -80,10 +80,6 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
           { "content_id" => "TAG-1" },
           { "content_id" => "TAG-2" }
         ],
-        and_facet_values: [
-          { "content_id" => "TAG-1" },
-          { "content_id" => "TAG-2" }
-        ],
         facet_groups: [
           { "content_id" => "TGRP-1" },
           { "content_id" => "TGRP-2" }


### PR DESCRIPTION
I forgot a place where the lookup was incorrect.

It was looking for `and_facet_values` in the payload.

It doesn't exist in the payload and it should take it's
values from `facet_values`.

Following on from https://github.com/alphagov/rummager/pull/1503 and https://github.com/alphagov/rummager/pull/1501