### PR TITLE
Increase default queue concurrency

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,9 +2,9 @@
 tag: search-api.publishing.service.gov.uk
 :concurrency: 5
 staging:
-  :concurrency:  12
+  :concurrency:  20
 production:
-  :concurrency:  12
+  :concurrency:  20
 :require: ./lib/rummager.rb
 :logfile: ./log/sidekiq.log
 :queues:
@@ -12,4 +12,4 @@ production:
   - bulk
 :limits:
   bulk: 4
-  default: 8
+  default: 16


### PR DESCRIPTION
Following a test of publishing-api losing connectivity
in staging, we found that the rate at which search-api
can process jobs in the default queue was too slow.

Increasing it from 8 to 16 to see if we can get search-api
to process jobs faster without impacting performance of
search queries.