### PR TITLE
Allow per-cluster search config and use new text similarity for es6

### DIFF
--- a/config/schema/elasticsearch_schema_b.yml
+++ b/config/schema/elasticsearch_schema_b.yml
@@ -1,0 +1,115 @@
+index:
+  settings:
+    mapping:
+      total_fields:
+        limit: 2000
+    analysis:
+      analyzer:
+        # At index time, elasticsearch will use an analyzer named default in the index settings
+        # if no analyzer is specified in the field mapping:
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/analyzer.html
+        #
+        # We don't need this at query time unless synonyms are disabled
+        # using a debug flag.
+        default:
+          type: custom
+          tokenizer: standard
+          filter: [standard, asciifolding, lowercase, stop, stemmer_override, stemmer_english]
+          char_filter: [normalize_quotes, strip_quotes]
+
+        # This analyzer does not filter out these stopwords:
+        # a, an, and, are, as, at, be, but, by,
+        # for, if, in, into, is, it,
+        # no, not, of, on, or, such,
+        # that, the, their, then, there, these,
+        # they, this, to, was, will, with
+        searchable_text:
+          type: custom
+          tokenizer: standard
+          filter: [standard, asciifolding, lowercase, stemmer_override, stemmer_english]
+          char_filter: [normalize_quotes, strip_quotes]
+
+        # Analyzer used at index time for the .synonym variants of searchable
+        # text fields.
+        with_index_synonyms:
+          type: custom
+          tokenizer: standard
+          filter: [standard, asciifolding, lowercase, index_synonym, stop, stemmer_override, stemmer_english]
+          char_filter: [normalize_quotes, strip_quotes]
+
+        # Analyzer used at search time for the .synonym variants of searchable
+        # text fields.
+        with_search_synonyms:
+          type: custom
+          tokenizer: standard
+          filter: [standard, asciifolding, lowercase, search_synonym, stop, stemmer_override, stemmer_english]
+          char_filter: [normalize_quotes, strip_quotes]
+
+        # An analyzer for doing "exact" word matching (but stripping wrapping whitespace, and case insensitive).
+        exact_match:
+          type: custom
+          tokenizer: keyword
+          filter: [asciifolding, trim, lowercase]
+          char_filter: [normalize_quotes]
+
+        # An analyzer for doing stemmed word matching for best bets.
+        best_bet_stemmed_match:
+          type: custom
+          tokenizer: standard
+          filter: [standard, asciifolding, lowercase, stemmer_override, stemmer_english]
+          char_filter: [normalize_quotes, strip_quotes]
+
+        # Analyzer used to process text supplied to the field for use in spelling correction.
+        spelling_analyzer:
+          type: custom
+          tokenizer: standard
+          filter: [standard, asciifolding, lowercase, shingle]
+          char_filter: [normalize_quotes, strip_quotes]
+
+        # Analyzer used to process text fields for use for sorting.
+        string_for_sorting:
+          type: custom
+          tokenizer: keyword
+          filter: [trim, lowercase]
+          char_filter: [normalize_quotes, strip_quotes]
+
+      tokenizer:
+
+      char_filter:
+        strip_quotes:
+          type: "pattern_replace"
+          pattern: "'"
+          replacement: ""
+
+        normalize_quotes:
+          type: "mapping"
+          mappings:
+            - "\u0091=>\u0027"
+            - "\u0092=>\u0027"
+            - "\u2018=>\u0027"
+            - "\u2019=>\u0027"
+            - "\uFF07=>\u0027"
+
+      filter:
+        stemmer_english:
+          type: stemmer
+          name: porter2
+    # The following settings were in puppet, but now index config
+    # can't be applied from the nodes, so they have to live here.
+    # This means that we can no longer (easily) have ci-agents or the
+    # dev VM use no replicas.
+    number_of_replicas: 1
+    number_of_shards: 3
+    refresh_interval: '1s'
+    search:
+      slowlog:
+        threshold:
+          query:
+            warn: '5s'
+            info: '2s'
+            debug: '1s'
+          fetch:
+            warn: '1s'
+            info: '800ms'
+            debug: '500ms'
+    max_result_window: 1000000

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -17,6 +17,7 @@ production: &default
       default: true
     - uri_key: base_uri_b
       key: B
+      schema_config_file: elasticsearch_schema_b.yml
       default: false
 
 development:
@@ -40,4 +41,5 @@ test:
       default: true
     - uri_key: base_uri_b
       key: B
+      schema_config_file: elasticsearch_schema_b.yml
       default: false

--- a/lib/clusters/cluster.rb
+++ b/lib/clusters/cluster.rb
@@ -1,10 +1,11 @@
 module Clusters
   class Cluster
-    attr_reader :key, :default
+    attr_reader :key, :schema_config_file, :default
 
-    def initialize(key:, uri_key:, default: false)
+    def initialize(key:, uri_key:, schema_config_file: 'elasticsearch_schema.yml', default: false)
       @key = key
       @uri_key = uri_key
+      @schema_config_file = schema_config_file
       @default = default
     end
 

--- a/lib/schema/schema_config.rb
+++ b/lib/schema/schema_config.rb
@@ -2,8 +2,9 @@
 class SchemaConfig
   attr_reader :field_definitions
 
-  def initialize(config_path)
+  def initialize(config_path, schema_config_file: 'elasticsearch_schema.yml')
     @config_path = config_path
+    @schema_config_file = schema_config_file
     @field_definitions = FieldDefinitionParser.new(config_path).parse
     @elasticsearch_types = ElasticsearchTypesParser.new(config_path, @field_definitions).parse
     @index_schemas = IndexSchemaParser.parse_all(config_path, @field_definitions, @elasticsearch_types)
@@ -35,14 +36,14 @@ class SchemaConfig
 
 private
 
-  attr_reader :config_path
+  attr_reader :config_path, :schema_config_file
 
   def synonym_config
     YAML.load_file(File.join(config_path, "synonyms.yml"))
   end
 
   def schema_yaml
-    load_yaml("elasticsearch_schema.yml")
+    load_yaml(schema_config_file)
   end
 
   def elasticsearch_index


### PR DESCRIPTION
```
$ ELASTICSEARCH_A_URI='http://localhost:9200' ELASTICSEARCH_B_URI='http://localhost:9201' bundle exec rake search:create_all_indices SEARCH_INDEX=all
...
$ curl localhost:9200/govuk/_settings 2>/dev/null | json_pp | grep -C5 similarity
               "total_fields" : {
                  "limit" : "2000"
               }
            },
            "number_of_replicas" : "1",
            "similarity" : {
               "default" : {
                  "type" : "classic"
               }
            },
            "number_of_shards" : "3"
$ curl localhost:9201/govuk/_settings 2>/dev/null | json_pp | grep -C5 similarity
$
```

---

[Trello card](https://trello.com/c/MX1MtsEf/717-switch-to-new-elasticsearch-text-similarity-metric-%F0%9F%8D%90-l)