### PR TITLE
Refactor core query

### DIFF
--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -51,21 +51,9 @@ module Search
             if search_params.quoted_search_phrase?
               core_query.quoted_phrase_query
             elsif search_params.ab_tests.fetch(:search_cluster_query, 'A') == 'B'
-              core_query.unquoted_phrase_query
+              core_query.unquoted_phrase_query_abvariant
             else
-              {
-                bool: {
-                  should: [
-                    core_query.match_phrase("title"),
-                    core_query.match_phrase("acronym"),
-                    core_query.match_phrase("description"),
-                    core_query.match_phrase("indexable_content"),
-                    core_query.match_all_terms(%w(title acronym description indexable_content)),
-                    core_query.match_any_terms(%w(title acronym description indexable_content)),
-                    core_query.minimum_should_match("all_searchable_text")
-                  ],
-                }
-              }
+              core_query.unquoted_phrase_query
             end
           )
         )

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -71,6 +71,22 @@ module QueryComponents
     end
 
     def unquoted_phrase_query
+      {
+        bool: {
+          should: [
+            match_phrase("title"),
+            match_phrase("acronym"),
+            match_phrase("description"),
+            match_phrase("indexable_content"),
+            match_all_terms(%w(title acronym description indexable_content)),
+            match_any_terms(%w(title acronym description indexable_content)),
+            minimum_should_match("all_searchable_text")
+          ],
+        }
+      }
+    end
+
+    def unquoted_phrase_query_abvariant
       should_coord_query([
         match_all_terms(%w(title), MATCH_ALL_TITLE_BOOST),
         match_all_terms(%w(acronym), MATCH_ALL_ACRONYM_BOOST),

--- a/spec/unit/query_components/core_query_spec.rb
+++ b/spec/unit/query_components/core_query_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe QueryComponents::CoreQuery do
     it "uses the synonyms analyzer" do
       builder = described_class.new(search_query_params)
 
-      query = builder.minimum_should_match("all_searchable_text")
+      query = builder.minimum_should_match("all_searchable_text", "text to search over")
 
       expect(query.to_s).to match(/all_searchable_text\.synonym/)
     end
@@ -13,7 +13,7 @@ RSpec.describe QueryComponents::CoreQuery do
     it "down-weight results which match fewer words in the search term" do
       builder = described_class.new(search_query_params)
 
-      query = builder.minimum_should_match("_all")
+      query = builder.minimum_should_match("_all", "text to search over")
       expect(query.to_s).to match(/"2<2 3<3 7<50%"/)
     end
   end
@@ -22,7 +22,7 @@ RSpec.describe QueryComponents::CoreQuery do
     it "uses the default analyzer" do
       builder = described_class.new(search_query_params(debug: { disable_synonyms: true }))
 
-      query = builder.minimum_should_match("_all")
+      query = builder.minimum_should_match("_all", "text to search over")
 
       expect(query.to_s).to match(/default/)
       expect(query.to_s).not_to match(/all_searchable_text\.synonym/)


### PR DESCRIPTION
Push the basic unquoted phrase query into core_query, and make all of the matching functions take the search query as a parameter.