### PR TITLE
Add popularity_b field to documents

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -27,6 +27,7 @@
     "part_of_taxonomy_tree",
     "policies",
     "popularity",
+    "popularity_b",
     "primary_publishing_organisation",
     "public_timestamp",
     "publishing_app",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -84,6 +84,11 @@
     "type": "float"
   },
 
+  "popularity_b": {
+    "description": "Popularity rank used to bias search results. Used at query time to compute a popularity score. A higher number indicates more pageviews. Updated nightly.",
+    "type": "integer"
+  },
+
   "organisations": {
     "description": "The organisations related to this page. This field is copied from the publishing-api. Note that means different things for different formats.",
     "type": "identifiers"

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -149,6 +149,14 @@
     }
   },
 
+  "integer": {
+    "description": "An integer with a max value of 2^31-1; used for ranking",
+    "es_config": {
+      "type": "integer",
+      "store": true
+    }
+  },
+
   "boolean": {
     "description": "A boolean value which can be returned and used for filtering and aggregating",
     "filter_type": "boolean",

--- a/lib/govuk_index/popularity_worker.rb
+++ b/lib/govuk_index/popularity_worker.rb
@@ -21,7 +21,10 @@ module GovukIndex
       base_path = record['identifier']['_id']
       OpenStruct.new(
         identifier: record['identifier'].merge('_version_type' => 'external_gte', '_type' => 'generic-document'),
-        document: record['document'].merge('popularity' => popularities[base_path]),
+        document: record['document'].merge(
+          'popularity' => popularities.dig(base_path, :popularity_score),
+          'popularity_b' => popularities.dig(base_path, :popularity_rank),
+        ),
       )
     end
 

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -61,10 +61,11 @@ module GovukIndex
     end
 
     def popularity
-      # popularity should be consistent across clusters, so look up in
-      # the default
-      lookup = Indexer::PopularityLookup.new("govuk_index", SearchConfig.default_instance)
-      lookup.lookup_popularities([link])[link]
+      popularity_values[:popularity_score]
+    end
+
+    def popularity_b
+      popularity_values[:popularity_rank]
     end
 
     def format
@@ -82,6 +83,15 @@ module GovukIndex
 
     def brexit_page?
       content_id == BREXIT_PAGE["content_id"]
+    end
+
+    def popularity_values
+      @popularity_values ||= begin
+        # popularity should be consistent across clusters, so look up in
+        # the default
+        lookup = Indexer::PopularityLookup.new("govuk_index", SearchConfig.default_instance)
+        lookup.lookup_popularities([link])[link] || {}
+      end
     end
   end
 end

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -82,6 +82,7 @@ module GovukIndex
         people:                              expanded_links.people,
         policy_groups:                       expanded_links.policy_groups,
         popularity:                          common_fields.popularity,
+        popularity_b:                        common_fields.popularity_b,
         primary_publishing_organisation:     expanded_links.primary_publishing_organisation,
         public_timestamp:                    common_fields.public_timestamp,
         updated_at:                          common_fields.updated_at,

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -32,11 +32,13 @@ module Indexer
 
     def prepare_popularity_field(doc_hash, popularities)
       pop = 0.0
-      unless popularities.nil?
-        link = doc_hash["link"]
-        pop = popularities[link]
+      pop_b = 0.0
+      link = doc_hash["link"]
+      unless popularities.dig(link, :popularity_score).nil?
+        pop = popularities.dig(link, :popularity_score)
+        pop_b = popularities.dig(link, :popularity_rank)
       end
-      doc_hash.merge("popularity" => pop)
+      doc_hash.merge("popularity" => pop, "popularity_b" => pop_b)
     end
 
     def prepare_tags_field(doc_hash)

--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -39,7 +39,13 @@ module Indexer
           popularity_score = 1.0 / (ranks[link] + SearchConfig.popularity_rank_offset)
         end
 
-        [link, popularity_score]
+        [
+          link,
+          {
+            popularity_score: popularity_score,
+            popularity_rank: ranks[link],
+          }
+        ]
       }]
     end
 

--- a/spec/unit/govuk_index/popularity_worker_spec.rb
+++ b/spec/unit/govuk_index/popularity_worker_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GovukIndex::PopularityWorker do
   end
 
   it "updates popularity field" do
-    stub_popularity_data('record_1' => 0.7)
+    stub_popularity_data('record_1' => { popularity_score: 0.7, popularity_rank: 0.5 })
 
     @record = { 'identifier' => { '_id' => 'record_1' },
                 'document' => { 'title' => 'test_doc' } }
@@ -34,12 +34,12 @@ RSpec.describe GovukIndex::PopularityWorker do
     expect(@processor).to have_received(:save).with(
       having_attributes(
         identifier: { '_id' => 'record_1', '_version_type' => 'external_gte', '_type' => 'generic-document' },
-        document: hash_including({ 'popularity' => 0.7, 'title' => 'test_doc' })
+        document: hash_including({ 'popularity' => 0.7, 'popularity_b' => 0.5, 'title' => 'test_doc' })
       )
     )
   end
 
-  def stub_popularity_data(data = Hash.new(0.5))
+  def stub_popularity_data(data = Hash.new({ popularity_score: 0.5, popularity_rank: 0.5 }))
     popularity_lookup = instance_double('popularity_lookup', lookup_popularities: data)
     allow(Indexer::PopularityLookup).to receive(:new).and_return(popularity_lookup)
   end

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -96,15 +96,22 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     payload = { "base_path" => "/some/path" }
 
     popularity = 0.0125356
+    popularity_rank = 0.001
 
     # rubocop:disable RSpec/MessageSpies
     expect(Indexer::PopularityLookup).to receive(:new).with('govuk_index', instance_of(SearchConfig)).and_return(@popularity_lookup)
-    expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return(payload["base_path"] => popularity)
+    expect(@popularity_lookup).to receive(:lookup_popularities).with([payload['base_path']]).and_return(
+      payload["base_path"] => {
+        popularity_score: popularity,
+        popularity_rank: popularity_rank,
+      }
+    )
     # rubocop:enable RSpec/MessageSpies
 
     presenter = common_fields_presenter(payload)
 
     expect(popularity).to eq(presenter.popularity)
+    expect(popularity_rank).to eq(presenter.popularity_b)
   end
 
   it "no popularity when no value is returned from lookup" do
@@ -117,7 +124,8 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     presenter = common_fields_presenter(payload)
 
-    expect(nil).to eq(presenter.popularity)
+    expect(presenter.popularity).to be_nil
+    expect(presenter.popularity_b).to be_nil
   end
 
   def common_fields_presenter(payload)

--- a/spec/unit/indexer/document_preparer_spec.rb
+++ b/spec/unit/indexer/document_preparer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Indexer::DocumentPreparer do
 
       updated_doc_hash = described_class.new("fake_client", "fake_index").prepared(
         doc_hash,
-        { "/some-link" => 0.5 }, true
+        { "/some-link" => { popularity_score: 0.5, popularity_rank: 0.01 } }, true
       )
 
       expect(0.5).to eq(updated_doc_hash["popularity"])


### PR DESCRIPTION
The new field will be the 'raw' rank of popularity, rather
than a computed version that we set as popularity.

The field will be useful, since we can test new popularity
functions at query time rather than computing the values
when they enter the index, requiring us to reindex all docs.

Trello: https://trello.com/c/Dbcmxucw/