### PR TITLE
Count search requests over the standard endpoint

### DIFF
--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -17,6 +17,7 @@ module Search
 
     # Search and combine the indices and return a hash of ResultSet objects
     def run(search_params)
+      log_search
       builder_payload = timed_build_query(search_params)
       builder = builder_payload[:builder]
       payload = builder_payload[:payload]
@@ -114,6 +115,10 @@ module Search
       response = spelling_index.raw_search(query)
 
       response['suggest']
+    end
+
+    def log_search
+      GovukStatsd.increment "search_query"
     end
   end
 end


### PR DESCRIPTION
We already [count the number of searches using batch queries](https://github.com/alphagov/search-api/blob/299fa6c5e3e35fa7d1d9335514539a3ece8c0f64/lib/search/batch_query.rb#L39) (currently nil!) but it's nice to be able to see the number of searches using the standard endpoint too.  We've just switched back to using the standard search endpoint where we can, but this has shown up a gap in the monitoring.

Counting requests has allowed us to identify slow running machines in the past because they've not been able to process as many.

(For example in this dashboard which notes the activity of finder-frontend and search-api https://grafana.production.govuk.digital/dashboard/db/search-requests-and-errors?panelId=3&fullscreen&orgId=1)

<img width="1016" alt="Screenshot 2019-06-06 14 52 16" src="https://user-images.githubusercontent.com/773037/59038380-dbf9c180-886a-11e9-88f5-0d11eb0c38de.png">
