### PR TITLE
Enable filtering on boolean fields

### DIFF
--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -166,6 +166,7 @@
 
   "boolean": {
     "description": "A boolean value which can be returned and used for filtering and aggregating",
+    "filter_type": "boolean",
     "es_config": {
       "type": "boolean",
       "include_in_all": false

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -225,6 +225,7 @@ private
     filter_class = {
       "text" => TextFieldFilter,
       "date" => DateFieldFilter,
+      "boolean" => BooleanFieldFilter,
     }.fetch(filter_type)
 
     filter = filter_class.new(field_name, values, operation, multivalue_query)
@@ -329,6 +330,30 @@ private
   class TextFieldFilter < Filter
     def type
       "string"
+    end
+  end
+
+  class BooleanFieldFilter < Filter
+    def initialize(field_name, values, operation, multivalue_query)
+      super
+      @values = parse_bool(values, field_name)
+    end
+
+    def type
+      "boolean"
+    end
+
+  private
+
+    def parse_bool(values, field_name)
+      values.map { |value|
+        if %w(true false).include?(value)
+          value
+        else
+          @errors << %{#{field_name} requires a boolean (true or false)}
+          'false'
+        end
+      }
     end
   end
 

--- a/lib/schema/field_types.rb
+++ b/lib/schema/field_types.rb
@@ -22,7 +22,7 @@ private
       end
 
       filter_type = value.delete("filter_type")
-      unless [nil, "text", "date"].include? filter_type
+      unless [nil, "text", "date", "boolean"].include? filter_type
         raise %{Invalid value for "filter_type" ("#{filter_type}") in field type "#{type_name}" in "#{types_file_path}"}
       end
 

--- a/lib/search/query_components/user_filter.rb
+++ b/lib/search/query_components/user_filter.rb
@@ -40,6 +40,8 @@ module QueryComponents
         end
       when "date"
         es_filters << date_filter(field_name, values.first)
+      when "boolean"
+        es_filters << bool_must_filter(field_name, values)
       else
         raise "Filter type not supported"
       end

--- a/spec/unit/query_components/filter_spec.rb
+++ b/spec/unit/query_components/filter_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe QueryComponents::Filter do
     SearchParameterParser::DateFieldFilter.new(field_name, values, :filter, :any)
   end
 
+  def make_boolean_filter_param(field_name, values)
+    SearchParameterParser::BooleanFieldFilter.new(field_name, values, :filter, :any)
+  end
+
   def text_filter(field_name, values, multivalue_query: :any)
     SearchParameterParser::TextFieldFilter.new(field_name, values, :filter, multivalue_query)
   end
@@ -36,6 +40,16 @@ RSpec.describe QueryComponents::Filter do
       result = builder.payload
 
       expect(result).to eq(bool: { must: ["range" => { "field_with_date" => { "from" => "2014-04-01T00:00:00+00:00", "to" => "2014-04-02T00:00:00+00:00" } }] })
+    end
+
+    it "appends the correct boolean filters" do
+      builder = described_class.new(
+        make_search_params([make_boolean_filter_param("field_with_boolean", %w(true))])
+      )
+
+      result = builder.payload
+
+      expect(result).to eq({ bool: { must: [{ bool: { must: [{ term: { "field_with_boolean" => "true" } }] } }] } })
     end
   end
 


### PR DESCRIPTION
This enables filtering on fields such as has_official_document, which are boolean fields.

This is possible with advanced_search, but is now possible with batch_search and search.

This is on integration (it may not be by the time this is reviewed): see `/api/search.json?filter_has_official_document=true`.

The fields that are now available are already documented:
https://docs.publishing.service.gov.uk/apis/search/fields.html

https://trello.com/c/0SfRvUJX/752-enable-boolean-filters-in-search-api