### PR TITLE
Highlight quoted query fragments in titles and descriptions

### DIFF
--- a/lib/search/query_components/base_component.rb
+++ b/lib/search/query_components/base_component.rb
@@ -11,5 +11,14 @@ module QueryComponents
     def search_term
       search_params.query
     end
+
+    # Use the synonym variant of the field unless we're disabling synonyms
+    def synonym_field(field_name)
+      return field_name if search_params.disable_synonyms?
+
+      raise ValueError if field_name.include?(".")
+
+      field_name + ".synonym"
+    end
   end
 end

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -154,15 +154,6 @@ module QueryComponents
       }
     end
 
-    # Use the synonym variant of the field unless we're disabling synonyms
-    def synonym_field(field_name)
-      return field_name if search_params.disable_synonyms?
-
-      raise ValueError if field_name.include?(".")
-
-      field_name + ".synonym"
-    end
-
   private
 
     def query_analyzer

--- a/lib/search/query_components/highlight.rb
+++ b/lib/search/query_components/highlight.rb
@@ -10,17 +10,21 @@ module QueryComponents
         fields: {
           title: {
             number_of_fragments: 0,
+            highlight_query: highlight_query(:title),
           },
           "title.synonym".to_sym => {
             number_of_fragments: 0,
+            highlight_query: highlight_query("title.synonym".to_sym),
           },
           description: {
             number_of_fragments: 1,
             fragment_size: 285,
+            highlight_query: highlight_query(:description),
           },
           "description.synonym".to_sym => {
             number_of_fragments: 1,
             fragment_size: 285,
+            highlight_query: highlight_query("description.synonym".to_sym),
           },
         },
       }
@@ -31,6 +35,21 @@ module QueryComponents
     def highlighted_field_requested?
       search_params.field_requested?("title_with_highlighting") ||
         search_params.field_requested?("description_with_highlighting")
+    end
+
+    def highlight_query(field)
+      components = quoted.map { |q| { match_phrase: { field => { query: q } } } }
+      components << { match: { field => { query: unquoted } } }
+
+      { bool: { should: components } }
+    end
+
+    def quoted
+      @quoted ||= search_params.parsed_query[:quoted] || []
+    end
+
+    def unquoted
+      @unquoted ||= search_params.parsed_query[:unquoted] || ""
     end
   end
 end

--- a/lib/search/query_components/highlight.rb
+++ b/lib/search/query_components/highlight.rb
@@ -8,23 +8,14 @@ module QueryComponents
         post_tags: ["</mark>"],
         encoder: "html",
         fields: {
-          title: {
+          synonym_field("title") => {
             number_of_fragments: 0,
-            highlight_query: highlight_query(:title),
+            highlight_query: highlight_query("title"),
           },
-          "title.synonym".to_sym => {
-            number_of_fragments: 0,
-            highlight_query: highlight_query("title.synonym".to_sym),
-          },
-          description: {
+          synonym_field("description") => {
             number_of_fragments: 1,
             fragment_size: 285,
-            highlight_query: highlight_query(:description),
-          },
-          "description.synonym".to_sym => {
-            number_of_fragments: 1,
-            fragment_size: 285,
-            highlight_query: highlight_query("description.synonym".to_sym),
+            highlight_query: highlight_query("description"),
           },
         },
       }
@@ -38,8 +29,8 @@ module QueryComponents
     end
 
     def highlight_query(field)
-      components = quoted.map { |q| { match_phrase: { field => { query: q } } } }
-      components << { match: { field => { query: unquoted } } }
+      components = quoted.map { |q| { match_phrase: { synonym_field(field) => { query: q } } } }
+      components << { match: { synonym_field(field) => { query: unquoted } } }
 
       { bool: { should: components } }
     end

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -37,6 +37,32 @@ RSpec.describe "ResultsWithHighlightingTest" do
     )
   end
 
+  it "highlights mixed quoted/unquoted queries" do
+    commit_document("government_test",
+                    "link" => "/some-nice-link",
+                    "description" => "This is a test search result of many results.")
+
+    get "/search?q=\"search+result\"+test&fields[]=description_with_highlighting"
+
+    expect(first_search_result).not_to be_key("description")
+    expect("This is a <mark>test</mark> <mark>search</mark> <mark>result</mark> of many results.").to eq(
+      first_search_result["description_with_highlighting"],
+    )
+  end
+
+  it "highlights quoted queries in their entirety (other than stopwords)" do
+    commit_document("government_test",
+                    "link" => "/some-nice-link",
+                    "description" => "The ministry of magic is a magic ministry.")
+
+    get "/search?q=\"ministry of magic\"&fields[]=description_with_highlighting"
+
+    expect(first_search_result).not_to be_key("description")
+    expect("The <mark>ministry</mark> of <mark>magic</mark> is a magic ministry.").to eq(
+      first_search_result["description_with_highlighting"],
+    )
+  end
+
   it "returns documents html escaped" do
     commit_document("government_test",
                     "title" => "Escape & highlight my title",

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -63,6 +63,32 @@ RSpec.describe "ResultsWithHighlightingTest" do
     )
   end
 
