### PR TITLE
Remove memoization

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -25,7 +25,7 @@ development:
 
 test:
   base_uri: <%= ENV.fetch('ELASTICSEARCH_URI', 'http://localhost:9200') %>
-  base_uri_b: <%= ENV["ELASTICSEARCH_B_URI"] %>
+  base_uri_b: <%= ENV.fetch("ELASTICSEARCH_B_URI", 'http://localhost:9201') %>
   content_index_names: ["government_test"]
   govuk_index_name: "govuk_test"
   auxiliary_index_names: ["page-traffic_test", "metasearch_test"]

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -1,0 +1,21 @@
+class Cache
+  COMBINED_INDEX_SCHEMA = 'COMBINED_INDEX_SCHEMA:'.freeze
+  SEARCH_SERVERS = 'SEARCH_SERVERS:'.freeze
+  SEARCH_CONFIG = 'SEARCH_CONFIG:'.freeze
+  CLUSTER = 'CLUSTER:'.freeze
+  ACTIVE_CLUSTERS = 'ACTIVE_CLUSTERS:'.freeze
+
+  @cache = {}
+
+  def self.get(key)
+    if @cache.has_key?(key)
+      @cache[key]
+    else
+      block_given? ? (@cache[key] = yield) : nil
+    end
+  end
+
+  def self.clear
+    @cache = {}
+  end
+end

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -4,6 +4,7 @@ class Cache
   SEARCH_CONFIG = 'SEARCH_CONFIG:'.freeze
   CLUSTER = 'CLUSTER:'.freeze
   ACTIVE_CLUSTERS = 'ACTIVE_CLUSTERS:'.freeze
+  STATSD_CLIENT = 'STATSD_CLIENT:'.freeze
 
   @cache = {}
 

--- a/lib/clusters/cluster.rb
+++ b/lib/clusters/cluster.rb
@@ -10,7 +10,7 @@ module Clusters
     end
 
     def uri
-      @uri ||= elasticsearch_config[uri_key]
+      @uri ||= ElasticsearchConfig.new.config[uri_key]
     end
 
     def inactive?
@@ -22,9 +22,5 @@ module Clusters
   private
 
     attr_reader :uri_key
-
-    def elasticsearch_config
-      @elasticsearch_config ||= ElasticsearchConfig.new.config
-    end
   end
 end

--- a/lib/clusters/clusters.rb
+++ b/lib/clusters/clusters.rb
@@ -2,11 +2,11 @@
 # the various elasticsearch clusters that search-api can talk to.
 module Clusters
   def self.count
-    @count ||= active.count
+    active.count
   end
 
   def self.default_cluster
-    @default_cluster ||= active.find(&:default)
+    active.find(&:default)
   end
 
   def self.validate_cluster_key!(cluster_key)
@@ -17,7 +17,7 @@ module Clusters
   end
 
   def self.cluster_keys
-    @cluster_keys ||= active.map(&:key)
+    active.map(&:key)
   end
 
   class InvalidClusterError < StandardError; end
@@ -32,7 +32,7 @@ module Clusters
   end
 
   def self.active
-    @active ||= begin
+    Cache.get(Cache::ACTIVE_CLUSTERS) do
       defined_clusters = ElasticsearchConfig.new.config['clusters']
       defined_clusters.map { |cluster| Cluster.new(cluster.deep_symbolize_keys) }
       .reject(&:inactive?)

--- a/lib/content_item_publisher/publisher.rb
+++ b/lib/content_item_publisher/publisher.rb
@@ -27,9 +27,13 @@ module ContentItemPublisher
 
       logger.info("Publishing #{presenter.description}")
 
-      Services.publishing_api.put_content(presenter.content_id, presenter.present)
-      Services.publishing_api.patch_links(presenter.content_id, presenter.present_links)
-      Services.publishing_api.publish(presenter.content_id)
+      publishing_api.put_content(presenter.content_id, presenter.present)
+      publishing_api.patch_links(presenter.content_id, presenter.present_links)
+      publishing_api.publish(presenter.content_id)
+    end
+
+    def publishing_api
+      @publishing_api ||= Services.publishing_api
     end
   end
 end

