### PR TITLE
Fix policy papers & consultations facet value

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -54,7 +54,7 @@ details:
       value: news_and_communications
     - label: Research and statistics
       value: research_and_statistics
-    - label: Policy and engagement
+    - label: Policy papers and consultations
       value: policy_and_engagement
     - label: Transparency and freedom of information releases
       value: transparency


### PR DESCRIPTION
The internal name of the supergroup is "policy_and_engagement", but
the human name is "policy papers and consultations".

https://trello.com/c/eexC0KOn/839-fix-policy-papers-consultations-facet-value