### PR TITLE
Reorder 'Digital, technology and computer services' alphabetically

### DIFF
--- a/config/find-eu-exit-guidance-business-email-signup.yml
+++ b/config/find-eu-exit-guidance-business-email-signup.yml
@@ -70,11 +70,6 @@ details:
       radio_button_name: Clothing and consumer goods manufacture
       topic_name: Clothing and consumer goods manufacture
       prechecked: false
-    - key: computer-services
-      content_id: 70e6087f-714e-4922-8e06-72cfff997785
-      radio_button_name: Digital, technology and computer services
-      topic_name: Digital, technology and computer services
-      prechecked: false
     - key: construction-contracting
       content_id: 9eb88205-118b-4f0b-abd9-ac6b469054c5
       radio_button_name: Construction
@@ -89,6 +84,11 @@ details:
       content_id: 77764805-73e6-4d47-9f20-aedd6de7dab9
       radio_button_name: Defence
       topic_name: Defence
+      prechecked: false
+    - key: computer-services
+      content_id: 70e6087f-714e-4922-8e06-72cfff997785
+      radio_button_name: Digital, technology and computer services
+      topic_name: Digital, technology and computer services
       prechecked: false
     - key: education
       content_id: 7c980b5d-a7ea-4d6e-aad1-e80e882566c4

--- a/spec/unit/indexer/fixtures/facet_config.yml
+++ b/spec/unit/indexer/fixtures/facet_config.yml
@@ -28,12 +28,12 @@ details:
       value: clothing-consumer-goods-manufacturing
     - label: Construction
       value: construction-contracting
-    - label: Digital, technology and computer services
-      value: computer-services
     - label: Creative industries
       value: creative-industries
     - label: Defence
       value: defence
+    - label: Digital, technology and computer services
+      value: computer-services
     - label: Education
       value: education
     - label: Electricity


### PR DESCRIPTION
Dependent on https://github.com/alphagov/content-tagger/pull/939.

Previous value was 'Computer services', so current position in the YAML files
would have been in alphabetical order. But following a review, this was renamed in
https://github.com/alphagov/search-api/commit/85500cce7e60d9de7cff28ea74c239dedd0c5b87 and should no longer appear in alphabetical order.

| Before | After |
|-------|-------|
|![in wrong order](https://user-images.githubusercontent.com/5111927/59666416-b646b380-91ac-11e9-87e3-0b3b3bf8a977.png)|![in right order](https://user-images.githubusercontent.com/5111927/59670273-96ff5480-91b3-11e9-838f-2a326c274aef.png)|

Trello card: https://trello.com/c/PADPKr9M