### PR TITLE
Set a useful user agent for the Search API OAuth client

### DIFF
--- a/lib/auth/gds_sso.rb
+++ b/lib/auth/gds_sso.rb
@@ -24,7 +24,14 @@ module Auth
 
     def oauth_client
       @oauth_client ||= OAuth2::Client.new(
-        oauth_id, oauth_secret, site: Plek.new.external_url_for("signon")
+        oauth_id,
+        oauth_secret,
+        site: Plek.new.external_url_for("signon"),
+        connection_opts: {
+          headers: {
+            user_agent: "oauth-client (#{ENV.fetch('GOVUK_APP_NAME', 'search-api')})"
+          }
+        }
       )
     end
 


### PR DESCRIPTION
This configuration propagates through to the Faraday gem, and should
replace the default user agent there.

I'm trying to track down requests to Signon, and passing a user agent
through which includes the app name will help with that.