### PR TITLE
Replace `indices` query with `should` query

### DIFF
--- a/lib/legacy_client/index_for_search.rb
+++ b/lib/legacy_client/index_for_search.rb
@@ -13,6 +13,15 @@ module LegacyClient
       @search_config = search_config
     end
 
+    def real_index_names
+      index_names.map do |index_name|
+        # this may throw an exception if the index name isn't found,
+        # but we want to propagate the error in that case as it
+        # shouldn't happen.
+        @client.indices.get_alias(index: index_name).keys.first
+      end
+    end
+
     def raw_search(payload)
       logger.debug "Request payload: #{payload.to_json}"
       @client.search(index: @index_names, type: 'generic-document', body: payload)

--- a/spec/unit/legacy_client/index_for_search_spec.rb
+++ b/spec/unit/legacy_client/index_for_search_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe LegacyClient::IndexForSearch do
+  it "makes a request to elasticsearch for the alias name" do
+    base_uri = SearchConfig.instance.base_uri
+    alias_name = "some-alias"
+    real_name = "some-index"
+
+    get_request = stub_request(:get, "#{base_uri}/#{alias_name}/_alias")
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: {
+          real_name => { 'aliases' => {} }
+        }.to_json
+      )
+
+    index_for_search = described_class.new(base_uri, [alias_name], nil, nil)
+    real_names = index_for_search.real_index_names
+
+    assert_requested(get_request)
+    expect(real_names).to eq([real_name])
+  end
+end

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -1,16 +1,31 @@
 require 'spec_helper'
 
 RSpec.describe Search::FormatMigrator do
+  # rubocop:disable RSpec/AnyInstance
+  before do
+    allow_any_instance_of(LegacyClient::IndexForSearch).to receive(:real_index_names).and_return(%w(govuk_test))
+  end
+  # rubocop:enable RSpec/AnyInstance
+
   it "when base query without migrated formats" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
     base_query = { filter: 'component' }
     expected = {
-      indices: {
-        indices: %w(government_test),
-        query: {
-          bool: { must: base_query }
-        },
-        no_match_query: 'none'
+      bool: {
+        minimum_should_match: 1,
+        should: [
+          {
+            bool: {
+              must: base_query,
+              must_not: { terms: { _index: %w(govuk_test) } }
+            }
+          },
+          {
+            bool: {
+              must_not: { match_all: {} }
+            }
+          }
+        ]
       }
     }
     expect(described_class.new(base_query).call).to eq(expected)
@@ -20,19 +35,28 @@ RSpec.describe Search::FormatMigrator do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
     base_query = { filter: 'component' }
     expected = {
-      indices: {
-        indices: %w(government_test),
-        query: {
-          bool: {
-            must: base_query,
-            must_not: { terms: { format: %w[help_page] } },
+      bool: {
+        minimum_should_match: 1,
+        should: [
+          {
+            bool: {
+              must: base_query,
+              must_not: [
+                { terms: { _index: %w(govuk_test) } },
+                { terms: { format: %w(help_page) } }
+              ]
+            }
+          },
+          {
+            bool: {
+              must: [
+                base_query,
+                { terms: { _index: %w(govuk_test) } },
+                { terms: { format: %w(help_page) } }
+              ]
+            }
           }
-        },
-        no_match_query: {
-          bool: {
-            must: [base_query, { terms: { format: %w[help_page] } }],
-          }
-        }
+        ]
       }
     }
     expect(described_class.new(base_query).call).to eq(expected)
@@ -41,10 +65,17 @@ RSpec.describe Search::FormatMigrator do
   it "when no base query without migrated formats" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
     expected = {
-      indices: {
-        indices: %w(government_test),
-        query: { bool: { must: { match_all: {} } } },
-        no_match_query: 'none'
+      bool: {
+        minimum_should_match: 1,
+        should: [
+          {
+            bool: {
+              must: { match_all: {} },
+              must_not: { terms: { _index: %w(govuk_test) } }
+            }
+          },
+          { bool: { must_not: { match_all: {} } } }
+        ]
       }
     }
     expect(described_class.new(nil).call).to eq(expected)
@@ -53,18 +84,28 @@ RSpec.describe Search::FormatMigrator do
   it "when no base query with migrated formats" do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
     expected = {
-      indices: {
-        indices: %w(government_test),
-        query: {
-          bool: {
-            must_not: { terms: { format: %w[help_page] } },
+      bool:
+      { minimum_should_match: 1,
+        should: [
+          {
+            bool: {
+              must: { match_all: {} },
+              must_not: [
+                { terms: { _index: %w(govuk_test) } },
+                { terms: { format: %w(help_page) } }
+              ]
+            }
+          },
+          {
+            bool: {
+              must: [
+                { match_all: {} },
+                { terms: { _index: %w(govuk_test) } },
+                { terms: { format: %w(help_page) } }
+              ]
+            }
           }
-        },
-        no_match_query: {
-          bool: {
-            must: { terms: { format: %w[help_page] } },
-          }
-        }
+        ]
       }
     }
     expect(described_class.new(nil).call).to eq(expected)

--- a/spec/unit/search/query_builder_spec.rb
+++ b/spec/unit/search/query_builder_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe Search::QueryBuilder do
+  # rubocop:disable RSpec/AnyInstance
   before do
+    allow_any_instance_of(LegacyClient::IndexForSearch).to receive(:real_index_names).and_return(%w(govuk_test))
     allow_any_instance_of(Search::BestBetsChecker).to receive(:best_bets).and_return([])
     allow_any_instance_of(Search::BestBetsChecker).to receive(:worst_bets).and_return([])
   end
+  # rubocop:enable RSpec/AnyInstance
 
   context "with a simple search query" do
     it "return a correct query object" do

--- a/spec/unit/sitemap/sitemap_generator_spec.rb
+++ b/spec/unit/sitemap/sitemap_generator_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator do
+  # rubocop:disable RSpec/AnyInstance
+  before do
+    allow_any_instance_of(LegacyClient::IndexForSearch).to receive(:real_index_names).and_return(%w(govuk_test))
+  end
+  # rubocop:enable RSpec/AnyInstance
+
   it "should generate sitemap" do
     sitemap = described_class.new(index_names: '')
 


### PR DESCRIPTION
The format migrator prevents users from getting duplicate results when
formats are migrated into the "govuk" index from the "government" or
"detailed" ones: it ensures that only non-migrated formats are
returned from the "government"/"detailed" indices and only migrated
formats are returned from the "govuk" index.

Previously it did this with an `indices` query.  They look like
this:

    { indices:
      { indices: ["list", "of", "indices"]
      , query: { query to perform against docs from the indices }
      , no_match_query: { query to perform against other docs }
      }
    }

However, the `indices` query has been deprecated in ES5 and removed in
ES6, in favour of just searching over the `_index` field in docs
directly.

This PR changes the `indices` query into a `should` with two clauses
where one clause matches documents in the "govuk" index and the other
clause matches documents in the other indices.  It's a bit more
cumbersome because the `terms` query I'm using [doesn't handle index
aliases](https://github.com/elastic/elasticsearch/issues/23306), and involves another round-trip to elasticsearch when
constructing the query to find out the real name of the "govuk" alias.

Index real names only change very infrequently (whenever we reindex
the cluster), so in principle they could be cached.  But we don't
currently have a good way for the reindexing rake task to signal to
the web processes that they need to purge their cache.

---

[Trello card](https://trello.com/c/iHfzqX4K/715-rewrite-deprecated-elasticsearch-indices-queries-%F0%9F%8D%90)