### PR TITLE
Add flag to response indicating if reranking happened

### DIFF
--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -9,7 +9,7 @@ module LearnToRank
     end
 
     def ranks
-      return [] unless feature_sets.any?
+      return nil unless feature_sets.any?
 
       GovukStatsd.time("reranker.fetch_scores") do
         fetch_new_scores(feature_sets)
@@ -34,19 +34,14 @@ module LearnToRank
       begin
         response = HTTParty.post(url, options)
       rescue SocketError
-        return default_ranks(examples)
+        return nil
       end
 
       log_response(response)
 
-      return default_ranks(examples) if ranker_error(response)
+      return nil if ranker_error(response)
 
-      JSON.parse(response.body).fetch("results", default_ranks(examples))
-    end
-
-    def default_ranks(examples)
-      # Use existing rank by giving higher score 3,2,1 to the first results.
-      (1..examples.count).reverse_each.to_a
+      JSON.parse(response.body).fetch("results")
     end
 
     def ranker_error(response)

--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -30,7 +30,13 @@ module LearnToRank
         }.to_json,
         headers: { "Content-Type" => "application/json" },
       }
-      response = HTTParty.post(url, options)
+
+      begin
+        response = HTTParty.post(url, options)
+      rescue SocketError
+        return default_ranks(examples)
+      end
+
       log_response(response)
 
       return default_ranks(examples) if ranker_error(response)

--- a/lib/learn_to_rank/reranker.rb
+++ b/lib/learn_to_rank/reranker.rb
@@ -8,6 +8,8 @@ module LearnToRank
       feature_sets = FeatureSets.new.call(query, es_results)
       new_scores   = Ranker.new(feature_sets).ranks
 
+      return nil if new_scores.nil?
+
       log_reranking
 
       reorder_results(es_results, new_scores)

--- a/lib/search/batch_query.rb
+++ b/lib/search/batch_query.rb
@@ -10,7 +10,7 @@ module Search
       es_responses = timed_msearch(payloads)["responses"]
 
       searches_params.map.with_index do |search_params, i|
-        process_es_response(search_params, builders[i], payloads[i], es_responses[i])
+        process_es_response(search_params, builders[i], payloads[i], es_responses[i], false)
       end
     end
 

--- a/lib/search/presenters/result_set_presenter.rb
+++ b/lib/search/presenters/result_set_presenter.rb
@@ -1,7 +1,7 @@
 module Search
   # Presents a combined set of results for a GOV.UK site search
   class ResultSetPresenter
-    attr_reader :es_response, :search_params
+    attr_reader :es_response, :reranked, :search_params
 
     # `registries` should be a map from registry names to registries,
     # which gets passed to the ResultSetPresenter class. For example:
@@ -16,7 +16,8 @@ module Search
                    registries: {},
                    aggregate_examples: {},
                    schema: nil,
-                   query_payload: {})
+                   query_payload: {},
+                   reranked: false)
 
       @es_response = es_response
       @aggregates = es_response["aggregations"]
@@ -25,6 +26,7 @@ module Search
       @aggregate_examples = aggregate_examples
       @schema = schema
       @query_payload = query_payload
+      @reranked = reranked
     end
 
     def present
@@ -35,6 +37,7 @@ module Search
         search_params.aggregate_name => presented_aggregates,
         suggested_queries: suggested_queries,
         es_cluster: search_params.cluster.key,
+        reranked: reranked,
       }
 
       if search_params.show_query?

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -84,10 +84,14 @@ module Search
       results = es_response.dig("hits", "hits").to_a
       return es_response if results.empty? || results[0].fetch("_score").nil?
 
