### PR TITLE
Enable automatic slicing on Elasticsearch reindexing

### DIFF
--- a/lib/schema_migrator.rb
+++ b/lib/schema_migrator.rb
@@ -10,7 +10,7 @@ class SchemaMigrator
 
   def reindex
     index_group.current.with_lock do
-      response = Services.elasticsearch(cluster: cluster, timeout: 60).reindex(
+      response = Services.elasticsearch(hosts: "#{cluster.uri}?slices=auto", timeout: 60).reindex(
         wait_for_completion: false,
         body: {
           source: {


### PR DESCRIPTION
This PR enabled slicing on the reindexing migration task, which in
localised testing provides a 20% performance improvement. This
improvement scales based on the number of shards available to
an index, so should be higher still on our Elasticsearch cluster.

Slicing enables Elasticsearch to split large scrolls into multiple
chunks, processing each one in parallel. It is safe and relatively
memory efficient, and should lead to no detriment to performance
even in cases where we see no gain.

This took some time as other approaches were experimented with
but they proved unstable or detrimental.

Trello: https://trello.com/c/XGUXvcRO/1016-spike-improve-performance-of-search-reindexing