### PR TITLE
Revert "Switch the UI for Research and Statistics email alerts"

### DIFF
--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -7,16 +7,33 @@ publishing_app: search-api
 rendering_app: finder-frontend
 schema_name: finder_email_signup
 title: Research and statistics
-description: You'll get an email every time research and statistics are updated, published or cancelled.
+description: <p>You can't subscribe to get email notifications about upcoming statistics.</p><p>Subscribe to published statistics to get an email every time statistics are published or updated.</p>
 details:
   email_filter_by:
   email_filter_name:
   subscription_list_title_prefix: Statistics
-  filter:
-    content_purpose_supergroup: research_and_statistics
+  filter: {}
   email_filter_facets:
   - facet_id: content_store_document_type
-    facet_name: document_type
+    facet_name: Research and statistics
+    facet_choices:
+    - key: statistics_published
+      filter_values:
+      - statistics
+      - national_statistics
+      - statistical_data_set
+      - official_statistics
+      radio_button_name: Statistics (published)
+      topic_name: Statistics (published)
+      prechecked: false
+    - key: research
+      filter_values:
+      - dfid_research_output
+      - independent_report
+      - research
+      radio_button_name: Research
+      topic_name: Research
+      prechecked: false
   - facet_id: organisations
     facet_name: organisations
   - facet_id: world_locations


### PR DESCRIPTION
Reverts alphagov/search-api#1664

Testing the new alerts on staging reveals there is an issue with alerts for some of the filter choices. Reverting both related PR's so I don't block deploys on search api any longer. 