### PR TITLE
Add reject condition for link to /search/all

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -11,6 +11,9 @@ description: Find content from government
 details:
   default_documents_per_page: 20
   document_noun: result
+  reject:
+    link:
+      - "/search/all"
   format_name: Documents
   hide_facets_by_default: true
   facets:


### PR DESCRIPTION
Adds a rejection condition for results for the all-content finder
where if a result has the link "search/all" it will be excluded from the
result set.

Linked to this [card](https://trello.com/c/qAwjASRS/176-remove-the-search-page-from-search-results-searchception-s)