### PR TITLE
Add popularity c variant

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -40,6 +40,7 @@
     "topic_content_ids",
     "topical_events",
     "updated_at",
-    "user_journey_document_supertype"
+    "user_journey_document_supertype",
+    "view_count"
   ]
 }

--- a/config/schema/elasticsearch_types/page-traffic.json
+++ b/config/schema/elasticsearch_types/page-traffic.json
@@ -2,6 +2,7 @@
   "use_base_type": false,
   "fields": [
     "path_components",
-    "rank_14"
+    "rank_14",
+    "vc_14"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -584,6 +584,16 @@
     "type": "float"
   },
 
+  "vc_14": {
+    "description": "Field used in the page-traffic index to hold the absolute view count of this document over a 14 day period. This is a fluctuating value used in ranking calculations.",
+    "type": "integer"
+  },
+
+  "view_count": {
+    "description": "Number of views a document has had. Equivalent to vc_14 in page-traffic index. Used for popularity boosting.",
+    "type": "integer"
+  },
+
   "spelling_text": {
     "description": "Generated field, populated with the same content as sent to the _all field, but tokenised into words, lowercased and shingled, not stemmed, etc",
     "type": "spelling_text"

--- a/lib/govuk_index/popularity_worker.rb
+++ b/lib/govuk_index/popularity_worker.rb
@@ -24,6 +24,7 @@ module GovukIndex
         document: record["document"].merge(
           "popularity" => popularities.dig(base_path, :popularity_score),
           "popularity_b" => popularities.dig(base_path, :popularity_rank),
+          "view_count" => popularities.dig(base_path, :view_count),
         ),
       )
     end

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -68,6 +68,10 @@ module GovukIndex
       popularity_values[:popularity_rank]
     end
 
+    def view_count
+      popularity_values[:view_count]
+    end
+
     def format
       document_type = payload["document_type"]
       CUSTOM_FORMAT_MAP[document_type] || document_type

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -129,6 +129,7 @@ module GovukIndex
         user_journey_document_supertype:     common_fields.user_journey_document_supertype,
         value_of_funding:                    specialist.value_of_funding,
         vessel_type:                         specialist.vessel_type,
+        view_count:                          common_fields.view_count,
         will_continue_on:                    specialist.will_continue_on,
         withdrawn_date:                      specialist.withdrawn_date,
         world_locations:                     expanded_links.world_locations,

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -33,12 +33,14 @@ module Indexer
     def prepare_popularity_field(doc_hash, popularities)
       pop = 0.0
       pop_b = 0.0
+      view_count = 0
       link = doc_hash["link"]
       unless popularities.dig(link, :popularity_score).nil?
         pop = popularities.dig(link, :popularity_score)
         pop_b = popularities.dig(link, :popularity_rank)
+        view_count = popularities.dig(link, :view_count)
       end
-      doc_hash.merge("popularity" => pop, "popularity_b" => pop_b)
+      doc_hash.merge("popularity" => pop, "popularity_b" => pop_b, "view_count" => view_count)
     end
 
     def prepare_tags_field(doc_hash)

--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -16,37 +16,44 @@ module Indexer
             path_components: links,
           },
         },
-        _source: { includes: %w[rank_14] },
+        _source: { includes: %w[rank_14 vc_14] },
         sort: [
           { rank_14: { order: "asc" } },
         ],
         size: 10 * links.size,
       })
 
-      ranks = Hash.new(traffic_index_size)
+      default_rank = Hash.new(
+        rank: traffic_index_size,
+        view_count: 1,
+      )
 
-      results["hits"]["hits"].each do |hit|
+      ranks = results["hits"]["hits"].each_with_object(default_rank) do |hit, hsh|
         link = hit["_id"]
-        rank = Array(hit["_source"]["rank_14"]).first
+        rank = Array(hit.dig("_source", "rank_14")).first
+        view_count = hit.dig("_source", "vc_14") || 1
         next if rank.nil?
 
-        ranks[link] = [rank, ranks[link]].min
+        hsh[link] = { rank: rank, view_count: view_count }
       end
 
       Hash[links.map { |link|
-        if ranks[link].zero?
+        if ranks[link][:rank].zero?
           popularity_score = 0
+          popularity_rank = 1
         else
-          popularity_score = 1.0 / (ranks[link] + SearchConfig.popularity_rank_offset)
+          popularity_score = 1.0 / (ranks[link][:rank] + SearchConfig.popularity_rank_offset)
+          popularity_rank = traffic_index_size - (ranks[link][:rank] || traffic_index_size)
         end
 
-        popularity_rank = traffic_index_size - (ranks[link] || traffic_index_size)
+        view_count = ranks[link][:view_count]
 
         [
           link,
           {
             popularity_score: popularity_score,
             popularity_rank: popularity_rank,
+            view_count: view_count,
           },
         ]
       }]

--- a/lib/search/query_components/popularity.rb
+++ b/lib/search/query_components/popularity.rb
@@ -8,6 +8,8 @@ module QueryComponents
 
       return logarithmic_boost(boosted_query) if search_params.use_logarithmic_popularity?
 
+      return logarithmic_boost_using_view_count(boosted_query) if search_params.use_view_count_popularity_boost?
+
       default_popularity_boost(boosted_query)
     end
 
@@ -38,6 +40,21 @@ module QueryComponents
             field: "popularity_b",
             modifier: "log1p",
             factor: POPULARITY_WEIGHT,
+          },
+        },
+      }
+    end
+
+    def logarithmic_boost_using_view_count(boosted_query)
+      {
+        function_score: {
+          boost_mode: :multiply,
+          max_boost: 5,
+          query: boosted_query,
+          field_value_factor: {
+            field: "view_count",
+            modifier: "log1p",
+            factor: 1,
           },
         },
       }

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -41,6 +41,10 @@ module Search
       ab_tests[:popularity] == "B"
     end
 
+    def use_view_count_popularity_boost?
+      ab_tests[:popularity] == "C"
+    end
+
     def disable_synonyms?
       debug[:disable_synonyms]
     end

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe SearchIndices::Index do
     stub_popularity_index_requests(["/foo/bar", "/foo/baz"], 1.0, 20)
 
     json_documents = [
-      { "document_type" => "edition", "link" => "/foo/bar", "title" => "TITLE ONE", "popularity" => "0.09090909090909091" },
-      { "document_type" => "edition", "link" => "/foo/baz", "title" => "TITLE TWO", "popularity" => "0.09090909090909091" },
+      { "document_type" => "edition", "link" => "/foo/bar", "title" => "TITLE ONE", "popularity" => "0.09090909090909091", "view_count" => "1" },
+      { "document_type" => "edition", "link" => "/foo/baz", "title" => "TITLE TWO", "popularity" => "0.09090909090909091", "view_count" => "2" },
     ]
 
     documents = json_documents.map do |json_document|
@@ -272,7 +272,7 @@ private
           "path_components" => paths,
         },
       },
-      "_source" => { "includes" => %w[rank_14] },
+      "_source" => { "includes" => %w[rank_14 vc_14] },
       "sort" => [
         { "rank_14" => { "order" => "asc" } },
       ],
@@ -285,6 +285,7 @@ private
             "_id" => path,
             "_source" => {
               "rank_14" => popularity,
+              "vc_14" => popularity,
             },
           }
         },


### PR DESCRIPTION
This adds view_count to content indexes

The view count is already in the popularity index, but not
specified as an indexed field. This makes it available in all
indexes for query time popularity boosting.

This uses view_count for query time boosting, to
see if using the absolute view count rather than
popularity rank will have an impact on relevancy.

Trello: https://trello.com/c/pNxIeTFc/1044