### PR TITLE
Shortcircuit highlighting when no query is present

### DIFF
--- a/lib/search/query_components/highlight.rb
+++ b/lib/search/query_components/highlight.rb
@@ -1,6 +1,7 @@
 module QueryComponents
   class Highlight < BaseComponent
     def payload
+      return unless search_params.parsed_query
       return unless highlighted_field_requested?
 
       {

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -1,6 +1,17 @@
 require "spec_helper"
 
 RSpec.describe "ResultsWithHighlightingTest" do
+  it "doesn't break without keywords" do
+    commit_document("government_test",
+                    "title" => "I am the result",
+                    "link" => "/some-nice-link")
+
+    get "/search?fields[]=title_with_highlighting"
+
+    expect(first_search_result).not_to be_key("title")
+    expect(first_search_result["title_with_highlighting"]).to eq("I am the result")
+  end
+
   it "returns highlighted title" do
     commit_document("government_test",
                     "title" => "I am the result",


### PR DESCRIPTION
We don't need to consider any result highlighting if there aren't any keywords in the query.

Resolves: https://sentry.io/organizations/govuk/issues/1267728499/?project=1461905&query=is%3Aunresolved