### PR TITLE
Boost step by steps

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -2,6 +2,7 @@ base:
   format:
     service_manual_guide: 0.3
     service_manual_topic: 0.3
+    step_by_step_nav: 2.5
     transaction: 1.5
     # Should appear below govuk (mainstream) content
     aaib_report: 0.2


### PR DESCRIPTION
In the absence of any boosting factor, step by steps will have it set to 1 which is lower than document collections and topical events. 😿 

2.5 is equivalent to things like answers and guides (they're in the navigation_document_supertype of guidance)

This is also used in sitemaps - so may affect relative ranking of these pages in external search engines.