### PR TITLE
Change the *_index.docs.count metric name

### DIFF
--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -183,8 +183,8 @@ You should run this task if the index schema has changed.
         docs = stats["_all"]["primaries"]["docs"]
 
         count = docs["count"]
-        statsd.gauge("#{index}_index.docs.count", count)
-        puts "#{index}_index.docs.count=#{count}"
+        statsd.gauge("#{index}_index.docs.total", count)
+        puts "#{index}_index.docs.total=#{count}"
 
         deleted = docs["deleted"]
         statsd.gauge("#{index}_index.docs.deleted", deleted)


### PR DESCRIPTION
Metrics ending in `.count` are usually used for timers in StatsD, and
there is some specific Graphite storage aggregation configuration for
them [1].

Sum isn't the correct aggregation method for these counts, and the
xFilesFactor needs to be lower to allow keeping the data for longer
than 8 days, so just change the metric name so that it's treated like
other gauges.

1: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/files/node/s_graphite/storage-aggregation.conf#L35-L40
```
[count]
pattern = \.count$
aggregationMethod = sum
xFilesFactor = 0.1
```