### PR TITLE
Change ES6 search query, gated behind a new A/B test

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -73,7 +73,7 @@ private
   def cluster
     @cluster ||=
       begin
-        cluster_key = ab_tests.fetch(:search_cluster, Clusters.default_cluster.key)
+        cluster_key = ab_tests.fetch(:search_cluster_query, Clusters.default_cluster.key)
         Clusters.get_cluster(cluster_key)
       rescue Clusters::ClusterNotFoundError
         @errors << "Invalid cluster. Accepted values: #{Clusters.cluster_keys.join(', ')}"

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -53,15 +53,7 @@ module Search
             else
               {
                 bool: {
-                  should: [
-                    core_query.match_phrase("title"),
-                    core_query.match_phrase("acronym"),
-                    core_query.match_phrase("description"),
-                    core_query.match_phrase("indexable_content"),
-                    core_query.match_all_terms(%w(title acronym description indexable_content)),
-                    core_query.match_any_terms(%w(title acronym description indexable_content)),
-                    core_query.minimum_should_match("all_searchable_text")
-                  ],
+                  should: core_query.unquoted_phrase_query
                 }
               }
             end

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -50,7 +50,7 @@ module Search
           format_boost.wrap(
             if search_params.quoted_search_phrase?
               core_query.quoted_phrase_query
-            elsif search_params.ab_tests.fetch(:search_cluster, 'A') == 'B'
+            elsif search_params.ab_tests.fetch(:search_cluster_query, 'A') == 'B'
               core_query.unquoted_phrase_query
             else
               {

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -51,11 +51,7 @@ module Search
             if search_params.quoted_search_phrase?
               core_query.quoted_phrase_query
             else
-              {
-                bool: {
-                  should: core_query.unquoted_phrase_query
-                }
-              }
+              core_query.unquoted_phrase_query
             end
           )
         )

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -50,8 +50,22 @@ module Search
           format_boost.wrap(
             if search_params.quoted_search_phrase?
               core_query.quoted_phrase_query
-            else
+            elsif search_params.ab_tests.fetch(:search_cluster, 'A') == 'B'
               core_query.unquoted_phrase_query
+            else
+              {
+                bool: {
+                  should: [
+                    core_query.match_phrase("title"),
+                    core_query.match_phrase("acronym"),
+                    core_query.match_phrase("description"),
+                    core_query.match_phrase("indexable_content"),
+                    core_query.match_all_terms(%w(title acronym description indexable_content)),
+                    core_query.match_any_terms(%w(title acronym description indexable_content)),
+                    core_query.minimum_should_match("all_searchable_text")
+                  ],
+                }
+              }
             end
           )
         )

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -63,13 +63,15 @@ module QueryComponents
 
     def unquoted_phrase_query
       [
-        match_phrase("title"),
-        match_phrase("acronym"),
-        match_phrase("description"),
-        match_phrase("indexable_content"),
-        match_all_terms(%w(title acronym description indexable_content)),
-        match_any_terms(%w(title acronym description indexable_content)),
-        minimum_should_match("all_searchable_text")
+        dis_max_query([
+          match_phrase("title"),
+          match_phrase("acronym"),
+          match_phrase("description"),
+          match_phrase("indexable_content"),
+          match_all_terms(%w(title acronym description indexable_content)),
+          match_any_terms(%w(title acronym description indexable_content)),
+          minimum_should_match("all_searchable_text")
+        ])
       ]
     end
 

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -69,7 +69,7 @@ module QueryComponents
           match_phrase("description", PHRASE_MATCH_DESCRIPTION_BOOST),
           match_phrase("indexable_content", PHRASE_MATCH_INDEXABLE_CONTENT_BOOST),
           match_all_terms(%w(title acronym description indexable_content)),
-          match_any_terms(%w(title acronym description indexable_content)),
+          match_any_terms(%w(title acronym description indexable_content), 0.2),
           minimum_should_match("all_searchable_text")
         ], tie_breaker: 0.7)
       ]
@@ -87,7 +87,7 @@ module QueryComponents
       }
     end
 
-    def match_phrase(field_name, boost)
+    def match_phrase(field_name, boost = 1.0)
       {
         match_phrase: {
           synonym_field(field_name) => {
@@ -99,11 +99,12 @@ module QueryComponents
       }
     end
 
-    def match_all_terms(fields)
+    def match_all_terms(fields, boost = 1.0)
       fields = fields.map { |f| synonym_field(f) }
 
       {
         multi_match: {
+          boost: boost,
           query: escape(search_term),
           operator: "and",
           fields: fields,
@@ -112,15 +113,16 @@ module QueryComponents
       }
     end
 
-    def match_any_terms(fields)
+    def match_any_terms(fields, boost = 1.0)
       fields = fields.map { |f| synonym_field(f) }
 
       {
         multi_match: {
+          boost: boost,
           query: escape(search_term),
           operator: "or",
           fields: fields,
-          analyzer: query_analyzer
+          analyzer: query_analyzer,
         }
       }
     end

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -70,15 +70,16 @@ module QueryComponents
           match_phrase("indexable_content", PHRASE_MATCH_INDEXABLE_CONTENT_BOOST),
           match_all_terms(%w(title acronym description indexable_content)),
           match_any_terms(%w(title acronym description indexable_content), 0.2),
-          minimum_should_match("all_searchable_text")
+          minimum_should_match("all_searchable_text", 0.2)
         ], tie_breaker: 0.7)
       ]
     end
 
