### PR TITLE
Use nDCG as the rank_eval metric

### DIFF
--- a/lib/debug/rank_eval.rb
+++ b/lib/debug/rank_eval.rb
@@ -78,12 +78,12 @@ module Debug
       # This is a fix for that situation.
       # @search_config.rank_eval(
       #   requests: requests,
-      #   metric: { dcg: { k: 10 } },
+      #   metric: { dcg: { k: 10, normalize: true } },
       # )
 
       uri = @search_config.base_uri
       options = {
-        body: { requests: requests, metric: { dcg: { k: 10 } } }.to_json,
+        body: { requests: requests, metric: { dcg: { k: 10, normalize: true } } }.to_json,
         headers: { "Content-Type" => "application/json" },
       }
       indices = "*"


### PR DESCRIPTION
DCG is a nice metric, but DCG scores from different queries aren't
comparable.  You can compare different scores in time for the same
query, but not scores for different queries.

This is ok if we consider all the queries in isolation, and just want
to see if the DCG score for each goes up or down, but not so great if
we want to compare different queries (eg, plotting the scores in a
heatmap, or even just being able to identify particularly poorly
performing queries).

Normalised DCG (nDCG) solves this problem and gives comparable scores.
nDCG works by dividing the DCG score by the idealised DCG score: the
DCG score you get if the results are returned in score order.  nDCG
scores are in the range of 0 to 1, with 1 meaning the results are
perfect.

It's not correct to say "this query has a higher DCG score than this
other query, therefore it's better" because DCG score is highly
influenced by what scores you give in your relevancy judgements.  But
it is correct to say "this query is closer to perfect than this other
query, therefore it's better".  That is, assuming your relevancy
judgements are an accurate representation of users preferences.

---

[Trello card](https://trello.com/c/tLDNw1Qd/1087-switch-rankeval-metric-to-ndcg)