--- a/lib/index_finder.rb
+++ b/lib/index_finder.rb
@@ -10,11 +10,11 @@ class IndexFinder
     end
 
     def search_config
-      @search_config ||= SearchConfig.default_instance
+      @search_config = SearchConfig.default_instance
     end
 
     def search_server
-      @search_server ||= search_config.search_server
+      @search_server = search_config.search_server
     end
   end
 end

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -39,6 +39,7 @@ initializers_path = File.expand_path("../config/initializers/*.rb", __dir__)
 Dir[initializers_path].each { |f| require f }
 
 require 'analytics_data'
+require 'cache'
 require File.expand_path('../config/logging_setup', __dir__)
 require 'document'
 require 'govuk_document_types'

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,7 +2,7 @@ require 'active_support/cache'
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(
+    GdsApi::PublishingApiV2.new(
       Plek.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
 
@@ -37,17 +37,13 @@ module Services
   end
 
   def self.statsd_client
-    @statsd_client ||= Statsd.new.tap { |sd| sd.namespace = "govuk.app.search-api" }
+    Cache.get(Cache::STATSD_CLIENT) do
+      Statsd.new.tap { |sd| sd.namespace = "govuk.app.search-api" }
+    end
   end
 
   def self.cache
-    @cache ||= if ENV['RACK_ENV'] == 'production'
-                 # Using a memory store as this is expected to store signon
-                 # tokens, this will be cleared each time the app starts
-                 ActiveSupport::Cache.lookup_store(:memory_store)
-               else
-                 ActiveSupport::Cache.lookup_store(:null_store)
-               end
+    ActiveSupport::Cache.lookup_store(:memory_store)
   end
 end
 

--- a/spec/integration/workers/indexer/amend_worker_spec.rb
+++ b/spec/integration/workers/indexer/amend_worker_spec.rb
@@ -14,18 +14,16 @@ RSpec.describe Indexer::AmendWorker do
   end
 
   it "amends documents" do
-    Sidekiq::Testing.fake! do
-      commit_document(index_name, document)
+    commit_document(index_name, document)
 
-      request = stub_request_to_publishing_api(content_id)
+    request = stub_request_to_publishing_api(content_id)
 
-      described_class.new.perform(index_name, link, updates)
+    described_class.new.perform(index_name, link, updates)
 
-      doc_with_updates = document.merge(updates)
+    doc_with_updates = document.merge(updates)
 
-      assert_requested request, times: cluster_count
-      expect_document_is_in_rummager(doc_with_updates, id: link, index: index_name)
-    end
+    assert_requested request, times: cluster_count
+    expect_document_is_in_rummager(doc_with_updates, id: link, index: index_name)
   end
 
   it "retries when index locked" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,7 +82,8 @@ RSpec.configure do |config|
     # search_config is a global object that has state, while most of the stubbing
     # is automatically reset, the index_names or passed into children object and
     # cached there.
-    SearchConfig.reset_instances
+    Cache.clear
+    Services.cache.clear
   end
 
   if config.files_to_run.one?

--- a/spec/support/index_helpers.rb
+++ b/spec/support/index_helpers.rb
@@ -3,7 +3,6 @@ class IndexHelpers
     puts "Setting up test indexes on clusters #{Clusters.active.map(&:key).join(',')}..."
     start_time = Time.now
 
-    clean_all
     create_all
 
     puts "Done in #{Time.now - start_time} seconds."

--- a/spec/unit/cache_spec.rb
+++ b/spec/unit/cache_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe Cache do
+  it 'stores a value' do
+    described_class.get('mykey') { 5 }
+
+    expect(described_class.get('mykey')).to eq(5)
+  end
+  it 'sets the value once' do
+    described_class.get('mykey') { 5 }
+    described_class.get('mykey') { 3 }
+    expect(described_class.get('mykey')).to eq(5)
+  end
+  it 'does not evaluate the second time if the resulting value is nil' do
+    computation = double('computation', compute: nil) #rubocop:disable RSpec/VerifiedDoubles
+    described_class.get('mykey') { computation.compute }
+    described_class.get('mykey') { computation.compute }
+    expect(computation).to have_received(:compute).once
+  end
+  it 'clears the cache' do
+    described_class.get('mykey') { 5 }
+    described_class.clear
+    described_class.get('mykey') { 3 }
+    expect(described_class.get('mykey')).to eq(3)
+  end
+end

--- a/spec/unit/content_item_publisher/facet_group_finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/facet_group_finder_publisher_spec.rb
@@ -33,34 +33,33 @@ RSpec.describe ContentItemPublisher::FacetGroupFinderPublisher do
 
       before do
         allow(logger).to receive(:info)
-        allow(Services.publishing_api).to receive(:put_content)
-        allow(Services.publishing_api).to receive(:patch_links)
-        allow(Services.publishing_api).to receive(:publish)
+        stub_any_publishing_api_put_content
+        stub_any_publishing_api_patch_links
+        stub_any_publishing_api_publish
 
         instance.call
       end
 
       it "drafts the finder" do
-        expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
+        assert_publishing_api_put_content(content_id, payload)
       end
 
       it "patches links for the finder" do
-        expect(Services.publishing_api).to have_received(:patch_links)
-          .with(content_id,
-            {
-              content_id: content_id,
-              links:
-                {
-                  "email_alert_signup" => [finder_config["signup_content_id"]],
-                  "facet_group" => %w(content_id_of_facet_group),
-                  "ordered_related_items" => finder_config["ordered_related_items"],
-                  "parent" => []
-                }
-            })
+        assert_publishing_api_patch_links(content_id, ->(request) {
+                                                        JSON.parse(request.body) == {
+                                                                'links' =>
+                                                                  {
+                                                                    "email_alert_signup" => [finder_config["signup_content_id"]],
+                                                                    "facet_group" => %w(content_id_of_facet_group),
+                                                                    "ordered_related_items" => finder_config["ordered_related_items"],
+                                                                    "parent" => []
+                                                                  }
+                                                              }
+                                                      })
       end
 
       it "publishes the finder to the Publishing API" do
-        expect(Services.publishing_api).to have_received(:publish).with(content_id)
+        assert_publishing_api_publish(content_id)
       end
     end
   end

--- a/spec/unit/content_item_publisher/finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_publisher_spec.rb
@@ -32,24 +32,23 @@ RSpec.describe ContentItemPublisher::FinderPublisher do
 
         before do
           allow(logger).to receive(:info)
-          allow(Services.publishing_api).to receive(:put_content)
-          allow(Services.publishing_api).to receive(:patch_links)
-          allow(Services.publishing_api).to receive(:publish)
+          stub_any_publishing_api_put_content
+          stub_any_publishing_api_patch_links
+          stub_any_publishing_api_publish
 
           instance.call
         end
 
         it "drafts the finder" do
-          expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
+          assert_publishing_api_put_content(content_id, payload)
         end
 
         it "patches links for the finder" do
-          expect(Services.publishing_api).to have_received(:patch_links)
-            .with(content_id, { content_id: content_id, links: anything })
+          assert_publishing_api_patch_links(content_id, ->(request) { JSON.parse(request.body).has_key?('links') })
         end
 
         it "publishes the finder to the Publishing API" do
-          expect(Services.publishing_api).to have_received(:publish).with(content_id)
+          assert_publishing_api_publish(content_id)
         end
       end
     end

--- a/spec/unit/govuk_index/page_traffic_loader_spec.rb
+++ b/spec/unit/govuk_index/page_traffic_loader_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe GovukIndex::PageTrafficLoader do
     line3 = [{ "val" => "e" }, { "data" => 1 }]
 
     Clusters.active.each do |cluster|
+      input.rewind
       # rubocop:disable RSpec/MessageSpies
       expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line1, 'new_index_name', cluster.key)
       expect(GovukIndex::PageTrafficWorker).to receive(:perform_async).with(line2, 'new_index_name', cluster.key)

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     popularity = 0.0125356
 
     # rubocop:disable RSpec/MessageSpies
-    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.default_instance).and_return(@popularity_lookup)
+    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', instance_of(SearchConfig)).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return(payload["base_path"] => popularity)
     # rubocop:enable RSpec/MessageSpies
 
