### PR TITLE
Add popularity b variant

### DIFF
--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -40,11 +40,13 @@ module Indexer
           popularity_score = 1.0 / (ranks[link] + SearchConfig.popularity_rank_offset)
         end
 
+        popularity_rank = traffic_index_size - (ranks[link] || traffic_index_size)
+
         [
           link,
           {
             popularity_score: popularity_score,
-            popularity_rank: ranks[link],
+            popularity_rank: popularity_rank,
           },
         ]
       }]
@@ -63,11 +65,13 @@ module Indexer
     end
 
     def traffic_index_size
-      results = traffic_index.raw_search({
-        query: { match_all: {} },
-        size: 0,
-      })
-      results["hits"]["total"]
+      @traffic_index_size ||= begin
+        results = traffic_index.raw_search({
+          query: { match_all: {} },
+          size: 0,
+        })
+        results["hits"]["total"]
+      end
     end
 
     def open_traffic_index

--- a/lib/search/query_components/popularity.rb
+++ b/lib/search/query_components/popularity.rb
@@ -1,10 +1,19 @@
 module QueryComponents
   class Popularity < BaseComponent
     POPULARITY_OFFSET = 0.001
+    POPULARITY_WEIGHT = 0.0000001
 
     def wrap(boosted_query)
       return boosted_query if search_params.disable_popularity?
 
+      return logarithmic_boost(boosted_query) if search_params.use_logarithmic_popularity?
+
+      default_popularity_boost(boosted_query)
+    end
+
+  private
+
+    def default_popularity_boost(boosted_query)
       {
         function_score: {
           boost_mode: :multiply, # Multiply script score with query score
@@ -14,6 +23,21 @@ module QueryComponents
               lang: "painless",
               inline: "doc['popularity'].value + #{POPULARITY_OFFSET}",
             },
+          },
+        },
+      }
+    end
+
+    def logarithmic_boost(boosted_query)
+      {
+        function_score: {
+          boost_mode: :multiply,
+          max_boost: 5,
+          query: boosted_query,
+          field_value_factor: {
+            field: "popularity_b",
+            modifier: "log1p",
+            factor: POPULARITY_WEIGHT,
           },
         },
       }

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -37,6 +37,10 @@ module Search
       debug[:disable_popularity]
     end
 
+    def use_logarithmic_popularity?
+      ab_tests[:popularity] == "B"
+    end
+
     def disable_synonyms?
       debug[:disable_synonyms]
     end

--- a/spec/unit/query_components/popularity_spec.rb
+++ b/spec/unit/query_components/popularity_spec.rb
@@ -20,4 +20,29 @@ RSpec.describe QueryComponents::Popularity do
       expect(result).not_to be_key(:function_score)
     end
   end
+
+  context "with b variant of popularity" do
+    it "makes popularity logarithmic" do
+      builder = described_class.new(
+        search_query_params(ab_tests: { popularity: "B" }),
+      )
+
+      result = builder.wrap({ some: "query" })
+
+      expect(result).to eq(
+        function_score: {
+          boost_mode: :multiply,
+          max_boost: 5,
+          field_value_factor: {
+            factor: described_class::POPULARITY_WEIGHT,
+            field: "popularity_b",
+            modifier: "log1p",
+          },
+          query: {
+            some: "query",
+          },
+        },
+      )
+    end
+  end
 end


### PR DESCRIPTION
Uses the suggested method of boosting by popularity from https://www.elastic.co/guide/en/elasticsearch/guide/current/boosting-by-popularity.html

This is not the default but can be enabled with `/api/search.json?ab_tests=popularity:B`.

Why make this change?

Currently our popularity booster gives massive gains to the most popular content, but doesn't help slightly less popular content. It produces [a bit of a cliff](https://www.wolframalpha.com/input/?i=x+*+%28%281.0+%2F+%28y+%2B+10%29%29+%2B+0.001%29+from+y%3D450000+to+0+from+x%3D0.01+to+2+) (lower ranks are better below):
 
![gains](https://user-images.githubusercontent.com/8124374/66223836-5c6ee880-e6cc-11e9-8fbc-d618f804c49d.gif)

This change aims to prevent popular content showing up in results when it is not relevant.

For example, a query for "education" currently has "Universal Credit" and "Apply to the EU Settlement Scheme" on the first page of results. With this change "Education Maintenance Allowance" and "Contact the Department for Education" appear on the first page of results.

A logarithmic scale decreases the cliff. This change reduces the impact of popularity on the most popular documents. I've tried to keep parity for the less popular results. I also added a cap of `5` to the boost, so there's a limit to the amount of boosting being popular will get your doc.

After (higher ranks are better - most popular doc has a rank of 450k):

![after](https://user-images.githubusercontent.com/8124374/66224964-2d0dab00-e6cf-11e9-8174-c622818671cf.gif)

<img width="373" alt="Screen Shot 2019-10-04 at 15 24 39" src="https://user-images.githubusercontent.com/8124374/66225147-9f7e8b00-e6cf-11e9-8b57-859e418b9fe5.png">

Result relevancy is improved for some queries but made worse for others, so before enabling this by default I'll do some testing. I'll do some manual testing with the search performance explorer and the rank eval API. If it looks good we can run an AB test.

For this to take effect we must run the following rake task:

```
PROCESS_ALL_DATA=true SEARCH_INDEX=all search:update_popularity
```

https://trello.com/c/tjrbWhML/1045-try-different-ways-of-computing-rank-based-popularity-boosts