### PR TITLE
Replace MAX_MODEL_BOOST with MAX_MODEL_SCORE, and base it on the minimum best bet score

### DIFF
--- a/lib/learn_to_rank/reranker.rb
+++ b/lib/learn_to_rank/reranker.rb
@@ -15,7 +15,6 @@ module LearnToRank
 
   private
 
-    DEFAULT_COUNT = 20
     MAX_MODEL_BOOST = 5
 
     def reorder_results(search_results, new_scores)

--- a/lib/learn_to_rank/reranker.rb
+++ b/lib/learn_to_rank/reranker.rb
@@ -1,6 +1,11 @@
 require "learn_to_rank/feature_sets"
 require "learn_to_rank/ranker"
 
+# autoloading would be nice here
+require "search/escaping"
+require "search/query_components/base_component"
+require "search/query_components/best_bets"
+
 module LearnToRank
   class Reranker
     # Reranker re-orders elasticsearch results using a pre-trained model
@@ -15,19 +20,19 @@ module LearnToRank
 
   private
 
-    MAX_MODEL_BOOST = 5
+    MAX_MODEL_SCORE = QueryComponents::BestBets::MIN_BEST_BET_SCORE - 1
 
     def reorder_results(search_results, new_scores)
       ranked = search_results
         .map
         .with_index { |result, index|
-          m_score = [new_scores[index], MAX_MODEL_BOOST].min
+          m_score = [new_scores[index], MAX_MODEL_SCORE].min
           es_score = result.fetch("_score", 0)
           result.merge(
             "model_score" => m_score,
             "original_rank" => index + 1,
             # keep best bet scores
-            "combined_score" => es_score > 1000 ? es_score : m_score,
+            "combined_score" => es_score > MAX_MODEL_SCORE ? es_score : m_score,
           )
         }
 

--- a/lib/search/query_components/best_bets.rb
+++ b/lib/search/query_components/best_bets.rb
@@ -1,5 +1,7 @@
 module QueryComponents
   class BestBets < BaseComponent
+    MIN_BEST_BET_SCORE = 1_000_000
+
     def initialize(metasearch_index:, search_params: Search::QueryParameters.new)
       @metasearch_index = metasearch_index
 
@@ -39,7 +41,7 @@ module QueryComponents
             query: {
               terms: { link: links },
             },
-            weight: (bb_max_position + 1 - position) * 1_000_000,
+            weight: (bb_max_position + 1 - position) * MIN_BEST_BET_SCORE,
           },
         }
       end


### PR DESCRIPTION
What the title says.

I thought it was better to add the `require`s to the ranker file than the best bets file, as we don't generally have them.  I think every file should `require` what it needs, but that would be a bit beyond the scope of this PR.