### PR TITLE
Remove and_facet_values

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -10,7 +10,6 @@
     "email_document_supertype",
     "facet_groups",
     "facet_values",
-    "and_facet_values",
     "format",
     "government_document_supertype",
     "indexable_content",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -164,11 +164,6 @@
       "type": "identifiers"
   },
 
-  "and_facet_values": {
-      "description": "Facet values associated the the documents. Copy to allow for AND filters",
-      "type": "identifiers"
-  },
-
   "updated_at": {
     "description": "When the page was last updated. This field is unreliable and may be deprecated in a future version.",
     "type": "date"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -16,7 +16,6 @@ module GovukIndex
         aircraft_category:                   specialist.aircraft_category,
         aircraft_type:                       specialist.aircraft_type,
         alert_type:                          specialist.alert_type,
-        and_facet_values:                    expanded_links.facet_values,
         assessment_date:                     specialist.assessment_date,
         business_sizes:                      specialist.business_sizes,
         business_stages:                     specialist.business_stages,

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -143,7 +143,6 @@ module Indexer
         'organisation_content_ids' => content_ids_for(links, 'organisations'),
         'facet_groups' => content_ids_for(links, 'facet_groups'),
         'facet_values' => content_ids_for(links, 'facet_values'),
-        'and_facet_values' => content_ids_for(links, 'facet_values'),
         'part_of_taxonomy_tree' => parts_of_taxonomy_for_all_taxons(links)
       }
     end

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe 'TaglookupDuringIndexingTest' do
         "mainstream_browse_page_content_ids" => ["BROWSE-1"],
         "organisation_content_ids" => ["ORG-1", "ORG-2"],
         "facet_groups" => ["TGRP-1", "TGRP-2"],
-        "facet_values" => ["TAG-1", "TAG-2"],
-        "and_facet_values" => ["TAG-1", "TAG-2"]
+        "facet_values" => ["TAG-1", "TAG-2"]
       },
       index: "government_test",
     )

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -598,31 +598,6 @@ RSpec.describe 'SearchTest' do
     })
   end
 
-  it "can perform AND filter across facet values" do
-    commit_ministry_of_magic_document({
-      "facet_values" => ['fe2fc3b5-a71b-4063-9605-12c3e6e179d6', '40c0f604-9388-4dd8-b114-3f2ffbe16cce'],
-      "and_facet_values" => ['fe2fc3b5-a71b-4063-9605-12c3e6e179d6', '40c0f604-9388-4dd8-b114-3f2ffbe16cce']
-    })
-    commit_treatment_of_dragons_document({ "facet_values" => ['e602eb34-a870-46ff-8ba4-de36689fb028'] })
-    get "/search?filter_facet_values=fe2fc3b5-a71b-4063-9605-12c3e6e179d6&filter_and_facet_values=69c7ec42-fe51-4af0-93c3-c3ef7f93860d"
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(0)
-    get "/search?filter_facet_values=248f13e2-c93d-4232-b44b-33cfe05b57e8&filter_and_facet_values=640c0f604-9388-4dd8-b114-3f2ffbe16cce"
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(0)
-    get "/search?filter_facet_values=fe2fc3b5-a71b-4063-9605-12c3e6e179d6&filter_and_facet_values=40c0f604-9388-4dd8-b114-3f2ffbe16cce"
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
-    expect_result_includes_ministry_of_magic_for_key(parsed_response, "results", {
-      "_id" => "/ministry-of-magic-site",
-      "document_type" => "edition",
-      "elasticsearch_type" => "edition",
-      "es_score" => nil,
-      "index" => "government_test",
-      "link" => "/ministry-of-magic-site"
-    })
-  end
-
   it "can filter by facet group" do
     commit_ministry_of_magic_document({ "facet_groups" => ['fe2fc3b5-a71b-4063-9605-12c3e6e179d6'] })
     commit_treatment_of_dragons_document({ "facet_groups" => ['e602eb34-a870-46ff-8ba4-de36689fb028'] })

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -137,12 +137,6 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
         facet_values: ["4577e252-45c3-4c91-a040-c9f8568d0150", "5e326667-0d05-4453-b3a0-a1c6e797171e"]
       )
     end
-
-    it 'returns and_facet_values' do
-      expect(presenter.document).to include(
-        and_facet_values: ["4577e252-45c3-4c91-a040-c9f8568d0150", "5e326667-0d05-4453-b3a0-a1c6e797171e"]
-      )
-    end
   end
 
   def elasticsearch_presenter(payload, type = "aaib_report")


### PR DESCRIPTION
Now that the EU Exit Business Readiness finder only has OR logic between all facets, the `and_facet_values` isn't needed any more (this was used to create the AND logic between the first two facets).

Trello card: https://trello.com/c/Xnxtwdnx