### PR TITLE
Enable supergroup finders to narrow subscriptions by hidden topic param

### DIFF
--- a/config/finders/guidance_and_regulation_email_signup.yml
+++ b/config/finders/guidance_and_regulation_email_signup.yml
@@ -19,6 +19,9 @@ details:
     facet_name: organisations
   - facet_id: world_locations
     facet_name: world locations
+  - facet_id: topic
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
   - facet_id: level_one_taxon
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics

--- a/config/finders/news_and_communications_email_signup.yml
+++ b/config/finders/news_and_communications_email_signup.yml
@@ -23,6 +23,9 @@ details:
     facet_name: organisations
   - facet_id: world_locations
     facet_name: world locations
+  - facet_id: topic
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
   - facet_id: level_one_taxon
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics

--- a/config/finders/policy_and_engagement_email_signup.yml
+++ b/config/finders/policy_and_engagement_email_signup.yml
@@ -33,6 +33,9 @@ details:
       - consultation_outcome
   - facet_id: world_locations
     facet_name: world locations
+  - facet_id: topic
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
   - facet_id: level_one_taxon
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics

--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -38,6 +38,9 @@ details:
     facet_name: organisations
   - facet_id: world_locations
     facet_name: world locations
+  - facet_id: topic
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
   - facet_id: level_one_taxon
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics

--- a/config/finders/transparency_email_signup.yml
+++ b/config/finders/transparency_email_signup.yml
@@ -21,6 +21,9 @@ details:
     facet_name: organisations
   - facet_id: world_locations
     facet_name: world locations
+  - facet_id: topic
+    filter_key: all_part_of_taxonomy_tree
+    facet_name: topics
   - facet_id: level_one_taxon
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics


### PR DESCRIPTION
From the topic pages, for instance  www.gov.uk/transport, we can access
the supergroupfinders which will have their search results narrowed by
the relevant topic.

The email subscription to these finders did not take the supplied 'topic'
parameter into account - this commit fixes that.

It is necessary to run the finder deploy rake task afterwards

trello: https://trello.com/c/0r8Pmg1k/897-ensure-hidden-topic-parameter-works-when-signing-up-to-finders
Also deploy and related: https://github.com/alphagov/finder-frontend/pull/1277