-    def minimum_should_match(field_name)
+    def minimum_should_match(field_name, boost = 1.0)
       {
         match: {
           synonym_field(field_name) => {
+            boost: boost,
             query: escape(search_term),
             analyzer: query_analyzer,
             minimum_should_match: MINIMUM_SHOULD_MATCH,

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -64,10 +64,10 @@ module QueryComponents
     def unquoted_phrase_query
       [
         dis_max_query([
-          match_phrase("title"),
-          match_phrase("acronym"),
-          match_phrase("description"),
-          match_phrase("indexable_content"),
+          match_phrase("title", PHRASE_MATCH_TITLE_BOOST),
+          match_phrase("acronym", PHRASE_MATCH_ACRONYM_BOOST),
+          match_phrase("description", PHRASE_MATCH_DESCRIPTION_BOOST),
+          match_phrase("indexable_content", PHRASE_MATCH_INDEXABLE_CONTENT_BOOST),
           match_all_terms(%w(title acronym description indexable_content)),
           match_any_terms(%w(title acronym description indexable_content)),
           minimum_should_match("all_searchable_text")
@@ -87,10 +87,11 @@ module QueryComponents
       }
     end
 
-    def match_phrase(field_name)
+    def match_phrase(field_name, boost)
       {
         match_phrase: {
           synonym_field(field_name) => {
+            boost: boost,
             query: escape(search_term),
             analyzer: query_analyzer,
           }

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -71,7 +71,7 @@ module QueryComponents
           match_all_terms(%w(title acronym description indexable_content)),
           match_any_terms(%w(title acronym description indexable_content)),
           minimum_should_match("all_searchable_text")
-        ])
+        ], tie_breaker: 0.7)
       ]
     end
 

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -61,6 +61,18 @@ module QueryComponents
       ]
     end
 
+    def unquoted_phrase_query
+      [
+        match_phrase("title"),
+        match_phrase("acronym"),
+        match_phrase("description"),
+        match_phrase("indexable_content"),
+        match_all_terms(%w(title acronym description indexable_content)),
+        match_any_terms(%w(title acronym description indexable_content)),
+        minimum_should_match("all_searchable_text")
+      ]
+    end
+
     def minimum_should_match(field_name)
       {
         match: {

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -531,7 +531,7 @@ RSpec.describe 'SearchTest' do
     expect(parsed_response.fetch("es_cluster")).to eq(Clusters.default_cluster.key)
 
     Clusters.active.each { |cluster|
-      get "/search?q=test&ab_tests=search_cluster:#{cluster.key}"
+      get "/search?q=test&ab_tests=search_cluster_query:#{cluster.key}"
       expect(parsed_response.fetch("es_cluster")).to eq(cluster.key)
     }
   end

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -95,21 +95,21 @@ RSpec.describe SearchParameterParser do
     expect(p.parsed_params).to match(expected_params({}))
   end
 
-  it "understands the search_cluster A/B parameter" do
+  it "understands the search_cluster_query A/B parameter" do
     cluster = Clusters.active.sample # random cluster
-    p = described_class.new({ "ab_tests" => ["search_cluster:#{cluster.key}"] }, @schema)
+    p = described_class.new({ "ab_tests" => ["search_cluster_query:#{cluster.key}"] }, @schema)
 
     expect(p.error).to eq("")
     expect(p).to be_valid
     expect(p.parsed_params).to match(
       expected_params(
-        ab_tests: { search_cluster: cluster.key },
+        ab_tests: { search_cluster_query: cluster.key },
         cluster: cluster_with_key(cluster.key),
        )
     )
   end
 
-  it "uses the default cluster if the search_cluster A/B parameter is not set" do
+  it "uses the default cluster if the search_cluster_query A/B parameter is not set" do
     p = described_class.new({ "ab_tests" => [] }, @schema)
 
     expect(p.error).to eq("")
@@ -117,14 +117,14 @@ RSpec.describe SearchParameterParser do
     expect(p.parsed_params).to match(expected_params(cluster: cluster_with_key(Clusters.default_cluster.key)))
   end
 
-  it "complains about invalid search_cluster A/B parameters" do
-    p = described_class.new({ "ab_tests" => ["search_cluster:invalid"] }, @schema)
+  it "complains about invalid search_cluster_query A/B parameters" do
+    p = described_class.new({ "ab_tests" => ["search_cluster_query:invalid"] }, @schema)
 
     expect(p.error).to eq(%{Invalid cluster. Accepted values: #{Clusters.active.map(&:key).join(', ')}})
     expect(p).not_to be_valid
     expect(p.parsed_params).to match(
       expected_params(
-        ab_tests: { search_cluster: "invalid" },
+        ab_tests: { search_cluster_query: "invalid" },
         cluster: cluster_with_key(Clusters.default_cluster.key),
       )
      )


### PR DESCRIPTION
Also removes the old A/B test.

**Reasoning:**

- ES6 removed coordination factors, but if a doc matches two subqueries that doesn't *necessarily* mean it's twice as good a match as a doc which matches one subquery.  So use a `dis_max` query with a tie-break of 0.7.

- Copy over the field boosting we use for quoted search queries - these were chosen for  reason (hopefully).

- Decrease the boosting of `match_any_terms` and `minimum_should_match` - these only ensure a doc contains *some* of the search terms, so they should pull a doc into the results, but they shouldn't be very significant factors in scoring.

These changes seem to work well, we've eyeballed ~100 queries, and there was nothing that looked particularly bad.

---

[Trello card](https://trello.com/c/dvLAhldZ/929-figure-out-result-ordering-weirdness-with-es6)
