### PR TITLE
Refactor SearchConfig to have one singleton per cluster

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,12 +22,8 @@ def logger
   Logging.logger.root
 end
 
-def search_config
-  SearchConfig.instance
-end
-
 def search_server(cluster: Clusters.default_cluster)
-  search_config.search_server(cluster: cluster)
+  search_config.instance(cluster).search_server
 end
 
 def clusters_from_args(args)

--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,7 @@ def index_names
   search_index = ENV["SEARCH_INDEX"]
   case search_index
   when "all"
-    search_config.all_index_names
+    SearchConfig.all_index_names
   when String
     [search_index]
   else

--- a/bin/stats
+++ b/bin/stats
@@ -30,7 +30,7 @@ end
 
 # The indexes which make up GOV.UK.
 index_names = %w(detailed government govuk)
-search_server = SearchConfig.new.search_server
+search_server = SearchConfig.new(Clusters.default_cluster).search_server
 indices = index_names.map { |name| search_server.index(name) }
 
 document_count = 0

--- a/bin/stats
+++ b/bin/stats
@@ -30,7 +30,7 @@ end
 
 # The indexes which make up GOV.UK.
 index_names = %w(detailed government govuk)
-search_server = SearchConfig.new(Clusters.default_cluster).search_server
+search_server = SearchConfig.default_instance.search_server
 indices = index_names.map { |name| search_server.index(name) }
 
 document_count = 0

--- a/lib/analytics_data.rb
+++ b/lib/analytics_data.rb
@@ -17,7 +17,7 @@ class AnalyticsData
           must: { match_all: {} },
         },
       },
-      post_filter: Search::FormatMigrator.new.call,
+      post_filter: Search::FormatMigrator.new(SearchConfig.instance(Clusters.default_cluster)).call,
     }
 
     ScrollEnumerator.new(client: client, index_names: @indices, search_body: query) do |hit|

--- a/lib/analytics_data.rb
+++ b/lib/analytics_data.rb
@@ -17,7 +17,7 @@ class AnalyticsData
           must: { match_all: {} },
         },
       },
-      post_filter: Search::FormatMigrator.new(SearchConfig.instance(Clusters.default_cluster)).call,
+      post_filter: Search::FormatMigrator.new(SearchConfig.default_instance).call,
     }
 
     ScrollEnumerator.new(client: client, index_names: @indices, search_body: query) do |hit|

--- a/lib/govuk_index/client.rb
+++ b/lib/govuk_index/client.rb
@@ -3,7 +3,7 @@ module GovukIndex
   private
 
     def index_name
-      @_index ||= search_config.govuk_index_name
+      @_index ||= SearchConfig.govuk_index_name
     end
   end
 end

--- a/lib/govuk_index/client.rb
+++ b/lib/govuk_index/client.rb
@@ -3,7 +3,9 @@ module GovukIndex
   private
 
     def index_name
+      # rubocop:disable Naming/MemoizedInstanceVariableName
       @_index ||= SearchConfig.govuk_index_name
+      # rubocop:enable Naming/MemoizedInstanceVariableName
     end
   end
 end

--- a/lib/govuk_index/page_traffic_loader.rb
+++ b/lib/govuk_index/page_traffic_loader.rb
@@ -47,7 +47,7 @@ module GovukIndex
 
     def index_group
       @index_group ||= SearchConfig.instance.search_server(cluster: cluster).index_group(
-        SearchConfig.instance.page_traffic_index_name
+        SearchConfig.page_traffic_index_name
       )
     end
   end

--- a/lib/govuk_index/page_traffic_loader.rb
+++ b/lib/govuk_index/page_traffic_loader.rb
@@ -46,7 +46,7 @@ module GovukIndex
     end
 
     def index_group
-      @index_group ||= SearchConfig.instance.search_server(cluster: cluster).index_group(
+      @index_group ||= SearchConfig.instance(cluster).search_server.index_group(
         SearchConfig.page_traffic_index_name
       )
     end

--- a/lib/govuk_index/popularity_worker.rb
+++ b/lib/govuk_index/popularity_worker.rb
@@ -28,7 +28,7 @@ module GovukIndex
     def retrieve_popularities_for(index_name, records)
       # popularity should be consistent across clusters, so look up in
       # the default
-      lookup = Indexer::PopularityLookup.new(index_name, SearchConfig.instance(Clusters.default_cluster))
+      lookup = Indexer::PopularityLookup.new(index_name, SearchConfig.default_instance)
       lookup.lookup_popularities(records.map { |r| r['identifier']['_id'] })
     end
   end

--- a/lib/govuk_index/popularity_worker.rb
+++ b/lib/govuk_index/popularity_worker.rb
@@ -26,7 +26,9 @@ module GovukIndex
     end
 
     def retrieve_popularities_for(index_name, records)
-      lookup = Indexer::PopularityLookup.new(index_name, SearchConfig.instance)
+      # popularity should be consistent across clusters, so look up in
+      # the default
+      lookup = Indexer::PopularityLookup.new(index_name, SearchConfig.instance(Clusters.default_cluster))
       lookup.lookup_popularities(records.map { |r| r['identifier']['_id'] })
     end
   end

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -49,7 +49,9 @@ module GovukIndex
     end
 
     def popularity
-      lookup = Indexer::PopularityLookup.new("govuk_index", SearchConfig.instance)
+      # popularity should be consistent across clusters, so look up in
+      # the default
+      lookup = Indexer::PopularityLookup.new("govuk_index", SearchConfig.instance(Clusters.default_cluster))
       lookup.lookup_popularities([link])[link]
     end
 

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -51,7 +51,7 @@ module GovukIndex
     def popularity
       # popularity should be consistent across clusters, so look up in
       # the default
-      lookup = Indexer::PopularityLookup.new("govuk_index", SearchConfig.instance(Clusters.default_cluster))
+      lookup = Indexer::PopularityLookup.new("govuk_index", SearchConfig.default_instance)
       lookup.lookup_popularities([link])[link]
     end
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -24,7 +24,7 @@ module SearchIndices
       @mappings = mappings
       @search_config = search_config
       @elasticsearch_types = @search_config.schema_config.elasticsearch_types(base_index_name)
-      @is_content_index = !(@search_config.auxiliary_index_names.include? base_index_name)
+      @is_content_index = !(SearchConfig.auxiliary_index_names.include? base_index_name)
     end
 
     # Translate index names like `govuk-2015-05-06t09..` into its proper

--- a/lib/index/client.rb
+++ b/lib/index/client.rb
@@ -43,10 +43,6 @@ module Index
       )
     end
 
-    def search_config
-      @_config ||= SearchConfig.instance
-    end
-
     def index_name
       raise "Must be implemented in child class"
     end

--- a/lib/index_finder.rb
+++ b/lib/index_finder.rb
@@ -10,7 +10,7 @@ class IndexFinder
     end
 
     def search_config
-      @search_config ||= SearchConfig.instance(Clusters.default_cluster)
+      @search_config ||= SearchConfig.default_instance
     end
 
     def search_server

--- a/lib/index_finder.rb
+++ b/lib/index_finder.rb
@@ -10,7 +10,7 @@ class IndexFinder
     end
 
     def search_config
-      @search_config ||= SearchConfig.instance
+      @search_config ||= SearchConfig.instance(Clusters.default_cluster)
     end
 
     def search_server

--- a/lib/index_finder.rb
+++ b/lib/index_finder.rb
@@ -2,7 +2,7 @@
 class IndexFinder
   class << self
     def content_index
-      search_config.search_server.index_for_search(search_config.content_index_names)
+      search_config.search_server.index_for_search(SearchConfig.content_index_names)
     end
 
     def by_name(index_name)

--- a/lib/indexer/compare_enumerator.rb
+++ b/lib/indexer/compare_enumerator.rb
@@ -84,7 +84,7 @@ module Indexer
     end
 
     def search_config
-      @search_config ||= SearchConfig.instance
+      @search_config ||= SearchConfig.instance(cluster)
     end
   end
 end

--- a/lib/indexer/comparer.rb
+++ b/lib/indexer/comparer.rb
@@ -45,7 +45,7 @@ module Indexer
     end
 
     def search_config
-      @search_config ||= SearchConfig.new(Clusters.default_cluster)
+      @search_config ||= SearchConfig.default_instance
     end
 
     def changed_fields(old_item, new_item)

--- a/lib/indexer/comparer.rb
+++ b/lib/indexer/comparer.rb
@@ -45,7 +45,7 @@ module Indexer
     end
 
     def search_config
-      @search_config ||= SearchConfig.new
+      @search_config ||= SearchConfig.new(Clusters.default_cluster)
     end
 
     def changed_fields(old_item, new_item)

--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -36,7 +36,7 @@ module Indexer
         if ranks[link] == 0
           popularity_score = 0
         else
-          popularity_score = 1.0 / (ranks[link] + @search_config.popularity_rank_offset)
+          popularity_score = 1.0 / (ranks[link] + SearchConfig.popularity_rank_offset)
         end
 
         [link, popularity_score]
@@ -67,7 +67,7 @@ module Indexer
         return nil
       end
 
