### PR TITLE
Remove brexit, eu exit synonym

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -18,7 +18,6 @@
 
 # Same meanings
 - search: abroad, overseas => abroad, overseas
-- search: brexit, eu exit => brexit, eu exit
 - search: motorbike, motorcycle => motorbike, motorcycle
 - search: opening times, opening hours => opening times, opening hours
 - search: sickness, illness => sickness, illness


### PR DESCRIPTION
We've decided that this is no longer helpful for users.  Existing
guidance is being updated to use "Brexit" instead of "EU Exit", and
cases where "EU Exit" remains are places like official names of
publications (eg, "The Customs (Export) (EU Exit) Regulations"), in
which case it's being used in a specialist sense.

---

[Trello card](https://trello.com/c/Kxc2K08n/891-remove-the-brexit-eu-exit-synonym-only-if-it-doesnt-massively-ruin-search-results)