### PR TITLE
Allow configuring Redis for test environment

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,8 @@ require "govuk_sidekiq/sidekiq_initializer"
 
 if ENV["RACK_ENV"] == "test"
   redis_config = {
-    url: "redis://127.0.0.1:6379/0",
+    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
+    port: ENV.fetch("REDIS_PORT", 6379),
     namespace: "search-api-test"
   }
 


### PR DESCRIPTION
Trello: https://trello.com/c/TutEPhvS/39-set-up-search-api

This uses the same environment variables that are allowed in other
environments to configure redis. The need for this change was prompted
by trying to run the tests for search-api in a docker environment.