### PR TITLE
Rewrite match quoted phrase queries

### DIFF
--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -53,10 +53,10 @@ module QueryComponents
       # individual fields
       [
         dis_max_query([
-          minimum_should_match_default_analyzer("title.no_stop", search_params.query, type: :phrase, boost: PHRASE_MATCH_TITLE_BOOST),
-          minimum_should_match_default_analyzer("acronym.no_stop", search_params.query, type: :phrase, boost: PHRASE_MATCH_ACRONYM_BOOST),
-          minimum_should_match_default_analyzer("description.no_stop", search_params.query, type: :phrase, boost: PHRASE_MATCH_DESCRIPTION_BOOST),
-          minimum_should_match_default_analyzer("indexable_content.no_stop", search_params.query, type: :phrase, boost: PHRASE_MATCH_INDEXABLE_CONTENT_BOOST)
+          match_phrase_default_analyzer("title.no_stop", search_params.query, PHRASE_MATCH_TITLE_BOOST),
+          match_phrase_default_analyzer("acronym.no_stop", search_params.query, PHRASE_MATCH_ACRONYM_BOOST),
+          match_phrase_default_analyzer("description.no_stop", search_params.query, PHRASE_MATCH_DESCRIPTION_BOOST),
+          match_phrase_default_analyzer("indexable_content.no_stop", search_params.query, PHRASE_MATCH_INDEXABLE_CONTENT_BOOST)
         ])
       ]
     end
@@ -131,20 +131,12 @@ module QueryComponents
       end
     end
 
-    # FIXME: this method is basically the same as #minimum_should_match, but
-    # doesn't override the analyzer.
-    # Boost is only used for quoted phrase queries.
-    # Minimum should match is only used for the optional id code query
-    # Operator doesn't seem to be used.
-    def minimum_should_match_default_analyzer(field_name, query, type: :boolean, boost: 1.0, minimum_should_match: MINIMUM_SHOULD_MATCH, operator: :or)
+    def match_phrase_default_analyzer(field_name, query, boost)
       {
-        match: {
+        match_phrase: {
           field_name => {
-            type: type,
             boost: boost,
             query: query,
-            minimum_should_match: minimum_should_match,
-            operator: operator,
           }
         }
       }


### PR DESCRIPTION
The `minimum_should_match_default_analyzer` method is only used in one
place, in constructing queries for quoted searches, and can be
simplified.

- The `type` field has been removed.  As this parameter is always
  `:phrase`, use `match_phrase` rather than `match`+`type`.

- The `operator` and `minimum_should_match` fields aren't used with
  `match_phrase` queries, so they can go away.

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html

---

[Trello card](https://trello.com/c/BwrHvyhP/778-fix-broken-elasticsearch-match-queries)