### PR TITLE
Generate sitemaps individually

### DIFF
--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -1,10 +1,35 @@
 class SitemapGenerator
-  EXCLUDED_FORMATS = %w[recommended-link].freeze
-
   def initialize(search_config)
     @search_config = search_config
     @all_documents = get_all_documents
   end
+
+  def sitemaps
+    @all_documents.each_slice(self.class.sitemap_limit).map do |chunk|
+      generate_xml(chunk)
+    end
+  end
+
+  # Generate a sitemap which matches the format specified in https://www.sitemaps.org/protocol.html
+  def generate_xml(chunk)
+    builder = Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
+      xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
+        chunk.each do |document|
+          xml.url {
+            xml.loc document.url
+            xml.lastmod document.last_updated if document.last_updated
+            xml.priority document.priority
+          }
+        end
+      end
+    end
+
+    builder.to_xml
+  end
+
+private
+
+  EXCLUDED_FORMATS = %w[recommended-link].freeze
 
   def self.sitemap_limit
     25_000
@@ -38,31 +63,6 @@ class SitemapGenerator
       enum.each { |doc| yielder << doc }
     end
   end
-
-  def sitemaps
-    @all_documents.each_slice(self.class.sitemap_limit).map do |chunk|
-      generate_xml(chunk)
-    end
-  end
-
-  # Generate a sitemap which matches the format specified in https://www.sitemaps.org/protocol.html
-  def generate_xml(chunk)
-    builder = Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
-      xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
-        chunk.each do |document|
-          xml.url {
-            xml.loc document.url
-            xml.lastmod document.last_updated if document.last_updated
-            xml.priority document.priority
-          }
-        end
-      end
-    end
-
-    builder.to_xml
-  end
-
-private
 
   StaticDocumentPresenter = Struct.new(:url, :last_updated, :priority)
 

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -4,10 +4,8 @@ class SitemapGenerator
     @all_documents = get_all_documents
   end
 
-  def sitemaps
-    @all_documents.each_slice(self.class.sitemap_limit).map do |chunk|
-      generate_xml(chunk)
-    end
+  def sitemap_chunks
+    @all_documents.each_slice(SITEMAP_LIMIT)
   end
 
   # Generate a sitemap which matches the format specified in https://www.sitemaps.org/protocol.html
@@ -30,10 +28,7 @@ class SitemapGenerator
 private
 
   EXCLUDED_FORMATS = %w[recommended-link].freeze
-
-  def self.sitemap_limit
-    25_000
-  end
+  SITEMAP_LIMIT = 25_000
 
   def get_all_documents
     search_body = {

--- a/lib/sitemap/sitemap_writer.rb
+++ b/lib/sitemap/sitemap_writer.rb
@@ -8,9 +8,10 @@ class SitemapWriter
   def write_sitemaps(search_config)
     sitemap_generator = SitemapGenerator.new(search_config)
     # write our sitemap files and return an array of filenames
-    sitemap_generator.sitemaps.map do |sitemap_xml|
+    sitemap_generator.sitemap_chunks.map do |chunk|
       filename, link_filename = next_filename
       File.open(File.join(@directory, filename), "w") do |file|
+        sitemap_xml = sitemap_generator.generate_xml(chunk)
         file.write(sitemap_xml)
       end
       [filename, link_filename]

--- a/spec/integration/sitemap/sitemap_generator_spec.rb
+++ b/spec/integration/sitemap/sitemap_generator_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe "SitemapGeneratorTest" do
   it "generates multiple sitemaps" do
-    allow(SitemapGenerator).to receive(:sitemap_limit).and_return(2)
+    stub_const("SitemapGenerator::SITEMAP_LIMIT", 2)
     add_sample_documents(
       [
         {
@@ -32,14 +32,14 @@ RSpec.describe "SitemapGeneratorTest" do
     )
 
     generator = SitemapGenerator.new(SearchConfig.default_instance)
-    sitemap_xml = generator.sitemaps
+    sitemap_xml = sitemaps(generator)
 
     expected_sitemap_count = 2 # sample_document.count + homepage / sitemap_limit rounded up
     expect(expected_sitemap_count).to eq(sitemap_xml.length)
   end
 
   it "does not include migrated formats from gocvernment" do
-    allow(SitemapGenerator).to receive(:sitemap_limit).and_return(2)
+    stub_const("SitemapGenerator::SITEMAP_LIMIT", 2)
     add_sample_documents(
       [
         {
@@ -54,7 +54,7 @@ RSpec.describe "SitemapGeneratorTest" do
       index_name: "government_test",
     )
     generator = SitemapGenerator.new(SearchConfig.default_instance)
-    sitemap_xml = generator.sitemaps
+    sitemap_xml = sitemaps(generator)
     expect(sitemap_xml.length).to eq(1)
 
     expect(sitemap_xml[0]).not_to include("/an-example-answer")
@@ -62,7 +62,7 @@ RSpec.describe "SitemapGeneratorTest" do
 
   it "includes homepage" do
     generator = SitemapGenerator.new(SearchConfig.default_instance)
-    sitemap_xml = generator.sitemaps
+    sitemap_xml = sitemaps(generator)
 
     pages = Nokogiri::XML(sitemap_xml[0])
       .css("url")
@@ -87,7 +87,7 @@ RSpec.describe "SitemapGeneratorTest" do
       index_name: "government_test",
     )
 
-    sitemap_xml = generator.sitemaps
+    sitemap_xml = sitemaps(generator)
 
     expect(sitemap_xml.length).to eq(1)
 
@@ -110,7 +110,7 @@ RSpec.describe "SitemapGeneratorTest" do
       index_name: "govuk_test",
     )
 
-    sitemap_xml = generator.sitemaps
+    sitemap_xml = sitemaps(generator)
 
     pages = Nokogiri::XML(sitemap_xml[0])
       .css("url")
@@ -136,7 +136,7 @@ RSpec.describe "SitemapGeneratorTest" do
       index_name: "govuk_test",
     )
 
-    sitemap_xml = generator.sitemaps
+    sitemap_xml = sitemaps(generator)
 
     pages = Nokogiri::XML(sitemap_xml[0])
       .css("url")
@@ -153,5 +153,9 @@ private
       insert_document(index_name, sample_document)
     end
     commit_index index_name
+  end
+
+  def sitemaps(generator)
+    generator.sitemap_chunks.map { |chunk| generator.generate_xml(chunk) }
   end
 end


### PR DESCRIPTION
Generating and writing the XML files to temp files individually, rather than generating them all at once and then writing them to temp files, is less memory intensive.

https://trello.com/c/tGJcHr2f/1041-investigate-sitemap-generation-failures