### PR TITLE
Correct bug on email signup page

### DIFF
--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -16,7 +16,7 @@ details:
     content_purpose_supergroup: research_and_statistics
   email_filter_facets:
   - facet_id: content_store_document_type
-    facet_name: document_type
+    facet_name: document type
   - facet_id: organisations
     facet_name: organisations
   - facet_id: world_locations


### PR DESCRIPTION
The facet name was incorrect, resulting in a typo in the signup confirmation text presented
to the user.

https://trello.com/c/jh8yogol/955-add-more-email-alerts-to-the-research-and-statistics-finder

[
<img width="646" alt="Screen Shot 2019-08-21 at 10 24 07" src="https://user-images.githubusercontent.com/17908089/63420089-e5bcab00-c3fd-11e9-8be4-19a46c16387b.png">
](url)