### PR TITLE
Revert "Uses new research_and_statistics filter"

### DIFF
--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -68,19 +68,33 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
-  - key: research_and_statistics
+  - key: content_store_document_type
     name: Statistics
     type: radio
     display_as_result_metadata: false
     filterable: true
     hide_facet_tag: true
     preposition: that are
+    option_lookup:
+      statistics_published:
+      - statistics
+      - national_statistics
+      - statistical_data_set
+      - official_statistics
+      statistics_upcoming:
+      - statistics_announcement
+      - national_statistics_announcement
+      - official_statistics_announcement
+      research:
+      - dfid_research_output
+      - independent_report
+      - research
     allowed_values:
     - label: Statistics (published)
-      value: published_statistics
+      value: statistics_published
       default: true
     - label: Statistics (upcoming)
-      value: upcoming_statistics
+      value: statistics_upcoming
     - label: Research
       value: research
   - key: organisations


### PR DESCRIPTION
The content item was causing problems on staging that I can't quite fathom. Until this has been figured out running the publish rake task will cause breakages, hence reverting until a solution has been found