### PR TITLE
Fix class variable caching in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ group :test do
   gem 'govuk-content-schema-test-helpers', '~> 1.6.1'
   gem "rack-test", "~> 1.1.0"
   gem 'rspec'
-  gem 'rspec-sidekiq'
   gem "simplecov", "~> 0.16.1"
   gem "simplecov-rcov", "~> 0.2.3"
   gem "timecop", "~> 0.9.1"

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :test do
   gem 'govuk-content-schema-test-helpers', '~> 1.6.1'
   gem "rack-test", "~> 1.1.0"
   gem 'rspec'
+  gem 'rspec-sidekiq'
   gem "simplecov", "~> 0.16.1"
   gem "simplecov-rcov", "~> 0.2.3"
   gem "timecop", "~> 0.9.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
+    rspec-sidekiq (3.0.3)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.8.0)
     rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
@@ -281,6 +284,7 @@ DEPENDENCIES
   rainbow
   rake (~> 12.3)
   rspec
+  rspec-sidekiq
   sidekiq-limit_fetch
   simplecov (~> 0.16.1)
   simplecov-rcov (~> 0.2.3)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,8 @@ require "govuk_sidekiq/sidekiq_initializer"
 
 if ENV["RACK_ENV"] == "test"
   redis_config = {
-    url: "redis://127.0.0.1:6379/0",
+    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
+    port: ENV.fetch("REDIS_PORT", 6379),
     namespace: "search-api-test"
   }
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,8 +2,8 @@ require "govuk_sidekiq/sidekiq_initializer"
 
 if ENV["RACK_ENV"] == "test"
   redis_config = {
-    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
-    port: ENV.fetch("REDIS_PORT", 6379),
+    host: ENV.fetch("REDIS_TEST_HOST", "127.0.0.1"),
+    port: ENV.fetch("REDIS_TEST_PORT", 6379),
     namespace: "search-api-test"
   }
 

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -25,7 +25,7 @@ development:
 
 test:
   base_uri: <%= ENV.fetch('ELASTICSEARCH_URI', 'http://localhost:9200') %>
-  base_uri_b: <%= ENV["ELASTICSEARCH_B_URI"] %>
+  base_uri_b: <%= ENV.fetch("ELASTICSEARCH_B_URI", 'http://localhost:9201') %>
   content_index_names: ["government_test"]
   govuk_index_name: "govuk_test"
   auxiliary_index_names: ["page-traffic_test", "metasearch_test"]

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -8,13 +8,11 @@ class Cache
   @@cache = {}
 
   def self.get(key)
-    @@cache[key] || begin
-       block_given? ? (@@cache[key] = yield) : nil
+    if @@cache.has_key?(key)
+      @@cache[key]
+    else
+      block_given? ? (@@cache[key] = yield) : nil
     end
-  end
-
-  def self.put(key, value)
-    @@cache[key] = value
   end
 
   def self.clear

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -1,21 +1,21 @@
 class Cache
-  COMBINED_INDEX_SCHEMA = 'COMBINED_INDEX_SCHEMA:'
-  SEARCH_SERVERS = 'SEARCH_SERVERS:'
-  SEARCH_CONFIG = 'SEARCH_CONFIG:'
-  CLUSTER = 'CLUSTER:'
-  ACTIVE_CLUSTERS = 'ACTIVE_CLUSTERS:'
+  COMBINED_INDEX_SCHEMA = 'COMBINED_INDEX_SCHEMA:'.freeze
+  SEARCH_SERVERS = 'SEARCH_SERVERS:'.freeze
+  SEARCH_CONFIG = 'SEARCH_CONFIG:'.freeze
+  CLUSTER = 'CLUSTER:'.freeze
+  ACTIVE_CLUSTERS = 'ACTIVE_CLUSTERS:'.freeze
 
-  @@cache = {}
+  @cache = {}
 
   def self.get(key)
-    if @@cache.has_key?(key)
-      @@cache[key]
+    if @cache.has_key?(key)
+      @cache[key]
     else
-      block_given? ? (@@cache[key] = yield) : nil
+      block_given? ? (@cache[key] = yield) : nil
     end
   end
 
   def self.clear
-    @@cache = {}
+    @cache = {}
   end
 end

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -1,0 +1,23 @@
+class Cache
+  COMBINED_INDEX_SCHEMA = 'COMBINED_INDEX_SCHEMA:'
+  SEARCH_SERVERS = 'SEARCH_SERVERS:'
+  SEARCH_CONFIG = 'SEARCH_CONFIG:'
+  CLUSTER = 'CLUSTER:'
+  ACTIVE_CLUSTERS = 'ACTIVE_CLUSTERS:'
+
+  @@cache = {}
+
+  def self.get(key)
+    @@cache[key] || begin
+       block_given? ? (@@cache[key] = yield) : nil
+    end
+  end
+
+  def self.put(key, value)
+    @@cache[key] = value
+  end
+
+  def self.clear
+    @@cache = {}
+  end
+end

--- a/lib/clusters/cluster.rb
+++ b/lib/clusters/cluster.rb
@@ -24,7 +24,7 @@ module Clusters
     attr_reader :uri_key
 
     def elasticsearch_config
