### PR TITLE
Add accessibility statement as corporate information page type

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -354,6 +354,7 @@ non_indexable:
 # whitehall formats
 - about
 - about_our_services
+- accessibility_statement
 - access_and_opening
 - authored_article
 - case_study


### PR DESCRIPTION
<img width="793" alt="Screen Shot 2019-06-11 at 12 49 03" src="https://user-images.githubusercontent.com/109225/59271100-08d31d80-8c4b-11e9-990f-0e30bc58f1b9.png">
<img width="1134" alt="Screen Shot 2019-06-11 at 12 50 27" src="https://user-images.githubusercontent.com/109225/59271101-08d31d80-8c4b-11e9-8579-b696b7481e45.png">
<img width="1165" alt="Screen Shot 2019-06-11 at 13 05 28" src="https://user-images.githubusercontent.com/109225/59271102-096bb400-8c4b-11e9-83db-ede2afbe5396.png">
<img width="1021" alt="Screen Shot 2019-06-11 at 13 06 18" src="https://user-images.githubusercontent.com/109225/59271103-096bb400-8c4b-11e9-8705-232b5c73a7bc.png">
<img width="943" alt="Screen Shot 2019-06-11 at 13 13 15" src="https://user-images.githubusercontent.com/109225/59271104-096bb400-8c4b-11e9-9a08-b3f786d3828e.png">

https://trello.com/c/Wb01UcFK/1046-add-accessibility-statement-to-list-of-corporate-information-for-organisations-whitehall-publisher