### PR TITLE
Add beta banner to Statistics finder

### DIFF
--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -11,7 +11,7 @@ signup_content_id: 119db584-0ae7-45e4-8f3a-fd79316c6921
 title: Research and statistics
 phase: beta
 details:
-  beta_message: "link to survey"
+  beta_message: Research and statistics search is new - <a href="https://www.smartsurvey.co.uk/s/research-statistics-search-survey/">tell us what you think</a>
   document_noun: result
   filter: {}
   format_name: statistic

--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -9,7 +9,9 @@ rendering_app: finder-frontend
 schema_name: finder
 signup_content_id: 119db584-0ae7-45e4-8f3a-fd79316c6921
 title: Research and statistics
+phase: beta
 details:
+  beta_message: "link to survey"
   document_noun: result
   filter: {}
   format_name: statistic


### PR DESCRIPTION
Adds a new survey link to the beta banner of the Research and Statistics finder

<img width="843" alt="Screen Shot 2019-05-30 at 13 43 39" src="https://user-images.githubusercontent.com/17908089/58633650-f66af280-82e0-11e9-844d-723ad5aa565b.png">


https://trello.com/c/GU9oNJot/722-add-beta-banner-to-search-research-and-statistics-s