### PR TITLE
[Do not merge] [Discuss] Allow queries to contain nested conditions

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -332,6 +332,17 @@ private
     end
   end
 
+  class NestedFieldFilter < Filter
+    def initialize(field_name, values, operation, multivalue_query)
+      super
+      @values = values
+    end
+
+    def type
+      "nested"
+    end
+  end
+
   def filter_name_lookup(name)
     FILTER_NAME_MAPPING.fetch(name, name)
   end


### PR DESCRIPTION
https://trello.com/c/kFwm0Wxe/125-spike-can-search-api-generate-and-or-query-combinations-for-elasticsearch

Updates user filters to allow a parameter structure which can denote **and/or** logic in the form of nested values.

eg. The query string:

```
Rack::Utils.parse_nested_query(
  "facet_values[and][0][]=A&facet_values[and][0][]=B&facet_values[and][1][]=C&facet_values[and][1][]=D"
)
=> {"facet_values"=>{"and"=>{"0"=>["A", "B"], "1"=>["C", "D"]}}}
```

produces the query clause:

```json
"bool" : {
  "must" : [
      { "terms" : { "facet_values" : ["A", "B"] } },
      { "terms" : { "facet_values" : ["C", "D"] } }
    ]
}
```

Which _(I think)_ equates to: _facet values must contain A or B, and C or D_. (Verified here https://www.toolsbuzz.com/query-converter and tested on integration ES instance).
The keys within the `and` hash are disregarded, these are necessary to construct a [Rack compliant set of request parameters](http://codefol.io/posts/How-Does-Rack-Parse-Query-Params-With-parse-nested-query/) which can be accurately separated into and/or clauses.