### PR TITLE
Remove references to govuk-app-deployment-secrets

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -1,9 +1,4 @@
 ---
-#
-# NOTE: This is a development copy of the find-eu-exit-guidance-business finder config
-# See https://github.com/alphagov/govuk-app-deployment-secrets/blob/master/shared_config/find-eu-exit-guidance-business.yml
-# for deployment config.
-#
 base_path: "/find-eu-exit-guidance-business"
 content_id: 42ce66de-04f3-4192-bf31-8394538e0734
 signup_content_id: 2818d67a-029a-4899-a438-a543d5c6a20d

--- a/doc/publishing-finders.md
+++ b/doc/publishing-finders.md
@@ -31,7 +31,3 @@ For new finder content items, use the rake task `publishing_api:publish_finder`.
 ```
 FINDER_CONFIG=news_and_communications.yml EMAIL_SIGNUP_CONFIG=news_and_communications_email_signup.yml publishing_api:publish_finder
 ```
-
-**NOTE:** The `find-eu-exit-guidance-business` finder config is overwritten by a
-[shared definition in the govuk-app-deployment-secrets repo](https://github.com/alphagov/govuk-app-deployment-secrets/blob/master/shared_config/find-eu-exit-guidance-business.yml), the file committed to the
-Search API repo is a development copy.


### PR DESCRIPTION
Trello: https://trello.com/c/T2ibAO7v

`shared_config` is no longer copied from `govuk-app-deployment-secrets`
`search-api` is now the source of truth for the business finder config.