### PR TITLE
Make ELASTICSEARCH_URI point to ES6 in e2e Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN gem install foreman
 
 ENV GOVUK_APP_NAME search-api
 ENV REDIS_HOST redis
-ENV ELASTICSEARCH_URI http://elasticsearch5:9200
+ENV ELASTICSEARCH_URI http://elasticsearch6:9200
 ENV ELASTICSEARCH_B_URI http://elasticsearch6:9200
 ENV PORT 3233
 ENV RABBITMQ_HOSTS rabbitmq


### PR DESCRIPTION
Mirroring govuk-puppet/pull/9648

---

[Trello card](https://trello.com/c/KhQTxJz7/1040-tidy-the-mess-caused-by-retiring-es5)