### PR TITLE
Make FormatMigrator fetch migrated_indices from specified cluster

### DIFF
--- a/lib/search/aggregate_example_fetcher.rb
+++ b/lib/search/aggregate_example_fetcher.rb
@@ -40,7 +40,7 @@ module Search
         filter = @query_builder.filter
       else
         query = nil
-        filter = Search::FormatMigrator.new.call
+        filter = Search::FormatMigrator.new(cluster: search_params.cluster).call
       end
 
       aggregate_options = @response_aggregates.dig(field_name, 'filtered_aggregations', "buckets") || []

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -72,7 +72,8 @@ module Search
 
     def filter
       Search::FormatMigrator.new(
-        QueryComponents::Filter.new(search_params).payload
+        base_query: QueryComponents::Filter.new(search_params).payload,
+        cluster: search_params.cluster,
       ).call
     end
 

--- a/lib/search/query_components/aggregates.rb
+++ b/lib/search/query_components/aggregates.rb
@@ -53,7 +53,8 @@ module QueryComponents
 
       {
         filter: Search::FormatMigrator.new(
-          applied_filter(applied_query_filters)
+          base_query: applied_filter(applied_query_filters),
+          cluster: search_params.cluster,
         ).call,
         aggs: { 'filtered_aggregations' => query }
       }

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -6,108 +6,118 @@ RSpec.describe Search::FormatMigrator do
     allow_any_instance_of(LegacyClient::IndexForSearch).to receive(:real_index_names).and_return(%w(govuk_test))
   end
   # rubocop:enable RSpec/AnyInstance
-
-  it "when base query without migrated formats" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
-    base_query = { filter: 'component' }
-    expected = {
-      bool: {
-        minimum_should_match: 1,
-        should: [
-          {
-            bool: {
-              must: base_query,
-              must_not: { terms: { _index: %w(govuk_test) } }
-            }
-          },
-          {
-            bool: {
-              must_not: { match_all: {} }
-            }
+  context "with every cluster" do
+    Clusters.active.each do |cluster|
+      it "when base query without migrated formats" do
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
+        base_query = { filter: 'component' }
+        expected = {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                bool: {
+                  must: base_query,
+                  must_not: { terms: { _index: %w(govuk_test) } }
+                }
+              },
+              {
+                bool: {
+                  must_not: { match_all: {} }
+                }
+              }
+            ]
           }
-        ]
-      }
-    }
-    expect(described_class.new(base_query).call).to eq(expected)
-  end
+        }
+        expect(described_class.new(
+          base_query: base_query,
+          cluster: cluster,
+        ).call).to eq(expected)
+      end
 
-  it "when base query with migrated formats" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
-    base_query = { filter: 'component' }
-    expected = {
-      bool: {
-        minimum_should_match: 1,
-        should: [
-          {
-            bool: {
-              must: base_query,
-              must_not: [
-                { terms: { _index: %w(govuk_test) } },
-                { terms: { format: %w(help_page) } }
-              ]
-            }
-          },
-          {
-            bool: {
-              must: [
-                base_query,
-                { terms: { _index: %w(govuk_test) } },
-                { terms: { format: %w(help_page) } }
-              ]
-            }
+      it "when base query with migrated formats" do
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
+        base_query = { filter: 'component' }
+        expected = {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                bool: {
+                  must: base_query,
+                  must_not: [
+                    { terms: { _index: %w(govuk_test) } },
+                    { terms: { format: %w(help_page) } }
+                  ]
+                }
+              },
+              {
+                bool: {
+                  must: [
+                    base_query,
+                    { terms: { _index: %w(govuk_test) } },
+                    { terms: { format: %w(help_page) } }
+                  ]
+                }
+              }
+            ]
           }
-        ]
-      }
-    }
-    expect(described_class.new(base_query).call).to eq(expected)
-  end
+        }
+        expect(described_class.new(base_query: base_query, cluster: cluster).call).to eq(expected)
+      end
 
-  it "when no base query without migrated formats" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
-    expected = {
-      bool: {
-        minimum_should_match: 1,
-        should: [
-          {
-            bool: {
-              must: { match_all: {} },
-              must_not: { terms: { _index: %w(govuk_test) } }
-            }
-          },
-          { bool: { must_not: { match_all: {} } } }
-        ]
-      }
-    }
-    expect(described_class.new(nil).call).to eq(expected)
-  end
-
-  it "when no base query with migrated formats" do
-    allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
-    expected = {
-      bool:
-      { minimum_should_match: 1,
-        should: [
-          {
-            bool: {
-              must: { match_all: {} },
-              must_not: [
-                { terms: { _index: %w(govuk_test) } },
-                { terms: { format: %w(help_page) } }
-              ]
-            }
-          },
-          {
-            bool: {
-              must: [
-                { match_all: {} },
-                { terms: { _index: %w(govuk_test) } },
-                { terms: { format: %w(help_page) } }
-              ]
-            }
+      it "when no base query without migrated formats" do
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
+        expected = {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                bool: {
+                  must: { match_all: {} },
+                  must_not: { terms: { _index: %w(govuk_test) } }
+                }
+              },
+              { bool: { must_not: { match_all: {} } } }
+            ]
           }
-        ]
-      }
-    }
-    expect(described_class.new(nil).call).to eq(expected)
+        }
+        expect(described_class.new(
+          cluster: cluster,
+        ).call).to eq(expected)
+      end
+
+      it "when no base query with migrated formats" do
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return('help_page' => :all)
+        expected = {
+          bool:
+          { minimum_should_match: 1,
+            should: [
+              {
+                bool: {
+                  must: { match_all: {} },
+                  must_not: [
+                    { terms: { _index: %w(govuk_test) } },
+                    { terms: { format: %w(help_page) } }
+                  ]
+                }
+              },
+              {
+                bool: {
+                  must: [
+                    { match_all: {} },
+                    { terms: { _index: %w(govuk_test) } },
+                    { terms: { format: %w(help_page) } }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+        expect(described_class.new(
+          cluster: cluster,
+        ).call).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently FormatMigrator fetches migrated_indices index names from the default cluster. Now that we want results from specified cluster, FormatMigrator needs to know that it should get the index names for the correct cluster.

Trello: https://trello.com/c/9bjDVKo6/824