-      es_response["hits"]["hits"] = LearnToRank::Reranker.new.rerank(
+      reranked = LearnToRank::Reranker.new.rerank(
         es_results: results,
         query: search_params.query,
       )
+
+      return es_response if reranked.nil?
+
+      es_response["hits"]["hits"] = reranked
       es_response
     end
 

--- a/spec/unit/learn_to_rank/ranker_spec.rb
+++ b/spec/unit/learn_to_rank/ranker_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe LearnToRank::Ranker do
     context "when there are no search results" do
       let(:query) { nil }
       let(:search_results) { [] }
-      it "returns an empty array without calling ranker" do
-        expect(ranks).to eq([])
+      it "returns nil without calling ranker" do
+        expect(ranks).to be_nil
       end
     end
 
@@ -27,9 +27,9 @@ RSpec.describe LearnToRank::Ranker do
     end
 
     context "when the ranker is unavailable" do
-      it "returns an array of ranks in descending order, to preserve original rank" do
+      it "returns nil" do
         stub_ranker_is_unavailable
-        expect(ranks).to eq([2, 1])
+        expect(ranks).to be_nil
       end
     end
   end

--- a/spec/unit/learn_to_rank/reranker_spec.rb
+++ b/spec/unit/learn_to_rank/reranker_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe LearnToRank::Reranker do
     context "when there are no search results" do
       let(:query) { nil }
       let(:search_results) { [] }
-      it "returns an empty array without calling ranker" do
-        expect(reranked).to eq([])
+      it "returns nil without calling ranker" do
+        expect(reranked).to be_nil
       end
     end
 
@@ -29,11 +29,9 @@ RSpec.describe LearnToRank::Reranker do
     end
 
     context "when the ranker is unavailable" do
-      it "returns an array of ranks in descending order, to preserve original rank" do
+      it "returns nil" do
         stub_ranker_is_unavailable
-        expect(reranked.count).to eq(2)
-        expect(reranked.first.dig("_source", "title")).to eq("More popular document")
-        expect(reranked.second.dig("_source", "title")).to eq("More relevant document")
+        expect(reranked).to be_nil
       end
     end
   end

--- a/spec/unit/result_set_presenter_spec.rb
+++ b/spec/unit/result_set_presenter_spec.rb
@@ -714,4 +714,41 @@ RSpec.describe Search::ResultSetPresenter do
   def text_filter(field_name, values)
     SearchParameterParser::TextFieldFilter.new(field_name, values, :filter, :any)
   end
+
+  context "reranked results" do
+    before do
+      @results = {
+        "hits" => {
+          "hits" => [],
+          "total" => 0,
+        },
+      }
+    end
+
+    it "sets reranked: false" do
+      output = described_class.new(
+        search_params: Search::QueryParameters.new(
+          start: 0,
+          aggregate_name: :aggregates,
+        ),
+        es_response: @results,
+        reranked: false,
+      ).present
+
+      expect(output[:reranked]).to eq(false)
+    end
+
+    it "sets reranked: true" do
+      output = described_class.new(
+        search_params: Search::QueryParameters.new(
+          start: 0,
+          aggregate_name: :aggregates,
+        ),
+        es_response: @results,
+        reranked: false,
+      ).present
+
+      expect(output[:reranked]).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
When A/B testing LTR, it's not enough to know that someone is in the B bucket - they have to be in the B bucket with the reranker working.  To do that, we need search-api to report if any reranking happened.

B bucket with reranker docker container not running:

<img width="328" alt="Screenshot 2019-11-26 at 11 50 18" src="https://user-images.githubusercontent.com/75235/69628061-79c49100-1043-11ea-9e8c-488fdd2f7929.png">

B bucket with reranker docker container running:

<img width="351" alt="Screenshot 2019-11-26 at 11 50 44" src="https://user-images.githubusercontent.com/75235/69628211-8648e980-1043-11ea-826e-49121db85a70.png">

B bucket with reranker docker container running but no results found:

<img width="258" alt="Screenshot 2019-11-26 at 11 50 49" src="https://user-images.githubusercontent.com/75235/69628332-919c1500-1043-11ea-9029-5350cfe6d716.png">

A bucket:

<img width="309" alt="Screenshot 2019-11-26 at 11 50 57" src="https://user-images.githubusercontent.com/75235/69628388-96f95f80-1043-11ea-8adb-d7d40f69e747.png">

---

[Trello card](https://trello.com/c/KuIjFRQT/1172-include-flag-in-search-api-response-if-results-are-ranked)