-      traffic_index_name = @search_config.auxiliary_index_names.find {|index|
+      traffic_index_name = SearchConfig.auxiliary_index_names.find {|index|
         index.start_with?("page-traffic")
       }
 

--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -67,7 +67,7 @@ module Indexer
         return nil
       end
 
-      traffic_index_name = SearchConfig.auxiliary_index_names.find {|index|
+      traffic_index_name = SearchConfig.auxiliary_index_names.find { |index|
         index.start_with?("page-traffic")
       }
 

--- a/lib/indexer/workers/base_worker.rb
+++ b/lib/indexer/workers/base_worker.rb
@@ -31,7 +31,7 @@ module Indexer
   private
 
     def indexes(index_name)
-      SearchConfig.instance.search_servers.map { |search_server|
+      SearchConfig.search_servers.map { |search_server|
         search_server.index(index_name)
       }
     end

--- a/lib/metasearch_index/client.rb
+++ b/lib/metasearch_index/client.rb
@@ -14,7 +14,7 @@ module MetasearchIndex
   private
 
     def index_name
-      @_index ||= search_config.metasearch_index_name
+      @_index ||= SearchConfig.metasearch_index_name
     end
   end
 end

--- a/lib/metasearch_index/client.rb
+++ b/lib/metasearch_index/client.rb
@@ -14,7 +14,9 @@ module MetasearchIndex
   private
 
     def index_name
+      # rubocop:disable Naming/MemoizedInstanceVariableName
       @_index ||= SearchConfig.metasearch_index_name
+      # rubocop:enable Naming/MemoizedInstanceVariableName
     end
   end
 end

--- a/lib/missing_metadata/runner.rb
+++ b/lib/missing_metadata/runner.rb
@@ -3,7 +3,7 @@ module MissingMetadata
     PAGE_SIZE = 200
     MAX_PAGES = 52
 
-    def initialize(missing_field_name, search_config: SearchConfig.new(Clusters.default_cluster), logger: STDOUT)
+    def initialize(missing_field_name, search_config: SearchConfig.default_instance, logger: STDOUT)
       @missing_field_name = missing_field_name
       @search_config = search_config
       publishing_api = Services.publishing_api

--- a/lib/missing_metadata/runner.rb
+++ b/lib/missing_metadata/runner.rb
@@ -33,7 +33,7 @@ module MissingMetadata
       (0..Float::INFINITY).lazy.each do |page|
         logger.puts "Fetching page #{page + 1}"
 
-        response = search_config.run_search(
+        response = SearchConfig.run_search(
           "filter_#{@missing_field_name}" => %w(_MISSING),
           "count" => [PAGE_SIZE.to_s],
           "start" => [(page * PAGE_SIZE).to_s],

--- a/lib/missing_metadata/runner.rb
+++ b/lib/missing_metadata/runner.rb
@@ -3,7 +3,7 @@ module MissingMetadata
     PAGE_SIZE = 200
     MAX_PAGES = 52
 
-    def initialize(missing_field_name, search_config: SearchConfig.new, logger: STDOUT)
+    def initialize(missing_field_name, search_config: SearchConfig.new(Clusters.default_cluster), logger: STDOUT)
       @missing_field_name = missing_field_name
       @search_config = search_config
       publishing_api = Services.publishing_api

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -41,6 +41,7 @@ private
       start: capped_start,
       count: capped_count,
       cluster: cluster,
+      search_config: SearchConfig.instance(cluster),
       query: normalize_query(single_param("q"), "query"),
       similar_to: normalize_query(single_param("similar_to"), "similar_to"),
       order: order,
@@ -70,13 +71,16 @@ private
   end
 
   def cluster
-    cluster_key = single_param('cluster')
-    Clusters.get_cluster(cluster_key)
-  rescue Clusters::ClusterNotFoundError
-    if cluster_key.present?
-      @errors << "Invalid cluster. Accepted values: #{Clusters.cluster_keys.join(', ')}"
-    end
-    Clusters.default_cluster
+    @cluster ||=
+      begin
+        cluster_key = single_param('cluster')
+        Clusters.get_cluster(cluster_key)
+      rescue Clusters::ClusterNotFoundError
+        if cluster_key.present?
+          @errors << "Invalid cluster. Accepted values: #{Clusters.cluster_keys.join(', ')}"
+        end
+        Clusters.default_cluster
+      end
   end
 
   def capped_start

--- a/lib/routes/content.rb
+++ b/lib/routes/content.rb
@@ -21,7 +21,7 @@ class Rummager < Sinatra::Application
 private
 
   def index
-    SearchConfig.instance(Clusters.default_cluster).content_index
+    SearchConfig.default_instance.content_index
   end
 
   def find_result_by_link(link)

--- a/lib/routes/content.rb
+++ b/lib/routes/content.rb
@@ -21,7 +21,7 @@ class Rummager < Sinatra::Application
 private
 
   def index
-    SearchConfig.instance.content_index
+    SearchConfig.instance(Clusters.default_cluster).content_index
   end
 
   def find_result_by_link(link)

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -41,7 +41,7 @@ class Rummager < Sinatra::Application
   end
 
   def search_server
-    SearchConfig.instance.search_server
+    SearchConfig.instance(Clusters.default_cluster).search_server
   end
 
   def current_index

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -41,7 +41,7 @@ class Rummager < Sinatra::Application
   end
 
   def search_server
-    SearchConfig.instance(Clusters.default_cluster).search_server
+    SearchConfig.default_instance.search_server
   end
 
   def current_index

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -147,7 +147,7 @@ class Rummager < Sinatra::Application
       query_params = parse_query_string(request.query_string)
 
       begin
-        results = SearchConfig.instance.run_search(query_params)
+        results = SearchConfig.run_search(query_params)
       rescue BaseParameterParser::ParseError => e
         status 422
         return { error: e.error }.to_json
@@ -172,7 +172,7 @@ class Rummager < Sinatra::Application
       searches = parsed_searches_parameters.values
       results = []
       begin
-        results = SearchConfig.instance.run_batch_search(searches)
+        results = SearchConfig.run_batch_search(searches)
       rescue BaseParameterParser::ParseError => e
         status 422
         return { error: e.error }.to_json

--- a/lib/schema_migrator.rb
+++ b/lib/schema_migrator.rb
@@ -1,10 +1,9 @@
 class SchemaMigrator
   attr_accessor :failed
 
-  def initialize(index_name, config, cluster: Clusters.default_cluster, wait_between_task_list_check: 5, io: STDOUT)
+  def initialize(index_name, cluster: Clusters.default_cluster, wait_between_task_list_check: 5, io: STDOUT)
     @index_name = index_name
     @cluster = cluster
-    @config = config
     @wait_between_task_list_check = wait_between_task_list_check
     @io = io
   end
@@ -67,7 +66,7 @@ private
   end
 
   def index_group
-    @index_group ||= @config.search_server(cluster: cluster).index_group(@index_name)
+    @index_group ||= SearchConfig.instance(cluster).search_server.index_group(@index_name)
   end
 
   def index

--- a/lib/search/aggregate_example_fetcher.rb
+++ b/lib/search/aggregate_example_fetcher.rb
@@ -40,7 +40,7 @@ module Search
         filter = @query_builder.filter
       else
         query = nil
-        filter = Search::FormatMigrator.new(cluster: search_params.cluster).call
+        filter = Search::FormatMigrator.new(search_params.search_config).call
       end
 
       aggregate_options = @response_aggregates.dig(field_name, 'filtered_aggregations', "buckets") || []

--- a/lib/search/batch_query.rb
+++ b/lib/search/batch_query.rb
@@ -25,7 +25,7 @@ module Search
       searches_params.map do |search_params|
         QueryBuilder.new(
           search_params: search_params,
-          content_index_names: content_index_names,
+          content_index_names: SearchConfig.content_index_names,
           metasearch_index: metasearch_index
         )
       end

--- a/lib/search/format_migrator.rb
+++ b/lib/search/format_migrator.rb
@@ -1,8 +1,8 @@
 module Search
   class FormatMigrator
-    def initialize(base_query: nil, cluster: Clusters.default_cluster)
+    def initialize(search_config, base_query: nil)
+      @search_config = search_config
       @base_query = base_query
-      @cluster = cluster
     end
 
     def call
@@ -16,10 +16,10 @@ module Search
 
   private
 
-    attr_reader :cluster
+    attr_reader :search_config
 
     def migrated_indices
-      SearchConfig.instance.new_content_index(cluster: cluster).real_index_names
+      search_config.new_content_index.real_index_names
     end
 
     def migrated_formats

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -72,8 +72,8 @@ module Search
 
     def filter
       Search::FormatMigrator.new(
+        search_params.search_config,
         base_query: QueryComponents::Filter.new(search_params).payload,
-        cluster: search_params.cluster,
       ).call
     end
 

--- a/lib/search/query_components/aggregates.rb
+++ b/lib/search/query_components/aggregates.rb
@@ -53,8 +53,8 @@ module QueryComponents
 
       {
         filter: Search::FormatMigrator.new(
+          search_params.search_config,
           base_query: applied_filter(applied_query_filters),
-          cluster: search_params.cluster,
         ).call,
         aggs: { 'filtered_aggregations' => query }
       }

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -17,7 +17,7 @@ module Search
         return_fields: [],
         ab_tests: {},
         cluster: Clusters.default_cluster,
-        search_config: SearchConfig.instance(Clusters.default_cluster)
+        search_config: SearchConfig.default_instance,
       }.merge(params)
       params.each do |k, v|
         public_send("#{k}=", v)

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -2,14 +2,23 @@ module Search
   # Value object that holds the parsed parameters for a search.
   class QueryParameters
     attr_accessor :query, :similar_to, :order, :start, :count, :return_fields,
-                  :aggregates, :aggregate_name, :filters, :debug, :suggest, :is_quoted_phrase, :ab_tests, :cluster
+                  :aggregates, :aggregate_name, :filters, :debug, :suggest, :is_quoted_phrase,
+                  :ab_tests, :cluster, :search_config
 
     # starts and ends with quotes with no quotes in between, with or without
     # leading or trailing whitespace
     QUOTED_STRING_REGEX = /^\s*"[^"]+"\s*$/
 
     def initialize(params = {})
-      params = { aggregates: [], filters: {}, debug: {}, return_fields: [], ab_tests: {}, cluster: Clusters.default_cluster }.merge(params)
+      params = {
+        aggregates: [],
+        filters: {},
+        debug: {},
+        return_fields: [],
+        ab_tests: {},
+        cluster: Clusters.default_cluster,
+        search_config: SearchConfig.instance(Clusters.default_cluster)
+      }.merge(params)
       params.each do |k, v|
         public_send("#{k}=", v)
       end

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -53,7 +53,7 @@ module Search
 
     def specialist_sectors
       BaseRegistry.new(
-        search_server.index_for_search([search_config.govuk_index_name]),
+        search_server.index_for_search([SearchConfig.govuk_index_name]),
         field_definitions,
         "specialist_sector"
       )
@@ -64,7 +64,7 @@ module Search
     end
 
     def index
-      search_server.index_for_search([search_config.registry_index])
+      search_server.index_for_search([SearchConfig.registry_index])
     end
 
     def field_definitions

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -22,6 +22,12 @@ class SearchConfig
       @instance[cluster.key] ||= new(cluster)
     end
 
+    def default_instance
+      # 'instance' doesn't have default parameters so that you have to
+      # explicitly think about and opt into the default.
+      instance(Clusters.default_cluster)
+    end
+
     def reset_instances
       # used in the tests because SearchConfig.instance is stateful
       @instance = {}
@@ -81,7 +87,7 @@ class SearchConfig
       # field (which is what can be overridden per-cluster).
       @combined_index_schema ||= CombinedIndexSchema.new(
         content_index_names + [govuk_index_name],
-        instance(Clusters.default_cluster).schema_config
+        default_instance.schema_config
       )
     end
   end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -1,12 +1,4 @@
 class SearchConfig
-  %w[
-    base_uri
-  ].each do |config_method|
-    define_method config_method do
-      elasticsearch.fetch(config_method)
-    end
-  end
-
   class << self
     attr_writer :instance
 

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -55,7 +55,7 @@ class SearchConfig
 
       search_params = Search::QueryParameters.new(parser.parsed_params)
 
-      instance(search_params.cluster).run_search_with_params(search_params)
+      search_params.search_config.run_search_with_params(search_params)
     end
 
     def run_batch_search(searches)
@@ -67,7 +67,7 @@ class SearchConfig
         search_params << Search::QueryParameters.new(parser.parsed_params)
       end
 
-      instance(search_params.first.cluster).run_batch_search_with_params(search_params)
+      search_params.first.search_config.run_batch_search_with_params(search_params)
     end
 
     def elasticsearch

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -71,11 +71,7 @@ class SearchConfig
     end
 
     def elasticsearch
-      @elasticsearch ||= es_config.config
-    end
-
-    def es_config
-      @es_config ||= ElasticsearchConfig.new
+      @elasticsearch ||= ElasticsearchConfig.new.config
     end
 
   private
@@ -109,7 +105,7 @@ class SearchConfig
 
   def schema_config
     @schema_config ||= SchemaConfig.new(
-      SearchConfig.es_config.config_path,
+      ElasticsearchConfig.new.config_path,
       schema_config_file: cluster.schema_config_file,
     )
   end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -138,6 +138,10 @@ class SearchConfig
     @new_content_index ||= search_server.index_for_search([SearchConfig.govuk_index_name])
   end
 
+  def base_uri
+    cluster.uri
+  end
+
 private
 
   attr_accessor :cluster

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -17,7 +17,7 @@ class SitemapGenerator
           must_not: { terms: { format: EXCLUDED_FORMATS } },
         }
       },
-      post_filter: Search::FormatMigrator.new.call,
+      post_filter: Search::FormatMigrator.new(@search_config).call,
     }
     property_boost_calculator = PropertyBoostCalculator.new
 

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -67,7 +67,7 @@ private
   StaticDocumentPresenter = Struct.new(:url, :last_updated, :priority)
 
   def index_names
