### PR TITLE
Healthcheck all clusters

### DIFF
--- a/spec/integration/app/healthcheck_spec.rb
+++ b/spec/integration/app/healthcheck_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'HealthcheckTest' do
     context "when elasticsearch CANNOT be connected to" do
       before do
         # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Elasticsearch::API::Cluster::ClusterClient).to receive(:health).and_raise(Faraday::ConnectionFailed)
+        allow_any_instance_of(Elasticsearch::API::Cluster::ClusterClient).to receive(:health).and_raise(Faraday::Error)
         # rubocop:enable RSpec/AnyInstance
       end
 


### PR DESCRIPTION
Now search-api talks to multiple clusters, this will ensure that we healthcheck the connectivity to all clusters, not just the default one.

Trello: https://trello.com/c/SF4gxCrs/797-healthcheck-for-elasticsearch6-connectivity-s