### PR TITLE
Add stats announcements display date

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -257,6 +257,11 @@
     "type": "date"
   },
 
+  "display_date": {
+    "description": "The display text for the proposed release date for a statistics announcement.  This may be approximate.",
+    "type": "identifier"
+  },
+
   "metadata": {
     "description": "The \"metadata\" field is intended for the storage of additional non-searchable document data. This allows additional information to be stored and displayed in search results without having to make changes to the schema.",
     "type": "opaque_object"


### PR DESCRIPTION
This is currently only available as a property of the [metadata field](https://www.gov.uk/api/search.json?filter_format=statistics_announcement&fields=metadata), which makes it tricky to expose using the "finder" pattern which is optimised for retrieving properties at the top level of a result.

Examples of current values for this are:
- "September to October 2019"
- "30 January 2020 9:30am"
- "October 2019"

I've named it fairly generically so that this field may be reused by things other than statistical announcements in future.  This is consistent with the `release_timestamp` field above it in the definition file.

https://trello.com/c/zucpgkPW/966-update-statistics-announcements-finder-to-use-provisional-dates