### PR TITLE
Add display_date to edition

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -11,6 +11,7 @@
     "document_collections",
     "document_series",
     "business_activity",
+    "display_date",
     "employ_eu_citizens",
     "end_date",
     "government_name",


### PR DESCRIPTION
We co-locate this with release date because they are related items. They seem to only be used in stats announcements at present though. 

Missed this from https://github.com/alphagov/search-api/pull/1657
https://trello.com/c/zucpgkPW/966-update-statistics-announcements-finder-to-use-provisional-dates