-    @search_config.content_index_names + [@search_config.govuk_index_name]
+    SearchConfig.content_index_names + [SearchConfig.govuk_index_name]
   end
 
   def homepage

--- a/lib/tasks/analytics.rake
+++ b/lib/tasks/analytics.rake
@@ -15,7 +15,6 @@ namespace :analytics do
     args.with_defaults(path: (ENV['EXPORT_PATH'] || 'data'))
     path = args[:path]
 
-    elasticsearch_config = SearchConfig.new.elasticsearch
     analytics_data = AnalyticsData.new(Clusters.default_cluster.uri, ALL_CONTENT_SEARCH_INDICES)
 
     FileUtils.mkdir_p(path)

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -9,14 +9,14 @@ ANSI_RESET = "\e[0m".freeze
 namespace :debug do
   desc "Pretty print a document in the old content indexes"
   task :show_old_index_link, [:link] do |_, args|
-    index = SearchConfig.instance.old_content_index
+    index = SearchConfig.instance(Clusters.default_cluster).old_content_index
     docs = index.get_document_by_link(args.link)
     pp docs
   end
 
   desc "Pretty print a document in the new content index"
   task :show_govuk_link, [:link] do |_, args|
-    index = SearchConfig.instance.new_content_index
+    index = SearchConfig.instance(Clusters.default_cluster).new_content_index
     docs = index.get_document_by_link(args.link)
     pp docs
   end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -9,14 +9,14 @@ ANSI_RESET = "\e[0m".freeze
 namespace :debug do
   desc "Pretty print a document in the old content indexes"
   task :show_old_index_link, [:link] do |_, args|
-    index = SearchConfig.instance(Clusters.default_cluster).old_content_index
+    index = SearchConfig.default_instance.old_content_index
     docs = index.get_document_by_link(args.link)
     pp docs
   end
 
   desc "Pretty print a document in the new content index"
   task :show_govuk_link, [:link] do |_, args|
-    index = SearchConfig.instance(Clusters.default_cluster).new_content_index
+    index = SearchConfig.default_instance.new_content_index
     docs = index.get_document_by_link(args.link)
     pp docs
   end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -206,7 +206,7 @@ this task will run against all active clusters.
       missing = []
       cluster_name = "cluster_#{cluster.key}"
 
-      SearchConfig.instance.all_index_names.each do |index|
+      SearchConfig.all_index_names.each do |index|
         begin
           stats = client.indices.stats index: index, docs: true
           docs = stats["_all"]["primaries"]["docs"]

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -34,7 +34,7 @@ namespace :search do
   task :create_all_indices, :clusters do |_, args|
     clusters_from_args(args).each do |cluster|
       index_names.each do |index_name|
-        index_group = search_config.search_server(cluster: cluster).index_group(index_name)
+        index_group = SearchConfig.instance(cluster).search_server.index_group(index_name)
         index = index_group.create_index
         index_group.switch_to(index) unless index_group.current_real
       end
@@ -44,7 +44,7 @@ namespace :search do
   desc "Create a brand new index and assign an alias if no alias currently exists"
   task :create_index, :index_name, :clusters do |_, args|
     clusters_from_args(args).each do |cluster|
-      index_group = search_config.search_server(cluster: cluster).index_group(args[:index_name])
+      index_group = SearchConfig.instance(cluster).search_server.index_group(args[:index_name])
       index = index_group.create_index
       index_group.switch_to(index) unless index_group.current_real
     end
@@ -54,7 +54,7 @@ namespace :search do
   task :lock, :clusters do |_, args|
     clusters_from_args(args).each do |cluster|
       index_names.each do |index_name|
-        SearchConfig.instance.search_server(cluster: cluster).index(index_name).lock
+        search_server(cluster: cluster).index(index_name).lock
       end
     end
   end
@@ -63,7 +63,7 @@ namespace :search do
   task :unlock, :clusters do |_, args|
     clusters_from_args(args).each do |cluster|
       index_names.each do |index_name|
-        SearchConfig.instance.search_server(cluster: cluster).index(index_name).unlock
+        search_server(cluster: cluster).index(index_name).unlock
       end
     end
   end
@@ -123,7 +123,7 @@ this task will run against all active clusters.
       failed_indices = []
 
       index_names.each do |index_name|
-        migrator = SchemaMigrator.new(index_name, search_config, cluster: cluster)
+        migrator = SchemaMigrator.new(index_name, cluster: cluster)
         migrator.reindex
 
         if migrator.failed == true

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -8,7 +8,7 @@ namespace :sitemap do
 
     output_directory = File.join(PROJECT_ROOT, "public")
     sitemap = Sitemap.new(output_directory)
-    sitemap.generate(SearchConfig.instance(Clusters.default_cluster))
+    sitemap.generate(SearchConfig.default_instance)
 
     sitemap.cleanup
   end

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -8,7 +8,7 @@ namespace :sitemap do
 
     output_directory = File.join(PROJECT_ROOT, "public")
     sitemap = Sitemap.new(output_directory)
-    sitemap.generate(SearchConfig.instance)
+    sitemap.generate(SearchConfig.instance(Clusters.default_cluster))
 
     sitemap.cleanup
   end

--- a/spec/integration/analytics_data_spec.rb
+++ b/spec/integration/analytics_data_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'AnalyticsDataTest' do
   before do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
-    @analytics_data_fetcher = AnalyticsData.new("http://localhost:9200", %w(government_test govuk_test))
+    @analytics_data_fetcher = AnalyticsData.new(SearchConfig.default_instance.base_uri, %w(government_test govuk_test))
   end
 
   it "fetches rows of analytics dimensions" do

