### PR TITLE
Add hidden_facet_tag

### DIFF
--- a/config/finders/official_documents_finder.yml
+++ b/config/finders/official_documents_finder.yml
@@ -56,6 +56,7 @@ details:
     preposition: Of type
     display_as_result_metadata: true
     filterable: true
+    hide_facet_tag: true
   - key: organisations
     name: Organisation
     short_name: Organisation


### PR DESCRIPTION
Finder frontend checks that `hidden_facet_tag = true` to choose what to render as hidden text for screen readers. The absence of this attribute is partially responsible for a bug in the rendering of hidden text for screen readers on the official docs finder:

https://trello.com/c/iyd3UY3z/734-fix-hidden-text-for-screen-readers-on-finders

Once https://github.com/alphagov/finder-frontend/pull/1170 has been merged this PR will fix the bug. 

Before:

<img width="798" alt="Screen Shot 2019-07-22 at 13 59 38" src="https://user-images.githubusercontent.com/17908089/61634417-31f2bf00-ac89-11e9-9c2f-f3d2416ef7b5.png">

After:

<img width="782" alt="Screen Shot 2019-07-22 at 13 59 48" src="https://user-images.githubusercontent.com/17908089/61634395-24d5d000-ac89-11e9-9975-c1e229bbc332.png">

Will run `rake publishing_api:publish_finder FINDER_CONFIG=official_documents_finder.yml` once this is merged