@@ -98,7 +98,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     payload = { "base_path" => "/some/path" }
 
     # rubocop:disable RSpec/MessageSpies
-    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', SearchConfig.default_instance).and_return(@popularity_lookup)
+    expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', instance_of(SearchConfig)).and_return(@popularity_lookup)
     expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return({})
     # rubocop:enable RSpec/MessageSpies
 

--- a/spec/unit/indexer/comparer_spec.rb
+++ b/spec/unit/indexer/comparer_spec.rb
@@ -80,7 +80,7 @@ private
     allow(Indexer::CompareEnumerator).to receive(:new).with(
       'index_a',
       'index_b',
-      Clusters.default_cluster,
+      satisfy { |c| c.key == Clusters.default_cluster.key },
       {},
       {},
     ).and_return([[left, right]].to_enum)

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -1,14 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe SearchParameterParser do
+  def cluster_with_key(key)
+    satisfy { |c| c.key == key }
+  end
+
   def expected_params(params)
     {
       start: 0,
       count: 10,
-      cluster: Clusters.default_cluster,
-      search_config: SearchConfig.default_instance,
       query: nil,
       similar_to: nil,
+      cluster: cluster_with_key(Clusters.default_cluster.key),
+      search_config: instance_of(SearchConfig),
       order: nil,
       return_fields: BaseParameterParser::DEFAULT_RETURN_FIELDS,
       filters: [],
@@ -73,7 +77,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about an unknown parameter" do
@@ -81,14 +85,14 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Unexpected parameters: p")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "allows the c parameter to be anything" do
     p = described_class.new({ "c" => ["1234567890"] }, @schema)
 
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "understands the cluster parameter" do
@@ -97,7 +101,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(cluster: cluster))
+    expect(p.parsed_params).to match(expected_params(cluster: cluster_with_key(cluster.key)))
   end
 
   it "complains about invalid cluster parameters" do
