### PR TITLE
Rename the "rummager:" rake tasks and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ rebuild the index nightly to incorporate the latest analytics.
 
 To create an empty index:
 
-    bundle exec rake rummager:create_index[<index_name>]
+    bundle exec rake search:create_index[<index_name>]
 
 To create an empty index for all rummager indices:
 
-    RUMMAGER_INDEX=all bundle exec rake rummager:create_all_indices
+    RUMMAGER_INDEX=all bundle exec rake search:create_all_indices
 
 ### Starting elasticsearch
 If you're running the GDS development VM you need to have elasticsearch running before running the tests or starting the application.
@@ -125,7 +125,7 @@ are 'good' results for some sample queries.
 
 After changing the schema, you'll need to recreate the index. This reindexes documents from the existing index.
 
-    RUMMAGER_INDEX=all bundle exec rake rummager:migrate_schema
+    RUMMAGER_INDEX=all bundle exec rake search:migrate_schema
 
 ### Internal only APIs
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To create an empty index:
 
 To create an empty index for all rummager indices:
 
-    RUMMAGER_INDEX=all bundle exec rake search:create_all_indices
+    SEARCH_INDEX=all bundle exec rake search:create_all_indices
 
 ### Starting elasticsearch
 If you're running the GDS development VM you need to have elasticsearch running before running the tests or starting the application.
@@ -125,7 +125,7 @@ are 'good' results for some sample queries.
 
 After changing the schema, you'll need to recreate the index. This reindexes documents from the existing index.
 
-    RUMMAGER_INDEX=all bundle exec rake search:migrate_schema
+    SEARCH_INDEX=all bundle exec rake search:migrate_schema
 
 ### Internal only APIs
 

--- a/Rakefile
+++ b/Rakefile
@@ -35,12 +35,13 @@ def elasticsearch_uri
 end
 
 def index_names
-  case ENV["RUMMAGER_INDEX"]
+  search_index = ENV["SEARCH_INDEX"]
+  case search_index
   when "all"
     search_config.all_index_names
   when String
-    [ENV["RUMMAGER_INDEX"]]
+    [search_index]
   else
-    raise "You must specify an index name in RUMMAGER_INDEX, or 'all'"
+    raise "You must specify an index name in SEARCH_INDEX, or 'all'"
   end
 end

--- a/doc/adding-new-fields.md
+++ b/doc/adding-new-fields.md
@@ -33,7 +33,7 @@ Some fields get expanded by Search API when they are presented in search results
 
 **Caution:** Do not run this rake task in production during working hours except in an emergency. Content published while the task is running will not be available in search results until the task completes. The impact of this can be reduced if you run the task out of peak publishing hours.
 
-In order for the new field to work as expected, you will need to run a Jenkins job on all environments. The job is "Search reindex with new schema" ([Link to integration version of task][reindex]), and will run the `rummager:migrate_schema` rake task. It can take over 2 hours to complete.
+In order for the new field to work as expected, you will need to run a Jenkins job on all environments. The job is "Search reindex with new schema" ([Link to integration version of task][reindex]), and will run the `search:migrate_schema` rake task. It can take over 2 hours to complete.
 
 [reindex]: https://deploy.integration.publishing.service.gov.uk/job/search_api_reindex_with_new_schema/
 
