### PR TITLE
Add 'topic' as a hidden parameter.

### DIFF
--- a/config/finders/guidance_and_regulation_finder.yml
+++ b/config/finders/guidance_and_regulation_finder.yml
@@ -38,6 +38,14 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
+  - key: topic
+    filter_key: all_part_of_taxonomy_tree
+    name: topic
+    short_name: topic
+    type: hidden
+    display_as_result_metadata: false
+    hide_facet_tag: true
+    filterable: true
   - key: organisations
     name: Organisation
     short_name: From

--- a/config/finders/news_and_communications_finder.yml
+++ b/config/finders/news_and_communications_finder.yml
@@ -48,6 +48,14 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
+  - key: topic
+    filter_key: all_part_of_taxonomy_tree
+    name: topic
+    short_name: topic
+    type: hidden
+    display_as_result_metadata: false
+    hide_facet_tag: true
+    filterable: true
   - key: organisations
     name: Organisation
     short_name: From

--- a/config/finders/policy_and_engagement_finder.yml
+++ b/config/finders/policy_and_engagement_finder.yml
@@ -38,6 +38,14 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
+  - key: topic
+    filter_key: all_part_of_taxonomy_tree
+    name: topic
+    short_name: topic
+    type: hidden
+    display_as_result_metadata: false
+    hide_facet_tag: true
+    filterable: true
   - key: content_store_document_type
     name: Document type
     preposition: of type

--- a/config/finders/services_finder.yml
+++ b/config/finders/services_finder.yml
@@ -17,6 +17,14 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
+  - key: topic
+    filter_key: all_part_of_taxonomy_tree
+    name: topic
+    short_name: topic
+    type: hidden
+    display_as_result_metadata: false
+    hide_facet_tag: true
+    filterable: true
   - display_as_result_metadata: true
     filterable: true
     key: organisations

--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -70,6 +70,14 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
+  - key: topic
+    filter_key: all_part_of_taxonomy_tree
+    name: topic
+    short_name: topic
+    type: hidden
+    display_as_result_metadata: false
+    hide_facet_tag: true
+    filterable: true
   - key: content_store_document_type
     name: Statistics
     type: research_and_statistics

--- a/config/finders/transparency_finder.yml
+++ b/config/finders/transparency_finder.yml
@@ -18,6 +18,14 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
+  - key: topic
+    filter_key: all_part_of_taxonomy_tree
+    name: topic
+    short_name: topic
+    type: hidden
+    display_as_result_metadata: false
+    hide_facet_tag: true
+    filterable: true
   - display_as_result_metadata: true
     filterable: true
     key: organisations


### PR DESCRIPTION
Topic refers to a taxon's content_id and filters the the finder accordingly.

Trello: https://trello.com/c/rjrtLu4N/821-allow-topic-parameter-in-supergroup-finder
See also: https://github.com/alphagov/finder-frontend/pull/1209