### PR TITLE
Don't index facet, facet_group, or facet_values docs

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -370,7 +370,10 @@ non_indexable:
 - decision
 - document_collection
 - equality_and_diversity
+- facet
+- facet_group
 - facet_value
+- facet_values
 - fatality_notice
 - field_of_operation
 #- finder # migrated


### PR DESCRIPTION
`facet_value` isn't the only facety doctype.