### PR TITLE
Use HTTParty to make rank eval request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ group :development do
 end
 
 gem "pry-byebug", group: %i[development test]
+
+gem "httparty", "~> 0.17.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,9 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    httparty (0.17.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
@@ -317,6 +320,7 @@ DEPENDENCIES
   govuk_message_queue_consumer (~> 3.5.0)
   govuk_schemas (~> 4.0.0)
   govuk_sidekiq (~> 3.0.3)
+  httparty (~> 0.17.1)
   irb (~> 1.0)
   logging (~> 2.2.2)
   loofah


### PR DESCRIPTION
We need to make a basic http request here rather than
using the elasticsearch ruby client.

This is due to two factors:
- AWS Elasticsearch service has a bug that prevents
calling the rank_eval API without an index. We've raised
a ticket with them but have not been given an ETA on when
this will be fixed.
- The Elasticsearch ruby client has a bug that prevents
specifying an index when using the API. We raised a PR
to fix this (https://github.com/elastic/elasticsearch-ruby/pull/724).

This makes the call specify all indexes '*' and doesn't use the
elasticsearch client library. Once either issue is fixed
we can remove this.



Trello: https://trello.com/c/Uq13lWgG