--- a/spec/integration/analytics_data_spec.rb
+++ b/spec/integration/analytics_data_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'AnalyticsDataTest' do
   before do
     allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
-    @analytics_data_fetcher = AnalyticsData.new(SearchConfig.instance.base_uri, %w(government_test govuk_test))
+    @analytics_data_fetcher = AnalyticsData.new("http://localhost:9200", %w(government_test govuk_test))
   end
 
   it "fetches rows of analytics dimensions" do

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'GovukIndex::PublishingEventProcessorTest' do
       insert_document("page-traffic_test", { rank_14: document_rank, path_components: [random_example["base_path"]] }, id: random_example["base_path"], type: "page-traffic")
       setup_page_traffic_data(document_count: document_count)
 
-      popularity = 1.0 / ([document_count, document_rank].min + SearchConfig.instance.popularity_rank_offset)
+      popularity = 1.0 / ([document_count, document_rank].min + SearchConfig.popularity_rank_offset)
 
       @queue.publish(random_example.to_json, content_type: "application/json")
       commit_index 'govuk_test'

--- a/spec/integration/govuk_index/updating_popularity_data_spec.rb
+++ b/spec/integration/govuk_index/updating_popularity_data_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     insert_document('page-traffic_test', { rank_14: document_rank, path_components: [id, '/test'] }, id: id, type: 'page-traffic')
     setup_page_traffic_data(document_count: document_count)
 
-    popularity = 1.0 / ([document_rank, document_count].min + SearchConfig.instance.popularity_rank_offset)
+    popularity = 1.0 / ([document_rank, document_count].min + SearchConfig.popularity_rank_offset)
 
     GovukIndex::PopularityUpdater.update('govuk_test')
 
@@ -28,7 +28,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     document_count = 4
     setup_page_traffic_data(document_count: document_count)
 
-    popularity = 1.0 / (document_count + SearchConfig.instance.popularity_rank_offset)
+    popularity = 1.0 / (document_count + SearchConfig.popularity_rank_offset)
 
     GovukIndex::PopularityUpdater.update('govuk_test')
 
@@ -80,7 +80,7 @@ RSpec.describe 'GovukIndex::UpdatingPopularityDataTest' do
     setup_page_traffic_data(document_count: document_count)
 
     GovukIndex::PopularityUpdater.update('govuk_test', process_all: true)
-    popularity = 1.0 / (document_count + SearchConfig.instance.popularity_rank_offset)
+    popularity = 1.0 / (document_count + SearchConfig.popularity_rank_offset)
 
     document = fetch_document_from_rummager(id: id, index: 'govuk_test')
     expect(popularity).to eq(document['_source']['popularity'])

--- a/spec/integration/indexer/index_group_spec.rb
+++ b/spec/integration/indexer/index_group_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'ElasticsearchIndexGroupTest' do
     expect(@index_group.index_names.count).to eq(1)
     expect(index.index_name).to eq(@index_group.index_names[0])
     expect(
-      SearchConfig.instance(Clusters.default_cluster).search_server.schema.elasticsearch_mappings("government")
+      SearchConfig.default_instance.search_server.schema.elasticsearch_mappings("government")
     ).to eq(index.mappings)
   end
 

--- a/spec/integration/indexer/index_group_spec.rb
+++ b/spec/integration/indexer/index_group_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'ElasticsearchIndexGroupTest' do
     expect(@index_group.index_names.count).to eq(1)
     expect(index.index_name).to eq(@index_group.index_names[0])
     expect(
-      SearchConfig.instance.search_server.schema.elasticsearch_mappings("government")
+      SearchConfig.instance(Clusters.default_cluster).search_server.schema.elasticsearch_mappings("government")
     ).to eq(index.mappings)
   end
 

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'MissingMetadataTest' do
       'link' => '/path/to_page',
     )
 
-    runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.instance(Clusters.default_cluster), logger: io)
+    runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.default_instance, logger: io)
     results = runner.retrieve_records_with_missing_value
 
     expect([{ _id: '/path/to_page', index: 'government_test' }]).to eq results
@@ -20,7 +20,7 @@ RSpec.describe 'MissingMetadataTest' do
       'content_id' => '8aea1742-9cc6-4dfb-a63b-12c3e66a601f',
     )
 
-    runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.instance(Clusters.default_cluster), logger: io)
+    runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.default_instance, logger: io)
     results = runner.retrieve_records_with_missing_value
 
     expect(results).to be_empty
@@ -33,7 +33,7 @@ RSpec.describe 'MissingMetadataTest' do
       'content_id' => '8aea1742-9cc6-4dfb-a63b-12c3e66a601f',
     )
 
-    runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.instance(Clusters.default_cluster), logger: io)
+    runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.default_instance, logger: io)
     results = runner.retrieve_records_with_missing_value
 
     expect([{ _id: '/path/to_page', index: 'government_test', content_id: '8aea1742-9cc6-4dfb-a63b-12c3e66a601f' }]).to eq results
@@ -47,7 +47,7 @@ RSpec.describe 'MissingMetadataTest' do
       'content_store_document_type' => 'guide',
     )
 
-    runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.instance(Clusters.default_cluster), logger: io)
+    runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.default_instance, logger: io)
     results = runner.retrieve_records_with_missing_value
 
     expect(results).to be_empty

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'MissingMetadataTest' do
       'link' => '/path/to_page',
     )
 
-    runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.instance, logger: io)
+    runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.instance(Clusters.default_cluster), logger: io)
     results = runner.retrieve_records_with_missing_value
 
     expect([{ _id: '/path/to_page', index: 'government_test' }]).to eq results
@@ -20,7 +20,7 @@ RSpec.describe 'MissingMetadataTest' do
       'content_id' => '8aea1742-9cc6-4dfb-a63b-12c3e66a601f',
     )
 
-    runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.instance, logger: io)
+    runner = MissingMetadata::Runner.new('content_id', search_config: SearchConfig.instance(Clusters.default_cluster), logger: io)
     results = runner.retrieve_records_with_missing_value
 
     expect(results).to be_empty
@@ -33,7 +33,7 @@ RSpec.describe 'MissingMetadataTest' do
       'content_id' => '8aea1742-9cc6-4dfb-a63b-12c3e66a601f',
     )
 
-    runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.instance, logger: io)
+    runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.instance(Clusters.default_cluster), logger: io)
     results = runner.retrieve_records_with_missing_value
 
     expect([{ _id: '/path/to_page', index: 'government_test', content_id: '8aea1742-9cc6-4dfb-a63b-12c3e66a601f' }]).to eq results
@@ -47,7 +47,7 @@ RSpec.describe 'MissingMetadataTest' do
       'content_store_document_type' => 'guide',
     )
 
-    runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.instance, logger: io)
+    runner = MissingMetadata::Runner.new('content_store_document_type', search_config: SearchConfig.instance(Clusters.default_cluster), logger: io)
     results = runner.retrieve_records_with_missing_value
 
     expect(results).to be_empty

--- a/spec/integration/schema_migrator_spec.rb
+++ b/spec/integration/schema_migrator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SchemaMigrator do
     index_group = search_server.index_group("govuk_test")
     original_index = index_group.current_real
 
-    migrator = described_class.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new)
+    migrator = described_class.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new)
     migrator.reindex
     migrator.switch_to_new_index
 
@@ -26,7 +26,7 @@ RSpec.describe SchemaMigrator do
     }
     commit_document("govuk_test", document)
 
-    SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2) do |migrator|
+    SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2) do |migrator|
       migrator.reindex
       migrator.switch_to_new_index
     end
@@ -39,7 +39,7 @@ RSpec.describe SchemaMigrator do
     it "identifies when content has not changed" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" })
 
-      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
+      SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         expect(migrator).not_to be_changed
@@ -49,7 +49,7 @@ RSpec.describe SchemaMigrator do
     it "finds added content" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" })
 
-      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
+      SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
@@ -62,7 +62,7 @@ RSpec.describe SchemaMigrator do
     it "finds removed content" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" }, type: "edition")
 
-      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
+      SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
@@ -78,7 +78,7 @@ RSpec.describe SchemaMigrator do
         { "link" => "/some-page", "title" => "Original title" }
       )
 
-      SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
+      SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock

--- a/spec/integration/schema_migrator_spec.rb
+++ b/spec/integration/schema_migrator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SchemaMigrator do
     }
     commit_document("govuk_test", document)
 
-    SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2) do |migrator|
+    described_class.new("govuk_test", wait_between_task_list_check: 0.2) do |migrator|
       migrator.reindex
       migrator.switch_to_new_index
     end
@@ -39,7 +39,7 @@ RSpec.describe SchemaMigrator do
     it "identifies when content has not changed" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" })
 
-      SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
+      described_class.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         expect(migrator).not_to be_changed
@@ -49,7 +49,7 @@ RSpec.describe SchemaMigrator do
     it "finds added content" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" })
 
-      SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
+      described_class.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
@@ -62,7 +62,7 @@ RSpec.describe SchemaMigrator do
     it "finds removed content" do
       commit_document("govuk_test", { "link" => "/a-page-to-be-reindexed" }, type: "edition")
 
-      SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
+      described_class.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock
@@ -78,7 +78,7 @@ RSpec.describe SchemaMigrator do
         { "link" => "/some-page", "title" => "Original title" }
       )
 
-      SchemaMigrator.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
+      described_class.new("govuk_test", wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
         migrator.reindex
 
         search_server.index_group("govuk_test").current_real.unlock

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'SitemapGeneratorTest' do
       index_name: "govuk_test"
     )
 
