### PR TITLE
Retry GA ETL on Google client error

### DIFF
--- a/lib/analytics/query_performance.rb
+++ b/lib/analytics/query_performance.rb
@@ -36,7 +36,7 @@ module Analytics
         retries ||= 0
         response = authenticated_service.batch_get_reports(reports_request)
         parse_ga_response(response).flatten(1)
-      rescue Google::Apis::TransmissionError, Google::Apis::RateLimitError, Google::Apis::ServerError => e
+      rescue Google::Apis::TransmissionError, Google::Apis::RateLimitError, Google::Apis::ServerError, Google::Apis::ClientError => e
         retry_wait_time = 5 * retries
         puts "Error fetching CTRS. Will retry in #{retry_wait_time} seconds... #{e}"
         sleep retry_wait_time


### PR DESCRIPTION
This will retry when a GA error is raised (custom dimensions not existing). It's a transient error.  The same request worked earlier in the same job, and on retrying the whole job. We've seen this happen once. Retrying should resolve it.

Error:

```
Google::Apis::ClientError: badRequest: Unknown dimensions(s): ga:productListName, ga:productListPosition, ga:dimension71, unknown metric(s): ga:productListCTR
```

https://trello.com/c/CmgFUhqg/1124-retry-on-custom-dimension-not-found-error-transient-ga-side-issue-in-etl