### PR TITLE
Remove American Samoa

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -64,7 +64,6 @@ migrated:
   - /world/afghanistan
   - /world/albania
   - /world/algeria
-  - /world/american-samoa
   - /world/andorra
   - /world/angola
   - /world/anguilla


### PR DESCRIPTION
American Samoa is an [Overseas Territory of the United Sates](https://en.wikipedia.org/wiki/Territories_of_the_United_States). For all
other Overseas Territories of the United Sates, we don't have specific
pages or Taxons in GOV.UK.

This is part of the work I'm doing to remove specific American Samoa
pages and redirect them to the corresponding USA pages. This commit does
not redirect anything. The redirection is done in the admin interface of
Content Tagger. I'm removing this line because it's simply not needed
anymore.

Trello card: https://trello.com/c/VHoxXkyC/1136-remove-and-redirect-american-samoa-pages
