### PR TITLE
When given a sort order, break ties by sorting on content ID

### DIFF
--- a/lib/search/query_components/sort.rb
+++ b/lib/search/query_components/sort.rb
@@ -10,7 +10,9 @@ module QueryComponents
         # Sort by popularity when there's no explicit ordering, and there's no
         # query (so there's no relevance scores).
         elsif search_term.nil? && !search_params.disable_popularity?
-          return [{ "popularity" => { order: "desc" } }]
+          return [{ "popularity" => { order: "desc" } }, tie_breaking_sort]
+        # If there's no explicit ordering, but there is a query (and
+        # so there are relevance scores), sort by relevance
         else
           return nil
         end
@@ -28,8 +30,17 @@ module QueryComponents
             # really) with a missing value.
             unmapped_type: "integer"
           }
-       }
+        },
+        tie_breaking_sort,
       ]
+    end
+
+    # use content ID (which never changes) as a tie breaker if two
+    # items are otherwise equally placed in the results -- this is so
+    # we're explicit about how to break the tie, rather than relying
+    # on however Elasticsearch chooses to do it.
+    def tie_breaking_sort
+      { "content_id" => { order: "asc" } }
     end
   end
 end

--- a/spec/unit/query_components/sort_spec_spec.rb
+++ b/spec/unit/query_components/sort_spec_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 RSpec.describe 'SortTest' do
   context "without explicit ordering" do
-    it "order by popularity" do
+    it "order by popularity, with a tie-breaker" do
       builder = QueryComponents::Sort.new(Search::QueryParameters.new)
 
       result = builder.payload
 
-      expect(result).to eq([{ "popularity" => { order: "desc" } }])
+      expect(result).to eq([{ "popularity" => { order: "desc" } }, { "content_id" => { order: "asc" } }])
     end
   end
 
@@ -22,22 +22,22 @@ RSpec.describe 'SortTest' do
   end
 
   context "search with ascending sort" do
-    it "put documents without a timestamp at the bottom" do
+    it "put documents without a timestamp at the bottom, with a tie-breaker" do
       builder = QueryComponents::Sort.new(Search::QueryParameters.new(order: %w(public_timestamp asc)))
 
       result = builder.payload
 
-      expect(result).to eq([{ "public_timestamp" => { order: "asc", missing: "_last", unmapped_type: "integer" } }])
+      expect(result).to eq([{ "public_timestamp" => { order: "asc", missing: "_last", unmapped_type: "integer" } }, { "content_id" => { order: "asc" } }])
     end
   end
 
   context "search with descending sort" do
-    it "put documents without a timestamp at the bottom" do
+    it "put documents without a timestamp at the bottom, with a tie-breaker" do
       builder = QueryComponents::Sort.new(Search::QueryParameters.new(order: %w(public_timestamp desc)))
 
       result = builder.payload
 
-      expect(result).to eq([{ "public_timestamp" => { order: "desc", missing: "_last", unmapped_type: "integer" } }])
+      expect(result).to eq([{ "public_timestamp" => { order: "desc", missing: "_last", unmapped_type: "integer" } }, { "content_id" => { order: "asc" } }])
     end
   end
 


### PR DESCRIPTION
If you have two items with the exact same timestamp, and sort by timestamp, they can't appear at the same position in the output.  The tie needs to be broken somehow.

We don't currently have a tie breaker, so it's done by Elasticsearch.  We'd like to have an explicit tie-break in our code, so we can ensure that the order of things remains consistent across changes to Elasticsearch (reindexes, upgrades, etc).  So, if we've got an explicit ordering, break ties by sorting on content ID.

I picked content ID because a document's content ID can't change---that would be a new document.

We were initially going to do this in finder-frontend just for Atom feeds, but I feel it makes more sense to go here, as a general solution.

---

[Trello card](https://trello.com/c/nTGzIEpy/914-ordering-of-atom-feeds-generated-by-finder-frontend-is-arbitrary)