### PR TITLE
Get search result CTR from Google Analytics

### DIFF
--- a/lib/analytics/load_service.rb
+++ b/lib/analytics/load_service.rb
@@ -7,7 +7,7 @@ module Analytics
     include Google::Apis::AnalyticsV3
     include Google::Auth
 
-    SCOPES = ["https://www.googleapis.com/auth/analytics.edit"].freeze
+    SCOPES = [AUTH_ANALYTICS_EDIT].freeze
 
     attr_reader :service
 

--- a/lib/analytics/overall_ctr.rb
+++ b/lib/analytics/overall_ctr.rb
@@ -1,0 +1,83 @@
+require "analytics/reporting_requester"
+
+module Analytics
+  class OverallCTR
+    include ReportRequester
+
+    # OverallCTR gets the aggregate click-through-rate (CTR) for
+    # individual site search results from Google Analytics.
+    # Returns a set of click through rates for the past 7 days:
+    # [
+    #   ["top_1_ctr", 25],
+    #   ["top_3_ctr", 50],
+    #   ["top_5_ctr", 70]
+    # ]
+    def call
+      response = authenticated_service.batch_get_reports(reports_request)
+      parse_ga_response(response)
+    end
+
+  private
+
+    def parse_ga_response(response)
+      default_hsh = Hash.new(0)
+      reports = response.reports.first.data.rows.each_with_object(default_hsh) do |row, hsh|
+        position = row.dimensions.first
+        ctr = Float(row.metrics.first.values.first)
+        hsh[position] = ctr
+      end
+
+      top_1_ctr = reports["1"]
+      top_3_ctr = top_1_ctr + reports["2"] + reports["3"]
+      top_5_ctr = top_3_ctr + reports["4"] + reports["5"]
+
+      [
+        ["top_1_ctr", top_1_ctr],
+        ["top_3_ctr", top_3_ctr],
+        ["top_5_ctr", top_5_ctr],
+      ]
+    end
+
+    def reports_request
+      GetReportsRequest.new(
+        report_requests: [
+          ReportRequest.new(
+            view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
+            page_size: 10,
+            metrics: [
+              Metric.new(expression: "ga:productListCTR"),
+              Metric.new(expression: "ga:productListClicks"),
+            ],
+            dimensions: [
+              Dimension.new(name: "ga:productListPosition"),
+              Dimension.new(name: "ga:productListName"),
+            ],
+            dimension_filter_clauses: [
+              DimensionFilterClause.new(
+                operator: "AND",
+                filters: [
+                  DimensionFilter.new(
+                    dimension_name: "ga:productListPosition",
+                    expressions: ["^[0-9]{1,1}$"],
+                  ),
+                  DimensionFilter.new(
+                    dimension_name: "ga:productListName",
+                    operator: "EXACT",
+                    case_sensitive: false,
+                    expressions: %w[Search],
+                  ),
+                ],
+              ),
+            ],
+            order_bys: [
+              OrderBy.new(
+                field_name: "ga:productListPosition",
+                sort_order: "ASCENDING",
+              ),
+            ],
+          ),
+        ],
+      )
+    end
+  end
+end

--- a/lib/analytics/popular_queries.rb
+++ b/lib/analytics/popular_queries.rb
@@ -1,0 +1,49 @@
+require "google/apis/analyticsreporting_v4"
+require "analytics/reporting_requester"
+
+module Analytics
+  class PopularQueries
+    include ReportRequester
+
+    # PopularQueries gets the top search queries from Google Analytics.
+    # Returns an array of searches and counts for the past 7 days
+    # [
+    #   ['universal credit', 1000000],
+    #   ['tax', 1000000],
+    #   ['vat', 1000000]
+    # ]
+    def queries
+      parse_ga_response(authenticated_service.batch_get_reports(reports_request))
+    end
+
+  private
+
+    def parse_ga_response(response)
+      data = response.reports.first.data.rows || []
+      data.map do |row|
+        search_term = row.dimensions.first
+        searches = Integer(row.metrics.first.values.first, 10)
+        [search_term, searches]
+      end
+    end
+
+    def reports_request
+      GetReportsRequest.new(
+        report_requests: [
+          ReportRequest.new(
+            view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
+            metrics: [Metric.new(expression: "ga:searchUniques")],
+            dimensions: [Dimension.new(name: "ga:searchKeyword")],
+            sampling_level: "LARGE",
+            order_bys: [
+              OrderBy.new(
+                field_name: "ga:searchUniques",
+                sort_order: "DESCENDING",
+              ),
+            ],
+          ),
+        ],
+      )
+    end
+  end
+end

