### PR TITLE
Remove UTR synonym

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -254,7 +254,7 @@
 - search: twov => twov, transit without visa
 - search: uj, ujm => uj, ujm, universal jobmatch
 - search: ukba, border agency, uk ba => ukba, border agency, ukvi, uk visas and immigration
-- search: utr, unique taxpayer reference => utr, unique taxpayer reference
+- search: unique taxpayer reference => utr, unique taxpayer reference
 
 # Acronyms with spaces or punctuation
 - search: c v => cv


### PR DESCRIPTION
When people search for "UTR" most want to find "Find a lost UTR number".

This is not helped by the UTR => unique taxpayer reference
synonym, since it drives down the desired results.

This is backed up by the click through rate:

```
Position	CTR	Title
1	27.36%	Register for and file your Self Assessment tax return
7	20.89%	Find a lost UTR number
8	5.18%	Sign up for Making Tax Digital for VAT
2	4.98%	Get an EORI number
5	1.45%	Apply for 30 hours free childcare
4	1.19%	Self Assessment tax returns
6	0.93%	Apply for Tax-Free Childcare
3	0.41%	Pay your Self Assessment tax bill
9	0.41%	High Income Child Benefit Tax Charge
```

Find a lost UTR number in position 7 gets 20% of clicks (in past week).

This should save a lot of scrolling and make search results
more relevant for queries for UTR.

https://trello.com/c/iESG02qw/1082-remove-utr-synonym