### PR TITLE
Filters business finder by new facet_groups

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -35,7 +35,7 @@ details:
     - name: A to Z
       key: title
   filter:
-    appear_in_find_eu_exit_guidance_business_finder: "yes"
+    facet_groups: ["52435175-82ed-4a04-adef-74c0199d0f46"]
   facets: []
 routes:
 - path: "/find-eu-exit-guidance-business"


### PR DESCRIPTION
Using the old filter meant content newly tagged to
the business finder wasn't showing up on the finder
as the new tagging system uses facet_groups. This
fixes that.