### PR TITLE
Revert "Remove American Samoa"

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -64,6 +64,7 @@ migrated:
   - /world/afghanistan
   - /world/albania
   - /world/algeria
+  - /world/american-samoa
   - /world/andorra
   - /world/angola
   - /world/anguilla


### PR DESCRIPTION
Reverts alphagov/search-api#1637

Trello card: https://trello.com/c/VHoxXkyC/1136-remove-and-redirect-american-samoa-pages