### PR TITLE
Stop explicitly disabling _all field

### DIFF
--- a/lib/schema/index_schema.rb
+++ b/lib/schema/index_schema.rb
@@ -18,7 +18,6 @@ class IndexSchema
     end
     mappings = {
       "generic-document" => {
-        "_all" => { "enabled" => false },
         "properties" => properties,
       },
     }


### PR DESCRIPTION
The _all field was deprecated in ES5 and removed in ES6.  This flag
to *disable* the _all field is deprecated in ES6 (and a no-op) and
removed in ES7.

---

Creating new indices before:

```
[2019-11-28T12:51:50,961][WARN ][o.e.d.i.m.AllFieldMapper ] [b1eVXD8] [_all] is deprecated in 6.0+ and will be removed in 7.0. As a replacement, you can use [copy_to] on mapping fields to create your own catch all field.
[2019-11-28T12:51:50,969][INFO ][o.e.c.m.MetaDataCreateIndexService] [b1eVXD8] [detailed-2019-11-28t12:51:50z-5d8906e4-a00d-4606-ac2d-4dde2a4bb5fa] creating index, cause [api], templates [], shards [3]/[1], mappings [generic-document]
[2019-11-28T12:51:51,028][WARN ][o.e.d.i.m.AllFieldMapper ] [b1eVXD8] [_all] is deprecated in 6.0+ and will be removed in 7.0. As a replacement, you can use [copy_to] on mapping fields to create your own catch all field.
[2019-11-28T12:51:51,356][WARN ][o.e.d.c.m.MetaDataCreateIndexService] [b1eVXD8] index or alias name [government-2019-11-28t12:51:51z-df3297cf-5a55-476c-9882-1736e1910ee1] containing ':' is deprecated. Elasticsearch 7.x will read, but not allow creation of new indices con
taining ':'
(...)
```

Creating new indices after:

```
[2019-11-28T12:52:49,549][WARN ][o.e.d.c.m.MetaDataCreateIndexService] [b1eVXD8] index or alias name [detailed-2019-11-28t12:52:49z-ad6a1847-b963-421e-b722-fa8e5536b40d] containing ':' is deprecated. Elasticsearch 7.x will read, but not allow creation of new indices containing ':'
[2019-11-28T12:52:49,579][INFO ][o.e.c.m.MetaDataCreateIndexService] [b1eVXD8] [detailed-2019-11-28t12:52:49z-ad6a1847-b963-421e-b722-fa8e5536b40d] creating index, cause [api], templates [], shards [3]/[1], mappings [generic-document]
[2019-11-28T12:52:49,755][WARN ][o.e.d.c.m.MetaDataCreateIndexService] [b1eVXD8] index or alias name [government-2019-11-28t12:52:49z-3ce173d8-3783-44a9-bed8-2c45ef2ddbbc] containing ':' is deprecated. Elasticsearch 7.x will read, but not allow creation of new indices containing ':'
(...)
```

---

[Trello card](https://trello.com/c/iayuJZjP/1184-fix-a-couple-of-es7-index-incompatibilities)