### PR TITLE
Load page traffic into all active clusters

### DIFF
--- a/lib/govuk_index/page_traffic_loader.rb
+++ b/lib/govuk_index/page_traffic_loader.rb
@@ -7,28 +7,30 @@ module GovukIndex
     end
 
     def load_from(iostream)
-      new_index = index_group.create_index
-      @logger.info "Created index #{new_index.real_name}"
+      Clusters.active.each do |cluster|
+        new_index = index_group(cluster).create_index
+        @logger.info "Created index #{new_index.real_name}"
 
-      old_index = index_group.current_real
-      @logger.info "Old index #{old_index.real_name}"
+        old_index = index_group(cluster).current_real
+        @logger.info "Old index #{old_index.real_name}"
 
-      old_index.with_lock do
-        @logger.info "Indexing to #{new_index.real_name}"
+        old_index.with_lock do
+          @logger.info "Indexing to #{new_index.real_name}"
 
-        in_even_sized_batches(iostream) do |lines|
-          GovukIndex::PageTrafficWorker.perform_async(lines, new_index.real_name)
+          in_even_sized_batches(iostream) do |lines|
+            GovukIndex::PageTrafficWorker.perform_async(lines, new_index.real_name, cluster.key)
+          end
+
+          GovukIndex::PageTrafficWorker.wait_until_processed
+          new_index.commit
         end
 
-        GovukIndex::PageTrafficWorker.wait_until_processed
-        new_index.commit
+        # We need to switch the aliases without a lock, since
+        # read_only_allow_delete prevents aliases being changed
+        # The page traffic loader is is a daily process, so there
+        # won't be a race condition
+        index_group(cluster).switch_to(new_index)
       end
-
-      # We need to switch the aliases without a lock, since
-      # read_only_allow_delete prevents aliases being changed
-      # The page traffic loader is is a daily process, so there
-      # won't be a race condition
-      index_group.switch_to(new_index)
     end
 
   private
@@ -40,10 +42,12 @@ module GovukIndex
       iostream.each_line.each_slice(batch_size * 2) do |batch|
         yield(batch.map { |b| JSON.parse(b) })
       end
+      iostream.pos = 0 # ensures we start at the beginning on next read.
     end
 
-    def index_group
-      @index_group ||= SearchConfig.instance.search_server.index_group(
+    def index_group(cluster)
+      @index_group ||= {}
+      @index_group[cluster.key] ||= SearchConfig.instance.search_server(cluster: cluster).index_group(
         SearchConfig.instance.page_traffic_index_name
       )
     end

--- a/lib/index/client.rb
+++ b/lib/index/client.rb
@@ -12,6 +12,7 @@ module Index
 
     def initialize(options = {})
       @_index = options.delete(:index_name)
+      @clusters = options.delete(:clusters) || Clusters.active
       @_options = options
     end
 
@@ -22,7 +23,7 @@ module Index
     end
 
     def bulk(params)
-      Clusters.active.map do |cluster|
+      clusters.map do |cluster|
         client(cluster: cluster).bulk(
           params.merge(index: index_name)
         )
@@ -30,6 +31,8 @@ module Index
     end
 
   private
+
+    attr_reader :clusters
 
     def client(cluster: Clusters.default_cluster)
       @_client ||= {}

--- a/spec/integration/govuk_index/page_traffic_loader_spec.rb
+++ b/spec/integration/govuk_index/page_traffic_loader_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe 'Loading page traffic data' do
     GovukIndex::PageTrafficLoader.new
       .load_from(StringIO.new(data))
 
-    document = fetch_document_from_rummager(id: id, index: 'page-traffic_test')
+    Clusters.active.each do |cluster|
+      document = fetch_document_from_rummager(id: id, index: 'page-traffic_test', cluster: cluster)
 
-    expect(document["_source"]["document_type"]).to eq('page_traffic')
-    expect(document['_source']['rank_14']).to eq(100)
+      expect(document["_source"]["document_type"]).to eq('page_traffic')
+      expect(document['_source']['rank_14']).to eq(100)
+    end
   end
 end

--- a/spec/unit/govuk_index/page_traffic_loader_spec.rb
+++ b/spec/unit/govuk_index/page_traffic_loader_spec.rb
@@ -20,10 +20,13 @@ RSpec.describe GovukIndex::PageTrafficLoader do
     line2 = [{ "val" => "c" }, { "data" => 1 }, { "val" => "d" }, { "data" => 1 }]
     line3 = [{ "val" => "e" }, { "data" => 1 }]
 
-    expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line1, 'new_index_name')
-    expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line2, 'new_index_name')
-    expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line3, 'new_index_name')
-
+    Clusters.active.each do |cluster|
+      # rubocop:disable RSpec/MessageSpies
+      expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line1, 'new_index_name', cluster.key)
+      expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line2, 'new_index_name', cluster.key)
+      expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line3, 'new_index_name', cluster.key)
+      # rubocop:enable RSpec/MessageSpies
+    end
     loader = GovukIndex::PageTrafficLoader.new(iostream_batch_size: 2)
 
     loader.load_from(input)


### PR DESCRIPTION
This loads page traffic data into all indexes, not just the primary one.

Just wraps the calls in a `Clusters.active.each do |cluster|`. It'll probably take twice as long, but the strain on the indexes should be the same.

There's possibly better ways to do this (e.g. copying from one index to another?). But this is consistent with the way data enters into all clusters elsewhere in search-api.

One thing that might be nice is to create a worker for each cluster.

https://trello.com/c/15tBcoJJ/809-get-es6-page-traffic-sync-working