-      @elasticsearch_config ||= ElasticsearchConfig.new.config
+      ElasticsearchConfig.new.config
     end
   end
 end

--- a/lib/clusters/clusters.rb
+++ b/lib/clusters/clusters.rb
@@ -32,7 +32,7 @@ module Clusters
   end
 
   def self.active
-    Cache.get(Cache::ACTIVE_CLUSTERS)  do
+    Cache.get(Cache::ACTIVE_CLUSTERS) do
       defined_clusters = ElasticsearchConfig.new.config['clusters']
       defined_clusters.map { |cluster| Cluster.new(cluster.deep_symbolize_keys) }
       .reject(&:inactive?)

--- a/lib/clusters/clusters.rb
+++ b/lib/clusters/clusters.rb
@@ -32,12 +32,10 @@ module Clusters
   end
 
   def self.active
-    Services.cache.fetch("elastic_search_active_clusters") do
-      begin
-        defined_clusters = ElasticsearchConfig.new.config['clusters']
-        defined_clusters.map { |cluster| Cluster.new(cluster.deep_symbolize_keys) }
-        .reject(&:inactive?)
-      end
+    Cache.get(Cache::ACTIVE_CLUSTERS)  do
+      defined_clusters = ElasticsearchConfig.new.config['clusters']
+      defined_clusters.map { |cluster| Cluster.new(cluster.deep_symbolize_keys) }
+      .reject(&:inactive?)
     end
   end
 end

--- a/lib/content_item_publisher/publisher.rb
+++ b/lib/content_item_publisher/publisher.rb
@@ -27,9 +27,13 @@ module ContentItemPublisher
 
       logger.info("Publishing #{presenter.description}")
 
-      Services.publishing_api.put_content(presenter.content_id, presenter.present)
-      Services.publishing_api.patch_links(presenter.content_id, presenter.present_links)
-      Services.publishing_api.publish(presenter.content_id)
+      publishing_api.put_content(presenter.content_id, presenter.present)
+      publishing_api.patch_links(presenter.content_id, presenter.present_links)
+      publishing_api.publish(presenter.content_id)
+    end
+
+    def publishing_api
+      @publishing_api ||= Services.publishing_api
     end
   end
 end

--- a/lib/govuk_index/page_traffic_loader.rb
+++ b/lib/govuk_index/page_traffic_loader.rb
@@ -13,10 +13,8 @@ module GovukIndex
 
       old_index = index_group.current_real
       @logger.info "Old index #{old_index.real_name}"
-
       old_index.with_lock do
         @logger.info "Indexing to #{new_index.real_name}"
-
         in_even_sized_batches(iostream) do |lines|
           GovukIndex::PageTrafficWorker.perform_async(lines, new_index.real_name, cluster.key)
         end

--- a/lib/index_finder.rb
+++ b/lib/index_finder.rb
@@ -10,11 +10,11 @@ class IndexFinder
     end
 
     def search_config
-      @search_config ||= SearchConfig.default_instance
+      @search_config = SearchConfig.default_instance
     end
 
     def search_server
-      @search_server ||= search_config.search_server
+      @search_server = search_config.search_server
     end
   end
 end

--- a/lib/indexer/workers/base_worker.rb
+++ b/lib/indexer/workers/base_worker.rb
@@ -32,6 +32,8 @@ module Indexer
 
     def indexes(index_name)
       SearchConfig.search_servers.map { |search_server|
+        puts "CALL INDEX"
+        puts caller
         search_server.index(index_name)
       }
     end

--- a/lib/indexer/workers/base_worker.rb
+++ b/lib/indexer/workers/base_worker.rb
@@ -32,8 +32,6 @@ module Indexer
 
     def indexes(index_name)
       SearchConfig.search_servers.map { |search_server|
-        puts "CALL INDEX"
-        puts caller
         search_server.index(index_name)
       }
     end

--- a/lib/indexer/workers/bulk_index_worker.rb
+++ b/lib/indexer/workers/bulk_index_worker.rb
@@ -5,7 +5,6 @@ module Indexer
     def perform(index_name, document_hashes)
       noun = document_hashes.size > 1 ? "documents" : "document"
       logger.info "Indexing #{document_hashes.size} queued #{noun} into #{index_name}"
-
       begin
         indexes(index_name).each { |index| index.bulk_index(document_hashes) }
       rescue SearchIndices::IndexLocked

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -39,6 +39,7 @@ initializers_path = File.expand_path("../config/initializers/*.rb", __dir__)
 Dir[initializers_path].each { |f| require f }
 
 require 'analytics_data'
+require 'cache'
 require File.expand_path('../config/logging_setup', __dir__)
 require 'document'
 require 'govuk_document_types'

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -80,10 +80,10 @@ class SearchConfig
       # index schema uses) is unaffected by the 'elasticsearch_settings'
       # field (which is what can be overridden per-cluster).
       Cache.get(Cache::COMBINED_INDEX_SCHEMA) do
