### PR TITLE
Handle best bet analyzer returning nothing

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -192,7 +192,7 @@ module SearchIndices
           },
         )
 
-        analyzed_query["tokens"].map { |token_info|
+        analyzed_query.fetch('tokens', []).map { |token_info|
           token_info["token"]
         }.join(" ")
       rescue Elasticsearch::Transport::Transport::Errors::BadRequest

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -92,7 +92,7 @@ module Indexer
           },
         )
 
-        analyzed_query["tokens"].map { |token_info|
+        analyzed_query.fetch('tokens', []).map { |token_info|
           token_info["token"]
         }.join(" ")
       rescue Elasticsearch::Transport::Transport::Errors::BadRequest


### PR DESCRIPTION
With ES5 if the best bet analyzer finds no tokens, we get this
response:

    {
       "tokens" : []
    }

However, with ES6 we get this response:

    {
    }

No tokens!

---

[Trello card](https://trello.com/c/XJLJh4Ax/915-fix-issue-with-best-bet-stemmed-analysis-for-es6)