### PR TITLE
Reject non-English content from the publishing-api

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -74,7 +74,7 @@ module GovukIndex
       if type_mapper.unpublishing_type?
         logger.info("#{routing_key} -> DELETE #{identifier}")
         processor.delete(presenter)
-      elsif MigratedFormats.non_indexable?(presenter.format, presenter.base_path, presenter.publishing_app)
+      elsif payload.fetch("locale", "en") != "en" || MigratedFormats.non_indexable?(presenter.format, presenter.base_path, presenter.publishing_app)
         logger.info("#{routing_key} -> BLOCKLISTED #{identifier}")
       elsif MigratedFormats.indexable?(presenter.format, presenter.base_path, presenter.publishing_app)
         logger.info("#{routing_key} -> INDEX #{identifier}")

--- a/spec/integration/govuk_index/locale_spec.rb
+++ b/spec/integration/govuk_index/locale_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+RSpec.describe "locales" do
+  before do
+    bunny_mock = BunnyMock.new
+    @channel = bunny_mock.start.channel
+
+    consumer = GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "locale.test",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      rabbitmq_connection: bunny_mock,
+    )
+
+    @queue = @channel.queue("locale.test")
+    consumer.run
+  end
+
+  it "indexes pages missing a locale" do
+    random_example = generate_random_example(
+      schema: "taxon",
+      payload: {
+        document_type: "taxon",
+        base_path: "/transport/magical/apparition",
+      },
+    )
+    random_example.delete("locale")
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("taxon" => :all)
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = { "link" => random_example["base_path"] }
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
+  end
+
+  it "indexes English pages" do
+    random_example = generate_random_example(
+      schema: "taxon",
+      payload: {
+        document_type: "taxon",
+        base_path: "/transport/magical/broomstick",
+      },
+    )
+    random_example["locale"] = "en"
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("taxon" => :all)
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = { "link" => random_example["base_path"] }
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
+  end
+
+  it "does not index non-English pages" do
+    random_example = generate_random_example(
+      schema: "taxon",
+      payload: {
+        document_type: "taxon",
+        base_path: "/transport/magical/floo-network",
+      },
+    )
+    random_example["locale"] = "cy"
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("taxon" => :all)
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expect_document_missing_in_rummager(id: random_example["base_path"], index: "govuk_test")
+  end
+end

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -43,6 +43,7 @@ module SpecHelpers
     payload[:document_type] ||= schema
     retry_attempts.times do
       random_example = GovukSchemas::RandomExample.for_schema(notification_schema: schema) do |hash|
+        hash["locale"] = "en"
         hash.merge!(payload.stringify_keys)
 
         unless details.empty?


### PR DESCRIPTION
We want to stop non-English content from getting into search for a few
reasons:

- there's no way to filter by language
- our stemming and synonyms are only set up for English
- there's barely any Welsh content in search anyway

We would like search to be locale-aware, and properly solve all those
problems, but that's a larger piece of work.

As a safety measure, assume content without a locale is English.

---

Tested by deleting `/vehicle-tax` and `/gwirio-gwybodaeth-trwydded-yrru-rhywun` from search, republishing both of them, and checking that only `/vehicle-tax` came back.

---

[Trello card](https://trello.com/c/tyj41c76/1182-have-search-api-reject-non-english-content-from-publishing-api)