### PR TITLE
Add person elasticsearch type

### DIFF
--- a/config/schema/elasticsearch_types/person.json
+++ b/config/schema/elasticsearch_types/person.json
@@ -1,0 +1,5 @@
+{
+  "fields": [
+    "role_appointments"
+  ]
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -139,6 +139,11 @@
     "type": "identifier"
   },
 
+  "role_appointments": {
+    "description": "This will include the \"content_ids\" of each role appointment.",
+    "type": "identifiers"
+  },
+
   "mainstream_browse_pages": {
     "description": "Mainstream browse pages the page can appear in (https://www.gov.uk/browse).",
     "type": "identifiers"

--- a/config/schema/indexes/govuk.json
+++ b/config/schema/indexes/govuk.json
@@ -20,6 +20,7 @@
     "manual",
     "manual_section",
     "medical_safety_alert",
+    "person",
     "policy",
     "raib_report",
     "residential_property_tribunal_decision",


### PR DESCRIPTION
This was missed in https://github.com/alphagov/search-api/pull/1804 and we need it to support indexing people from the messaging queue.

This change will also require reindexing the schemas.