### PR TITLE
Update description for Brexit landing page

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -10,7 +10,7 @@ module GovukIndex
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "title" => "Get ready for Brexit",
-      "description" => "The UK is leaving the EU. Find out how you should get ready for Brexit and what government is doing."
+      "description" => "The UK is leaving the EU, find out how you should get ready for Brexit."
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     presenter = common_fields_presenter(payload)
 
     expect(presenter.title).to eq("Get ready for Brexit")
-    expect(presenter.description).to eq("The UK is leaving the EU. Find out how you should get ready for Brexit and what government is doing.")
+    expect(presenter.description).to eq("The UK is leaving the EU, find out how you should get ready for Brexit.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
The full stop was causing the sentence to become truncated in search ([relevant method in `finder-frontend`](https://github.com/alphagov/finder-frontend/blob/944f7b7ee714ee3c5407002736c4a71eefff1c3a/app/models/document.rb#L36-L39)).  Therefore updating to ensure the full description gets displayed.

Trello card: https://trello.com/c/xvP2NMsw