### PR TITLE
Time round-trips to elasticsearch

### DIFF
--- a/lib/search/batch_query.rb
+++ b/lib/search/batch_query.rb
@@ -6,7 +6,7 @@ module Search
       log_search_count(searches_params)
       builders = create_query_builders(searches_params)
       payloads = aggregate_payloads(builders)
-      es_responses = index.msearch(payloads)["responses"]
+      es_responses = timed_msearch(payloads)["responses"]
 
       searches_params.map.with_index do |search_params, i|
         process_es_response(search_params, builders[i], payloads[i], es_responses[i])
@@ -14,6 +14,12 @@ module Search
     end
 
   private
+
+    def timed_msearch(payloads)
+      GovukStatsd.time("elasticsearch.msearch") do
+        index.msearch(payloads)
+      end
+    end
 
     def create_query_builders(searches_params)
       searches_params.map do |search_params|

--- a/lib/search/best_bets_checker.rb
+++ b/lib/search/best_bets_checker.rb
@@ -82,7 +82,7 @@ module Search
     # the best bet should appear at.
     def fetch_bets
       analyzed_users_query = " #{@metasearch_index.analyzed_best_bet_query(@query)} "
-      es_response = @metasearch_index.raw_search(lookup_payload)
+      es_response = timed_raw_search(lookup_payload)
 
       es_response["hits"]["hits"].map do |hit|
         details = JSON.parse(Array(hit["_source"]["details"]).first)
@@ -99,6 +99,12 @@ module Search
         end
       end
       .compact
+    end
+
+    def timed_raw_search(payload)
+      GovukStatsd.time("elasticsearch.best_bets_raw_search") do
+        @metasearch_index.raw_search(payload)
+      end
     end
 
     # Return a payload for a query across the best_bets type in the metasearch

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -24,13 +24,19 @@ module Search
       )
 
       payload     = process_elasticsearch_errors { builder.payload }
-      es_response = process_elasticsearch_errors { index.raw_search(payload) }
+      es_response = process_elasticsearch_errors { timed_raw_search(payload) }
       process_es_response(search_params, builder, payload, es_response)
     end
 
   private
 
     attr_reader :metasearch_index
+
+    def timed_raw_search(payload)
+      GovukStatsd.time("elasticsearch.raw_search") do
+        index.raw_search(payload)
+      end
+    end
 
     def content_index_names
       # index is a IndexForSearch object, which combines all the content indexes


### PR DESCRIPTION
We saw a series of spikes in the 99th percentile of search-api request durations.  We want to know if it was elasticsearch.