### PR TITLE
Show person search results from new govuk index

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -51,6 +51,7 @@ migrated:
 - hmrc_manual_section
 - manual
 - manual_section
+- person
 - policy
 - recommended-link # Search admin
 - service_manual_guide
@@ -294,7 +295,6 @@ migrated:
   - '/find-local-council'
 
 indexable:
-- person
 - ministerial_role
 
 non_indexable_path:


### PR DESCRIPTION
We've [migrated person pages so now they are being picked up by search-api from the message queue](https://github.com/alphagov/search-api/pull/1804). This PR changes it so search results are now coming from that new index rather than the old government index.