@@ -105,7 +109,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Invalid cluster. Accepted values: #{Clusters.active.map(&:key).join(', ')}})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(cluster: Clusters.default_cluster))
+    expect(p.parsed_params).to match(expected_params(cluster: cluster_with_key(Clusters.default_cluster.key)))
   end
 
   it "complains about a repeated cluster parameter" do
@@ -113,7 +117,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Too many values (2) for parameter "cluster" (must occur at most once)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(cluster: Clusters.default_cluster))
+    expect(p.parsed_params).to match(expected_params(cluster: cluster_with_key(Clusters.default_cluster.key)))
   end
 
   it "complain about multiple unknown parameters" do
@@ -121,14 +125,14 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Unexpected parameters: p, boo")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "understands the start parameter" do
     p = described_class.new({ "start" => ["5"] }, @schema)
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(start: 5))
+    expect(p.parsed_params).to match(expected_params(start: 5))
   end
 
   it "complains about a non-integer start parameter" do
@@ -136,7 +140,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Invalid value \"5.5\" for parameter \"start\" (expected positive integer)")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a negative start parameter" do
@@ -144,7 +148,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Invalid negative value \"-1\" for parameter \"start\" (expected positive integer)")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a non-decimal start parameter" do
@@ -152,7 +156,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Invalid value \"x\" for parameter \"start\" (expected positive integer)")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a repeated start parameter" do
@@ -160,7 +164,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Too many values (2) for parameter "start" (must occur at most once)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(start: 2))
+    expect(p.parsed_params).to match(expected_params(start: 2))
   end
 
   it "complains about a start parameter that is too large" do
@@ -168,7 +172,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Maximum result set start point (as specified in 'start') is 900000")
     expect(p).not_to be_valid
-    expect(expected_params(start: 0)).to eq(p.parsed_params)
+    expect(p.parsed_params).to match(expected_params(start: 0))
   end
 
   it "understands the count parameter" do
@@ -176,7 +180,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(count: 5))
+    expect(p.parsed_params).to match(expected_params(count: 5))
   end
 
   it "complains about a non-integer count parameter" do
@@ -184,7 +188,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Invalid value \"5.5\" for parameter \"count\" (expected positive integer)")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a negative count parameter" do
@@ -192,7 +196,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Invalid negative value \"-1\" for parameter \"count\" (expected positive integer)")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a non-decimal count parameter" do
@@ -200,7 +204,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Invalid value \"x\" for parameter \"count\" (expected positive integer)")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a repeated count parameter" do
@@ -208,7 +212,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Too many values (2) for parameter "count" (must occur at most once)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(count: 2))
+    expect(p.parsed_params).to match(expected_params(count: 2))
   end
 
   it "complains about an overly large count parameter" do
