### PR TITLE
Exclude specialist doc types from news and comms finder

### DIFF
--- a/config/finders/news_and_communications_email_signup.yml
+++ b/config/finders/news_and_communications_email_signup.yml
@@ -10,7 +10,9 @@ title: News and communications
 description: You'll get an email each time news or communications are published.
 details:
   filter:
-    content_purpose_supergroup: news_and_communications
+    content_purpose_subgroup:
+    - news
+    - speeches_and_statements
   email_filter_by:
   email_filter_name:
   subscription_list_title_prefix: 'News and communications ' # whitespace intended

--- a/config/finders/news_and_communications_finder.yml
+++ b/config/finders/news_and_communications_finder.yml
@@ -12,8 +12,9 @@ signup_content_id: 54fa4dca-4dfb-40a5-b860-127716f02e75
 details:
   document_noun: result
   filter:
-    content_purpose_supergroup:
-    - news_and_communications
+    content_purpose_subgroup:
+    - news
+    - speeches_and_statements
   format_name: News or communications
   show_summaries: true
   sort:


### PR DESCRIPTION
trello: https://trello.com/c/IUEMbTEA/589-exclude-2-content-subgroups-from-news-and-comms-finder
trello: https://trello.com/c/hG5slHr3/667-exclude-specialist-doc-types-from-news-n-comms-finder
see also: https://github.com/alphagov/govuk-content-schemas/pull/887