### PR TITLE
Update url for Official Documents Finder

### DIFF
--- a/config/finders/official_documents_finder.yml
+++ b/config/finders/official_documents_finder.yml
@@ -1,5 +1,5 @@
 ---
-base_path: "/search/official-documents"
+base_path: "/official-documents"
 content_id: e96a1b16-a011-4dc6-9f6a-a54561c4db90
 description: Find official documents from government
 document_type: finder


### PR DESCRIPTION
Following convention of other specialist finders, the new official docs finder url is `/official-documents`

Following this change I will run rake `publishing_api:publish_supergroup_finders`

Ref [Trello](https://trello.com/c/6xFJqfAw/724-spin-up-finder-for-content-that-has-official-doc-status-s)