### PR TITLE
Change publishing_app and rendering_app to search-api

### DIFF
--- a/config/find-eu-exit-guidance-business-email-signup.yml
+++ b/config/find-eu-exit-guidance-business-email-signup.yml
@@ -3,7 +3,7 @@ base_path: "/find-eu-exit-guidance-business/email-signup"
 content_id: 2818d67a-029a-4899-a438-a543d5c6a20d
 document_type: finder_email_signup
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: Find EU Exit guidance for your business

--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -12,7 +12,7 @@ description: 'This is the information that has been published so far for your bu
 name: 'Find EU Exit guidance for your business'
 locale: en
 public_updated_at: '2018-11-23T09:00:00.000+00:00'
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 links:
   facet_group:

--- a/config/finders/advanced-search.yml
+++ b/config/finders/advanced-search.yml
@@ -6,7 +6,7 @@ document_type: search
 locale: en
 name: Advanced search
 phase: live
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 search_user_need_document_supertype: government

--- a/config/finders/all_content_email_signup.yml
+++ b/config/finders/all_content_email_signup.yml
@@ -3,7 +3,7 @@ base_path: "/search/all/email-signup"
 content_id: 49838f97-5d2e-407a-8876-30c4abe2a6bc
 document_type: finder_email_signup
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: Search

--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -3,7 +3,7 @@ base_path: "/search/all"
 content_id: dd395436-9b40-41f3-8157-740a453ac972
 document_type: finder
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 title: Search

--- a/config/finders/citizen_readiness_finder.yml
+++ b/config/finders/citizen_readiness_finder.yml
@@ -5,7 +5,7 @@ description: Detailed information about Brexit changes if you live in the UK.
 document_type: finder
 locale: en
 parent: ecb55f9d-0823-43bd-a116-dbfab2b76ef9 # /prepare-eu-exit
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 title: Detailed EU Exit guidance

--- a/config/finders/guidance_and_regulation_email_signup.yml
+++ b/config/finders/guidance_and_regulation_email_signup.yml
@@ -3,7 +3,7 @@ base_path: "/search/guidance-and-regulation/email-signup"
 content_id: 30974a3c-b86d-4f12-883d-783e97055690
 document_type: finder_email_signup
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: Guidance and regulation

--- a/config/finders/guidance_and_regulation_finder.yml
+++ b/config/finders/guidance_and_regulation_finder.yml
@@ -4,7 +4,7 @@ content_id: b8507038-e3b5-422c-bc51-28ff1ed12370
 signup_content_id: 30974a3c-b86d-4f12-883d-783e97055690
 document_type: finder
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 title: Guidance and regulation

--- a/config/finders/news_and_communications_email_signup.yml
+++ b/config/finders/news_and_communications_email_signup.yml
@@ -3,7 +3,7 @@ base_path: "/search/news-and-communications/email-signup"
 content_id: 54fa4dca-4dfb-40a5-b860-127716f02e75
 document_type: finder_email_signup
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: News and communications

--- a/config/finders/news_and_communications_finder.yml
+++ b/config/finders/news_and_communications_finder.yml
@@ -3,7 +3,7 @@ base_path: "/search/news-and-communications"
 content_id: 622e9691-4b4f-4e9c-bce1-098b0c4f5ee2
 document_type: finder
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 title: News and communications

--- a/config/finders/policy_and_engagement_email_signup.yml
+++ b/config/finders/policy_and_engagement_email_signup.yml
@@ -3,7 +3,7 @@ base_path: "/search/policy-papers-and-consultations/email-signup"
 content_id: 5a4dc517-57cf-4dd6-873f-f1d29f6d540c
 document_type: finder_email_signup
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: Policy papers and consultations

--- a/config/finders/policy_and_engagement_finder.yml
+++ b/config/finders/policy_and_engagement_finder.yml
@@ -3,7 +3,7 @@ base_path: "/search/policy-papers-and-consultations"
 content_id: 45bb9f22-096a-4e4c-a39e-04a65ff82da7
 document_type: finder
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 title: Policy papers and consultations

--- a/config/finders/services_finder.yml
+++ b/config/finders/services_finder.yml
@@ -39,7 +39,7 @@ details:
     name: Relevance
 document_type: finder
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 title: Services

