### PR TITLE
Restore memoization for Services.cache

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -43,7 +43,7 @@ module Services
   end
 
   def self.cache
-    ActiveSupport::Cache.lookup_store(:memory_store)
+    @cache ||= ActiveSupport::Cache.lookup_store(:memory_store)
   end
 end
 


### PR DESCRIPTION
Even though it sounds like lookup_store would look up the relevant
cache store, it actually generates a brand new one each time. This
defeats the purpose of using it as a cache, as it's always empty.

Therefore, return to memoizing the value.

This fixes an issue where the Search API was making lots of requests
to Signon, as the API user information wasn't being cached.