### PR TITLE
Adjust Brexit topic page title / description

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -7,12 +7,16 @@ module GovukIndex
       "service_manual_service_standard" => "service_manual_guide",
       "topic" => "specialist_sector",
     }.freeze
+    BREXIT_PAGE = {
+      "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      "title" => "Get ready for Brexit",
+      "description" => "The UK is leaving the EU. Find out how you should get ready for Brexit and what government is doing."
+    }.freeze
     extend MethodBuilder
 
     delegate_to_payload :content_id
     delegate_to_payload :content_purpose_document_supertype
     delegate_to_payload :content_store_document_type, hash_key: "document_type"
-    delegate_to_payload :description
     delegate_to_payload :email_document_supertype
     delegate_to_payload :government_document_supertype
     delegate_to_payload :navigation_document_supertype
@@ -41,7 +45,11 @@ module GovukIndex
     end
 
     def title
-      [section_id, payload["title"]].compact.join(" - ")
+      brexit_page? ? BREXIT_PAGE["title"] : [section_id, payload["title"]].compact.join(" - ")
+    end
+
+    def description
+      brexit_page? ? BREXIT_PAGE["description"] : payload["description"]
     end
 
     def is_withdrawn
@@ -67,5 +75,9 @@ module GovukIndex
   private
 
     attr_reader :payload
+
+    def brexit_page?
+      content_id == BREXIT_PAGE["content_id"]
+    end
   end
 end

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -65,6 +65,19 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     expect(presenter.link).to eq("some_url")
   end
 
+  it "adjusts the title and description for the Brexit topic page" do
+    payload = {
+      "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      "title" => "some title",
+      "description" => "some description"
+    }
+
+    presenter = common_fields_presenter(payload)
+
+    expect(presenter.title).to eq("Get ready for Brexit")
+    expect(presenter.description).to eq("The UK is leaving the EU. Find out how you should get ready for Brexit and what government is doing.")
+  end
+
   it "withdrawn when withdrawn notice present" do
     payload = {
       "base_path" => "/some/path",


### PR DESCRIPTION
We need a title and description for the Brexit topic page that does not
match that of the taxon. This adds logic to hardcode what should show up
in search

Co-authored-by: Bruce Bolt <bruce.bolt@digital.cabinet-office.gov.uk>