### PR TITLE
Add find brexit guidance finder definition

### DIFF
--- a/config/finders/find-brexit-guidance-email-signup.yml
+++ b/config/finders/find-brexit-guidance-email-signup.yml
@@ -1,0 +1,25 @@
+---
+base_path: "/find-brexit-guidance/email-signup"
+content_id: 631a000b-dcfa-4cb9-a608-776f78142c6c
+document_type: finder_email_signup
+locale: en
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder_email_signup
+title: Find Brexit guidance
+description: Sign up for email alerts to Brexit guidance.
+details:
+  email_filter_by: facet_values
+  email_filter_facets:
+  - facet_id: business_activity
+    facet_name: Organisation activity
+    facet_choices:
+    - key: product-or-goods
+      content_id: d2f4d296-bc2f-4e97-aad8-ebb45637ebca
+      radio_button_name: Product or goods
+      topic_name: Product or goods
+      prechecked: false
+  subscription_list_title_prefix: 'Find Brexit guidance'
+routes:
+- path: "/find-brexit-guidance/email-signup"
+  type: exact

--- a/config/finders/find-brexit-guidance.yml
+++ b/config/finders/find-brexit-guidance.yml
@@ -1,0 +1,42 @@
+---
+base_path: "/find-brexit-guidance"
+content_id: cecbd248-c326-45a9-a8e5-63d5e8e0b6fd
+signup_content_id: 631a000b-dcfa-4cb9-a608-776f78142c6c
+title: Find Brexit guidance
+description: 'This is the information that has been published so far to prepare you for Brexit. You can change what information you get using the checkboxes. Come back to this page regularly or sign up to receive emails when new information is published.'
+name: 'Find Brexit guidance'
+locale: en
+public_updated_at: '2018-11-23T09:00:00.000+00:00'
+publishing_app: search-api
+rendering_app: finder-frontend
+links:
+  facet_group:
+  - "e6dc1c00-453a-4fac-96ec-66a2f11ae327"
+details:
+  beta: false
+  document_noun: publication
+  summary: 'This is the information that has been published so far to prepare you for Brexit. You can change what information you get using the checkboxes. Come back to this page regularly or sign up to receive emails when new information is published.'
+  canonical_link: true
+  sort:
+    - name: Most viewed
+      key: -popularity
+    - name: Relevance
+      key: -relevance
+      default: true
+    - name: Most recent
+      key: -public_timestamp
+    - name: A to Z
+      key: title
+  filter:
+    facet_groups: ["e6dc1c00-453a-4fac-96ec-66a2f11ae327"]
+  facets: []
+routes:
+- path: "/find-brexit-guidance"
+  type: exact
+- path: "/find-brexit-guidance.atom"
+  type: exact
+- path: "/find-brexit-guidance.json"
+  type: exact
+document_type: finder
+schema_name: finder
+ordered_related_items: []


### PR DESCRIPTION
This adds a definition file for a finder to support dynamic lists for Brexit guidance.