### PR TITLE
Tweak B query variant

### DIFF
--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -88,13 +88,16 @@ module QueryComponents
 
     def unquoted_phrase_query_abvariant(query = search_term)
       should_coord_query([
-        match_all_terms(%w(title), query, MATCH_ALL_TITLE_BOOST),
-        match_all_terms(%w(acronym), query, MATCH_ALL_ACRONYM_BOOST),
-        match_all_terms(%w(description), query, MATCH_ALL_DESCRIPTION_BOOST),
-        match_all_terms(%w(indexable_content), query, MATCH_ALL_INDEXABLE_CONTENT_BOOST),
-        match_all_terms(%w(title acronym description indexable_content), query, MATCH_ALL_MULTI_BOOST),
-        match_any_terms(%w(title acronym description indexable_content), query, MATCH_ANY_MULTI_BOOST),
-        minimum_should_match("all_searchable_text", query, MATCH_MINIMUM_BOOST)
+        match_phrase("title", query, 10),
+        match_phrase("acronym", query, 10),
+        match_phrase("description", query, 5),
+        match_phrase("indexable_content", query, 2),
+        match_all_terms(%w(title), query),
+        match_all_terms(%w(acronym), query),
+        match_all_terms(%w(description), query),
+        match_all_terms(%w(indexable_content), query),
+        match_all_terms(%w(title acronym description indexable_content), query),
+        minimum_should_match("all_searchable_text", query)
       ])
     end
 


### PR DESCRIPTION
There are three changes here:

**Phrase matching:**
It seems that phrase matching contributes strongly to DCG score.  Even
though we know phrase matching has problems (the "brexit business"
example), it makes sense that it is useful in many cases, as there are
many search queries like "income tax" and "vehicle tax", which are
phrases which appear on the page.

**Incomplete matching:**
Removing the match_any_terms seems to improve DCG score.  The
minimum_should_match kind of covers the same niche anyway.

**Boosting:**
Much simpler boosting, only for the phrase matching.

With these changes, comparing to the A variant with all of our
relevancy judgements, we get:

- A wins on 49
- B wins on 49
- A and B tie on 10

Of the 49 A wins, only 27 of them have a >5% difference in DCG score.
I want to investigate those further, but I think it's also useful to
get this query in front of real users, as our relevancy judgements are
limited in scope.

---

[Trello card](https://trello.com/c/UIHH2BUZ/1005-figure-out-which-fields-are-most-correlated-with-dcg-score)