### PR TITLE
Add elasticsearch connectivity checks

### DIFF
--- a/lib/healthcheck/elasticsearch_connectivity_check.rb
+++ b/lib/healthcheck/elasticsearch_connectivity_check.rb
@@ -1,0 +1,53 @@
+require 'govuk_app_config'
+
+module Healthcheck
+  # This is a custom check that is called by GovukHealthcheck
+  # See GovukHealthcheck (govuk_app_config/docs/healthchecks.md) for usage info
+  class ElasticsearchConnectivityCheck
+    def name
+      :elasticsearch_connectivity
+    end
+
+    def status
+      can_connect? ? :ok : :critical
+    end
+
+    def message
+      if can_connect?
+        "search-api can to connect to elasticsearch"
+      else
+        "search-api CANNOT connect to elasticsearch!"
+      end
+    end
+
+    def details
+      can_connect? ? { extra: cluster_health } : {}
+    end
+
+    # Optional
+    def enabled?
+      true # false if the check is not relevant at this time
+    end
+
+  private
+
+    def can_connect?
+      cluster_health.present?
+    rescue Faraday::Error
+      false
+    end
+
+    def cluster_health
+      # Makes a call to the elasticsearch cluster
+      @cluster_health ||= elasticsearch_client.cluster.health
+    end
+
+    def elasticsearch_url
+      SearchConfig.instance.base_uri
+    end
+
+    def elasticsearch_client
+      @elasticsearch_client ||= Services::elasticsearch(hosts: elasticsearch_url)
+    end
+  end
+end

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -5,6 +5,7 @@ require 'rummager'
 require 'routes/content'
 require 'govuk_app_config'
 require 'healthcheck/sidekiq_queue_latencies_check'
+require 'healthcheck/elasticsearch_connectivity_check'
 
 class Rummager < Sinatra::Application
   class AttemptToUseDefaultMainstreamIndex < StandardError; end
@@ -334,7 +335,8 @@ class Rummager < Sinatra::Application
   get '/healthcheck' do
     checks = [
       GovukHealthcheck::SidekiqRedis,
-      Healthcheck::SidekiqQueueLatenciesCheck
+      Healthcheck::SidekiqQueueLatenciesCheck,
+      Healthcheck::ElasticsearchConnectivityCheck,
     ]
 
     GovukHealthcheck.healthcheck(checks).to_json


### PR DESCRIPTION
This will add another healthcheck to the /healthcheck endpoint which will be polled by Icinga. This will tell us whether Elasticsearch cannot be connected to by search-api.

![Screen Shot 2019-05-08 at 18 02 49](https://user-images.githubusercontent.com/8124374/57393758-af934c80-71bb-11e9-96dd-2f34d45614e6.png)

This will replace the existing check in govuk-puppet for the same thing. A govuk-puppet PR will remove it (https://github.com/alphagov/govuk-puppet/pull/9101) and can be merged after this PR.

Trello: https://trello.com/c/cNvfdZfU/372