-    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
+    generator = SitemapGenerator.new(SearchConfig.default_instance)
     sitemap_xml = generator.sitemaps
 
     expected_sitemap_count = 2 # sample_document.count + homepage / sitemap_limit rounded up
@@ -54,7 +54,7 @@ RSpec.describe 'SitemapGeneratorTest' do
       ],
       index_name: "government_test"
     )
-    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
+    generator = SitemapGenerator.new(SearchConfig.default_instance)
     sitemap_xml = generator.sitemaps
     expect(sitemap_xml.length).to eq(1)
 
@@ -62,7 +62,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "should include homepage" do
-    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
+    generator = SitemapGenerator.new(SearchConfig.default_instance)
     sitemap_xml = generator.sitemaps
 
     pages = Nokogiri::XML(sitemap_xml[0])
@@ -74,7 +74,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "should not include recommended links" do
-    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
+    generator = SitemapGenerator.new(SearchConfig.default_instance)
     add_sample_documents(
       [
         {
@@ -96,7 +96,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "links should include timestamps" do
-    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
+    generator = SitemapGenerator.new(SearchConfig.default_instance)
     add_sample_documents(
       [
         {
@@ -122,7 +122,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "links should include priorities" do
-    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
+    generator = SitemapGenerator.new(SearchConfig.default_instance)
     add_sample_documents(
       [
         {

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'SitemapGeneratorTest' do
       index_name: "govuk_test"
     )
 
-    generator = SitemapGenerator.new(SearchConfig.instance)
+    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
     sitemap_xml = generator.sitemaps
 
     expected_sitemap_count = 2 # sample_document.count + homepage / sitemap_limit rounded up
@@ -54,7 +54,7 @@ RSpec.describe 'SitemapGeneratorTest' do
       ],
       index_name: "government_test"
     )
-    generator = SitemapGenerator.new(SearchConfig.instance)
+    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
     sitemap_xml = generator.sitemaps
     expect(sitemap_xml.length).to eq(1)
 
@@ -62,7 +62,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "should include homepage" do
-    generator = SitemapGenerator.new(SearchConfig.instance)
+    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
     sitemap_xml = generator.sitemaps
 
     pages = Nokogiri::XML(sitemap_xml[0])
@@ -74,7 +74,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "should not include recommended links" do
-    generator = SitemapGenerator.new(SearchConfig.instance)
+    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
     add_sample_documents(
       [
         {
@@ -96,7 +96,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "links should include timestamps" do
-    generator = SitemapGenerator.new(SearchConfig.instance)
+    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
     add_sample_documents(
       [
         {
@@ -122,7 +122,7 @@ RSpec.describe 'SitemapGeneratorTest' do
   end
 
   it "links should include priorities" do
-    generator = SitemapGenerator.new(SearchConfig.instance)
+    generator = SitemapGenerator.new(SearchConfig.instance(Clusters.default_cluster))
     add_sample_documents(
       [
         {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,7 +82,7 @@ RSpec.configure do |config|
     # search_config is a global object that has state, while most of the stubbing
     # is automatically reset, the index_names or passed into children object and
     # cached there.
-    SearchConfig.instance = SearchConfig.new
+    SearchConfig.reset_instances
   end
 
   if config.files_to_run.one?

--- a/spec/support/index_helpers.rb
+++ b/spec/support/index_helpers.rb
@@ -23,7 +23,7 @@ class IndexHelpers
     raise "Attempting to clean non-test index: #{index_name}" unless index_name =~ /test/
 
     Clusters.active.each { |cluster|
-      search_server = SearchConfig.instance.search_server(cluster: cluster)
+      search_server = SearchConfig.instance(cluster).search_server
       index_group = search_server.index_group(index_name)
 
       # Delete any indices left over
@@ -44,7 +44,7 @@ class IndexHelpers
 
   def self.create_test_index(group_name = DEFAULT_INDEX_NAME)
     Clusters.active.each { |cluster|
-      index_group = SearchConfig.instance.search_server(cluster: cluster).index_group(group_name)
+      index_group = SearchConfig.instance(cluster).search_server.index_group(group_name)
       index = index_group.create_index
       index_group.switch_to(index)
     }

--- a/spec/support/index_helpers.rb
+++ b/spec/support/index_helpers.rb
@@ -10,8 +10,7 @@ class IndexHelpers
   end
 
   def self.all_index_names
-    config = SearchConfig.instance
-    config.content_index_names + config.auxiliary_index_names + [config.govuk_index_name]
+    SearchConfig.content_index_names + SearchConfig.auxiliary_index_names + [SearchConfig.govuk_index_name]
   end
 
   def self.clean_all

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -244,8 +244,7 @@ private
   end
 
   def build_sample_documents_on_content_indices(documents_per_index:)
-    config = SearchConfig.instance
-    index_names = config.content_index_names + [config.govuk_index_name]
+    index_names = SearchConfig.content_index_names + [SearchConfig.govuk_index_name]
     index_names.each do |index_name|
       add_sample_documents(index_name, documents_per_index)
     end

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -60,16 +60,16 @@ module IntegrationSpecHelper
     WebMock.disable_net_connect!(allow: nil)
   end
 
-  def search_config
-    SearchConfig.instance
+  def search_config(cluster = Clusters.default_cluster)
+    SearchConfig.instance(cluster)
   end
 
   def with_just_one_cluster
     allow(Clusters).to receive(:active).and_return([Clusters.default_cluster])
   end
 
-  def search_server
-    search_config.search_server
+  def search_server(cluster = Clusters.default_cluster)
+    search_config(cluster).search_server
   end
 
   def sample_document
@@ -222,10 +222,10 @@ module IntegrationSpecHelper
   end
 
   def try_remove_test_index(index_name = nil)
-    index_name ||= SearchConfig.instance.default_index_name
-    raise "Attempting to delete non-test index: #{index_name}" unless index_name =~ /test/
-
     clusters.each { |cluster|
+      index_name ||= SearchConfig.instance(cluster).default_index_name
+      raise "Attempting to delete non-test index: #{index_name}" unless index_name =~ /test/
+
       if client(cluster: cluster).indices.exists?(index: index_name)
         client(cluster: cluster).indices.delete(index: index_name)
       end

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -251,7 +251,7 @@ private
 
   def build_government_index
     base_uri = "http://example.com:9200"
-    search_config = SearchConfig.new
+    search_config = SearchConfig.instance(Clusters.default_cluster)
     described_class.new(base_uri, "government_test", "government_test", default_mappings, search_config)
   end
 
@@ -302,7 +302,7 @@ private
 
   def stub_traffic_index
     base_uri = "http://example.com:9200"
-    search_config = SearchConfig.new
+    search_config = SearchConfig.instance(Clusters.default_cluster)
     traffic_index = described_class.new(base_uri, "page-traffic_test", "page-traffic_test", page_traffic_mappings, search_config)
     allow_any_instance_of(Indexer::PopularityLookup).to receive(:traffic_index).and_return(traffic_index)
     allow(traffic_index).to receive(:real_name).and_return("page-traffic_test")

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -251,7 +251,7 @@ private
 
   def build_government_index
     base_uri = "http://example.com:9200"
-    search_config = SearchConfig.instance(Clusters.default_cluster)
+    search_config = SearchConfig.default_instance
     described_class.new(base_uri, "government_test", "government_test", default_mappings, search_config)
   end
 
@@ -302,7 +302,7 @@ private
 
   def stub_traffic_index
     base_uri = "http://example.com:9200"
-    search_config = SearchConfig.instance(Clusters.default_cluster)
+    search_config = SearchConfig.default_instance
     traffic_index = described_class.new(base_uri, "page-traffic_test", "page-traffic_test", page_traffic_mappings, search_config)
     allow_any_instance_of(Indexer::PopularityLookup).to receive(:traffic_index).and_return(traffic_index)
     allow(traffic_index).to receive(:real_name).and_return("page-traffic_test")

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -84,8 +84,10 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     popularity = 0.0125356
 
+    # rubocop:disable RSpec/MessageSpies
     expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance(Clusters.default_cluster)).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return(payload["base_path"] => popularity)
+    # rubocop:enable RSpec/MessageSpies
 
     presenter = common_fields_presenter(payload)
 
@@ -95,8 +97,10 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
   it "no popularity when no value is returned from lookup" do
     payload = { "base_path" => "/some/path" }
 
+    # rubocop:disable RSpec/MessageSpies
     expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance(Clusters.default_cluster)).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return({})
+    # rubocop:enable RSpec/MessageSpies
 
     presenter = common_fields_presenter(payload)
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     popularity = 0.0125356
 
     # rubocop:disable RSpec/MessageSpies
-    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance(Clusters.default_cluster)).and_return(@popularity_lookup)
+    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.default_instance).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return(payload["base_path"] => popularity)
     # rubocop:enable RSpec/MessageSpies
 
@@ -98,7 +98,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     payload = { "base_path" => "/some/path" }
 
     # rubocop:disable RSpec/MessageSpies
-    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance(Clusters.default_cluster)).and_return(@popularity_lookup)
+    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.default_instance).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return({})
     # rubocop:enable RSpec/MessageSpies
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     popularity = 0.0125356
 
-    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance).and_return(@popularity_lookup)
+    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance(Clusters.default_cluster)).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return(payload["base_path"] => popularity)
 
     presenter = common_fields_presenter(payload)
@@ -95,7 +95,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
   it "no popularity when no value is returned from lookup" do
     payload = { "base_path" => "/some/path" }
 
-    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance).and_return(@popularity_lookup)
+    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.instance(Clusters.default_cluster)).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return({})
 
     presenter = common_fields_presenter(payload)

--- a/spec/unit/index/elasticsearch_processor_spec.rb
+++ b/spec/unit/index/elasticsearch_processor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Index::ElasticsearchProcessor do
     client = double('client')
     allow(Services).to receive('elasticsearch').and_return(client)
     # rubocop:disable RSpec/MessageSpies
-    expect(client).to receive(:bulk).exactly(cluster_count).times.with(index: SearchConfig.instance.govuk_index_name, body: [{ index: presenter.identifier }, presenter.document])
+    expect(client).to receive(:bulk).exactly(cluster_count).times.with(index: SearchConfig.govuk_index_name, body: [{ index: presenter.identifier }, presenter.document])
     # rubocop:enable RSpec/MessageSpies
     subject.save(presenter)
     subject.commit
@@ -39,7 +39,7 @@ RSpec.describe Index::ElasticsearchProcessor do
     allow(Services).to receive('elasticsearch').and_return(client)
     # rubocop:disable RSpec/MessageSpies
     expect(client).to receive(:bulk).exactly(cluster_count).times.with(
-      index: SearchConfig.instance.govuk_index_name,
+      index: SearchConfig.govuk_index_name,
       body: [
         {
           delete: presenter.identifier

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe SearchIndices::IndexGroup do
     headers: { "Content-Type" => "application/json" },
   }.freeze
 
+  BASE_URI = "http://example.com:9200".freeze
+
   before do
     @schema = SearchConfig.instance.search_server.schema
     @server = SearchIndices::SearchServer.new(
-      SearchConfig.instance.base_uri,
+      BASE_URI,
       @schema,
       %w(government custom),
       'govuk',
@@ -24,7 +26,7 @@ RSpec.describe SearchIndices::IndexGroup do
       "settings" => @schema.elasticsearch_settings("government"),
       "mappings" => @schema.elasticsearch_mappings("government"),
     }.to_json
-    stub = stub_request(:put, %r(#{SearchConfig.instance.base_uri}/government-.*))
+    stub = stub_request(:put, %r(#{BASE_URI}/government-.*))
       .with(body: expected_body)
       .to_return(ELASTICSEARCH_OK)
     index = @server.index_group("government").create_index
@@ -36,7 +38,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "switch index with no existing alias" do
     new_index = double("New index", index_name: "test-new")
-    get_stub = stub_request(:get, "#{SearchConfig.instance.base_uri}/_alias")
+    get_stub = stub_request(:get, "#{BASE_URI}/_alias")
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -49,7 +51,7 @@ RSpec.describe SearchIndices::IndexGroup do
         { "add" => { "index" => "test-new", "alias" => "test" } }
       ]
     }.to_json
-    post_stub = stub_request(:post, "#{SearchConfig.instance.base_uri}/_aliases")
+    post_stub = stub_request(:post, "#{BASE_URI}/_aliases")
       .with(
         body: expected_body,
         headers: { 'Content-Type' => 'application/json' }
@@ -64,7 +66,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "switch index with existing alias" do
     new_index = double("New index", index_name: "test-new")
-    get_stub = stub_request(:get, "#{SearchConfig.instance.base_uri}/_alias")
+    get_stub = stub_request(:get, "#{BASE_URI}/_alias")
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -80,7 +82,7 @@ RSpec.describe SearchIndices::IndexGroup do
         { "add" => { "index" => "test-new", "alias" => "test" } }
       ]
     }.to_json
-    post_stub = stub_request(:post, "#{SearchConfig.instance.base_uri}/_aliases")
+    post_stub = stub_request(:post, "#{BASE_URI}/_aliases")
       .with(body: expected_body)
       .to_return(ELASTICSEARCH_OK)
 
@@ -93,7 +95,7 @@ RSpec.describe SearchIndices::IndexGroup do
   it "switch index with multiple existing aliases" do
     # Not expecting the system to get into this state, but it should cope
     new_index = double("New index", index_name: "test-new")
-    get_stub = stub_request(:get, "#{SearchConfig.instance.base_uri}/_alias")
+    get_stub = stub_request(:get, "#{BASE_URI}/_alias")
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -111,7 +113,7 @@ RSpec.describe SearchIndices::IndexGroup do
         { "add" => { "index" => "test-new", "alias" => "test" } }
       ]
     }.to_json
-    post_stub = stub_request(:post, "#{SearchConfig.instance.base_uri}/_aliases")
+    post_stub = stub_request(:post, "#{BASE_URI}/_aliases")
       .with(body: expected_body)
       .to_return(ELASTICSEARCH_OK)
 
@@ -123,7 +125,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "switch index with existing real index" do
     new_index = double("New index", index_name: "test-new")
-    stub_request(:get, "#{SearchConfig.instance.base_uri}/_alias")
+    stub_request(:get, "#{BASE_URI}/_alias")
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -138,7 +140,7 @@ RSpec.describe SearchIndices::IndexGroup do
   end
 
   it "index names with no indices" do
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -150,7 +152,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "index names with index" do
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -166,7 +168,7 @@ RSpec.describe SearchIndices::IndexGroup do
     this_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     other_name = "fish-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"
 
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -180,7 +182,7 @@ RSpec.describe SearchIndices::IndexGroup do
   end
 
   it "clean with no indices" do
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -192,7 +194,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "clean with dead index" do
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -201,7 +203,7 @@ RSpec.describe SearchIndices::IndexGroup do
         }.to_json
       )
 
-    delete_stub = stub_request(:delete, "#{SearchConfig.instance.base_uri}/#{index_name}")
+    delete_stub = stub_request(:delete, "#{BASE_URI}/#{index_name}")
       .to_return(ELASTICSEARCH_OK)
 
     @server.index_group("test").clean
@@ -211,7 +213,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "clean with live index" do
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -228,7 +230,7 @@ RSpec.describe SearchIndices::IndexGroup do
       "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012",
       "test-2012-03-01t12:00:00z-abcdefab-abcd-abcd-abcd-abcdefabcdef"
     ]
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -239,7 +241,7 @@ RSpec.describe SearchIndices::IndexGroup do
       )
 
     delete_stubs = index_names.map { |index_name|
-      stub_request(:delete, "#{SearchConfig.instance.base_uri}/#{index_name}")
+      stub_request(:delete, "#{BASE_URI}/#{index_name}")
         .to_return(ELASTICSEARCH_OK)
     }
 
@@ -252,7 +254,7 @@ RSpec.describe SearchIndices::IndexGroup do
     live_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     dead_name = "test-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"
 
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -262,7 +264,7 @@ RSpec.describe SearchIndices::IndexGroup do
         }.to_json
       )
 
-    delete_stub = stub_request(:delete, "#{SearchConfig.instance.base_uri}/#{dead_name}")
+    delete_stub = stub_request(:delete, "#{BASE_URI}/#{dead_name}")
       .to_return(ELASTICSEARCH_OK)
 
     @server.index_group("test").clean
@@ -273,7 +275,7 @@ RSpec.describe SearchIndices::IndexGroup do
   it "clean with other alias" do
     # If there's an alias we don't know about, that should save the index
     index_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -290,7 +292,7 @@ RSpec.describe SearchIndices::IndexGroup do
     this_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
     other_name = "fish-2012-03-01t12:00:00z-87654321-4321-4321-4321-210987654321"
 
-    stub_request(:get, %r{#{SearchConfig.instance.base_uri}/test\*\?.*})
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
       .to_return(
         status: 200,
         headers: { 'Content-Type' => 'application/json' },
@@ -300,7 +302,7 @@ RSpec.describe SearchIndices::IndexGroup do
         }.to_json
       )
 
-    delete_stub = stub_request(:delete, "#{SearchConfig.instance.base_uri}/#{this_name}")
+    delete_stub = stub_request(:delete, "#{BASE_URI}/#{this_name}")
       .to_return(ELASTICSEARCH_OK)
 
     @server.index_group("test").clean

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe SearchIndices::IndexGroup do
   BASE_URI = "http://example.com:9200".freeze
 
   before do
-    @schema = SearchConfig.instance.search_server.schema
+    @schema = SearchConfig.instance(Clusters.default_cluster).search_server.schema
     @server = SearchIndices::SearchServer.new(
       BASE_URI,
       @schema,
       %w(government custom),
       'govuk',
       ["government"],
-      SearchConfig.new
+      SearchConfig.instance(Clusters.default_cluster),
     )
   end
 

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe SearchIndices::IndexGroup do
   BASE_URI = "http://example.com:9200".freeze
 
   before do
-    @schema = SearchConfig.instance(Clusters.default_cluster).search_server.schema
+    @schema = SearchConfig.default_instance.search_server.schema
     @server = SearchIndices::SearchServer.new(
       BASE_URI,
       @schema,
       %w(government custom),
       'govuk',
       ["government"],
-      SearchConfig.instance(Clusters.default_cluster),
+      SearchConfig.default_instance,
     )
   end
 

--- a/spec/unit/legacy_client/index_for_search_spec.rb
+++ b/spec/unit/legacy_client/index_for_search_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe LegacyClient::IndexForSearch do
   it "makes a request to elasticsearch for the alias name" do
-    base_uri = SearchConfig.instance.base_uri
+    base_uri = "http://localhost:9200"
     alias_name = "some-alias"
     real_name = "some-index"
 

--- a/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
+++ b/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
 
   before do
     base_uri = "http://example.com:9200"
-    search_config = SearchConfig.instance(Clusters.default_cluster)
+    search_config = SearchConfig.default_instance
     @wrapper = described_class.new(base_uri, "government_test", "government_test", default_mappings, search_config)
   end
 

--- a/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
+++ b/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
 
   before do
     base_uri = "http://example.com:9200"
-    search_config = SearchConfig.new
+    search_config = SearchConfig.instance(Clusters.default_cluster)
     @wrapper = described_class.new(base_uri, "government_test", "government_test", default_mappings, search_config)
   end
 

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SearchParameterParser do
       start: 0,
       count: 10,
       cluster: Clusters.default_cluster,
+      search_config: SearchConfig.instance(Clusters.default_cluster),
       query: nil,
       similar_to: nil,
       order: nil,

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SearchParameterParser do
       start: 0,
       count: 10,
       cluster: Clusters.default_cluster,
-      search_config: SearchConfig.instance(Clusters.default_cluster),
+      search_config: SearchConfig.default_instance,
       query: nil,
       similar_to: nil,
       order: nil,

--- a/spec/unit/query_components/best_bets_spec.rb
+++ b/spec/unit/query_components/best_bets_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe QueryComponents::BestBets do
   context "when best bets is disabled in debug" do
     it "return the query without modification" do
       builder = described_class.new(
-        metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index,
+        metasearch_index: SearchConfig.default_instance.metasearch_index,
         search_params: Search::QueryParameters.new(debug: { disable_best_bets: true })
       )
 
@@ -16,7 +16,7 @@ RSpec.describe QueryComponents::BestBets do
 
   context "with a single best bet url" do
     it "include the ID of the document in the results" do
-      builder = described_class.new(metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index)
+      builder = described_class.new(metasearch_index: SearchConfig.default_instance.metasearch_index)
       allow(builder).to receive(:best_bets).and_return(1 => ['/best-bet'])
 
       result = builder.wrap('QUERY')
@@ -28,7 +28,7 @@ RSpec.describe QueryComponents::BestBets do
 
   context "with two best bet urls on different positions" do
     it "include IDs of the documents in the results" do
-      builder = described_class.new(metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index)
+      builder = described_class.new(metasearch_index: SearchConfig.default_instance.metasearch_index)
       allow(builder).to receive(:best_bets).and_return(1 => ['/best-bet'], 2 => ['/other-best-bet'])
 
       result = builder.wrap('QUERY')
@@ -48,7 +48,7 @@ RSpec.describe QueryComponents::BestBets do
 
   context "with two best bet urls on the same position" do
     it "include IDs of the documents in the results" do
-      builder = described_class.new(metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index)
+      builder = described_class.new(metasearch_index: SearchConfig.default_instance.metasearch_index)
       allow(builder).to receive(:best_bets).and_return(1 => ['/best-bet', '/other-best-bet'])
 
       result = builder.wrap('QUERY')
@@ -60,7 +60,7 @@ RSpec.describe QueryComponents::BestBets do
 
   context "with a 'worst bet'" do
     it "completely exclude the documents from the results" do
-      builder = described_class.new(metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index)
+      builder = described_class.new(metasearch_index: SearchConfig.default_instance.metasearch_index)
       allow(builder).to receive(:worst_bets).and_return(['/worst-bet', '/other-worst-bet'])
 
       result = builder.wrap({})

--- a/spec/unit/query_components/best_bets_spec.rb
+++ b/spec/unit/query_components/best_bets_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe QueryComponents::BestBets do
   context "when best bets is disabled in debug" do
     it "return the query without modification" do
       builder = described_class.new(
-        metasearch_index: SearchConfig.instance.metasearch_index,
+        metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index,
         search_params: Search::QueryParameters.new(debug: { disable_best_bets: true })
       )
 
@@ -16,7 +16,7 @@ RSpec.describe QueryComponents::BestBets do
 
   context "with a single best bet url" do
     it "include the ID of the document in the results" do
-      builder = described_class.new(metasearch_index: SearchConfig.instance.metasearch_index)
+      builder = described_class.new(metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index)
       allow(builder).to receive(:best_bets).and_return(1 => ['/best-bet'])
 
       result = builder.wrap('QUERY')
@@ -28,7 +28,7 @@ RSpec.describe QueryComponents::BestBets do
 
   context "with two best bet urls on different positions" do
     it "include IDs of the documents in the results" do
-      builder = described_class.new(metasearch_index: SearchConfig.instance.metasearch_index)
+      builder = described_class.new(metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index)
       allow(builder).to receive(:best_bets).and_return(1 => ['/best-bet'], 2 => ['/other-best-bet'])
 
       result = builder.wrap('QUERY')
@@ -48,7 +48,7 @@ RSpec.describe QueryComponents::BestBets do
 
   context "with two best bet urls on the same position" do
     it "include IDs of the documents in the results" do
-      builder = described_class.new(metasearch_index: SearchConfig.instance.metasearch_index)
+      builder = described_class.new(metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index)
       allow(builder).to receive(:best_bets).and_return(1 => ['/best-bet', '/other-best-bet'])
 
       result = builder.wrap('QUERY')
@@ -60,7 +60,7 @@ RSpec.describe QueryComponents::BestBets do
 
   context "with a 'worst bet'" do
     it "completely exclude the documents from the results" do
-      builder = described_class.new(metasearch_index: SearchConfig.instance.metasearch_index)
+      builder = described_class.new(metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index)
       allow(builder).to receive(:worst_bets).and_return(['/worst-bet', '/other-worst-bet'])
 
       result = builder.wrap({})

--- a/spec/unit/schema/combined_index_schema_spec.rb
+++ b/spec/unit/schema/combined_index_schema_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe CombinedIndexSchema do
   before do
-    search_config = SearchConfig.new
+    search_config = SearchConfig.new(Clusters.default_cluster)
     @index_names = SearchConfig.content_index_names + [SearchConfig.govuk_index_name]
     @combined_schema = described_class.new(@index_names, search_config.schema_config)
   end

--- a/spec/unit/schema/combined_index_schema_spec.rb
+++ b/spec/unit/schema/combined_index_schema_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe CombinedIndexSchema do
   before do
-    search_config = SearchConfig.new(Clusters.default_cluster)
+    search_config = SearchConfig.default_instance
     @index_names = SearchConfig.content_index_names + [SearchConfig.govuk_index_name]
     @combined_schema = described_class.new(@index_names, search_config.schema_config)
   end

--- a/spec/unit/schema/combined_index_schema_spec.rb
+++ b/spec/unit/schema/combined_index_schema_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe CombinedIndexSchema do
   before do
     search_config = SearchConfig.new
-    @index_names = search_config.content_index_names + [search_config.govuk_index_name]
+    @index_names = SearchConfig.content_index_names + [SearchConfig.govuk_index_name]
     @combined_schema = described_class.new(@index_names, search_config.schema_config)
   end
 

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Search::FormatMigrator do
           }
         }
         expect(described_class.new(
+          SearchConfig.instance(Clusters.default_cluster),
           base_query: base_query,
-          cluster: cluster,
         ).call).to eq(expected)
       end
 
@@ -63,7 +63,10 @@ RSpec.describe Search::FormatMigrator do
             ]
           }
         }
