### PR TITLE
Use 'like' instead of 'docs' in more_like_this query

### DIFF
--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -124,7 +124,7 @@ module Search
 
       {
         more_like_this: {
-          docs: docs,
+          like: docs,
           min_doc_freq: 0, # Revert to the ES 1.7 default
         }
       }


### PR DESCRIPTION
The `docs` and `ids` parameters have been removed in ES6.  The `like` parameter is pretty flexible, and in particular can take a list of documents in multi-get style (pairs of IDs and indices), which is the same as `docs`.

- **ES5:** https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-mlt-query.html
- **ES6:** https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-mlt-query.html

This isn't enough to make the more like this tests pass with ES6, as they now fail due to `indices` queries which need rewriting.

---

[Trello card](https://trello.com/c/uTJ7qe7J/188-fix-broken-elasticsearch-morelikethis-queries-%F0%9F%8D%90)