### PR TITLE
Remove beta banner from Research and Stats finder

### DIFF
--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -9,9 +9,8 @@ rendering_app: finder-frontend
 schema_name: finder
 signup_content_id: 119db584-0ae7-45e4-8f3a-fd79316c6921
 title: Research and statistics
-phase: beta
+phase: live
 details:
-  beta_message: Research and statistics search is new - <a href="https://www.smartsurvey.co.uk/s/research-statistics-search-survey/">tell us what you think</a>
   document_noun: result
   filter: {}
   format_name: statistic


### PR DESCRIPTION
Remove beta banner

Once merged I will run rake `FINDER_CONFIG=statistics_finder.yml publishing_api:publish_finder`

https://trello.com/c/5KQjA1sE/921-remove-the-beta-banner-from-the-research-statistics-finder