@@ -216,7 +220,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Maximum result set size (as specified in 'count') is 1500})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(count: 10))
+    expect(p.parsed_params).to match(expected_params(count: 10))
   end
 
   it "understands the q parameter" do
@@ -224,7 +228,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(query: "search-term"))
+    expect(p.parsed_params).to match(expected_params(query: "search-term"))
   end
 
   it "complains when the q parameter is too long" do
@@ -235,7 +239,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Query exceeds the maximum allowed length})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(query: too_long_query))
+    expect(p.parsed_params).to match(expected_params(query: too_long_query))
   end
 
   it "complains about a repeated q parameter" do
@@ -243,7 +247,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Too many values (2) for parameter "q" (must occur at most once)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(query: "hello"))
+    expect(p.parsed_params).to match(expected_params(query: "hello"))
   end
 
   it "strips whitespace from the query" do
@@ -251,7 +255,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(query: "cheese"))
+    expect(p.parsed_params).to match(expected_params(query: "cheese"))
   end
 
   it "puts the query in normalized form" do
@@ -259,7 +263,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(query: "caf\u00e8"))
+    expect(p.parsed_params).to match(expected_params(query: "caf\u00e8"))
   end
 
   it "complains about invalid unicode in the query" do
@@ -267,7 +271,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Invalid unicode in query")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(query: nil))
+    expect(p.parsed_params).to match(expected_params(query: nil))
   end
 
   it "understands the similar_to parameter" do
@@ -275,7 +279,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(similar_to: "/search-term"))
+    expect(p.parsed_params).to match(expected_params(similar_to: "/search-term"))
   end
 
   it "complains about a repeated similar_to parameter" do
@@ -283,7 +287,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Too many values (2) for parameter "similar_to" (must occur at most once)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(similar_to: "/hello"))
+    expect(p.parsed_params).to match(expected_params(similar_to: "/hello"))
   end
 
   it "strips whitespace from similar_to parameter" do
@@ -291,7 +295,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(similar_to: "/cheese"))
+    expect(p.parsed_params).to match(expected_params(similar_to: "/cheese"))
   end
 
   it "puts the similar_to parameter in normalized form" do
@@ -299,7 +303,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(similar_to: "/caf\u00e8"))
+    expect(p.parsed_params).to match(expected_params(similar_to: "/caf\u00e8"))
   end
 
   it "complains about invalid unicode in the similar_to parameter" do
@@ -307,7 +311,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Invalid unicode in similar_to")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(similar_to: nil))
+    expect(p.parsed_params).to match(expected_params(similar_to: nil))
   end
 
   it "complains when both q and similar_to parameters are provided" do
@@ -315,7 +319,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Parameters 'q' and 'similar_to' cannot be used together")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(query: "hello", similar_to: "/world"))
+    expect(p.parsed_params).to match(expected_params(query: "hello", similar_to: "/world"))
   end
 
   it "sets the order parameter to nil when the similar_to parameter is provided" do
@@ -323,7 +327,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(similar_to: "/hello"))
+    expect(p.parsed_params).to match(expected_params(similar_to: "/hello"))
   end
 
   it "understands filter paramers" do
