### PR TITLE
Update landing page content to match campaign

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -10,7 +10,7 @@ module GovukIndex
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "title" => "Get ready for Brexit",
-      "description" => "The UK is leaving the EU, find out how you should get ready for Brexit.",
+      "description" => "Get ready for Brexit on 31 October 2019, check what you need to do.",
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     presenter = common_fields_presenter(payload)
 
     expect(presenter.title).to eq("Get ready for Brexit")
-    expect(presenter.description).to eq("The UK is leaving the EU, find out how you should get ready for Brexit.")
+    expect(presenter.description).to eq("Get ready for Brexit on 31 October 2019, check what you need to do.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
Followed this PR as an example: https://github.com/alphagov/search-api/pull/1681

Updates the internal search description for the landing page.