+  it "highlights synonyms" do
+    commit_document("government_test",
+                    "link" => "/some-nice-link",
+                    "description" => "This is one (1) page.")
+
+    get "/search?q=one&fields[]=description_with_highlighting"
+
+    expect(first_search_result).not_to be_key("description")
+    expect("This is <mark>one</mark> (<mark>1</mark>) page.").to eq(
+      first_search_result["description_with_highlighting"],
+    )
+  end
+
+  it "doesn't highlight synonyms if they're disabled" do
+    commit_document("government_test",
+                    "link" => "/some-nice-link",
+                    "description" => "This is one (1) page.")
+
+    get "/search?q=one&fields[]=description_with_highlighting&debug=disable_synonyms"
+
+    expect(first_search_result).not_to be_key("description")
+    expect("This is <mark>one</mark> (1) page.").to eq(
+      first_search_result["description_with_highlighting"],
+    )
+  end
+
   it "returns documents html escaped" do
     commit_document("government_test",
                     "title" => "Escape & highlight my title",

--- a/spec/unit/query_components/highlight_spec.rb
+++ b/spec/unit/query_components/highlight_spec.rb
@@ -2,28 +2,20 @@ require "spec_helper"
 
 RSpec.describe QueryComponents::Highlight do
   describe "#payload" do
-    it "enables highlighting on title" do
-      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[title_with_highlighting])
-
-      payload = described_class.new(parameters).payload
-
-      expect(payload[:fields].keys).to include(:title)
-    end
-
     it "enables highlighting on title with synonyms" do
       parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[title_with_highlighting])
 
       payload = described_class.new(parameters).payload
 
-      expect(payload[:fields].keys).to include(:"title.synonym")
+      expect(payload[:fields].keys).to include("title.synonym")
     end
 
-    it "enables highlighting on description" do
-      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[description_with_highlighting])
+    it "enables highlighting on title without synonyms" do
+      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[title_with_highlighting], debug: { disable_synonyms: true })
 
       payload = described_class.new(parameters).payload
 
-      expect(payload[:fields].keys).to include(:description)
+      expect(payload[:fields].keys).to include("title")
     end
 
     it "enables highlighting on description with synonyms" do
@@ -31,7 +23,15 @@ RSpec.describe QueryComponents::Highlight do
 
       payload = described_class.new(parameters).payload
 
-      expect(payload[:fields].keys).to include(:"description.synonym")
+      expect(payload[:fields].keys).to include("description.synonym")
+    end
+
+    it "enables highlighting on description without synonyms" do
+      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[description_with_highlighting], debug: { disable_synonyms: true })
+
+      payload = described_class.new(parameters).payload
+
+      expect(payload[:fields].keys).to include("description")
     end
 
     it "does not enable highlighting when not requested" do

--- a/spec/unit/query_components/highlight_spec.rb
+++ b/spec/unit/query_components/highlight_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe QueryComponents::Highlight do
   describe "#payload" do
     it "enables highlighting on title" do
-      parameters = Search::QueryParameters.new(return_fields: %w[title_with_highlighting])
+      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[title_with_highlighting])
 
       payload = described_class.new(parameters).payload
 
@@ -11,7 +11,7 @@ RSpec.describe QueryComponents::Highlight do
     end
 
     it "enables highlighting on title with synonyms" do
-      parameters = Search::QueryParameters.new(return_fields: %w[title_with_highlighting])
+      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[title_with_highlighting])
 
       payload = described_class.new(parameters).payload
 
@@ -19,7 +19,7 @@ RSpec.describe QueryComponents::Highlight do
     end
 
     it "enables highlighting on description" do
-      parameters = Search::QueryParameters.new(return_fields: %w[description_with_highlighting])
+      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[description_with_highlighting])
 
       payload = described_class.new(parameters).payload
 
@@ -27,7 +27,7 @@ RSpec.describe QueryComponents::Highlight do
     end
 
     it "enables highlighting on description with synonyms" do
-      parameters = Search::QueryParameters.new(return_fields: %w[description_with_highlighting])
+      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[description_with_highlighting])
 
       payload = described_class.new(parameters).payload
 
@@ -35,7 +35,7 @@ RSpec.describe QueryComponents::Highlight do
     end
 
     it "does not enable highlighting when not requested" do
-      parameters = Search::QueryParameters.new(return_fields: %w[title])
+      parameters = Search::QueryParameters.new(parsed_query: {}, return_fields: %w[title])
 
       payload = described_class.new(parameters).payload
 


### PR DESCRIPTION
Highlighting is done on the title and description fields (or their
.synonym fields), but quoted queries are run against the .no_stop
fields.

One approach would be to add the .no_stop fields to the highlighting
query, and then using that field in Search::HighlightedField if the
other fields aren't present.  But that wouldn't help with queries that
mix quoted and unquoted fragments.

For queries which match quoted and unquoted fragments, we want to
combine highlighting from two different fields.  We can do this by
using a (much simpler!) query to highlight results.  I've used
"match_phrase" for quoted fragments (so they're highlighted in their
entirety) and "match" for any unquoted fragment (so individual
keywords are highlighted).

Highlighting quoted fragments isn't perfect:

- Stopwords aren't highlighted
- Synonyms are applied (so a quoted query could match something new)

I'm not sure how best to work around those issues.  We could do all
highlighting against the no_stop field and apply all the index-time
synonyms at query-time for the unquoted fragment.  But this way is
better than not working at all.

---

[Trello card](https://trello.com/c/Gshiupx4/1056-highlight-quoted-search-terms)