### PR TITLE
Revert "Correct bug on email signup page"

### DIFF
--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -16,7 +16,7 @@ details:
     content_purpose_supergroup: research_and_statistics
   email_filter_facets:
   - facet_id: content_store_document_type
-    facet_name: document type
+    facet_name: document_type
   - facet_id: organisations
     facet_name: organisations
   - facet_id: world_locations


### PR DESCRIPTION
Reverts alphagov/search-api#1668

Testing the new alerts added by (https://github.com/alphagov/search-api/pull/1664) on staging reveals there is an issue with alerts for some of the filter choices. Reverting both related PR's so I don't block deploys on search api any longer. 