-      CombinedIndexSchema.new(
-          content_index_names + [govuk_index_name],
-          default_instance.schema_config
-        )
+        CombinedIndexSchema.new(
+            content_index_names + [govuk_index_name],
+            default_instance.schema_config
+          )
       end
     end
   end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -81,8 +81,8 @@ class SearchConfig
       # field (which is what can be overridden per-cluster).
       Cache.get(Cache::COMBINED_INDEX_SCHEMA) do
         CombinedIndexSchema.new(
-            content_index_names + [govuk_index_name],
-            default_instance.schema_config
+          content_index_names + [govuk_index_name],
+          default_instance.schema_config
           )
       end
     end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -68,7 +68,7 @@ class SearchConfig
 
     def elasticsearch
       Cache.get(Cache::SEARCH_CONFIG) do
-        @elasticsearch = ElasticsearchConfig.new.config
+        ElasticsearchConfig.new.config
       end
     end
 

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -18,8 +18,9 @@ class SearchConfig
     end
 
     def instance(cluster)
-      @instance ||= {}
-      @instance[cluster.key] ||= new(cluster)
+      Cache.get("#{Cache::CLUSTER}#{cluster.key}") do
+        new(cluster)
+      end
     end
 
     def default_instance
@@ -28,13 +29,8 @@ class SearchConfig
       instance(Clusters.default_cluster)
     end
 
-    def reset_instances
-      # used in the tests because SearchConfig.instance is stateful
-      @instance = {}
-    end
-
     def search_servers
-      @search_servers ||= begin
+      Cache.get(Cache::SEARCH_SERVERS) do
         Clusters.active.map { |cluster| SearchConfig.instance(cluster).search_server }
       end
     end
@@ -71,7 +67,9 @@ class SearchConfig
     end
 
     def elasticsearch
-      @elasticsearch ||= ElasticsearchConfig.new.config
+      Cache.get(Cache::SEARCH_CONFIG) do
+        @elasticsearch = ElasticsearchConfig.new.config
+      end
     end
 
   private
@@ -81,10 +79,12 @@ class SearchConfig
       # fine because the 'elasticsearch_types' field (which the combined
       # index schema uses) is unaffected by the 'elasticsearch_settings'
       # field (which is what can be overridden per-cluster).
