### PR TITLE
Spelling suggestions for phrases containing typos

### DIFF
--- a/lib/search/query_components/suggest.rb
+++ b/lib/search/query_components/suggest.rb
@@ -9,6 +9,7 @@ module QueryComponents
           phrase: {
             field: SPELLING_FIELD,
             size: 1,
+            max_errors: 3,
             direct_generator: [{
               field: SPELLING_FIELD,
               suggest_mode: 'missing',


### PR DESCRIPTION
https://trello.com/c/eVEQVC6G/997-how-might-we-make-spelling-suggestions-handle-phrases-and-correct-all-misspelled-words

## Before
If a phrase query contains two typos, suggestions are only returned for one of the words.
```
https://www.gov.uk/search/all.json?keywords=drving+loicence
=>
suggestions": [
{
"keywords": "drving licence"
}
]
```

## After:
The whole phrase is corrected.
```
https://www.gov.uk/search/all.json?keywords=drving+loicence
=>
suggestions": [
{
"keywords": "driving licence",
}
]
```

## How
Adds the max_errors parameter to our search query. From the [ES documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/search-suggesters.html), `max_errors` is "The maximum percentage of the terms considered to be misspellings in order to form a correction". 