### PR TITLE
Add people as a field to `all_searchable_text`

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -324,7 +324,7 @@
 
   "people": {
     "description": "Links to people associated with this page (https://www.gov.uk/government/people).",
-    "type": "identifiers"
+    "type": "searchable_identifiers"
   },
 
   "policy_groups": {


### PR DESCRIPTION
A simple modification that enables documents to be searched by the people field identifier.

Trello: https://trello.com/c/nT2yAoYH/1020-add-person-as-a-field-to-allsearchabletext-%F0%9F%8D%90