-      @combined_index_schema ||= CombinedIndexSchema.new(
-        content_index_names + [govuk_index_name],
-        default_instance.schema_config
-      )
+      Cache.get(Cache::COMBINED_INDEX_SCHEMA) do
+      CombinedIndexSchema.new(
+          content_index_names + [govuk_index_name],
+          default_instance.schema_config
+        )
+      end
     end
   end
 

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,7 +2,7 @@ require 'active_support/cache'
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(
+    GdsApi::PublishingApiV2.new(
       Plek.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
 
@@ -37,17 +37,11 @@ module Services
   end
 
   def self.statsd_client
-    @statsd_client ||= Statsd.new.tap { |sd| sd.namespace = "govuk.app.search-api" }
+    Statsd.new.tap { |sd| sd.namespace = "govuk.app.search-api" }
   end
 
   def self.cache
-    @cache ||= if ENV['RACK_ENV'] == 'production'
-                 # Using a memory store as this is expected to store signon
-                 # tokens, this will be cleared each time the app starts
-                 ActiveSupport::Cache.lookup_store(:memory_store)
-               else
-                 ActiveSupport::Cache.lookup_store(:null_store)
-               end
+    ActiveSupport::Cache.lookup_store(:memory_store)
   end
 end
 

--- a/spec/integration/workers/indexer/amend_worker_spec.rb
+++ b/spec/integration/workers/indexer/amend_worker_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 require 'sidekiq/testing'
 
 RSpec.describe Indexer::AmendWorker do
-  let(:index_name) {'government_test'}
-  let(:link) {'/doc-for-deletion'}
-  let(:content_id) {'41609206-8736-4ff3-b582-63c9fccafe4d'}
-  let(:document) {{"title" => 'Old title', "content_id" => content_id, "link" => link}}
-  let(:updates) {{"title" => "New title"}}
-  let(:cluster_count) {Clusters.count}
+  let(:index_name) { 'government_test' }
+  let(:link) { '/doc-for-deletion' }
+  let(:content_id) { '41609206-8736-4ff3-b582-63c9fccafe4d' }
+  let(:document) { { "title" => 'Old title', "content_id" => content_id, "link" => link } }
+  let(:updates) { { "title" => "New title" } }
+  let(:cluster_count) { Clusters.count }
 
-  before(:each) do
+  before do
     Sidekiq::Worker.clear_all
   end
 
@@ -31,7 +31,6 @@ RSpec.describe Indexer::AmendWorker do
   it "retries when index locked" do
     Sidekiq::Testing.fake! do
       with_just_one_cluster
-      lock_delay = Indexer::DeleteWorker::LOCK_DELAY
       mock_index = double("index") # rubocop:disable RSpec/VerifiedDoubles
       # rubocop:disable RSpec/MessageSpies
       expect(mock_index).to receive(:amend).and_raise(SearchIndices::IndexLocked)
@@ -44,7 +43,7 @@ RSpec.describe Indexer::AmendWorker do
       worker = described_class.new
       expect {
         worker.perform(index_name, link, updates)
-      }.to change {Indexer::AmendWorker.jobs.count}.by(1)
+      }.to change { described_class.jobs.count }.by(1)
     end
   end
 

--- a/spec/integration/workers/indexer/amend_worker_spec.rb
+++ b/spec/integration/workers/indexer/amend_worker_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Indexer::AmendWorker do
   let(:content_id) {'41609206-8736-4ff3-b582-63c9fccafe4d'}
   let(:document) {{"title" => 'Old title', "content_id" => content_id, "link" => link}}
   let(:updates) {{"title" => "New title"}}
+  let(:cluster_count) {Clusters.count}
 
   before(:each) do
     Sidekiq::Worker.clear_all
@@ -22,11 +23,7 @@ RSpec.describe Indexer::AmendWorker do
 
       doc_with_updates = document.merge(updates)
 
-      # Previously, this used a let to store Clusters.count, however,
-      # I _think_ that this meant that if the test that only used one cluster ran before
-      # this one, then the incorrect cluster count was stored, the request was made twice
-      # but it asserted that there should only be one request, which is wrong
-      assert_requested request, times: Clusters.count
+      assert_requested request, times: cluster_count
       expect_document_is_in_rummager(doc_with_updates, id: link, index: index_name)
     end
   end
@@ -37,11 +34,9 @@ RSpec.describe Indexer::AmendWorker do
       lock_delay = Indexer::DeleteWorker::LOCK_DELAY
       mock_index = double("index") # rubocop:disable RSpec/VerifiedDoubles
       # rubocop:disable RSpec/MessageSpies
+      expect(mock_index).to receive(:amend).and_raise(SearchIndices::IndexLocked)
 
-      # We can change these to allow (IMHO) becausee don't really care how many times they were called, that's
-      # an implementation detail, we only care that the job count was increased
-      allow(mock_index).to receive(:amend).and_raise(SearchIndices::IndexLocked)
-      allow_any_instance_of(SearchIndices::SearchServer).to receive(:index) # rubocop:disable RSpec/AnyInstance
+      expect_any_instance_of(SearchIndices::SearchServer).to receive(:index) # rubocop:disable RSpec/AnyInstance
                                                                .with(index_name)
                                                                .and_return(mock_index)
 

--- a/spec/integration/workers/indexer/amend_worker_spec.rb
+++ b/spec/integration/workers/indexer/amend_worker_spec.rb
@@ -1,41 +1,51 @@
 require 'spec_helper'
+require 'sidekiq/testing'
 
 RSpec.describe Indexer::AmendWorker do
-  let(:index_name) { 'government_test' }
-  let(:link) { '/doc-for-deletion' }
-  let(:content_id) { '41609206-8736-4ff3-b582-63c9fccafe4d' }
-  let(:document) { { "title" => 'Old title', "content_id" => content_id, "link" => link } }
-  let(:updates) { { "title" => "New title" } }
-  let(:cluster_count) { Clusters.count }
+  let(:index_name) {'government_test'}
+  let(:link) {'/doc-for-deletion'}
+  let(:content_id) {'41609206-8736-4ff3-b582-63c9fccafe4d'}
+  let(:document) {{"title" => 'Old title', "content_id" => content_id, "link" => link}}
+  let(:updates) {{"title" => "New title"}}
+  let(:cluster_count) {Clusters.count}
+
+  before(:each) do
+    Sidekiq::Worker.clear_all
+  end
 
   it "amends documents" do
-    commit_document(index_name, document)
+    Sidekiq::Testing.fake! do
+      commit_document(index_name, document)
 
-    request = stub_request_to_publishing_api(content_id)
+      request = stub_request_to_publishing_api(content_id)
 
-    described_class.new.perform(index_name, link, updates)
+      described_class.new.perform(index_name, link, updates)
 
-    doc_with_updates = document.merge(updates)
+      doc_with_updates = document.merge(updates)
 
-    assert_requested request, times: cluster_count
-    expect_document_is_in_rummager(doc_with_updates, id: link, index: index_name)
+      assert_requested request, times: cluster_count
+      expect_document_is_in_rummager(doc_with_updates, id: link, index: index_name)
+    end
   end
 
   it "retries when index locked" do
-    with_just_one_cluster
-    lock_delay = Indexer::DeleteWorker::LOCK_DELAY
-    mock_index = double("index") # rubocop:disable RSpec/VerifiedDoubles
-    # rubocop:disable RSpec/MessageSpies
-    expect(mock_index).to receive(:amend).and_raise(SearchIndices::IndexLocked)
-    expect_any_instance_of(SearchIndices::SearchServer).to receive(:index) # rubocop:disable RSpec/AnyInstance
-      .with(index_name)
-      .and_return(mock_index)
+    Sidekiq::Testing.fake! do
+      with_just_one_cluster
+      lock_delay = Indexer::DeleteWorker::LOCK_DELAY
+      mock_index = double("index") # rubocop:disable RSpec/VerifiedDoubles
+      # rubocop:disable RSpec/MessageSpies
+      expect(mock_index).to receive(:amend).and_raise(SearchIndices::IndexLocked)
 
-    expect(described_class).to receive(:perform_in)
-      .with(lock_delay, index_name, link, updates)
-    # rubocop:enable RSpec/MessageSpies
-    worker = described_class.new
-    worker.perform(index_name, link, updates)
+      expect_any_instance_of(SearchIndices::SearchServer).to receive(:index) # rubocop:disable RSpec/AnyInstance
+                                                               .with(index_name)
+                                                               .and_return(mock_index)
+
+      # rubocop:enable RSpec/MessageSpies
+      worker = described_class.new
+      expect {
+        worker.perform(index_name, link, updates)
+      }.to change {Indexer::AmendWorker.jobs.count}.by(1)
+    end
   end
 
   it "forwards to failure queue" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,7 @@ RSpec.configure do |config|
     # is automatically reset, the index_names or passed into children object and
     # cached there.
     SearchConfig.reset_instances
+    Services.cache.clear
   end
 
   if config.files_to_run.one?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,7 +82,7 @@ RSpec.configure do |config|
     # search_config is a global object that has state, while most of the stubbing
     # is automatically reset, the index_names or passed into children object and
     # cached there.
-    SearchConfig.reset_instances
+    Cache.clear
     Services.cache.clear
   end
 

--- a/spec/support/index_helpers.rb
+++ b/spec/support/index_helpers.rb
@@ -3,7 +3,7 @@ class IndexHelpers
     puts "Setting up test indexes on clusters #{Clusters.active.map(&:key).join(',')}..."
     start_time = Time.now
 
-    clean_all
+
     create_all
 
     puts "Done in #{Time.now - start_time} seconds."

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -53,7 +53,6 @@ module IntegrationSpecHelper
     allowed_paths << '_tasks'
 
     allow_urls = %r{#{allowed_hosts.map { |host| "#{host}/(#{allowed_paths.join('|')})" }.join('|')}}
-
     WebMock.disable_net_connect!(allow: allow_urls)
     yield
   ensure

--- a/spec/unit/cache_spec.rb
+++ b/spec/unit/cache_spec.rb
@@ -1,27 +1,26 @@
 require 'spec_helper'
 
 RSpec.describe Cache do
-  it 'should store a value' do
-    Cache.get('mykey') { 5 }
+  it 'stores a value' do
+    described_class.get('mykey') { 5 }
 
-    expect(Cache.get('mykey')).to eq(5)
+    expect(described_class.get('mykey')).to eq(5)
   end
-  it 'should set the value once' do
-    Cache.get('mykey') { 5 }
-    Cache.get('mykey') { 3 }
-    expect(Cache.get('mykey')).to eq(5)
+  it 'sets the value once' do
+    described_class.get('mykey') { 5 }
+    described_class.get('mykey') { 3 }
+    expect(described_class.get('mykey')).to eq(5)
   end
-  it 'should not evaluate the second time if the resulting value is nil' do
-    computation = double('computation', compute: nil)
-    Cache.get('mykey') { computation.compute }
-    Cache.get('mykey') { computation.compute }
+  it 'does not evaluate the second time if the resulting value is nil' do
+    computation = instance_double('Object', compute: nil)
+    described_class.get('mykey') { computation.compute }
+    described_class.get('mykey') { computation.compute }
     expect(computation).to have_received(:compute).once
   end
   it 'clears the cache' do
-    Cache.get('mykey') { 5 }
-    Cache.clear
-    Cache.get('mykey') { 3 }
-    expect(Cache.get('mykey')).to eq(3)
+    described_class.get('mykey') { 5 }
+    described_class.clear
+    described_class.get('mykey') { 3 }
+    expect(described_class.get('mykey')).to eq(3)
   end
-
 end

--- a/spec/unit/cache_spec.rb
+++ b/spec/unit/cache_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Cache do
+  it 'should store a value' do
+    Cache.get('mykey') { 5 }
+
+    expect(Cache.get('mykey')).to eq(5)
+  end
+  it 'should set the value once' do
+    Cache.get('mykey') { 5 }
+    Cache.get('mykey') { 3 }
+    expect(Cache.get('mykey')).to eq(5)
+  end
+  it 'should not evaluate the second time if the resulting value is nil' do
+    computation = double('computation', compute: nil)
+    Cache.get('mykey') { computation.compute }
+    Cache.get('mykey') { computation.compute }
+    expect(computation).to have_received(:compute).once
+  end
+  it 'clears the cache' do
+    Cache.get('mykey') { 5 }
+    Cache.clear
+    Cache.get('mykey') { 3 }
+    expect(Cache.get('mykey')).to eq(3)
+  end
+
+end

--- a/spec/unit/content_item_publisher/facet_group_finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/facet_group_finder_publisher_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe ContentItemPublisher::FacetGroupFinderPublisher do
   finder_config["details"]["facets"] = []
 
   context "when publishing finder config has facet group in it's links" do
-    subject(:instance) {described_class.new(finder, timestamp)}
+    subject(:instance) { described_class.new(finder, timestamp) }
 
-    let(:finder) {finder_config}
-    let(:content_id) {finder["content_id"]}
-    let(:timestamp) {Time.now.iso8601}
-    let(:logger) {instance_double("Logger")}
+    let(:finder) { finder_config }
+    let(:content_id) { finder["content_id"] }
+    let(:timestamp) { Time.now.iso8601 }
+    let(:logger) { instance_double("Logger") }
 
     before do
       allow(Logger).to receive(:new).and_return(logger)
     end
 
     describe "#call" do
-      let(:publishing_api) {instance_double("GdsApi::PublishingApiV2")}
+      let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
       let(:payload) {
         ContentItemPublisher::FacetGroupFinderPresenter.new(finder, timestamp).present
       }
@@ -45,7 +45,8 @@ RSpec.describe ContentItemPublisher::FacetGroupFinderPublisher do
       end
 
       it "patches links for the finder" do
-        assert_publishing_api_patch_links(content_id, ->(request) {JSON.parse(request.body) == {
+        assert_publishing_api_patch_links(content_id, ->(request) {
+  JSON.parse(request.body) == {
           'links' =>
             {
               "email_alert_signup" => [finder_config["signup_content_id"]],
@@ -53,7 +54,8 @@ RSpec.describe ContentItemPublisher::FacetGroupFinderPublisher do
               "ordered_related_items" => finder_config["ordered_related_items"],
               "parent" => []
             }
-        }})
+        }
+}                                                      )
       end
 
       it "publishes the finder to the Publishing API" do

--- a/spec/unit/content_item_publisher/facet_group_finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/facet_group_finder_publisher_spec.rb
@@ -14,53 +14,50 @@ RSpec.describe ContentItemPublisher::FacetGroupFinderPublisher do
   finder_config["details"]["facets"] = []
 
   context "when publishing finder config has facet group in it's links" do
-    subject(:instance) { described_class.new(finder, timestamp) }
+    subject(:instance) {described_class.new(finder, timestamp)}
 
-    let(:finder) { finder_config }
-    let(:content_id) { finder["content_id"] }
-    let(:timestamp) { Time.now.iso8601 }
-    let(:logger) { instance_double("Logger") }
+    let(:finder) {finder_config}
+    let(:content_id) {finder["content_id"]}
+    let(:timestamp) {Time.now.iso8601}
+    let(:logger) {instance_double("Logger")}
 
     before do
       allow(Logger).to receive(:new).and_return(logger)
     end
 
     describe "#call" do
-      let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+      let(:publishing_api) {instance_double("GdsApi::PublishingApiV2")}
       let(:payload) {
         ContentItemPublisher::FacetGroupFinderPresenter.new(finder, timestamp).present
       }
 
       before do
         allow(logger).to receive(:info)
-        allow(Services.publishing_api).to receive(:put_content)
-        allow(Services.publishing_api).to receive(:patch_links)
-        allow(Services.publishing_api).to receive(:publish)
+        stub_any_publishing_api_put_content
+        stub_any_publishing_api_patch_links
+        stub_any_publishing_api_publish
 
         instance.call
       end
 
       it "drafts the finder" do
-        expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
+        assert_publishing_api_put_content(content_id, payload)
       end
 
       it "patches links for the finder" do
-        expect(Services.publishing_api).to have_received(:patch_links)
-          .with(content_id,
+        assert_publishing_api_patch_links(content_id, ->(request) {JSON.parse(request.body) == {
+          'links' =>
             {
-              content_id: content_id,
-              links:
-                {
-                  "email_alert_signup" => [finder_config["signup_content_id"]],
-                  "facet_group" => %w(content_id_of_facet_group),
-                  "ordered_related_items" => finder_config["ordered_related_items"],
-                  "parent" => []
-                }
-            })
+              "email_alert_signup" => [finder_config["signup_content_id"]],
+              "facet_group" => %w(content_id_of_facet_group),
+              "ordered_related_items" => finder_config["ordered_related_items"],
+              "parent" => []
+            }
+        }})
       end
 
       it "publishes the finder to the Publishing API" do
-        expect(Services.publishing_api).to have_received(:publish).with(content_id)
+        assert_publishing_api_publish(content_id)
       end
     end
   end

--- a/spec/unit/content_item_publisher/finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_publisher_spec.rb
@@ -32,24 +32,23 @@ RSpec.describe ContentItemPublisher::FinderPublisher do
 
         before do
           allow(logger).to receive(:info)
-          allow(Services.publishing_api).to receive(:put_content)
-          allow(Services.publishing_api).to receive(:patch_links)
-          allow(Services.publishing_api).to receive(:publish)
+          stub_any_publishing_api_put_content
+          stub_any_publishing_api_patch_links
+          stub_any_publishing_api_publish
 
           instance.call
         end
 
         it "drafts the finder" do
-          expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
+          assert_publishing_api_put_content(content_id, payload)
         end
 
         it "patches links for the finder" do
-          expect(Services.publishing_api).to have_received(:patch_links)
-            .with(content_id, { content_id: content_id, links: anything })
+          assert_publishing_api_patch_links(content_id, ->(request) { JSON.parse(request.body).has_key?('links') })
         end
 
         it "publishes the finder to the Publishing API" do
-          expect(Services.publishing_api).to have_received(:publish).with(content_id)
+          assert_publishing_api_publish(content_id)
         end
       end
     end

--- a/spec/unit/govuk_index/page_traffic_loader_spec.rb
+++ b/spec/unit/govuk_index/page_traffic_loader_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe GovukIndex::PageTrafficLoader do
     line3 = [{ "val" => "e" }, { "data" => 1 }]
 
     Clusters.active.each do |cluster|
+      input.rewind
       # rubocop:disable RSpec/MessageSpies
       expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line1, 'new_index_name', cluster.key)
       expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line2, 'new_index_name', cluster.key)

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     popularity = 0.0125356
 
     # rubocop:disable RSpec/MessageSpies
