### PR TITLE
Add Burma news path to block list

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -298,6 +298,7 @@ indexable: []
 
 non_indexable_path:
 - '/help/cookie-details'
+- '/world/burma/news'
 
 non_indexable:
 - calculator


### PR DESCRIPTION
Currently, "/world/burma/news" shows up in search as a duplicate to "/world/myanmar/news". This change will stop this duplication in search. 

Trello: https://trello.com/c/DauneS2z