### PR TITLE
Decrease default queue concurrency

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,9 +2,9 @@
 tag: search-api.publishing.service.gov.uk
 :concurrency: 5
 staging:
-  :concurrency:  20
+  :concurrency:  12
 production:
-  :concurrency:  20
+  :concurrency:  12
 :require: ./lib/rummager.rb
 :logfile: ./log/sidekiq.log
 :queues:
@@ -12,4 +12,4 @@ production:
   - bulk
 :limits:
   bulk: 4
-  default: 16
+  default: 8


### PR DESCRIPTION
This number sidekiq workers isn't necessary and uses up too much memory.

This reverts commit 0e22f6a0f8c90ed4d6a1a8ca8aefef71c2043df5.