### PR TITLE
Add some more fields to service standard reports

### DIFF
--- a/config/schema/elasticsearch_types/service_standard_report.json
+++ b/config/schema/elasticsearch_types/service_standard_report.json
@@ -4,11 +4,14 @@
     "assessment_date",
     "business_activity",
     "employ_eu_citizens",
+    "eu_uk_government_funding",
     "intellectual_property",
     "personal_data",
     "public_sector_procurement",
-    "eu_uk_government_funding",
     "regulations_and_standards",
-    "sector_business_area"
+    "result",
+    "sector_business_area",
+    "service_provider",
+    "stage"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -684,6 +684,18 @@
     "description": "The date when the assessment was held.",
     "type": "date"
   },
+  "result": {
+    "description": "The result of the assessment.",
+    "type": "searchable_identifier"
+  },
+  "service_provider": {
+    "description": "The organisation providing the service under assessment.",
+    "type": "identifier"
+  },
+  "stage": {
+    "description": "The current stage of the service under assessment.",
+    "type": "searchable_identifier"
+  },
 
   "content_store_document_type": {
     "description": "The document type as stored in the Content Store",


### PR DESCRIPTION
Recreation of https://github.com/alphagov/search-api-es2-to-es5-migration/pull/46

https://trello.com/c/1yxNntVF/931-add-new-metadata-filters-to-service-standard-reports-finder