### PR TITLE
Handle Google::Apis::ServerError in GA ETL

### DIFF
--- a/lib/analytics/query_performance.rb
+++ b/lib/analytics/query_performance.rb
@@ -36,7 +36,7 @@ module Analytics
         retries ||= 0
         response = authenticated_service.batch_get_reports(reports_request)
         parse_ga_response(response).flatten(1)
-      rescue Google::Apis::TransmissionError, Google::Apis::RateLimitError => e
+      rescue Google::Apis::TransmissionError, Google::Apis::RateLimitError, Google::Apis::ServerError => e
         retry_wait_time = 5 * retries
         puts "Error fetching CTRS. Will retry in #{retry_wait_time} seconds... #{e}"
         sleep retry_wait_time


### PR DESCRIPTION
This is happening for some reason, so lets do a backoff and handle it.

https://sentry.io/organizations/govuk/issues/1315949959/events/de20f5de8ca448ec921d9c26afc7c978/?project=1461905