### PR TITLE
Rename Burma to Myanmar

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -95,7 +95,6 @@ migrated:
   - /world/brunei
   - /world/bulgaria
   - /world/burkina-faso
-  - /world/burma
   - /world/burundi
   - /world/cambodia
   - /world/cameroon
@@ -199,6 +198,7 @@ migrated:
   - /world/montserrat
   - /world/morocco
   - /world/mozambique
+  - /world/myanmar
   - /world/namibia
   - /world/nauru
   - /world/nepal


### PR DESCRIPTION
[Burma is now going to be referred to officially as Myanmar.](https://trello.com/c/8Y2fbezn/1066-country-name-change-burma-myanmar)