-        expect(described_class.new(base_query: base_query, cluster: cluster).call).to eq(expected)
+        expect(described_class.new(
+          SearchConfig.instance(Clusters.default_cluster),
+          base_query: base_query,
+        ).call).to eq(expected)
       end
 
       it "when no base query without migrated formats" do
@@ -83,7 +86,7 @@ RSpec.describe Search::FormatMigrator do
           }
         }
         expect(described_class.new(
-          cluster: cluster,
+          SearchConfig.instance(Clusters.default_cluster),
         ).call).to eq(expected)
       end
 
@@ -115,7 +118,7 @@ RSpec.describe Search::FormatMigrator do
           }
         }
         expect(described_class.new(
-          cluster: cluster,
+          SearchConfig.instance(Clusters.default_cluster),
         ).call).to eq(expected)
       end
     end

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Search::FormatMigrator do
           }
         }
         expect(described_class.new(
-          SearchConfig.instance(Clusters.default_cluster),
+          SearchConfig.default_instance,
           base_query: base_query,
         ).call).to eq(expected)
       end
@@ -64,7 +64,7 @@ RSpec.describe Search::FormatMigrator do
           }
         }
         expect(described_class.new(
-          SearchConfig.instance(Clusters.default_cluster),
+          SearchConfig.default_instance,
           base_query: base_query,
         ).call).to eq(expected)
       end
