### PR TITLE
Reduce sidekiq healthcheck sensitivity

### DIFF
--- a/lib/healthcheck/sidekiq_queue_latencies_check.rb
+++ b/lib/healthcheck/sidekiq_queue_latencies_check.rb
@@ -18,8 +18,8 @@ module Healthcheck
     def search_queue_thresholds
       {
         'default' => {
-          critical: 15.seconds,
-          warning: 2.5.seconds,
+          critical: 1.minute,
+          warning: 30.seconds,
         },
         'bulk' => {
           critical: 30.minutes,

--- a/spec/integration/app/healthcheck_spec.rb
+++ b/spec/integration/app/healthcheck_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe 'HealthcheckTest' do
       end
     end
 
-    context "when queue latency is 5 (seconds)" do
-      let(:queue_latency) { 5.seconds }
+    context "when queue latency is high" do
+      let(:queue_latency) { 32.seconds }
 
       it "retuns a warning status" do
         get "/healthcheck"
@@ -84,8 +84,8 @@ RSpec.describe 'HealthcheckTest' do
     end
 
 
-    context "when queue latency is 15 (seconds)" do
-      let(:queue_latency) { 15.seconds }
+    context "when queue latency is very high" do
+      let(:queue_latency) { 2.minutes }
 
       it "retuns a critical status" do
         get "/healthcheck"


### PR DESCRIPTION
This increases the latency thresholds for the default queue to make the
corresponding healthcheck alert less sensitive, since a brief spike in
the queue size seems to have triggered it unnecessarily.