-    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.default_instance).and_return(@popularity_lookup)
+    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', instance_of(SearchConfig)).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return(payload["base_path"] => popularity)
     # rubocop:enable RSpec/MessageSpies
 
@@ -98,7 +98,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     payload = { "base_path" => "/some/path" }
 
     # rubocop:disable RSpec/MessageSpies
-    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.default_instance).and_return(@popularity_lookup)
+    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', instance_of(SearchConfig)).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return({})
     # rubocop:enable RSpec/MessageSpies
 

--- a/spec/unit/govuk_index/publishing_event_worker_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_worker_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe GovukIndex::PublishingEventWorker do
 
   before do
     allow(Index::ElasticsearchProcessor).to receive(:new).and_return(actions)
+
+    @statsd_client = double('statsd_client', increment: nil)
+    allow(Services).to receive(:statsd_client).and_return @statsd_client
   end
 
   let(:actions) { instance_double('actions') }
@@ -23,8 +26,8 @@ RSpec.describe GovukIndex::PublishingEventWorker do
       expect(actions).to receive(:save)
       expect(actions).to receive(:commit).and_return(responses)
 
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
+      expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+      expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
       # rubocop:enable RSpec/MessageSpies
       worker.perform([['routing.key', payload]])
     end
@@ -43,8 +46,8 @@ RSpec.describe GovukIndex::PublishingEventWorker do
         expect(actions).to receive(:delete)
         expect(actions).to receive(:commit).and_return(responses)
 
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete')
         # rubocop:enable RSpec/MessageSpies
         worker.perform([['routing.unpublish', payload]])
       end