@@ -86,7 +86,7 @@ RSpec.describe Search::FormatMigrator do
           }
         }
         expect(described_class.new(
-          SearchConfig.instance(Clusters.default_cluster),
+          SearchConfig.default_instance,
         ).call).to eq(expected)
       end
 
@@ -118,7 +118,7 @@ RSpec.describe Search::FormatMigrator do
           }
         }
         expect(described_class.new(
-          SearchConfig.instance(Clusters.default_cluster),
+          SearchConfig.default_instance,
         ).call).to eq(expected)
       end
     end

--- a/spec/unit/search/query_builder_spec.rb
+++ b/spec/unit/search/query_builder_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Search::QueryBuilder do
     described_class.new(
       search_params: Search::QueryParameters.new({ filters: [] }.merge(params)),
       content_index_names: SearchConfig.content_index_names,
-      metasearch_index: SearchConfig.instance.metasearch_index
+      metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index
     )
   end
 end

--- a/spec/unit/search/query_builder_spec.rb
+++ b/spec/unit/search/query_builder_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Search::QueryBuilder do
   def builder_with_params(params)
     described_class.new(
       search_params: Search::QueryParameters.new({ filters: [] }.merge(params)),
-      content_index_names: SearchConfig.instance.content_index_names,
+      content_index_names: SearchConfig.content_index_names,
       metasearch_index: SearchConfig.instance.metasearch_index
     )
   end

