### PR TITLE
Use display_date for statistics announcements

### DIFF
--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -30,11 +30,11 @@ details:
   - name: Release date (oldest)
     key: release_timestamp
   facets:
-  - key: release_timestamp
-    name: release_timestamp
+  - key: display_date
+    name: display_date
     short_name: Release date
     preposition: from
-    type: date
+    type: text
     display_as_result_metadata: true
     filterable: false
   - key: statistics_announcement_state

--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -30,20 +30,6 @@ details:
   - name: Release date (oldest)
     key: release_timestamp
   facets:
-  - key: display_date
-    name: display_date
-    short_name: Release date
-    preposition: from
-    type: text
-    display_as_result_metadata: true
-    filterable: false
-  - key: statistics_announcement_state
-    name: State
-    short_name: State
-    preposition: from
-    type: text
-    display_as_result_metadata: true
-    filterable: false
   - key: display_type
     name: content_store_document_type
     short_name: Document type
@@ -106,6 +92,20 @@ details:
     type: date
     display_as_result_metadata: true
     filterable: true
+  - key: display_date
+    name: display_date
+    short_name: Release date
+    preposition: from
+    type: text
+    display_as_result_metadata: true
+    filterable: false
+  - key: statistics_announcement_state
+    name: State
+    short_name: State
+    preposition: from
+    type: text
+    display_as_result_metadata: true
+    filterable: false
   default_documents_per_page: 20
 routes:
 - path: "/search/research-and-statistics"


### PR DESCRIPTION
We use this because stats announcement dates can be woolly (eg in August or
September 2020).  At present we're only showing exact dates which is not always
the intent of the publisher.

View by commit to see that this is a small change.

Not to be deployed until stats have been resent to search

https://trello.com/c/zucpgkPW/966-update-statistics-announcements-finder-to-use-provisional-dates