### PR TITLE
Add hidden content_store_document_type facet to all-content finder

### DIFF
--- a/config/finders/all_content_email_signup.yml
+++ b/config/finders/all_content_email_signup.yml
@@ -17,6 +17,8 @@ details:
   email_filter_facets:
   - facet_id: content_purpose_supergroup
     facet_name: content_purpose_supergroup
+  - facet_id: content_store_document_type
+    facet_name: content_store_document_type
   - facet_id: people
     facet_name: people
   - facet_id: organisations

--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -39,6 +39,14 @@ details:
     allowed_values: []
   - display_as_result_metadata: false
     filterable: true
+    key: content_store_document_type
+    name: Document type
+    preposition: Of type
+    type: hidden_clearable
+    show_option_select_filter: false
+    allowed_values: []
+  - display_as_result_metadata: false
+    filterable: true
     key: content_purpose_supergroup
     name: Show only
     preposition: in


### PR DESCRIPTION
We don't want users to think about document types, because they're
confusing and departments use them inconsistently, but sometimes a
department does want to be able to link users to (eg) a search scoped
to their decisions and nothing else.

<img width="1029" alt="Screen Shot 2019-08-05 at 16 32 26" src="https://user-images.githubusercontent.com/75235/62476337-b15eb300-b79e-11e9-94d0-47da05ab4e63.png">

No visible doctype facet, but nevertheless restricted to decisions.

---

[Trello card](https://trello.com/c/jpLSQGAS/923-discover-facets-and-urls-relevant-for-scrutineer-y-finders)