### PR TITLE
Fix landing page desc

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -10,7 +10,7 @@ module GovukIndex
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "title" => "Get ready for Brexit",
-      "description" => "A Brexit deal has been agreed in principle with the EU. Find out what this means for you.",
+      "description" => "A Brexit deal has been agreed in principle with the EU, find out what this means for you.",
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     presenter = common_fields_presenter(payload)
 
     expect(presenter.title).to eq("Get ready for Brexit")
-    expect(presenter.description).to eq("A Brexit deal has been agreed in principle with the EU. Find out what this means for you.")
+    expect(presenter.description).to eq("A Brexit deal has been agreed in principle with the EU, find out what this means for you.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
The description automatically cuts off at the first full stop. We got around this previously by changing the full stop to a comma.