### PR TITLE
Add rake task for evaluating reranker model

### DIFF
--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -1,5 +1,3 @@
-require "learn_to_rank/reranker"
-
 # Performs a search across all indices used for the GOV.UK site search
 module Search
   class Query

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -70,7 +70,7 @@ module Search
     end
 
     def rerank
-      !ENV["ENABLE_LTR"].nil? && order == "relevance" && ab_tests[:relevance] == "B"
+      !ENV["ENABLE_LTR"].nil? && [nil, "relevance"].include?(order) && ab_tests[:relevance] == "B"
     end
 
   private


### PR DESCRIPTION
This adds rake task `learn_to_rank:reranker:evaluate`

It prints out the nDCG scores for a set of relevancy judgements for both with and without the model.

Example

```
√ settlement status:                 0.9048338344524521  0.9792419017254543
√ sign in:                           0.9969040781092816  0.9969040781092816
√ spouse visa:                       0.9915901905629085  0.9915901905629085
x status:                            0.8659573096844624  0.8620115740375698
√ student finance:                   0.9866150564456257  0.9969517474425478
√ travelling to eu after brexit:     0.6534972696065786  0.6758840844016503
√ tsp:                               0.7851953694513244  0.8508067946367461
x vat:                               1.0                 0.9822546866590027
x view and prove your rights:        0.962538916913698   0.5786231434269723
x visa:                              1.0                 0.7367283992687399
x average_ndcg:                      0.8297312043580153  0.8105249574954304
---
without model score: 0.8297312043580153
with model score: 0.8105249574954304
The model has a bad score
```

This is helpful for evaluating a model change quickly without running the `relevancy:ndcg` job twice and manually comparing results.