### PR TITLE
Add /search/all.atom route

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -80,5 +80,7 @@ details:
 routes:
 - path: "/search/all"
   type: exact
+- path: "/search/all.atom"
+  type: exact
 - path: "/search/all.json"
   type: exact


### PR DESCRIPTION
I checked the other finders and they all have a feed route already.

---

[Trello card](https://trello.com/c/kd6iAV1I/794-allow-atom-feeds-on-the-all-content-finder-s)