### PR TITLE
Add a synonym of Myanmar for Burma

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -1111,3 +1111,7 @@
 
 # Common misspellings of key people, in both publishing and searching
 - both: asad, assad => asad, assad
+
+# Country changes
+- search: burma => burma, myanmar
+- search: myanmar => burma, myanmar


### PR DESCRIPTION
This change ensures that searches for Myanmar also returns results for Burma and vice versa. This will surface more content when searching across gov.uk.

Searching Burma returns 692 results:
![Screen Shot 2019-07-11 at 13 13 28](https://user-images.githubusercontent.com/6651749/61057685-b45bc300-a3ed-11e9-97fe-7c4c9b0ee422.png)

Searching Myanmar returns 8 results:
![Screen Shot 2019-07-11 at 13 13 48](https://user-images.githubusercontent.com/6651749/61057702-baea3a80-a3ed-11e9-896f-41375c440b65.png)

Trello: https://trello.com/c/DauneS2z