@@ -65,8 +68,8 @@ RSpec.describe GovukIndex::PublishingEventWorker do
         expect(actions).to receive(:save)
         expect(actions).to receive(:commit).and_return(responses)
 
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
         # rubocop:enable RSpec/MessageSpies
         worker.perform([['routing.unpublish', payload]])
       end
@@ -84,9 +87,9 @@ RSpec.describe GovukIndex::PublishingEventWorker do
         expect(actions).to receive(:delete)
         expect(actions).to receive(:commit).and_return(failure_response)
 
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete_error')
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete_error')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
         # rubocop:enable RSpec/MessageSpies
         expect {
           worker.perform([['routing.unpublish', payload]])
@@ -105,8 +108,8 @@ RSpec.describe GovukIndex::PublishingEventWorker do
         expect(actions).to receive(:delete)
         expect(actions).to receive(:commit).and_return(responses)
 
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.already_deleted')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.already_deleted')
         # rubocop:enable RSpec/MessageSpies
         worker.perform([['routing.unpublish', payload]])
       end
@@ -192,9 +195,9 @@ RSpec.describe GovukIndex::PublishingEventWorker do
       expect(actions).to receive(:save).twice
       expect(actions).to receive(:commit).and_return(responses)
 
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.multiple_responses')
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index').twice
+      expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
+      expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.multiple_responses')
+      expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index').twice
       # rubocop:enable RSpec/MessageSpies
       worker.perform([['routing.key', payload1], ['routing.key', payload2]])
     end
