### PR TITLE
Serve sitemap files from bucket root

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -350,7 +350,7 @@ class Rummager < Sinatra::Application
   end
 
   get "/sitemaps/:sitemap" do |sitemap|
-    serve_from_s3("sitemaps/#{sitemap}")
+    serve_from_s3(sitemap)
   end
 
   def serve_from_s3(key)


### PR DESCRIPTION
In #1740 we inadvertently started to store sitemap_N.xml files in the
bucket root, rather than in /sitemaps.

---

<img width="559" alt="Screenshot 2019-10-25 at 10 42 02" src="https://user-images.githubusercontent.com/75235/67561088-1b3e8700-f714-11e9-8849-28420c7ad458.png">