@@ -389,7 +393,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(
+    expect(p.parsed_params).to match(
       expected_params(
         filters: [
           text_filter("organisations", [
@@ -439,8 +443,8 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{"spells" is not a valid filter field})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(
-      expected_params(filters: [text_filter("organisations", ["hm-magic"])])
+    expect(p.parsed_params).to match(
+      expected_params(filters: [text_filter("organisations", %w[hm-magic])])
     )
   end
 
@@ -455,8 +459,8 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{"spells" is not a valid reject field})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(
-      expected_params(filters: [text_filter("organisations", ["hm-magic"], :reject)])
+    expect(p.parsed_params).to match(
+      expected_params(filters: [text_filter("organisations", %w[hm-magic], :reject)])
     )
   end
 
@@ -568,7 +572,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params({ order: %w(public_timestamp asc) }))
+    expect(p.parsed_params).to match(expected_params({ order: %w(public_timestamp asc) }))
   end
 
   it "understands a descending sort" do
@@ -576,7 +580,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params({ order: %w(public_timestamp desc) }))
+    expect(p.parsed_params).to match(expected_params({ order: %w(public_timestamp desc) }))
   end
 
   it "complains about disallowed sort fields" do
@@ -584,7 +588,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{"spells" is not a valid sort field})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about disallowed descending sort fields" do
@@ -592,7 +596,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{"spells" is not a valid sort field})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a repeated sort parameter" do
@@ -600,7 +604,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Too many values (2) for parameter "order" (must occur at most once)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(order: %w(public_timestamp asc)))
+    expect(p.parsed_params).to match(expected_params(order: %w(public_timestamp asc)))
   end
 
   it "understands a aggregate field" do
@@ -608,7 +612,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(
+    expect(p.parsed_params).to match(
       expected_params(aggregates: { "organisations" => expected_aggregate_params(requested: 10) })
     )
   end
@@ -621,7 +625,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(
+    expect(p.parsed_params).to match(
       expected_params(
         aggregates: {
           "organisations" => expected_aggregate_params(requested: 10),
@@ -639,7 +643,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{"spells" is not a valid aggregate field})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(
+    expect(p.parsed_params).to match(
       expected_params(aggregates: { "organisations" => expected_aggregate_params(requested: 10) })
     )
   end
@@ -652,7 +656,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{"spells" is not a valid aggregate field. Invalid value "magic" for first parameter for aggregate "organisations" (expected positive integer)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about empty values for aggregate parameter" do
@@ -660,7 +664,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Invalid value "" for first parameter for aggregate "organisations" (expected positive integer)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a repeated aggregate parameter" do
@@ -668,7 +672,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Too many values (2) for parameter "aggregate_organisations" (must occur at most once)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(
+    expect(p.parsed_params).to match(
       expected_params(aggregates: { "organisations" => expected_aggregate_params(requested: 5) })
     )
   end
@@ -680,7 +684,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(
+    expect(p.parsed_params).to match(
       expected_params(
         aggregates: {
           "organisations" => expected_aggregate_params(
@@ -701,13 +705,13 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
-      )
-}
+    expect(p.parsed_params).to match(expected_params(
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
+                                       )
+                                 }
     ))
   end
 
@@ -718,7 +722,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{"filt" is not a valid sort option in aggregate "organisations". "value.unknown" is not a valid sort option in aggregate "organisations"})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
 
@@ -729,13 +733,13 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
-        )
-      }
+    expect(p.parsed_params).to match(expected_params(
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           order: [[:filtered, 1], [:"value.link", 1], [:count, -1]],
+                                         )
+                                       }
     ))
   end
 
@@ -746,13 +750,13 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          scope: :all_filters,
-        )
-      }
+    expect(p.parsed_params).to match(expected_params(
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           scope: :all_filters,
+                                         )
+                                       }
     ))
   end
 
@@ -763,7 +767,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{"unknown" is not a valid scope option in aggregate "organisations"})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a repeated examples option" do
@@ -773,7 +777,7 @@ RSpec.describe SearchParameterParser do
 
     expect(%{Too many values (2) for parameter "examples" in aggregate "organisations" (must occur at most once)}).to eq(p.error)
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "merges fields from repeated example fields options" do
@@ -783,15 +787,15 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          examples: 5,
-          example_fields: %w(slug title link),
-          example_scope: :global,
-        )
-      }
+    expect(p.parsed_params).to match(expected_params(
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           examples: 5,
+                                           example_fields: %w(slug title link),
+                                           example_scope: :global,
+                                         )
+                                       }
     ))
   end
 
@@ -802,7 +806,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("example_scope parameter must be set to 'query' or 'global' when requesting examples")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({ aggregates: {} }))
+    expect(p.parsed_params).to match(expected_params({ aggregates: {} }))
   end
 
   it "allows example scope to be set to 'query'" do
