### PR TITLE
Adds topical event as a filterable parameter

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -87,6 +87,15 @@ details:
     short_name: Updated
     preposition: Updated
     type: date
+  - display_as_result_metadata: false
+    filterable: true
+    key: topical_events
+    name: Topical event
+    preposition: about
+    short_name: about
+    type: hidden
+    show_option_select_filter: false
+    allowed_values: []
   show_summaries: true
   sort:
   - default: true

--- a/config/finders/news_and_communications_finder.yml
+++ b/config/finders/news_and_communications_finder.yml
@@ -85,6 +85,15 @@ details:
     type: date
     display_as_result_metadata: true
     filterable: true
+  - display_as_result_metadata: false
+    filterable: true
+    key: topical_events
+    name: Topical event
+    preposition: about
+    short_name: about
+    type: hidden
+    show_option_select_filter: false
+    allowed_values: []
   default_documents_per_page: 20
 routes:
 - path: "/search/news-and-communications"

--- a/config/finders/policy_and_engagement_finder.yml
+++ b/config/finders/policy_and_engagement_finder.yml
@@ -91,6 +91,15 @@ details:
     type: date
     display_as_result_metadata: true
     filterable: true
+  - display_as_result_metadata: false
+    filterable: true
+    key: topical_events
+    name: Topical event
+    preposition: about
+    short_name: about
+    type: hidden
+    show_option_select_filter: false
+    allowed_values: []
   default_documents_per_page: 20
 routes:
 - path: "/search/policy-papers-and-consultations"


### PR DESCRIPTION
Topical events have links to publications and announcements which redirect to these finders.  Until this change, the parameter would just be ignored.

This does not show a facet or a facet tag for topical events, but allows us to filter by topical event which fixes the issue in https://govuk.zendesk.com/agent/tickets/3732860.

We'll address this more fully with planned work.