@@ -49,4 +49,4 @@ For the new elasticsearch configuration to take effect, you need to manually reb
 
 In the past, this was done automatically every night by the [`search_fetch_analytics`](https://github.com/alphagov/search-analytics) jenkins job, but this automation [was reverted](https://github.com/alphagov/search-analytics/commit/a5c3ac58f7198eba74ab7b5bd5555aa07490442a#diff-0484c7ea1cf547a292a2190d0c1c060b). You must run this manually.
 
-If you prefer running a rake task rather than a pre-written Jenkins job, you can run `RUMMAGER_INDEX=all CONFIRM_INDEX_MIGRATION_START=1 rummager:migrate_schema`.
+If you prefer running a rake task rather than a pre-written Jenkins job, you can run `RUMMAGER_INDEX=all CONFIRM_INDEX_MIGRATION_START=1 search:migrate_schema`.

--- a/doc/adding-new-fields.md
+++ b/doc/adding-new-fields.md
@@ -49,4 +49,4 @@ For the new elasticsearch configuration to take effect, you need to manually reb
 
 In the past, this was done automatically every night by the [`search_fetch_analytics`](https://github.com/alphagov/search-analytics) jenkins job, but this automation [was reverted](https://github.com/alphagov/search-analytics/commit/a5c3ac58f7198eba74ab7b5bd5555aa07490442a#diff-0484c7ea1cf547a292a2190d0c1c060b). You must run this manually.
 
-If you prefer running a rake task rather than a pre-written Jenkins job, you can run `RUMMAGER_INDEX=all CONFIRM_INDEX_MIGRATION_START=1 search:migrate_schema`.
+If you prefer running a rake task rather than a pre-written Jenkins job, you can run `SEARCH_INDEX=all CONFIRM_INDEX_MIGRATION_START=1 search:migrate_schema`.

--- a/doc/popularity.md
+++ b/doc/popularity.md
@@ -22,4 +22,4 @@ is run after populating the page-traffic index. As part of the migration, the
 popularity for each document will be computed from the page-traffic index and
 merged into the documents. To do this, run:
 
-    RUMMAGER_INDEX=all CONFIRM_INDEX_MIRATION_START=1 bundle exec rake rummager:migrate_schema
+    RUMMAGER_INDEX=all CONFIRM_INDEX_MIRATION_START=1 bundle exec rake search:migrate_schema

--- a/doc/popularity.md
+++ b/doc/popularity.md
@@ -22,4 +22,4 @@ is run after populating the page-traffic index. As part of the migration, the
 popularity for each document will be computed from the page-traffic index and
 merged into the documents. To do this, run:
 
-    RUMMAGER_INDEX=all CONFIRM_INDEX_MIRATION_START=1 bundle exec rake search:migrate_schema
+    SEARCH_INDEX=all CONFIRM_INDEX_MIRATION_START=1 bundle exec rake search:migrate_schema

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -300,7 +300,7 @@ class Rummager < Sinatra::Application
     prevent_access_to_govuk
     if params["delete_all"]
       # No longer supported; instead use the
-      # `rummager:switch_to_empty_index` Rake command
+      # `search:switch_to_empty_index` Rake command
       halt 400
     else
       action = current_index.delete(params["link"])

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -1,7 +1,7 @@
 require 'rummager'
 
-namespace :rummager do
-  desc "Lists current Rummager indices, pass [all] to show inactive indices"
+namespace :search do
+  desc "Lists current indices, pass [all] to show inactive indices"
   task :list_indices, :all do |_, args|
     show_all = args[:all] || false
     index_names.each do |name|
@@ -201,7 +201,7 @@ You should run this task if the index schema has changed.
   desc "
   Check for any taxons that are not in a draft state for a particular format.
   Usage
-  rake 'rummager:check_for_non_draft_taxons[format_name, elasticsearch_index]'
+  rake 'search:check_for_non_draft_taxons[format_name, elasticsearch_index]'
   "
   task :check_for_non_draft_taxons, [:format, :index_name] do |_, args|
     format = args[:format]

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -1,9 +1,6 @@
 require 'rummager'
 
 namespace :rummager do
-  # this is needed to support the migration to ES 2.4
-  ELASTICSEARCH_VERSION = '2.4'.freeze
-
   desc "Lists current Rummager indices, pass [all] to show inactive indices"
   task :list_indices, :all do |_, args|
     show_all = args[:all] || false


### PR DESCRIPTION
The first step in de-rummagering the repository.  This should be deployed with the other changes which link to this PR.

---

[Trello card](https://trello.com/c/QFqYu8XR/656-%F0%9F%92%80-update-rummager-code-and-documentation-to-refer-only-to-search-api-%F0%9F%92%80)