### PR TITLE
PopularityLookup handle traffic index not existing

### DIFF
--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -7,7 +7,7 @@ module Indexer
 
     def lookup_popularities(links)
       if traffic_index.nil?
-        return nil
+        return {}
       end
 
       results = traffic_index.raw_search({


### PR DESCRIPTION
The lookup_popularities method should return a hash, even if the traffic index does not exist. An empty hash is expected if no matched links are found so this is expected behaviour.