@@ -206,10 +209,10 @@ RSpec.describe GovukIndex::PublishingEventWorker do
       expect(actions).to receive(:save)
       expect(actions).to receive(:delete)
       expect(actions).to receive(:commit).and_return(responses)
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.multiple_responses')
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
-      expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete')
+      expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
+      expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.multiple_responses')
+      expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
+      expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.delete')
       # rubocop:enable RSpec/MessageSpies
       worker.perform([['routing.key', payload1], ['routing.key', payload_delete]])
     end
@@ -220,11 +223,11 @@ RSpec.describe GovukIndex::PublishingEventWorker do
         allow(actions).to receive(:commit).and_return(
           [{ 'items' => [{ 'index' => { 'status' => 500 } }, { 'index' => { 'status' => 500 } }] }]
         )
-        allow(Services.statsd_client).to receive(:increment)
+        allow(@statsd_client).to receive(:increment)
       end
 
       it 'will reprocess the entire batch using ES retry mechanism' do
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
+        expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-consumed').twice
 
         expect {
           worker.perform([['routing.key', payload1], ['routing.key', payload2]])
@@ -232,8 +235,8 @@ RSpec.describe GovukIndex::PublishingEventWorker do
       end
 
       it 'will notify for each message that fails' do
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index_error').twice
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index_error').twice
+        expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
 
         expect {
           worker.perform([['routing.key', payload1], ['routing.key', payload2]])
@@ -241,7 +244,7 @@ RSpec.describe GovukIndex::PublishingEventWorker do
       end
 
       it 'will notify that the batch failed' do
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.sidekiq-retry')
 
         expect {
           worker.perform([['routing.key', payload1], ['routing.key', payload2]])
@@ -255,7 +258,7 @@ RSpec.describe GovukIndex::PublishingEventWorker do
         allow(actions).to receive(:commit).and_return(
           [{ 'items' => [{ 'index' => { 'status' => 200 } }, { 'index' => { 'status' => 500 } }] }]
         )
-        allow(Services.statsd_client).to receive(:increment)
+        allow(@statsd_client).to receive(:increment)
         # allow(GovukIndex::PublishingEventWorker).to receive(:perform_async)
       end
 
@@ -266,8 +269,8 @@ RSpec.describe GovukIndex::PublishingEventWorker do
       end
 
       it 'will notify for each message that fails' do
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index_error')
-        expect(Services.statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index_error')
+        expect(@statsd_client).to receive(:increment).with('govuk_index.elasticsearch.index')
         expect {
           worker.perform([['routing.key', payload1], ['routing.key', payload2]])
         }.to raise_error(GovukIndex::ElasticsearchRetryError)
@@ -279,7 +282,7 @@ RSpec.describe GovukIndex::PublishingEventWorker do
       allow(actions).to receive(:commit).and_return(
         [{ 'items' => [{ 'index' => { 'status' => 200 } }] }]
       )
-      allow(Services.statsd_client).to receive(:increment)
+      allow(@statsd_client).to receive(:increment)
 
       expect {
         worker.perform([['routing.key', payload1], ['routing.key', payload2]])

--- a/spec/unit/indexer/comparer_spec.rb
+++ b/spec/unit/indexer/comparer_spec.rb
@@ -80,7 +80,7 @@ private
     allow(Indexer::CompareEnumerator).to receive(:new).with(
       'index_a',
       'index_b',
-      satisfy {|c| c.key == Clusters.default_cluster.key },
+      satisfy { |c| c.key == Clusters.default_cluster.key },
       {},
       {},
     ).and_return([[left, right]].to_enum)

--- a/spec/unit/indexer/comparer_spec.rb
+++ b/spec/unit/indexer/comparer_spec.rb
@@ -80,7 +80,7 @@ private
     allow(Indexer::CompareEnumerator).to receive(:new).with(
       'index_a',
       'index_b',
-      Clusters.default_cluster,
+      satisfy {|c| c.key == Clusters.default_cluster.key },
       {},
       {},
     ).and_return([[left, right]].to_enum)

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe SearchParameterParser do
-
   def cluster_with_key(key)
-    satisfy {|c| c.key == key}
+    satisfy { |c| c.key == key }
   end
 
   def expected_params(params)
@@ -445,7 +444,7 @@ RSpec.describe SearchParameterParser do
     expect(p.error).to eq(%{"spells" is not a valid filter field})
     expect(p).not_to be_valid
     expect(p.parsed_params).to match(
-      expected_params(filters: [text_filter("organisations", ["hm-magic"])])
+      expected_params(filters: [text_filter("organisations", %w[hm-magic])])
     )
   end
 
@@ -461,7 +460,7 @@ RSpec.describe SearchParameterParser do
     expect(p.error).to eq(%{"spells" is not a valid reject field})
     expect(p).not_to be_valid
     expect(p.parsed_params).to match(
-      expected_params(filters: [text_filter("organisations", ["hm-magic"], :reject)])
+      expected_params(filters: [text_filter("organisations", %w[hm-magic], :reject)])
     )
   end
 
@@ -707,12 +706,12 @@ RSpec.describe SearchParameterParser do
     expect(p.error).to eq("")
     expect(p).to be_valid
     expect(p.parsed_params).to match(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
-      )
-}
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
+                                       )
+                                 }
     ))
   end
 
