### PR TITLE
Remove use of include_in_all

### DIFF
--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -4,8 +4,7 @@
     "filter_type": "text",
     "es_config": {
       "type": "keyword",
-      "index": true,
-      "include_in_all": false
+      "index": true
     }
   },
 
@@ -15,8 +14,7 @@
     "multivalued": true,
     "es_config": {
       "type": "keyword",
-      "index": true,
-      "include_in_all": false
+      "index": true
     }
   },
 
@@ -26,7 +24,6 @@
     "es_config": {
       "type": "keyword",
       "index": true,
-      "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"]
     }
   },
@@ -38,7 +35,6 @@
     "es_config": {
       "type": "keyword",
       "index": true,
-      "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"]
     }
   },
@@ -48,19 +44,16 @@
     "es_config": {
       "type": "text",
       "index": true,
-      "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"],
       "fields": {
         "no_stop": {
           "type": "text",
           "index": true,
-          "include_in_all": false,
           "analyzer": "searchable_text"
         },
         "synonym": {
           "type": "text",
           "index": true,
-          "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
         }
@@ -74,12 +67,10 @@
       "type": "text",
       "index": true,
       "analyzer": "searchable_text",
-      "include_in_all": false,
       "fields": {
         "synonym": {
           "type": "text",
           "index": true,
-          "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
         }
@@ -92,26 +83,22 @@
     "es_config": {
       "type": "text",
       "index": true,
-      "include_in_all": true,
       "copy_to": ["spelling_text"],
       "fields": {
         "sort": {
           "type": "text",
           "index": true,
           "analyzer": "string_for_sorting",
-          "include_in_all": false,
           "fielddata": true
         },
         "no_stop": {
           "type": "text",
           "index": true,
-          "include_in_all": false,
           "analyzer": "searchable_text"
         },
         "synonym": {
           "type": "text",
           "index": true,
-          "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
         }
@@ -123,8 +110,7 @@
     "description": "A piece of text which can be returned, but which is not searchable",
     "es_config": {
       "type": "text",
-      "index": false,
-      "include_in_all": false
+      "index": false
     }
   },
 
@@ -133,8 +119,7 @@
     "es_config": {
       "type": "text",
       "index": true,
-      "analyzer": "spelling_analyzer",
-      "include_in_all": false
+      "analyzer": "spelling_analyzer"
     }
   },
 
@@ -168,8 +153,7 @@
     "description": "A boolean value which can be returned and used for filtering and aggregating",
     "filter_type": "boolean",
     "es_config": {
-      "type": "boolean",
-      "include_in_all": false
+      "type": "boolean"
     }
   },
 
@@ -177,8 +161,7 @@
     "description": "A date which can be returned and used for ordering, filtering and aggregating",
     "filter_type": "date",
     "es_config": {
-      "type": "date",
-      "include_in_all": false
+      "type": "date"
     }
   },
 
@@ -189,8 +172,7 @@
     "es_config": {
       "type": "object",
       "enabled": "true",
-      "dynamic": "strict",
-      "include_in_all": false
+      "dynamic": "strict"
     }
   },
 
@@ -199,8 +181,7 @@
     "children": "dynamic",
     "es_config": {
       "type": "object",
-      "enabled": "false",
-      "include_in_all": false
+      "enabled": "false"
     }
   }
 }

--- a/lib/schema/index_schema.rb
+++ b/lib/schema/index_schema.rb
@@ -18,6 +18,7 @@ class IndexSchema
     end
     mappings = {
       "generic-document" => {
+        "_all" => { "enabled" => false },
         "properties" => properties
       }
     }

--- a/spec/support/default_mappings.rb
+++ b/spec/support/default_mappings.rb
@@ -3,14 +3,13 @@ module Fixtures
     def default_mappings
       {
         "generic-document" => {
-          "_all" => { "enabled" => true },
           "properties" => {
             "title" => { "type" => "text", "index" => true },
             "description" => { "type" => "text", "index" => true },
-            "format" => { "type" => "keyword", "index" => true, "include_in_all" => false },
-            "link" => { "type" => "keyword", "index" => true, "include_in_all" => false },
+            "format" => { "type" => "keyword", "index" => true },
+            "link" => { "type" => "keyword", "index" => true },
             "indexable_content" => { "type" => "text", "index" => true },
-            "mainstream_browse_pages" => { "type" => "keyword", "index" => true, "include_in_all" => false },
+            "mainstream_browse_pages" => { "type" => "keyword", "index" => true },
           }
         }
       }
@@ -19,7 +18,6 @@ module Fixtures
     def page_traffic_mappings
       {
         "page-traffic" => {
-          "_all" => { "enabled" => false },
           "dynamic_templates" => [
             {
               "view_count" => {

--- a/spec/unit/schema/elasticsearch_types_parser_spec.rb
+++ b/spec/unit/schema/elasticsearch_types_parser_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ElasticsearchTypesParser do
     before do
       field_definitions = FieldDefinitionParser.new(schema_dir).parse
       @types = described_class.new(schema_dir, field_definitions).parse
-      @identifier_es_config = { "type" => "keyword", "index" => true, "include_in_all" => false }
+      @identifier_es_config = { "type" => "keyword", "index" => true }
     end
 
     it "recognise the `manual section` type" do

--- a/spec/unit/schema/index_schema_parser_spec.rb
+++ b/spec/unit/schema/index_schema_parser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe IndexSchemaParser do
       field_definitions = FieldDefinitionParser.new(schema_dir).parse
       elasticsearch_types = ElasticsearchTypesParser.new(schema_dir, field_definitions).parse
       @index_schemas = described_class.parse_all(schema_dir, field_definitions, elasticsearch_types)
-      @identifier_es_config = { "type" => "keyword", "index" => true, "include_in_all" => false }
+      @identifier_es_config = { "type" => "keyword", "index" => true }
     end
 
     it "have a schema for the govuk index" do


### PR DESCRIPTION
~This branches off #1553, and should be rebased after that is merged.~

---

We're not using the `_all` field at all, in fact the `all_searchable_text` and `spelling_text` fields are described as alternatives to `_all` that we do use.  We don't generate any queries for `_all` (outside of in a few of the tests), so remove the configuration.

---

[Trello card](https://trello.com/c/lSa4fDiJ/718-make-elasticsearch-index-schema-definitions-es6-compatible-%F0%9F%8D%90)