### PR TITLE
Bump elasticsearch gem to version 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "activesupport", "~> 5.2.3"
-gem "elasticsearch", "~> 5"
+gem "elasticsearch", "~> 6"
 gem "gds-api-adapters", "~> 59.2"
 gem "govuk_app_config", "~> 1.16.1"
 gem "govuk_document_types", "~> 0.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,12 +29,12 @@ GEM
     docile (1.3.0)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (5.0.5)
-      elasticsearch-api (= 5.0.5)
-      elasticsearch-transport (= 5.0.5)
-    elasticsearch-api (5.0.5)
+    elasticsearch (6.3.1)
+      elasticsearch-api (= 6.3.1)
+      elasticsearch-transport (= 6.3.1)
+    elasticsearch-api (6.3.1)
       multi_json
-    elasticsearch-transport (5.0.5)
+    elasticsearch-transport (6.3.1)
       faraday
       multi_json
     faraday (0.15.4)
@@ -254,7 +254,7 @@ DEPENDENCIES
   activesupport (~> 5.2.3)
   bunny-mock (~> 1.7)
   climate_control (~> 0.2)
-  elasticsearch (~> 5)
+  elasticsearch (~> 6)
   gds-api-adapters (~> 59.2)
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk-lint (~> 3.11.2)

--- a/lib/debug/synonyms.rb
+++ b/lib/debug/synonyms.rb
@@ -28,11 +28,11 @@ module Debug
       end
 
       def analyze_query(query)
-        client.indices.analyze text: query, analyzer: 'with_search_synonyms', index: index
+        client.indices.analyze index: index, body: { text: query, analyzer: 'with_search_synonyms' }
       end
 
       def analyze_index(query)
-        client.indices.analyze text: query, analyzer: 'with_index_synonyms', index: index
+        client.indices.analyze index: index, body: { text: query, analyzer: 'with_index_synonyms' }
       end
     end
   end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -184,7 +184,13 @@ module SearchIndices
     # duplicated in document_preparer.rb
     def analyzed_best_bet_query(query)
       begin
-        analyzed_query = @client.indices.analyze(index: @index_name, text: query, analyzer: "best_bet_stemmed_match")
+        analyzed_query = @client.indices.analyze(
+          index: @index_name,
+          body: {
+            text: query,
+            analyzer: "best_bet_stemmed_match",
+          },
+        )
 
         analyzed_query["tokens"].map { |token_info|
           token_info["token"]

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -84,7 +84,13 @@ module Indexer
     # duplicated in index.rb
     def analyzed_best_bet_query(query)
       begin
-        analyzed_query = @client.indices.analyze(index: @index_name, text: query, analyzer: "best_bet_stemmed_match")
+        analyzed_query = @client.indices.analyze(
+          index: @index_name,
+          body: {
+            text: query,
+            analyzer: "best_bet_stemmed_match",
+          },
+        )
 
         analyzed_query["tokens"].map { |token_info|
           token_info["token"]

--- a/lib/metasearch_index/client.rb
+++ b/lib/metasearch_index/client.rb
@@ -5,7 +5,10 @@ module MetasearchIndex
     end
 
     def analyze(params)
-      client.indices.analyze(params.merge(index: index_name))
+      client.indices.analyze(
+        index: index_name,
+        body: params,
+      )
     end
 
   private

--- a/spec/integration/schema/stemming_spec.rb
+++ b/spec/integration/schema/stemming_spec.rb
@@ -60,7 +60,13 @@ private
   end
 
   def fetch_tokens_for_analyzer(query, analyzer)
-    result = client.indices.analyze(index: 'government_test', analyzer: analyzer.to_s, text: query)
+    result = client.indices.analyze(
+      index: 'government_test',
+      body: {
+        analyzer: analyzer.to_s,
+        text: query,
+      }
+    )
     mappings = result['tokens']
     mappings.map { |mapping| mapping['token'] }
   end


### PR DESCRIPTION
We're still using elasticsearch 5, but by using version 6 of the gem
we can start to make changes to make search-api compatible with both.

---

This has now been on staging for about a day.  I've done some manual testing:

- Republishing all detailed guides from whitehall
- Republishing all transactions from publishing-api
- Publishing new guidance from whitehall & checking it appears in search
- Withdrawing guidance from whitehall & checking it disappears from search.
- Searching for a thing with a best bet

---

[Trello card](https://trello.com/c/uTsa3fpt/163-make-search-api-talk-to-both-es5-and-es6-%F0%9F%8D%90)