--- a/spec/unit/search/query_builder_spec.rb
+++ b/spec/unit/search/query_builder_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Search::QueryBuilder do
     described_class.new(
       search_params: Search::QueryParameters.new({ filters: [] }.merge(params)),
       content_index_names: SearchConfig.content_index_names,
-      metasearch_index: SearchConfig.instance(Clusters.default_cluster).metasearch_index
+      metasearch_index: SearchConfig.default_instance.metasearch_index
     )
   end
 end

--- a/spec/unit/search_server_spec.rb
+++ b/spec/unit/search_server_spec.rb
@@ -9,35 +9,35 @@ RSpec.describe SearchIndices::SearchServer do
   end
 
   it "returns an index" do
-    search_server = described_class.new("http://l", schema_config, ["government_test", "page-traffic_test"], 'govuk_test', ["government_test"], SearchConfig.new)
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
     index = search_server.index("government_test")
     expect(index).to be_a(SearchIndices::Index)
     expect(index.index_name).to eq("government_test")
   end
 
   it "returns an index for govuk index" do
-    search_server = described_class.new("http://l", schema_config, ["government_test", "page-traffic_test"], 'govuk_test', ["government_test"], SearchConfig.new)
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
     index = search_server.index("govuk_test")
     expect(index).to be_a(SearchIndices::Index)
     expect(index.index_name).to eq("govuk_test")
   end
 
   it "raises an error for unknown index" do
-    search_server = described_class.new("http://l", schema_config, ["government_test", "page-traffic_test"], 'govuk_test', ["government_test"], SearchConfig.new)
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
     expect {
       search_server.index("z")
     }.to raise_error(SearchIndices::NoSuchIndex)
   end
 
   it "can get multi index" do
-    search_server = described_class.new("http://l", schema_config, ["government_test", "page-traffic_test"], 'govuk_test', ["government_test"], SearchConfig.new)
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
     index = search_server.index_for_search(%w{government_test page-traffic_test})
     expect(index).to be_a(LegacyClient::IndexForSearch)
     expect(index.index_names).to eq(["government_test", "page-traffic_test"])
   end
 
   it "raises an error for unknown index in multi index" do
-    search_server = described_class.new("http://l", schema_config, ["government_test", "page-traffic_test"], 'govuk_test', ["government_test"], SearchConfig.new)
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
     expect {
       search_server.index_for_search(%w{government_test unknown})
     }.to raise_error(SearchIndices::NoSuchIndex)

--- a/spec/unit/search_server_spec.rb
+++ b/spec/unit/search_server_spec.rb
@@ -9,35 +9,35 @@ RSpec.describe SearchIndices::SearchServer do
   end
 
   it "returns an index" do
-    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.default_instance)
     index = search_server.index("government_test")
     expect(index).to be_a(SearchIndices::Index)
     expect(index.index_name).to eq("government_test")
   end
 
   it "returns an index for govuk index" do
-    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.default_instance)
     index = search_server.index("govuk_test")
     expect(index).to be_a(SearchIndices::Index)
     expect(index.index_name).to eq("govuk_test")
   end
 
   it "raises an error for unknown index" do
-    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.default_instance)
     expect {
       search_server.index("z")
     }.to raise_error(SearchIndices::NoSuchIndex)
   end
 
   it "can get multi index" do
-    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.default_instance)
     index = search_server.index_for_search(%w{government_test page-traffic_test})
     expect(index).to be_a(LegacyClient::IndexForSearch)
     expect(index.index_names).to eq(["government_test", "page-traffic_test"])
   end
 
   it "raises an error for unknown index in multi index" do
-    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.new(Clusters.default_cluster))
+    search_server = described_class.new("http://l", schema_config, %w[government_test page-traffic_test], 'govuk_test', %w[government_test], SearchConfig.default_instance)
     expect {
       search_server.index_for_search(%w{government_test unknown})
     }.to raise_error(SearchIndices::NoSuchIndex)

--- a/spec/unit/sitemap/sitemap_generator_spec.rb
+++ b/spec/unit/sitemap/sitemap_generator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SitemapGenerator do
   # rubocop:enable RSpec/AnyInstance
 
   it "should generate sitemap" do
-    sitemap = described_class.new(SearchConfig.instance(Clusters.default_cluster))
+    sitemap = described_class.new(SearchConfig.default_instance)
 
     sitemap_xml = sitemap.generate_xml([
       build_document('https://www.gov.uk/page'),
@@ -24,7 +24,7 @@ RSpec.describe SitemapGenerator do
   end
 
   it "links should include timestamps" do
-    sitemap = described_class.new(SearchConfig.instance(Clusters.default_cluster))
+    sitemap = described_class.new(SearchConfig.default_instance)
 
     sitemap_xml = sitemap.generate_xml([
       build_document('/some-page', timestamp: "2014-01-28T14:41:50+00:00"),
@@ -36,7 +36,7 @@ RSpec.describe SitemapGenerator do
   end
 
   it "missing timestamps are ignored" do
-    sitemap = described_class.new(SearchConfig.instance(Clusters.default_cluster))
+    sitemap = described_class.new(SearchConfig.default_instance)
 
     sitemap_xml = sitemap.generate_xml([
       build_document('/page-without-date'),
@@ -48,7 +48,7 @@ RSpec.describe SitemapGenerator do
   end
 
   it "page priority is document priority" do
-    sitemap = described_class.new(SearchConfig.instance(Clusters.default_cluster))
+    sitemap = described_class.new(SearchConfig.default_instance)
 
     document = build_document('/some-path')
     allow(document).to receive(:priority).and_return(0.48)

--- a/spec/unit/sitemap/sitemap_generator_spec.rb
+++ b/spec/unit/sitemap/sitemap_generator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SitemapGenerator do
   # rubocop:enable RSpec/AnyInstance
 
   it "should generate sitemap" do
-    sitemap = described_class.new(index_names: '')
+    sitemap = described_class.new(SearchConfig.instance(Clusters.default_cluster))
 
     sitemap_xml = sitemap.generate_xml([
       build_document('https://www.gov.uk/page'),
@@ -24,7 +24,7 @@ RSpec.describe SitemapGenerator do
   end
 
   it "links should include timestamps" do
-    sitemap = described_class.new(index_names: '')
+    sitemap = described_class.new(SearchConfig.instance(Clusters.default_cluster))
 
     sitemap_xml = sitemap.generate_xml([
       build_document('/some-page', timestamp: "2014-01-28T14:41:50+00:00"),
@@ -36,7 +36,7 @@ RSpec.describe SitemapGenerator do
   end
 
   it "missing timestamps are ignored" do
-    sitemap = described_class.new(index_names: '')
+    sitemap = described_class.new(SearchConfig.instance(Clusters.default_cluster))
 
     sitemap_xml = sitemap.generate_xml([
       build_document('/page-without-date'),
@@ -48,7 +48,7 @@ RSpec.describe SitemapGenerator do
   end
 
   it "page priority is document priority" do
-    sitemap = described_class.new(index_names: '')
+    sitemap = described_class.new(SearchConfig.instance(Clusters.default_cluster))
 
     document = build_document('/some-path')
     allow(document).to receive(:priority).and_return(0.48)


### PR DESCRIPTION
Once upon a time, `SearchConfig` was written to be a singleton.  This is great because it means you don't need to pass around instances, and it's not like it has any parameters you'd want to vary anyway.  A perfect use-case for singletons!

Then we did add a parameter you'd want to vary: the `cluster` parameter (#1569).

So most of the `SearchConfig` methods gained this `cluster` parameter, and suddenly everything which used the `SearchConfig` needed to know which cluster was involved, which lead to bugs like trying to use the name of the A-cluster `govuk` index when querying the B-cluster (#1598).

This was kind of ugly, and resulted in extra details (which cluster is involved) leaking everywhere.

---

This PR refactors `SearchConfig` in two ways:

1. All of the instance methods of `SearchConfig` which don't depend on the cluster have been made into class methods.

2. `SearchConfig.instance` now takes a cluster as a parameter and gives you a singleton *for that cluster and that cluster only*.

There's only one method with a `cluster` parameter: `SearchConfig.instance`.

You can instantiate that where you know about clusters, and pass it around.  The `SearchConfig` instance is included in the parsed search parameters (https://github.com/alphagov/search-api/compare/msw/search-config-multitons#diff-ffd1e106d51fda621cbe236a94af230bR45), so we're back in the good old days of `FormatMigrator` not needing to know about clusters (https://github.com/alphagov/search-api/compare/msw/search-config-multitons#diff-9c33d3755e40621e634488b1bc1fa3dcR3), it just needs to use the `SearchConfig` instance it is given.

---

I also made some changes to try to make it more difficult to misuse clusters:

1. I removed the `SearchConfig.instance.base_uri` method.  It was only used in the tests.  Using it in the application code would be wrong because it refers to the A-cluster.

2. I added a `SearchConfig.default_instance` method.  Things which don't care about clusters (or only run against the A-cluster) can use it.  I did this rather give the `cluster` parameter of `SearchConfig.instance` a default value so that you have to explicitly opt in to using the default configuration.

---

There are a lot of changes strewn throughout the code, but they're mostly one-line changes.

I recommend reviewing this PR commit-by-commit.

[Trello card](https://trello.com/c/uU9X6aZY/836-tidy-up-multi-cluster-code-in-search-api)