--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -3,7 +3,7 @@ base_path: "/search/research-and-statistics/email-signup"
 content_id: 119db584-0ae7-45e4-8f3a-fd79316c6921
 document_type: finder_email_signup
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: Research and statistics

--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -4,7 +4,7 @@ content_id: 8f827d53-9ad1-4b90-b6ae-2301c1ecdf02
 description: Find statistics from government
 document_type: finder
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 signup_content_id: 119db584-0ae7-45e4-8f3a-fd79316c6921

--- a/config/finders/transparency_email_signup.yml
+++ b/config/finders/transparency_email_signup.yml
@@ -3,7 +3,7 @@ base_path: "/search/transparency-and-freedom-of-information-releases/email-signu
 content_id: 92f7eb26-030b-4a41-962e-d8e0f8814654
 document_type: finder_email_signup
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: Transparency and freedom of information releases

--- a/config/finders/transparency_finder.yml
+++ b/config/finders/transparency_finder.yml
@@ -56,7 +56,7 @@ details:
     name: Updated (oldest)
 document_type: finder
 locale: en
-publishing_app: rummager
+publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder
 title: Transparency and freedom of information releases

--- a/lib/content_item_publisher/content_item_presenter.rb
+++ b/lib/content_item_publisher/content_item_presenter.rb
@@ -17,7 +17,7 @@ module ContentItemPublisher
         locale: "en",
         phase: "live",
         public_updated_at: timestamp,
-        publishing_app: "rummager",
+        publishing_app: "search-api",
         rendering_app: "finder-frontend",
         routes: content_item["routes"],
         schema_name: content_item["schema_name"],

--- a/lib/indexer/workers/metadata_tagger_notification_worker.rb
+++ b/lib/indexer/workers/metadata_tagger_notification_worker.rb
@@ -37,7 +37,7 @@ module Indexer
         government_document_supertype: "other",
         content_id: document["content_id"],
         public_updated_at: Time.now.iso8601,
-        publishing_app: document.fetch("publishing_app", "rummager"),
+        publishing_app: document.fetch("publishing_app", "search-api"),
         base_path: document["link"],
         priority: "high",
       }

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -14,7 +14,7 @@ class SpecialRoutePublisher
     %w(/search /search.json /search/opensearch.xml).each do |path|
       publishing_api.put_path(
         path,
-        publishing_app: 'rummager',
+        publishing_app: 'search-api',
         override_existing: true
       )
     end
@@ -23,7 +23,7 @@ class SpecialRoutePublisher
   def publish(route)
     @publisher.publish(
       route.merge(
-        publishing_app: "rummager",
+        publishing_app: "search-api",
         format: "special_route",
         public_updated_at: Time.now.iso8601,
         update_type: "major",
@@ -59,7 +59,7 @@ class SpecialRoutePublisher
         type: "exact",
       },
       {
-        rendering_app: "rummager",
+        rendering_app: "search-api",
         content_id: "0818867d-8026-482c-b797-306fb74f5a2d",
         base_path: "/api/search.json",
         title: "GOV.UK search results API",
@@ -67,7 +67,7 @@ class SpecialRoutePublisher
         type: "exact",
       },
       {
-        rendering_app: "rummager",
+        rendering_app: "search-api",
         content_id: "5edd25bd-987f-45d3-8eca-5fb35cbf2978",
         base_path: "/api/batch_search.json",
         title: "GOV.UK batch search results API",
@@ -75,7 +75,7 @@ class SpecialRoutePublisher
         type: "exact",
       },
       {
-        rendering_app: "rummager",
+        rendering_app: "search-api",
         base_path: "/sitemap.xml",
         content_id: "fee32a90-397a-4761-9f98-b06e47d2b798",
         title: "GOV.UK sitemap index",
@@ -83,7 +83,7 @@ class SpecialRoutePublisher
         type: "exact",
       },
       {
-        rendering_app: "rummager",
+        rendering_app: "search-api",
         base_path: "/sitemaps",
         content_id: "c202c6a5-656c-40d1-ae55-36fab995709c",
         title: "GOV.UK sitemaps prefix",


### PR DESCRIPTION
I'll need to change the path reservations in publishing-api as this gets deployed.

See also https://github.com/alphagov/govuk-app-deployment-secrets/pull/122

---

[Trello card](https://trello.com/c/eHXh51HY/650-republish-things-published-by-or-rendered-by-rummager-to-refer-to-search-api)