--- a/lib/analytics/query_performance.rb
+++ b/lib/analytics/query_performance.rb
@@ -1,0 +1,118 @@
+require "analytics/reporting_requester"
+
+module Analytics
+  class QueryPerformance
+    include ReportRequester
+
+    # QueryPerformance gets the CTR for each of a given set of queries
+    # Returns a set of queries and their top_n_ctr for the past 7 days
+    # [
+    #   [ "universal credit.top_1_ctr", 10 ],
+    #   [ "universal credit.top_3_ctr", 23 ],
+    #   [ "universal credit.top_5_ctr", 40 ],
+    #   [ "tax.top_1_ctr", 12 ],
+    #   [ "tax.top_2_ctr", 14 ],
+    #   ...
+    # ]
+    def initialize(queries: [])
+      @queries = queries
+    end
+
+    def call
+      build_requests.map { |req| get_ctrs_for_batch(req) }.flatten(1)
+    end
+
+  private
+
+    attr_reader :queries, :service
+
+    def get_ctrs_for_batch(reports_request)
+      begin
+        retries ||= 0
+        response = authenticated_service.batch_get_reports(reports_request)
+        parse_ga_response(response).flatten(1)
+      rescue Google::Apis::TransmissionError => e
+        puts "Error fetching CTRS. Will retry in 5 seconds... #{e}"
+        sleep 5
+        retry if (retries += 1) < 3
+        []
+      end
+    end
+
+    def parse_ga_response(response)
+      response.reports.map do |query_report|
+        hsh   = Hash.new(0)
+        rows  = query_report.data.rows || []
+        return [] if rows.empty?
+
+        ctrs = rows.map.each_with_object(hsh) do |row, obj|
+          position = row.dimensions.first
+          ctr = Float(row.metrics.first.values.first)
+          obj[position] = ctr
+        end
+
+        top_1_ctr = ctrs["1"]
+        top_3_ctr = top_1_ctr + ctrs["2"] + ctrs["3"]
+        top_5_ctr = top_3_ctr + ctrs["4"] + ctrs["5"]
+        query = query_report.data.rows.first.dimensions.last
+
+        [
+          ["#{query}.top_1_ctr", top_1_ctr],
+          ["#{query}.top_3_ctr", top_3_ctr],
+          ["#{query}.top_5_ctr", top_5_ctr],
+        ]
+      end
+    end
+
+    def build_requests
+      # GetReportsRequest can have a max of 5 report_requests.
+      build_report_requests.in_groups_of(5).map do |report_reqs|
+        GetReportsRequest.new(report_requests: report_reqs)
+      end
+    end
+
+    def build_report_requests
+      # rubocop:disable Metrics/BlockLength
+      queries.map do |query|
+        ReportRequest.new(
+          view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
+          metrics: [Metric.new(expression: "ga:productListCTR")],
+          dimensions: [
+            Dimension.new(name: "ga:productListPosition"),
+            Dimension.new(name: "ga:dimension71"),
+          ],
+          sampling_level: "LARGE",
+          dimension_filter_clauses: [
+            DimensionFilterClause.new(
+              operator: "AND",
+              filters: [
+                DimensionFilter.new(
+                  dimension_name: "ga:productListPosition",
+                  expressions: ["^[0-9]{1,1}$"],
+                ),
+                DimensionFilter.new(
+                  dimension_name: "ga:productListName",
+                  operator: "EXACT",
+                  case_sensitive: false,
+                  expressions: %w[Search],
+                ),
+                DimensionFilter.new(
+                  dimension_name: "ga:dimension71",
+                  operator: "EXACT",
+                  expressions: [query],
+                ),
+              ],
+            ),
+          ],
+          order_bys: [
+            OrderBy.new(
+              field_name: "ga:productListPosition",
+              sort_order: "ASCENDING",
+            ),
+          ],
+        )
+        # rubocop:enable Metrics/BlockLength
+      end
+    end
+  end
+end