@@ -735,12 +734,12 @@ RSpec.describe SearchParameterParser do
     expect(p.error).to eq("")
     expect(p).to be_valid
     expect(p.parsed_params).to match(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
-        )
-      }
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
+                                         )
+                                       }
     ))
   end
 
@@ -752,12 +751,12 @@ RSpec.describe SearchParameterParser do
     expect(p.error).to eq("")
     expect(p).to be_valid
     expect(p.parsed_params).to match(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          scope: :all_filters,
-        )
-      }
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           scope: :all_filters,
+                                         )
+                                       }
     ))
   end
 
@@ -789,14 +788,14 @@ RSpec.describe SearchParameterParser do
     expect(p.error).to eq("")
     expect(p).to be_valid
     expect(p.parsed_params).to match(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          examples: 5,
-          example_fields: %w(slug title link),
-          example_scope: :global,
-        )
-      }
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           examples: 5,
+                                           example_fields: %w(slug title link),
+                                           example_scope: :global,
+                                         )
+                                       }
     ))
   end
 
@@ -817,14 +816,14 @@ RSpec.describe SearchParameterParser do
 
     expect(p).to be_valid
     expect(p.parsed_params).to match(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          examples: 5,
-          example_fields: %w(slug title),
-          example_scope: :query,
-        )
-      }
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           examples: 5,
+                                           example_fields: %w(slug title),
+                                           example_scope: :query,
+                                         )
+                                       }
     ))
   end
 
@@ -900,7 +899,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Some requested fields are not valid return fields: [\"waffle\"]")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to match(expected_params(return_fields: ["title"]))
+    expect(p.parsed_params).to match(expected_params(return_fields: %w[title]))
   end
 
   it "understands the debug parameter" do


### PR DESCRIPTION
Our work on [govuk-docker](https://github.com/alphagov/govuk-docker/pull/100) found some problems where running tests on search-api with two clusters of elasticsearch weren't passing, this fixes that