### PR TITLE
Remove CONFIRM_INDEX_MIGRATION_START

### DIFF
--- a/doc/adding-new-fields.md
+++ b/doc/adding-new-fields.md
@@ -49,4 +49,4 @@ For the new elasticsearch configuration to take effect, you need to manually reb
 
 In the past, this was done automatically every night by the [`search_fetch_analytics`](https://github.com/alphagov/search-analytics) jenkins job, but this automation [was reverted](https://github.com/alphagov/search-analytics/commit/a5c3ac58f7198eba74ab7b5bd5555aa07490442a#diff-0484c7ea1cf547a292a2190d0c1c060b). You must run this manually.
 
-If you prefer running a rake task rather than a pre-written Jenkins job, you can run `SEARCH_INDEX=all CONFIRM_INDEX_MIGRATION_START=1 search:migrate_schema`.
+If you prefer running a rake task rather than a pre-written Jenkins job, you can run `SEARCH_INDEX=all search:migrate_schema`.

--- a/doc/popularity.md
+++ b/doc/popularity.md
@@ -22,4 +22,4 @@ is run after populating the page-traffic index. As part of the migration, the
 popularity for each document will be computed from the page-traffic index and
 merged into the documents. To do this, run:
 
-    SEARCH_INDEX=all CONFIRM_INDEX_MIRATION_START=1 bundle exec rake search:migrate_schema
+    SEARCH_INDEX=all bundle exec rake search:migrate_schema

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -118,8 +118,6 @@ Specify a list of clusters `migrate_schema['A B C']` if you like, otherwise
 this task will run against all active clusters.
 "
   task :migrate_schema, [:clusters] do |_, args|
-    raise('Please set `CONFIRM_INDEX_MIGRATION_START` to run this task') unless ENV['CONFIRM_INDEX_MIGRATION_START']
-
     clusters_from_args(args).each do |cluster|
       puts "Migrating schema on cluster #{cluster.key}"
       failed_indices = []


### PR DESCRIPTION
This doesn't actually add any safety because the jenkins job which
invokes this task does it automatically - it just adds an extra step
for people invoking `rake` directly.