### PR TITLE
Use time a document was inserted into search for sitemaps

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -165,7 +165,7 @@
   },
 
   "updated_at": {
-    "description": "When the page was last updated. This field is unreliable and may be deprecated in a future version.",
+    "description": "Time of the last indexing. May be significantly newer than `public_timestamp`, as that usually only reflects major updates and not minor ones.",
     "type": "date"
   },
 

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -40,6 +40,10 @@ module GovukIndex
       end
     end
 
+    def updated_at
+      DateTime.now
+    end
+
     def base_path
       payload["base_path"]
     end

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -84,6 +84,7 @@ module GovukIndex
         popularity:                          common_fields.popularity,
         primary_publishing_organisation:     expanded_links.primary_publishing_organisation,
         public_timestamp:                    common_fields.public_timestamp,
+        updated_at:                          common_fields.updated_at,
         publishing_app:                      common_fields.publishing_app,
         railway_type:                        specialist.railway_type,
         regions:                             specialist.regions,
@@ -131,6 +132,10 @@ module GovukIndex
         withdrawn_date:                      specialist.withdrawn_date,
         world_locations:                     expanded_links.world_locations
       }.reject { |_, v| v.nil? }
+    end
+
+    def updated_at
+      common_fields.updated_at
     end
 
     def format

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -229,6 +229,7 @@ class Rummager < Sinatra::Application
     request.body.rewind
     documents = [JSON.parse(request.body.read)].flatten.map { |hash|
       hash["document_type"] ||= hash.fetch("_type", "edition")
+      hash["updated_at"] = DateTime.now
       current_index.document_from_hash(hash)
     }
 

--- a/lib/sitemap/sitemap_presenter.rb
+++ b/lib/sitemap/sitemap_presenter.rb
@@ -16,17 +16,18 @@ class SitemapPresenter
   end
 
   def last_updated
-    return nil unless document['public_timestamp']
+    timestamp = document.fetch('updated_at', document.fetch('public_timestamp', nil))
+    return nil unless timestamp
 
     # Attempt to parse timestamp to validate it
-    parsed_date = DateTime.iso8601(document['public_timestamp'])
+    parsed_date = DateTime.iso8601(timestamp)
 
     # Limit timestamps for old documents to GOV.UK was launch date
     return GOVUK_LAUNCH_DATE.iso8601 if parsed_date < GOVUK_LAUNCH_DATE
 
-    document['public_timestamp']
+    timestamp
   rescue ArgumentError
-    @logger.warn("Invalid timestamp '#{document['public_timestamp']}' for page '#{document['link']}'")
+    @logger.warn("Invalid timestamp '#{timestamp}' for page '#{document['link']}'")
     # Ignore invalid or missing timestamps
     nil
   end

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     }.to raise_error(GovukIndex::NotIdentifiable)
   end
 
+  it "sets the updated_at timestamp" do
+    payload = generate_random_example(payload: { payload_version: 1 })
+    presenter = elasticsearch_presenter(payload, "help_page")
+    expect(presenter.updated_at).not_to be nil
+  end
+
   context "external content" do
     it "is valid if it has a URL" do
       payload = {

--- a/spec/unit/sitemap/sitemap_presenter_spec.rb
+++ b/spec/unit/sitemap/sitemap_presenter_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe SitemapPresenter do
     expect(presenter.last_updated).to eq("2014-01-28T14:41:50+00:00")
   end
 
+  it "updated_at overrides public_timestamp if both are present" do
+    document = build_document(url: "/some/path")
+    document["public_timestamp"] = "2014-01-28T14:41:50+00:00"
+    document["updated_at"] = "2019-01-28T14:41:50+00:00"
+    presenter = described_class.new(document, @boost_calculator)
+    expect(presenter.last_updated).to eq("2019-01-28T14:41:50+00:00")
+  end
+
   it "last updated is timestamp if timestamp is date" do
     document = build_document(
       url: "/some/path",


### PR DESCRIPTION
Sitemaps currently use the `public_timestamp`, which is the time of the last major update.  However, we want search engines to be aware of even minor updates.  A change to a document means a change is pushed to search, so using the time the document got reindexed is a good proxy for changes.

The field is already present, so we don't need to reindex, but it's not used.  However, once this PR is deployed, the `updated_at` will start to gradually get populated as things are updated.

---

[Trello card](https://trello.com/c/fVDwVHnm/1001-use-updateddate-in-sitemapxml)