### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/lib/healthcheck/sidekiq_queue_latencies_check.rb
+++ b/lib/healthcheck/sidekiq_queue_latencies_check.rb
@@ -1,0 +1,31 @@
+require 'govuk_app_config'
+
+module Healthcheck
+  # See GovukHealthcheck (govuk_app_config/docs/healthchecks.md) for usage info
+  class SidekiqQueueLatenciesCheck < GovukHealthcheck::SidekiqQueueLatencyCheck
+    def warning_threshold(queue:)
+      # the warning threshold for a particular queue
+      search_queue_thresholds[queue][:warning]
+    end
+
+    def critical_threshold(queue:)
+      # the critical threshold for a particular queue
+      search_queue_thresholds[queue][:critical]
+    end
+
+  private
+
+    def search_queue_thresholds
+      {
+        'default' => {
+          critical: 15.seconds,
+          warning: 2.5.seconds,
+        },
+        'bulk' => {
+          critical: 30.minutes,
+          warning: 5.minutes,
+        }
+      }
+    end
+  end
+end

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -3,6 +3,8 @@ set :root, File.dirname(__FILE__)
 
 require 'rummager'
 require 'routes/content'
+require 'govuk_app_config'
+require 'healthcheck/sidekiq_queue_latencies_check'
 
 class Rummager < Sinatra::Application
   class AttemptToUseDefaultMainstreamIndex < StandardError; end
@@ -325,6 +327,17 @@ class Rummager < Sinatra::Application
       }
     end
     status.to_json
+  end
+
+  # Healthcheck using govuk_app_config for Icinga alerts
+  # See govuk_app_config/healthcheck for guidance on adding checks.
+  get '/healthcheck' do
+    checks = [
+      GovukHealthcheck::SidekiqRedis,
+      Healthcheck::SidekiqQueueLatenciesCheck
+    ]
+
+    GovukHealthcheck.healthcheck(checks).to_json
   end
 
   # these endpoints are used to capture any usage of old endpoints which relied on a default index.

--- a/spec/integration/app/healthcheck_spec.rb
+++ b/spec/integration/app/healthcheck_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe 'HealthcheckTest' do
+  let(:queues) {
+    { "bulk" => 2, "default" => 1 }
+  }
+  let(:queue_latency) { 1.seconds }
+
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Sidekiq::Stats).to receive(:queues).and_return(queues)
+    allow_any_instance_of(Sidekiq::Queue).to receive(:latency).and_return(queue_latency)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe "#redis_connectivity check" do
+    # We only check for cannot connect because govuk_app_config has tests for this
+    context "when Sidekiq CANNOT connect to Redis" do
+      before do
+        allow(Sidekiq).to receive(:redis_info).and_raise(Errno::ECONNREFUSED)
+      end
+
+      it "returns a critical status" do
+        get "/healthcheck"
+
+        expect(parsed_response['status']).to eq 'critical'
+      end
+    end
+  end
+
+  describe "#sidekiq_queue_latency check" do
+    before do
+      allow(Sidekiq).to receive(:redis_info).and_return({})
+    end
+
+    context "when queue latency is 2 (seconds)" do
+      let(:queue_latency) { 2.seconds }
+
+      it "retuns an OK status" do
+        get "/healthcheck"
+
+        expect(last_response).to be_ok
+
+        expect(parsed_response.dig('checks', 'sidekiq_queue_latency', 'status')).to eq 'ok'
+      end
+    end
+
+    context "when queue latency is 5 (seconds)" do
+      let(:queue_latency) { 5.seconds }
+
+      it "retuns a warning status" do
+        get "/healthcheck"
+
+        expect(parsed_response['status']).to eq 'warning'
+        expect(parsed_response.dig('checks', 'sidekiq_queue_latency', 'status')).to eq 'warning'
+      end
+    end
+
+
+    context "when queue latency is 15 (seconds)" do
+      let(:queue_latency) { 15.seconds }
+
+      it "retuns a critical status" do
+        get "/healthcheck"
+
+        expect(parsed_response['status']).to eq('critical')
+        expect(parsed_response.dig('checks', 'sidekiq_queue_latency', 'status')).to eq 'critical'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a healthcheck endpoint, which returns a response
that can be used by Icinga to create alerts. At the moment
we have two alerts:
- Sidekiq cannot connect to Redis
- Sidekiq queue latency is beyond a certain threshold

The first alert is a new one, which will help us if the redis
queues arent accessible.

The second alert is designed to replace the Icinga alert in
govuk-puppet which looks at graphite to create the alert.
I will remove that alert once this one is up and working.

Once this is merged, I will make a change to govuk-puppet
to make Icinga poll the search-api /healthcheck endpoint
and create alerts using the result.

Trello: https://trello.com/c/cNvfdZfU/372