### PR TITLE
Switch the UI for Research and Statistics email alerts

### DIFF
--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -7,33 +7,16 @@ publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: Research and statistics
-description: <p>You can't subscribe to get email notifications about upcoming statistics.</p><p>Subscribe to published statistics to get an email every time statistics are published or updated.</p>
+description: You'll get an email every time research and statistics are updated, published or cancelled.
 details:
   email_filter_by:
   email_filter_name:
   subscription_list_title_prefix: Statistics
-  filter: {}
+  filter:
+    content_purpose_supergroup: research_and_statistics
   email_filter_facets:
   - facet_id: content_store_document_type
-    facet_name: Research and statistics
-    facet_choices:
-    - key: statistics_published
-      filter_values:
-      - statistics
-      - national_statistics
-      - statistical_data_set
-      - official_statistics
-      radio_button_name: Statistics (published)
-      topic_name: Statistics (published)
-      prechecked: false
-    - key: research
-      filter_values:
-      - dfid_research_output
-      - independent_report
-      - research
-      radio_button_name: Research
-      topic_name: Research
-      prechecked: false
+    facet_name: document_type
   - facet_id: organisations
     facet_name: organisations
   - facet_id: world_locations


### PR DESCRIPTION
Card https://trello.com/c/jh8yogol/955-add-more-email-alerts-to-the-research-and-statistics-finder
Pair programming effort with @SamJamCul 

## Before: 
Currently we only have email alerts for the two facets which filter on content store document type ie published stats, and research. 

<img width="450" alt="Screen Shot 2019-08-19 at 14 27 02" src="https://user-images.githubusercontent.com/17908089/63269220-aec78780-c28d-11e9-92c2-3eb96bd9eb84.png">

## After:
<img width="637" alt="Screen Shot 2019-08-19 at 14 58 58" src="https://user-images.githubusercontent.com/17908089/63271373-eb957d80-c291-11e9-9497-5fc2bbba964f.png">

## Why:

We use the checkbox style of sign up for just a handful of specialist finders. Which makes sense because these finders are searching within a specific document type. However across the majority of specialist and non-specialist finders, we use the "without checkbox" style far more frequently. The research and stats finder applies multiple filters (`format`,`statistic_announcement_state`,`content_store_document_type`). It is much simpler to implement email alerts without the checkboxes, and it also feels better to be moving the UI more in line with the majority of our finders. 

## Testing:

Ran `publishing_api:publish_finder` to republish the finder and email alert config file on integration
Visited finder on integration env and signed up to an email alert
SSH'ed onto email-alert-api machine:
```
pp SubscriberList.last
#<SubscriberList:0x00007fc0b69dfa98
 id: 23476,
 title:
  "Statistics with 1 document_type and organisation of Ministry of Defence",
 created_at: Mon, 19 Aug 2019 15:49:54 BST +01:00,
 updated_at: Mon, 19 Aug 2019 15:49:54 BST +01:00,
 document_type: "",
 tags: {},
 links:
  {"content_store_document_type"=>{"any"=>["cancelled_statistics"]},
   "organisations"=>{"any"=>["d994e55c-48c9-4795-b872-58d8ec98af12"]},
   "content_purpose_supergroup"=>{"any"=>["research_and_statistics"]}},
 email_document_supertype: "",
 government_document_supertype: "",
 signon_user_uid: "6b613dc0-9495-0135-5890-005056010baa",
 slug:
  "statistics-with-1-document_type-and-organisation-of-ministry-of-defence">

 pp SubscriberList.last.subscribers
[#<Subscriber:0x00007fc0b6b63798
  id: 1028913,
  address: "mytest@gmail.com",
  created_at: Mon, 19 Aug 2019 15:50:43 BST +01:00,
  updated_at: Mon, 19 Aug 2019 15:50:43 BST +01:00,
  signon_user_uid: "467e0080-b7dd-0135-5939-005056010baa",
  deactivated_at: nil>]
```
