### PR TITLE
Add "/help/cookie-details" to block list

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -296,6 +296,9 @@ migrated:
 
 indexable: []
 
+non_indexable_path:
+- '/help/cookie-details'
+
 non_indexable:
 - calculator
 - license_finder

--- a/lib/govuk_index/migrated_formats.rb
+++ b/lib/govuk_index/migrated_formats.rb
@@ -5,11 +5,15 @@ module GovukIndex
     def non_indexable?(format, path, app)
       non_indexable_formats[format] &&
         (non_indexable_formats[format] == :all || non_indexable_formats[format].include?(path) ||
-          published_by_non_indexable_app?(format, app))
+          published_by_non_indexable_app?(format, app)) || non_indexable_path.include?(path)
     end
 
     def non_indexable_formats
       @non_indexable_formats ||= convert_to_allowed_hash(data_file['non_indexable'])
+    end
+
+    def non_indexable_path
+      @non_indexable_path ||= data_file['non_indexable_path']
     end
 
     def indexable?(format, path, app)

--- a/spec/unit/govuk_index/migrated_formats_spec.rb
+++ b/spec/unit/govuk_index/migrated_formats_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe GovukIndex::MigratedFormats do
     end
   end
 
+  describe 'content that has indexable format but non-indexable path' do
+    it 'returns true if the content is non indexable for a format that is otherwise indexable' do
+      non_indexable_path = described_class.non_indexable_path
+
+      expect(non_indexable_path.include?('/help/cookie-details')).to be true
+      expect(described_class.non_indexable?('help_page', '/help/cookie-details', 'publisher')).to be true
+    end
+  end
+
   describe 'content that can be published by both Content Publisher and Whitehall' do
     it '#non_indexable? returns false if content is published by Content Publisher' do
       expect(described_class.non_indexable?('news_story', '/a-path', 'content-publisher')).to be false


### PR DESCRIPTION
This page needs to be hidden from search, as it's additional
information if the user has come form "/help/cookies/".
Visiting this page directly is not useful.

Note that you will still have to remove the page from the search index manually through the Search Admin. This only prevents it from being re-indexed.