### PR TITLE
Fix search-analytics-data-load

### DIFF
--- a/bin/page_traffic_load
+++ b/bin/page_traffic_load
@@ -16,5 +16,24 @@ LIBRARY_PATH = PROJECT_ROOT + "lib/"
 $LOAD_PATH << LIBRARY_PATH unless $LOAD_PATH.include?(LIBRARY_PATH)
 
 require "rummager"
+require 'tempfile'
 
-GovukIndex::PageTrafficLoader.new.load_from($stdin)
+puts 'Creating temporary file to store $stdin...'
+tmp = Tempfile.open('stdin')
+
+begin
+  puts 'Copying stream to temporary file...'
+  IO.copy_stream($stdin, tmp)
+  puts 'Opening temporary file as $stdin'
+  $stdin.reopen(tmp)
+
+  Clusters.active.each do |cluster|
+    puts "Performing page traffic load for cluster #{cluster.key}..."
+    $stdin.rewind
+    GovukIndex::PageTrafficLoader.new(cluster: cluster).load_from($stdin)
+  end
+ensure
+  puts 'All done. Closing and deleting the temporary file...'
+  tmp.close
+  tmp.unlink
+end

--- a/lib/govuk_index/page_traffic_loader.rb
+++ b/lib/govuk_index/page_traffic_loader.rb
@@ -1,39 +1,40 @@
 module GovukIndex
   class PageTrafficLoader
-    def initialize(iostream_batch_size: 250)
+    def initialize(cluster: Clusters.default_cluster, iostream_batch_size: 250)
       @iostream_batch_size = iostream_batch_size
       @logger = Logging.logger[self]
       @logger.level = :info
+      @cluster = cluster
     end
 
     def load_from(iostream)
-      Clusters.active.each do |cluster|
-        new_index = index_group(cluster).create_index
-        @logger.info "Created index #{new_index.real_name}"
+      new_index = index_group.create_index
+      @logger.info "Created index #{new_index.real_name}"
 
-        old_index = index_group(cluster).current_real
-        @logger.info "Old index #{old_index.real_name}"
+      old_index = index_group.current_real
+      @logger.info "Old index #{old_index.real_name}"
 
-        old_index.with_lock do
-          @logger.info "Indexing to #{new_index.real_name}"
+      old_index.with_lock do
+        @logger.info "Indexing to #{new_index.real_name}"
 
-          in_even_sized_batches(iostream) do |lines|
-            GovukIndex::PageTrafficWorker.perform_async(lines, new_index.real_name, cluster.key)
-          end
-
-          GovukIndex::PageTrafficWorker.wait_until_processed
-          new_index.commit
+        in_even_sized_batches(iostream) do |lines|
+          GovukIndex::PageTrafficWorker.perform_async(lines, new_index.real_name, cluster.key)
         end
 
-        # We need to switch the aliases without a lock, since
-        # read_only_allow_delete prevents aliases being changed
-        # The page traffic loader is is a daily process, so there
-        # won't be a race condition
-        index_group(cluster).switch_to(new_index)
+        GovukIndex::PageTrafficWorker.wait_until_processed
+        new_index.commit
       end
+
+      # We need to switch the aliases without a lock, since
+      # read_only_allow_delete prevents aliases being changed
+      # The page traffic loader is is a daily process, so there
+      # won't be a race condition
+      index_group.switch_to(new_index)
     end
 
   private
+
+    attr_reader :cluster
 
     # Breaks the given input stream into batches of documents
     # This is due to ES recommendations for index optimisation
@@ -42,12 +43,10 @@ module GovukIndex
       iostream.each_line.each_slice(batch_size * 2) do |batch|
         yield(batch.map { |b| JSON.parse(b) })
       end
-      iostream.pos = 0 # ensures we start at the beginning on next read.
     end
 
-    def index_group(cluster)
-      @index_group ||= {}
-      @index_group[cluster.key] ||= SearchConfig.instance.search_server(cluster: cluster).index_group(
+    def index_group
+      @index_group ||= SearchConfig.instance.search_server(cluster: cluster).index_group(
         SearchConfig.instance.page_traffic_index_name
       )
     end

--- a/spec/integration/govuk_index/page_traffic_loader_spec.rb
+++ b/spec/integration/govuk_index/page_traffic_loader_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe 'Loading page traffic data' do
       { rank_14: 100, vf_14: 0.345, vc_14: 12 }.to_json
     ].join("\n")
 
-    GovukIndex::PageTrafficLoader.new
-      .load_from(StringIO.new(data))
-
     Clusters.active.each do |cluster|
+      GovukIndex::PageTrafficLoader.new(cluster: cluster)
+        .load_from(StringIO.new(data))
+
       document = fetch_document_from_rummager(id: id, index: 'page-traffic_test', cluster: cluster)
 
       expect(document["_source"]["document_type"]).to eq('page_traffic')

--- a/spec/unit/govuk_index/page_traffic_loader_spec.rb
+++ b/spec/unit/govuk_index/page_traffic_loader_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe GovukIndex::PageTrafficLoader do
       expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line2, 'new_index_name', cluster.key)
       expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line3, 'new_index_name', cluster.key)
       # rubocop:enable RSpec/MessageSpies
-    end
-    loader = GovukIndex::PageTrafficLoader.new(iostream_batch_size: 2)
+      loader = described_class.new(cluster: cluster, iostream_batch_size: 2)
 
-    loader.load_from(input)
+      loader.load_from(input)
+    end
   end
 end


### PR DESCRIPTION
This fixes a bug introduced in 3eacc88ee0c6979cad91bb2f7a72214b7f91a6c3.

Setting StringIO.pos = 0 is forbidden, and results in a
`error: Errno::ESPIPE: Illegal seek @ rb_io_set_pos - <STDIN>`

This happens because we are reading from data that is being piped in.

The workaround is to store the stream as a temp file, this seems like the nicest way to do it! This lets us call `.rewind` and run the traffic load for each cluster.

Trello: https://trello.com/c/Q4nK0icC/828