### PR TITLE
Make "post" and "postal" stem the same

### DIFF
--- a/config/schema/stems.yml
+++ b/config/schema/stems.yml
@@ -43,6 +43,7 @@ rules: [
   "parking => parking",  # not park
   "paye => paye",  # not pay
   "permitted => permitted",
+  "postal => post",
   "practical => practical",
   "practice => practice",
   "probate => probate",  # not probation


### PR DESCRIPTION
We noticed that, if you search for "postal vote", the word "post" in the description doesn't get highlighted.