### PR TITLE
Try again to change the *_index.docs.count metric name

### DIFF
--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -212,8 +212,8 @@ this task will run against all active clusters.
           docs = stats["_all"]["primaries"]["docs"]
 
           count = docs["count"]
-          statsd.gauge("#{cluster_name}.#{index}_index.docs.count", count)
-          puts "#{cluster_name}.#{index}_index.docs.count=#{count}"
+          statsd.gauge("#{cluster_name}.#{index}_index.docs.total", count)
+          puts "#{cluster_name}.#{index}_index.docs.total=#{count}"
 
           deleted = docs["deleted"]
           statsd.gauge("#{cluster_name}.#{index}_index.docs.deleted", deleted)


### PR DESCRIPTION
The previous attempt at making this change looks to have been lost
during [1].

1: https://github.com/alphagov/search-api/pull/1569/commits/803fb832de78e5e4fb3f56c9123fb0c9989ea37f

Metrics ending in `.count` are usually used for timers in StatsD, and
there is some specific Graphite storage aggregation configuration for
them [2].

Sum isn't the correct aggregation method for these counts, and the
xFilesFactor needs to be lower to allow keeping the data for longer
than 8 days, so just change the metric name so that it's treated like
other gauges.

2: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/files/node/s_graphite/storage-aggregation.conf#L35-L40
```
[count]
pattern = \.count$
aggregationMethod = sum
xFilesFactor = 0.1
```