### PR TITLE
Switch from string to text / keyword

### DIFF
--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -3,8 +3,8 @@
     "description": "An identifier, can be used for exact (case and whitespace sensitive) lookup and aggregating",
     "filter_type": "text",
     "es_config": {
-      "type": "string",
-      "index": "not_analyzed",
+      "type": "keyword",
+      "index": true,
       "include_in_all": false
     }
   },
@@ -14,8 +14,8 @@
     "filter_type": "text",
     "multivalued": true,
     "es_config": {
-      "type": "string",
-      "index": "not_analyzed",
+      "type": "keyword",
+      "index": true,
       "include_in_all": false
     }
   },
@@ -24,8 +24,8 @@
     "description": "Like an identifier, but should also be considered in non-field-specific text searches",
     "filter_type": "text",
     "es_config": {
-      "type": "string",
-      "index": "not_analyzed",
+      "type": "keyword",
+      "index": true,
       "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"]
     }
@@ -36,8 +36,8 @@
     "filter_type": "text",
     "multivalued": true,
     "es_config": {
-      "type": "string",
-      "index": "not_analyzed",
+      "type": "keyword",
+      "index": true,
       "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"]
     }
@@ -46,20 +46,20 @@
   "searchable_text": {
     "description": "A piece of plain text that should be split into words and considered in searches",
     "es_config": {
-      "type": "string",
-      "index": "analyzed",
+      "type": "text",
+      "index": true,
       "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"],
       "fields": {
         "no_stop": {
-          "type": "string",
-          "index": "analyzed",
+          "type": "text",
+          "index": true,
           "include_in_all": false,
           "analyzer": "searchable_text"
         },
         "synonym": {
-          "type": "string",
-          "index": "analyzed",
+          "type": "text",
+          "index": true,
           "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
@@ -71,14 +71,14 @@
   "all_searchable_text_type": {
     "description": "A type for a special single field that all searchable text is copied into (using `copy_to` directives in elasticsearch). We use this instead of the built-in `_all` so that we can analyze it in multiple ways",
     "es_config": {
-      "type": "string",
-      "index": "analyzed",
+      "type": "text",
+      "index": true,
       "analyzer": "searchable_text",
       "include_in_all": false,
       "fields": {
         "synonym": {
-          "type": "string",
-          "index": "analyzed",
+          "type": "text",
+          "index": true,
           "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
@@ -90,27 +90,27 @@
   "searchable_sortable_text": {
     "description": "A piece of plain text that should be split into words and considered in searches, but can also be sorted on",
     "es_config": {
-      "type": "string",
-      "index": "analyzed",
+      "type": "text",
+      "index": true,
       "include_in_all": true,
       "copy_to": ["spelling_text"],
       "fields": {
         "sort": {
-          "type": "string",
-          "index": "analyzed",
+          "type": "text",
+          "index": true,
           "analyzer": "string_for_sorting",
           "include_in_all": false,
           "fielddata": true
         },
         "no_stop": {
-          "type": "string",
-          "index": "analyzed",
+          "type": "text",
+          "index": true,
           "include_in_all": false,
           "analyzer": "searchable_text"
         },
         "synonym": {
-          "type": "string",
-          "index": "analyzed",
+          "type": "text",
+          "index": true,
           "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
@@ -122,8 +122,8 @@
   "unsearchable_text": {
     "description": "A piece of text which can be returned, but which is not searchable",
     "es_config": {
-      "type": "string",
-      "index": "no",
+      "type": "text",
+      "index": false,
       "include_in_all": false
     }
   },
@@ -131,8 +131,8 @@
   "spelling_text": {
     "description": "Text which is tokenised into words and lowercased, but not stemmed, stopworded, etc. This can be used for spelling correction, or exact word matching",
     "es_config": {
-      "type": "string",
-      "index": "analyzed",
+      "type": "text",
+      "index": true,
       "analyzer": "spelling_analyzer",
       "include_in_all": false
     }
@@ -141,8 +141,8 @@
   "best_bet_exact_match_text": {
     "description": "Type used in best-bets implementation for matching the whole stored query exactly (other than lowercasing and whitespace trimming)",
     "es_config": {
-      "type": "string",
-      "index": "analyzed",
+      "type": "text",
+      "index": true,
       "analyzer": "exact_match"
     }
   },
@@ -150,8 +150,8 @@
   "best_bet_stemmed_match_text": {
     "description": "Type used in best-bets implementation for matching the stored query with stemming and word splitting",
     "es_config": {
-      "type": "string",
-      "index": "analyzed",
+      "type": "text",
+      "index": true,
       "analyzer": "best_bet_stemmed_match"
     }
   },

--- a/spec/support/default_mappings.rb
+++ b/spec/support/default_mappings.rb
@@ -5,12 +5,12 @@ module Fixtures
         "generic-document" => {
           "_all" => { "enabled" => true },
           "properties" => {
-            "title" => { "type" => "string", "index" => "analyzed" },
-            "description" => { "type" => "string", "index" => "analyzed" },
-            "format" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
-            "link" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
-            "indexable_content" => { "type" => "string", "index" => "analyzed" },
-            "mainstream_browse_pages" => { "type" => "string", "index" => "not_analyzed", "include_in_all" => false },
+            "title" => { "type" => "text", "index" => true },
+            "description" => { "type" => "text", "index" => true },
+            "format" => { "type" => "keyword", "index" => true, "include_in_all" => false },
+            "link" => { "type" => "keyword", "index" => true, "include_in_all" => false },
+            "indexable_content" => { "type" => "text", "index" => true },
+            "mainstream_browse_pages" => { "type" => "keyword", "index" => true, "include_in_all" => false },
           }
         }
       }
@@ -41,7 +41,7 @@ module Fixtures
             }
           ],
           "properties" => {
-            "path_components" => { "type" => "string", "index" => "not_analyzed" }
+            "path_components" => { "type" => "keyword", "index" => true }
           }
         }
       }

--- a/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
+++ b/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
@@ -106,21 +106,21 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
   end
 
   it "filter params on a boolean mapping property are convered to true based on something that looks truthy" do
-    @wrapper.mappings['generic-document']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
+    @wrapper.mappings['generic-document']['properties']['boolean_property'] = { "type" => "boolean", "index" => true }
     stub_empty_search(body: /#{Regexp.escape("{\"term\":{\"boolean_property\":true}")}/)
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'true'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => '1'))
   end
 
   it "filter params on a boolean mapping property are convered to false based on something that looks falsey" do
-    @wrapper.mappings['generic-document']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
+    @wrapper.mappings['generic-document']['properties']['boolean_property'] = { "type" => "boolean", "index" => true }
     stub_empty_search(body: /#{Regexp.escape("\"term\":{\"boolean_property\":false}")}/)
     @wrapper.advanced_search(default_params.merge('boolean_property' => 'false'))
     @wrapper.advanced_search(default_params.merge('boolean_property' => '0'))
   end
 
   it "filter params on a boolean mapping property are rejected if they dont look truthy or falsey" do
-    @wrapper.mappings['generic-document']['properties']['boolean_property'] = { "type" => "boolean", "index" => "analyzed" }
+    @wrapper.mappings['generic-document']['properties']['boolean_property'] = { "type" => "boolean", "index" => true }
     stub_empty_search
 
     expect_rejected_search('Invalid value "falsey" for boolean property "boolean_property"', default_params.merge('boolean_property' => 'falsey'))
@@ -131,7 +131,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
   end
 
   it "filter params on a date mapping property are turned into a range filter with order based on the key in the value" do
-    @wrapper.mappings['generic-document']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
+    @wrapper.mappings['generic-document']['properties']['date_property'] = { "type" => "date", "index" => true }
 
     stub_empty_search(body: /#{Regexp.escape("\"range\":{\"date_property\":{\"to\":\"2013-02-02\"}}")}/)
     @wrapper.advanced_search(default_params.merge('date_property' => { 'to' => '2013-02-02' }))
@@ -151,7 +151,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
   end
 
   it "filter params on a date mapping property without a before or after key in the value are rejected" do
-    @wrapper.mappings['generic-document']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
+    @wrapper.mappings['generic-document']['properties']['date_property'] = { "type" => "date", "index" => true }
     stub_empty_search
 
     expect_rejected_search('Invalid value {} for date property "date_property"', default_params.merge('date_property' => {}))
@@ -162,7 +162,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
   end
 
   it "filter params on a date mapping property without a incorrectly formatted date are rejected" do
-    @wrapper.mappings['generic-document']['properties']['date_property'] = { "type" => "date", "index" => "analyzed" }
+    @wrapper.mappings['generic-document']['properties']['date_property'] = { "type" => "date", "index" => true }
     stub_empty_search
 
     expect_rejected_search('Invalid value {"before"=>"2 Feb 2013"} for date property "date_property"', default_params.merge('date_property' => { 'before' => '2 Feb 2013' }))

--- a/spec/unit/schema/elasticsearch_types_parser_spec.rb
+++ b/spec/unit/schema/elasticsearch_types_parser_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ElasticsearchTypesParser do
     before do
       field_definitions = FieldDefinitionParser.new(schema_dir).parse
       @types = described_class.new(schema_dir, field_definitions).parse
-      @identifier_es_config = { "type" => "string", "index" => "not_analyzed", "include_in_all" => false }
+      @identifier_es_config = { "type" => "keyword", "index" => true, "include_in_all" => false }
     end
 
     it "recognise the `manual section` type" do

--- a/spec/unit/schema/index_schema_parser_spec.rb
+++ b/spec/unit/schema/index_schema_parser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe IndexSchemaParser do
       field_definitions = FieldDefinitionParser.new(schema_dir).parse
       elasticsearch_types = ElasticsearchTypesParser.new(schema_dir, field_definitions).parse
       @index_schemas = described_class.parse_all(schema_dir, field_definitions, elasticsearch_types)
-      @identifier_es_config = { "type" => "string", "index" => "not_analyzed", "include_in_all" => false }
+      @identifier_es_config = { "type" => "keyword", "index" => true, "include_in_all" => false }
     end
 
     it "have a schema for the govuk index" do


### PR DESCRIPTION
Following the suggested migration here:
https://www.elastic.co/blog/strings-are-dead-long-live-strings

Analyzed string fields:

    { "type" "string"
    , "index": "analyzed"
    }

Become text fields:

    { "type" "text"
    , "index": true
    }

Non-analyzed string fields:

    { "type" "string"
    , "index": "not_analyzed"
    }

Become keyword fields:

    { "type" "keyword"
    , "index": true
    }

---

[Trello card](https://trello.com/c/lSa4fDiJ/718-make-elasticsearch-index-schema-definitions-es6-compatible-%F0%9F%8D%90)