### PR TITLE
Add new "search_cluster" A/B test parameter, remove "cluster"

### DIFF
--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -531,7 +531,7 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response.fetch("es_cluster")).to eq(Clusters.default_cluster.key)
 
     Clusters.active.each { |cluster|
-      get "/search?q=test&cluster=#{cluster.key}"
+      get "/search?q=test&ab_tests=search_cluster:#{cluster.key}"
       expect(parsed_response.fetch("es_cluster")).to eq(cluster.key)
     }
   end


### PR DESCRIPTION
Given that the two clusters are for A/B testing, and we're not going
to be running multiple clusters long-term, this makes sense.  It's
also consistent with how finder-frontend and
search-performance-explorer expect search-api to work.

---

[Trello card](https://trello.com/c/NoPriEaY/854-use-abtests-parameter-in-search-api-for-cluster-selection)