### PR TITLE
Remove combine_mode from business finder email signup

### DIFF
--- a/config/find-eu-exit-guidance-business-email-signup.yml
+++ b/config/find-eu-exit-guidance-business-email-signup.yml
@@ -9,7 +9,6 @@ schema_name: finder_email_signup
 title: Find EU Exit guidance for your business
 description: You'll get an email each time EU Exit guidance is published.
 details:
-  combine_mode: or
   email_filter_by: facet_values
   email_filter_facets:
   - facet_id: sector_business_area


### PR DESCRIPTION
The `combine_mode` value was added to enable the use of the OrJoinedFacetSubscriberList model when signing up to business finder email alerts.  This model has been removed, so the toggle parameter is no longer needed, since we can identify this type of finder using the `email_filter_by` value.

Trello card: https://trello.com/c/udPtHvz2/158-remove-orjoinedfacetsubscriberlist-from-email-alert-api