@@ -811,15 +815,15 @@ RSpec.describe SearchParameterParser do
     }, @schema)
 
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(
-      aggregates: {
-        "organisations" => expected_aggregate_params(
-          requested: 10,
-          examples: 5,
-          example_fields: %w(slug title),
-          example_scope: :query,
-        )
-      }
+    expect(p.parsed_params).to match(expected_params(
+                                       aggregates: {
+                                         "organisations" => expected_aggregate_params(
+                                           requested: 10,
+                                           examples: 5,
+                                           example_fields: %w(slug title),
+                                           example_scope: :query,
+                                         )
+                                       }
     ))
   end
 
@@ -830,7 +834,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("example_scope parameter must be set to 'query' or 'global' when requesting examples")
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "complains about a repeated example scope option" do
@@ -840,7 +844,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Too many values (2) for parameter "example_scope" in aggregate "organisations" (must occur at most once)})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "validates options in the values for the aggregate parameter" do
@@ -854,7 +858,7 @@ RSpec.describe SearchParameterParser do
       %{Unexpected options in aggregate "organisations": example},
     ].join(". "))
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params({}))
+    expect(p.parsed_params).to match(expected_params({}))
   end
 
   it "accepts facets as a alias for aggregates" do
@@ -887,7 +891,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(return_fields: %w(title description)))
+    expect(p.parsed_params).to match(expected_params(return_fields: %w(title description)))
   end
 
   it "complains about invalid fields parameters" do
@@ -895,7 +899,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("Some requested fields are not valid return fields: [\"waffle\"]")
     expect(p).not_to be_valid
-    expect(expected_params(return_fields: ["title"])).to eq(p.parsed_params)
+    expect(p.parsed_params).to match(expected_params(return_fields: %w[title]))
   end
 
   it "understands the debug parameter" do
@@ -903,7 +907,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq(%{Unknown debug option "unknown_option"})
     expect(p).not_to be_valid
-    expect(p.parsed_params).to eq(expected_params(debug: { disable_best_bets: true, disable_popularity: true }))
+    expect(p.parsed_params).to match(expected_params(debug: { disable_best_bets: true, disable_popularity: true }))
   end
 
   it "merges values from repeated debug parameters" do
@@ -911,7 +915,7 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(debug: { disable_best_bets: true, explain: true, disable_popularity: true }))
+    expect(p.parsed_params).to match(expected_params(debug: { disable_best_bets: true, explain: true, disable_popularity: true }))
   end
 
   it "ignores empty options in the debug parameter" do
@@ -919,35 +923,35 @@ RSpec.describe SearchParameterParser do
 
     expect(p.error).to eq("")
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(debug: {}))
+    expect(p.parsed_params).to match(expected_params(debug: {}))
   end
 
   it "understands explain in the debug parameter" do
     p = described_class.new({ "debug" => ["explain"] }, @schema)
 
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(debug: { explain: true }))
+    expect(p.parsed_params).to match(expected_params(debug: { explain: true }))
   end
 
   it "understands disable synonyms in the debug parameter" do
     p = described_class.new({ "debug" => ["disable_synonyms"] }, @schema)
 
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(debug: { disable_synonyms: true }))
+    expect(p.parsed_params).to match(expected_params(debug: { disable_synonyms: true }))
   end
 
   it "understands the test variant parameter" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length:A"] }, @schema)
 
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(ab_tests: { min_should_match_length: 'A' }))
+    expect(p.parsed_params).to match(expected_params(ab_tests: { min_should_match_length: 'A' }))
   end
 
   it "understands multiple test variant parameters" do
     p = described_class.new({ "ab_tests" => ["min_should_match_length:A,other_test_case:B"] }, @schema)
 
     expect(p).to be_valid
-    expect(p.parsed_params).to eq(expected_params(ab_tests: { min_should_match_length: 'A', other_test_case: 'B' }))
+    expect(p.parsed_params).to match(expected_params(ab_tests: { min_should_match_length: 'A', other_test_case: 'B' }))
   end
 
   it "complains about invalid test variant where no variant type is provided" do


### PR DESCRIPTION
  Currently most caching of large configuration files is done by using
  memoization in several classes.

  This PR adds a very simple caching solution so that all memoizations
  can be done in this one class.

  This has as an advantage that caching can be controlled centrally
  and that before each test we only need to clear this one cache
  to ensure that all caching throughout the app has been cleared