### PR TITLE
Finders are published with the correct phase tag

### DIFF
--- a/lib/content_item_publisher/content_item_presenter.rb
+++ b/lib/content_item_publisher/content_item_presenter.rb
@@ -15,7 +15,7 @@ module ContentItemPublisher
         details: content_item["details"],
         document_type: content_item["document_type"],
         locale: "en",
-        phase: "live",
+        phase: content_item["phase"] || "live",
         public_updated_at: timestamp,
         publishing_app: "search-api",
         rendering_app: "finder-frontend",


### PR DESCRIPTION
At the moment, the phase tag is being reset to `live` when the finder config files are published by the rake task. This PR corrects that. 

Trello https://trello.com/c/GU9oNJot/722-add-beta-banner-to-search-research-and-statistics-s