### PR TITLE
Adds Official documents finder

### DIFF
--- a/config/finders/official_documents_finder.yml
+++ b/config/finders/official_documents_finder.yml
@@ -1,0 +1,81 @@
+---
+base_path: "/search/official-documents"
+content_id: e96a1b16-a011-4dc6-9f6a-a54561c4db90
+description: Find official documents from government
+document_type: finder
+locale: en
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder
+title: Official documents
+details:
+  document_noun: result
+  filter:
+    has_official_document: true
+  format_name: Official documents
+  show_summaries: true
+  sort:
+  - name: Most viewed
+    key: "-popularity"
+  - name: Relevance
+    key: "-relevance"
+  - name: Updated (newest)
+    key: "-public_timestamp"
+    default: true
+  - name: Updated (oldest)
+    key: public_timestamp
+  facets:
+  - key: release_timestamp
+    name: release_timestamp
+    short_name: Release date
+    preposition: from
+    type: date
+    display_as_result_metadata: true
+    filterable: false
+  - key: display_type
+    name: content_store_document_type
+    short_name: Document type
+    preposition: from
+    type: text
+    display_as_result_metadata: true
+    filterable: false
+  - key: _unused
+    filter_key: all_part_of_taxonomy_tree
+    keys:
+    - level_one_taxon
+    - level_two_taxon
+    name: topic
+    short_name: topic
+    type: taxon
+    display_as_result_metadata: false
+    filterable: true
+    preposition: about
+  - key: content_store_document_type
+    name: official documents
+    type: official_documents
+    preposition: Of type
+    display_as_result_metadata: true
+    filterable: true
+  - key: organisations
+    name: Organisation
+    short_name: Organisation
+    preposition: from
+    type: text
+    show_option_select_filter: true
+    display_as_result_metadata: true
+    filterable: true
+  - key: public_timestamp
+    short_name: Updated
+    name: Updated
+    preposition: Updated
+    type: date
+    display_as_result_metadata: true
+    filterable: true
+  default_documents_per_page: 20
+routes:
+- path: "/search/official-documents"
+  type: exact
+- path: "/search/official-documents.atom"
+  type: exact
+- path: "/search/official-documents.json"
+  type: exact

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -93,6 +93,9 @@ namespace :publishing_api do
       {
         finder: 'services_finder.yml',
       },
+      {
+        finder: 'official_documents_finder.yml',
+      }
     ]
 
     puts "PUBLISHING ALL SUPERGROUP FINDERS..."


### PR DESCRIPTION
This adds the configuration for an official docs finder ready for publication by search api rake task
publishing_api.rake

[Trello](https://trello.com/c/6xFJqfAw/724-spin-up-finder-for-content-that-has-official-doc-status-s)

This PR relates to [this work](https://github.com/alphagov/govuk-content-schemas/pull/) which adds the new official document finder to the `govuk-content-schema` repo. 
It also relates to [this work](https://github.com/alphagov/finder-frontend/pull/1154) on finder frontend.