### PR TITLE
Fix reference to SearchConfig in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ def logger
 end
 
 def search_server(cluster: Clusters.default_cluster)
-  search_config.instance(cluster).search_server
+  SearchConfig.instance(cluster).search_server
 end
 
 def clusters_from_args(args)


### PR DESCRIPTION
This PR fixes the reference to `SearchConfig` in the `Rakefile`. It was previously set to `search_config`, however this method was recently removed.