### PR TITLE
Phrase-match and require quoted query fragments

### DIFF
--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -48,13 +48,7 @@ module Search
       best_bets.wrap(
         popularity_boost.wrap(
           format_boost.wrap(
-            if search_params.quoted_search_phrase?
-              core_query.quoted_phrase_query
-            elsif search_params.ab_tests.fetch(:search_cluster_query, 'A') == 'B'
-              core_query.unquoted_phrase_query_abvariant
-            else
-              core_query.unquoted_phrase_query
-            end
+            core_query.mixed_quoted_unquoted_query
           )
         )
       )

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -60,7 +60,11 @@ module QueryComponents
       quoted = search_params.parsed_query[:quoted].map { |query| quoted_phrase_query(query) }
 
       unquoted_query = search_params.parsed_query[:unquoted]
-      unquoted = unquoted_phrase_query(unquoted_query)
+      unquoted = if search_params.ab_tests.fetch(:search_cluster_query, 'A') == 'B'
+                   unquoted_phrase_query_abvariant(unquoted_query)
+                 else
+                   unquoted_phrase_query(unquoted_query)
+                 end
 
       if quoted.empty?
         unquoted

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -1,7 +1,7 @@
 module Search
   # Value object that holds the parsed parameters for a search.
   class QueryParameters
-    attr_accessor :query, :similar_to, :order, :start, :count, :return_fields,
+    attr_accessor :query, :parsed_query, :similar_to, :order, :start, :count, :return_fields,
                   :aggregates, :aggregate_name, :filters, :debug, :suggest, :is_quoted_phrase,
                   :ab_tests, :cluster, :search_config
 


### PR DESCRIPTION
These queries all give different results in Google:

- `marzipan shoes` (most results)
- `"marzipan" shoes`
- `marzipan "shoes"`
- `"marzipan shoes"` (least results)

The behaviour seems to be that all quoted fragments are phrase-matched whereas unquoted fragments are not required to be present.

We currently treat `"marzipan" shoes` and `marzipan "shoes"` the same as `marzipan shoes`.  Quotes only affect the query if the *entire* query is quoted.

*However* the finder-frontend UI does display quoted fragments differently to unquoted fragments, which is misleading to users if the quotes don't actually matter.

---

This PR separates quoted and unquoted query fragments, performing a `must` `quoted_phrase_query` for each quoted fragment, and a `should` `unquoted_phrase_query` for any unquoted fragment.

An open question is how to handle the relative weighting of the required and non-required query fragments.  How much more significantly should a result which matches both the required and optional parts of the query rank than a result which only matches the required bits?  Can a result which only matches the required bits do so *really well* and outrank a result which matches both the required and the optional bits?

---

[Trello card](https://trello.com/c/3KVL5I44/989-add-support-for-mixing-quoted-and-unquoted-query-fragments)