### PR TITLE
Don't send viewcounts and rank_eval for individual queries to graphite

### DIFF
--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -66,7 +66,6 @@ namespace :debug do
       maxlen = results[:query_scores].map { |query, _| query.length }.max
       results[:query_scores].each do |query, score|
         puts "#{(query + ':').ljust(maxlen + 1)} #{score}"
-        send_to_graphite("#{query}.rank_eval", score)
       end
       puts "---"
       puts "overall score: #{results[:score]}"

--- a/lib/tasks/relevancy.rake
+++ b/lib/tasks/relevancy.rake
@@ -48,8 +48,6 @@ namespace :relevancy do
   task :send_ga_data_to_graphite do
     puts "Sending overall CTR to graphite"
     report_overall_ctr
-    puts "Sending viewcounts to graphite"
-    report_popular_queries
     puts "Sending query click-through-rates to graphite"
     report_query_ctr
     puts "Finished"
@@ -65,7 +63,8 @@ def report_query_ctr
 end
 
 def report_popular_queries
-  report(popular_queries.map { |(query, viewcount)| ["#{query}.viewcount", viewcount] })
+  puts "Popular queries:"
+  popular_queries.map { |(query, viewcount)| puts "#{query}: #{viewcount}" }
 end
 
 def popular_queries


### PR DESCRIPTION
This is taking up a fair amount of disk space on graphite. For example viewcounts took up 4GB.

We aren't using viewcounts. rank_eval might be useful in future, because we'd be able to see how relevancy for a query had changed over time, but it's not useful at the moment.

https://trello.com/c/3e0NSK06/1162-stop-logging-view-count-and-rank-eval-for-individual-queries