### PR TITLE
Enable AB testing for Levenshtein algorithm for suggestions

### DIFF
--- a/lib/search/query_components/suggest.rb
+++ b/lib/search/query_components/suggest.rb
@@ -3,6 +3,12 @@ module QueryComponents
     SPELLING_FIELD = "spelling_text".freeze
 
     def payload
+      return levenshtein_payload if search_params.use_levenshtein?
+
+      regular_payload
+    end
+
+    def regular_payload
       {
         text: search_term,
         spelling_suggestions: {
@@ -13,6 +19,25 @@ module QueryComponents
             direct_generator: [{
               field: SPELLING_FIELD,
               suggest_mode: "missing",
+              sort: "score",
+            }],
+          }.merge(highlight),
+        },
+      }
+    end
+
+    def levenshtein_payload
+      {
+        text: search_term,
+        spelling_suggestions: {
+          phrase: {
+            field: SPELLING_FIELD,
+            size: 1,
+            max_errors: 3,
+            direct_generator: [{
+              field: SPELLING_FIELD,
+              suggest_mode: "missing",
+              string_distance: "levenshtein",
               sort: "score",
             }],
           }.merge(highlight),

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -33,6 +33,10 @@ module Search
       return_fields.include?(name)
     end
 
+    def use_levenshtein?
+      ab_tests[:spelling_suggestions] == "B"
+    end
+
     def disable_popularity?
       debug[:disable_popularity]
     end

--- a/spec/unit/query_components/suggest_spec.rb
+++ b/spec/unit/query_components/suggest_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe QueryComponents::Suggest do
+  context "with b variant of suggestions" do
+    it "makes the suggestion algorithm levenshtein" do
+      SPELLING_FIELD = "spelling_text".freeze
+
+      builder = described_class.new(
+        search_query_params(suggest: "spelling_with_highlighting", ab_tests: { spelling_suggestions: "B" }),
+      )
+
+      result = builder.payload
+
+      expect(result).to eq(
+        text: search_query_params.query,
+        spelling_suggestions: {
+          phrase: {
+            field: SPELLING_FIELD,
+            size: 1,
+            max_errors: 3,
+            direct_generator: [{
+              field: SPELLING_FIELD,
+              suggest_mode: "missing",
+              string_distance: "levenshtein",
+              sort: "score",
+            }],
+          }.merge(highlight: {
+            pre_tag: "<mark>",
+            post_tag: "</mark>",
+          }),
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR allows us to use the Levenshtein algorithm for search
suggestions over the default Elasticsearch algorithm, which relies on
an "optimised" system that may not be too accurate for our purposes.

Trello card: https://trello.com/c/c2YUDVg3/1117-try-different-ways-of-doing-spelling-suggestions