### PR TITLE
Update email subscription title prefix for...

### DIFF
--- a/config/find-eu-exit-guidance-business-email-signup.yml
+++ b/config/find-eu-exit-guidance-business-email-signup.yml
@@ -417,7 +417,7 @@ details:
       radio_button_name: Defence contracts
       topic_name: Defence contracts
       prechecked: false
-  subscription_list_title_prefix: 'Find EU Exit guidance for your business'
+  subscription_list_title_prefix: 'Find Brexit guidance for your business'
 routes:
 - path: "/find-eu-exit-guidance-business/email-signup"
   type: exact


### PR DESCRIPTION
Business Readiness subscriptions.

We are changing all instances of `EU Exit` to `Brexit` across
GOV.UK. This is part of the changes made on email subscription lists.

Related to https://github.com/alphagov/email-alert-api/pull/921

Trello card: https://trello.com/c/GnNdTWi9/1160-change-email-template-eu-exit-to-brexit