### PR TITLE
Add Myanmar to IDF Locations

### DIFF
--- a/config/schema/elasticsearch_types/international_development_fund.json
+++ b/config/schema/elasticsearch_types/international_development_fund.json
@@ -78,6 +78,10 @@
         "value": "mozambique"
       },
       {
+        "label": "Myanmar",
+        "value": "myanmar"
+      },
+      {
         "label": "Nepal",
         "value": "nepal"
       },


### PR DESCRIPTION
Add Myanmar in elasticsearch_types, this will correct the
finder indexing for Myanmar in advance of the documents
being retagged.