### PR TITLE
Make people indexable

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -28,6 +28,7 @@ manual: manual
 manual_section: manual_section
 medical_safety_alert: medical_safety_alert # Specialist Publisher
 news_story: edition
+person: person
 place: edition
 policy: policy # Policy Publisher
 press_release: edition

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -293,7 +293,8 @@ migrated:
   - '/help/cookies'
   - '/find-local-council'
 
-indexable: []
+indexable:
+- person
 
 non_indexable_path:
 - '/help/cookie-details'
@@ -402,7 +403,6 @@ non_indexable:
 - organisation
 - our_energy_use
 - our_governance
-- person
 - personal_information_charter
 - petitions_and_campaigns
 - policy_area

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -88,6 +88,7 @@ module GovukIndex
         updated_at:                          common_fields.updated_at,
         publishing_app:                      common_fields.publishing_app,
         railway_type:                        specialist.railway_type,
+        role_appointments:                   expanded_links.role_appointments,
         regions:                             specialist.regions,
         registration:                        specialist.registration,
         rendering_app:                       common_fields.rendering_app,
@@ -187,6 +188,8 @@ module GovukIndex
         base_path.gsub(%r{^/browse/}, "")
       elsif format == "policy"
         base_path.gsub(%r{^/government/policies/}, "")
+      elsif format == "person"
+        base_path.gsub(%r{^/government/people/}, "")
       end
     end
 

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -28,6 +28,10 @@ module GovukIndex
       organisation_slugs("primary_publishing_organisation")
     end
 
+    def role_appointments
+      content_ids("role_appointments")
+    end
+
     def taxons
       content_ids("taxons")
     end

--- a/spec/integration/govuk_index/person_spec.rb
+++ b/spec/integration/govuk_index/person_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+RSpec.describe "Person publishing" do
+  before do
+    bunny_mock = BunnyMock.new
+    @channel = bunny_mock.start.channel
+
+    consumer = GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "people.test",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      rabbitmq_connection: bunny_mock,
+    )
+
+    @queue = @channel.queue("people.test")
+    consumer.run
+  end
+
+  let(:role_appointments) do
+    [
+      {
+        "content_id" => SecureRandom.uuid,
+        "title" => "Prime Minister",
+        "locale" => "en",
+      },
+    ]
+  end
+
+  it "indexes a person" do
+    random_example = generate_random_example(
+      schema: "person",
+      payload: {
+        document_type: "person",
+        base_path: "/government/people/mark-smith",
+        description: "A person.",
+        expanded_links: {
+          role_appointments: role_appointments,
+        },
+      },
+    )
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("person" => :all)
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = {
+       "link" => random_example["base_path"],
+       "role_appointments" => [role_appointments.first["content_id"]],
+       "description" => "A person.",
+       "slug" => "mark-smith",
+     }
+
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "person")
+  end
+end

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -273,6 +273,24 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.policy_groups).to eq(%w[micropig-advisory-group])
   end
 
+  describe "role_appointments" do
+    let(:expanded_links) do
+      {
+        "role_appointments" => [
+          {
+              "content_id" => "215f612f-6491-4241-9d91-dd39d1759792",
+              "locale" => "en",
+              "title" => "Prime Minister",
+          },
+        ],
+      }
+    end
+
+    subject(:presenter) { expanded_links_presenter(expanded_links) }
+
+    specify { expect(presenter.role_appointments).to eq(%w[215f612f-6491-4241-9d91-dd39d1759792]) }
+  end
+
   it "default_news_image" do
     default_news_image_url = "https://www.test.gov.uk/default_news_image.jpg"
     expanded_links = {


### PR DESCRIPTION
This is the first step to migrating this format out of Whitehall and into the Search API.

It makes the format available for the Search API to parse and index in Elasticsearch.

I followed the instructions here for how to do this: https://github.com/alphagov/search-api/blob/master/doc/new-indexing-process.md

Depends on https://github.com/alphagov/govuk-content-schemas/pull/937 and https://github.com/alphagov/whitehall/pull/5182.

[Trello Card](https://trello.com/c/6YMqZnlo/1575-start-indexing-people-in-the-search-api)