### PR TITLE
Allow filtering the transparency finder by doctype

### DIFF
--- a/config/finders/transparency_email_signup.yml
+++ b/config/finders/transparency_email_signup.yml
@@ -15,6 +15,8 @@ details:
   filter:
     content_purpose_supergroup: transparency
   email_filter_facets:
+  - facet_id: content_store_document_type
+    facet_name: document type
   - facet_id: people
     facet_name: people
   - facet_id: organisations

--- a/config/finders/transparency_finder.yml
+++ b/config/finders/transparency_finder.yml
@@ -26,6 +26,19 @@ details:
     display_as_result_metadata: false
     hide_facet_tag: true
     filterable: true
+  - key: content_store_document_type
+    name: Document type
+    preposition: of type
+    type: text
+    display_as_result_metadata: false
+    filterable: true
+    allowed_values:
+    - label: Corporate report
+      value: corporate_report
+    - label: FOI release
+      value: foi_release
+    - label: Transparency data
+      value: transparency
   - display_as_result_metadata: true
     filterable: true
     key: organisations


### PR DESCRIPTION

<img width="1000" alt="Screen Shot 2019-08-06 at 09 49 36" src="https://user-images.githubusercontent.com/75235/62525562-8a03f680-b82f-11e9-808d-8b0730cc7976.png">


"Document type" and "Of type" is the wording we use in the policy papers & consultations finder.

---

[Trello card](https://trello.com/c/jpLSQGAS/923-discover-facets-and-urls-relevant-for-scrutineer-y-finders)