--- a/lib/analytics/reporting_requester.rb
+++ b/lib/analytics/reporting_requester.rb
@@ -1,0 +1,36 @@
+require "google/apis/analyticsreporting_v4"
+require "googleauth"
+require "analytics/google_analytics_export_credentials"
+
+module Analytics
+  module ReportRequester
+    include Google::Apis::AnalyticsreportingV4
+    include Google::Auth
+
+    SCOPES = [AUTH_ANALYTICS].freeze
+
+    REQUIRED_ENV_VARS = %w(
+      GOOGLE_PRIVATE_KEY
+      GOOGLE_CLIENT_EMAIL
+      GOOGLE_ANALYTICS_GOVUK_VIEW_ID
+    ).freeze
+
+    def authenticated_service
+      assert_has_required_env_vars
+
+      service = AnalyticsReportingService.new
+      service.authorization = GoogleAnalyticsExportCredentials.authorization(SCOPES)
+      service
+    end
+
+    def assert_has_required_env_vars
+      return unless missing_env_vars.any?
+
+      raise ArgumentError, "Required environment variables #{missing_env_vars.to_sentence} are unset."
+    end
+
+    def missing_env_vars
+      REQUIRED_ENV_VARS.select { |var| ENV[var].nil? }
+    end
+  end
+end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -66,11 +66,11 @@ namespace :debug do
       maxlen = results[:query_scores].map { |query, _| query.length }.max
       results[:query_scores].each do |query, score|
         puts "#{(query + ':').ljust(maxlen + 1)} #{score}"
-        send_to_graphite(query, score)
+        send_to_graphite("#{query}.rank_eval", score)
       end
       puts "---"
       puts "overall score: #{results[:score]}"
-      send_to_graphite("overall_score", results[:score])
+      send_to_graphite("overall_score.rank_eval", results[:score])
     ensure
       if csv.is_a?(Tempfile)
         file.close
@@ -94,7 +94,7 @@ namespace :debug do
     return unless ENV["SEND_TO_GRAPHITE"]
 
     Services.statsd_client.gauge(
-      "relevancy.query.#{query.downcase.gsub(" ", "_")}.rank_eval",
+      "relevancy.query.#{query.downcase.gsub(" ", "_")}",
       score,
     )
   end

--- a/lib/tasks/relevancy.rake
+++ b/lib/tasks/relevancy.rake
@@ -1,0 +1,59 @@
+require "rummager"
+require "analytics/overall_ctr"
+require "analytics/popular_queries"
+require "analytics/query_performance"
+
+namespace :relevancy do
+  desc "Show overall click-through-rate for top 3 results and top 10 results"
+  task :show_overall_ctr do
+    report_overall_ctr
+  end
+
+  desc "Show underperforming queries from top 1_000 most popular queries"
+  task :show_underperfoming_queries do
+    report_query_ctr
+  end
+
+  desc "Print the top 1_000 most popular search queries and their view counts"
+  task :show_top_queries do
+    report_popular_queries
+  end
+
+  desc "Send Google Analytics relevancy data to Graphite
+  Takes about 10 minutes.
+  Requires SEND_TO_GRAPHITE envvar being set"
+  task :send_ga_data_to_graphite do
+    puts "Sending overall CTR to graphite"
+    report_overall_ctr
+    puts "Sending viewcounts to graphite"
+    report_popular_queries
+    puts "Sending query click-through-rates to graphite"
+    report_query_ctr
+    puts "Finished"
+  end
+end
+
+def report_overall_ctr
+  report(Analytics::OverallCTR.new.call)
+end
+
+def report_query_ctr
+  report(Analytics::QueryPerformance.new(queries: popular_queries.map { |q| q[0] }).call)
+end
+
+def report_popular_queries
+  report(popular_queries.map { |(query, viewcount)| ["#{query}.viewcount", viewcount] })
+end
+
+def popular_queries
+  @popular_queries ||= Analytics::PopularQueries.new.queries
+end
+
+def report(stats = [])
+  puts "STATS (past 7 days):"
+  puts "=================="
+  stats.each do |(stat, reading)|
+    puts "#{stat.downcase.gsub(' ', '_')}: #{reading}"
+    send_to_graphite(stat, reading)
+  end
+end


### PR DESCRIPTION
This adds rake tasks to get click-through-rate (CTR) data on search
queries from Google Analytics, and optionally send these to graphite
with statsd.

These will be displayed in the search relevancy dashboard.

`relevancy:show_overall_ctr` gets the overall CTR on site search (top_1, top_3, top_5).

`relevancy:show_underperfoming_queries` gets the top 1,000 queries and their CTR.

`relevancy:show_top_queries` gets the top 1,000 queries and their view count.

In graphite the stats will be represented as (e.g.):

`relevancy.query.top_3_ctr`
`relevancy.query.universal_credit.viewcount`
`relevancy.query.universal_credit.top_1_ctr`

Added to dashboard here: https://github.com/alphagov/govuk-puppet/pull/9756.

What the result is:

<img width="1425" alt="ctr" src="https://user-images.githubusercontent.com/8124374/67791796-ffb6e180-fa6f-11e9-9141-3a31eacab5bf.png">

Trello: https://trello.com/c/VY85d6Ks/1069