### PR TITLE
Show facets on all_finder

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -15,7 +15,7 @@ details:
     link:
       - "/search/all"
   format_name: Documents
-  hide_facets_by_default: true
+  hide_facets_by_default: false
   facets:
   - key: "_unused"
     display_as_result_metadata: false


### PR DESCRIPTION
We are looking to show facets on desktop for all_content_finder but keep them hidden on mobile.

Logic in the finder-frontend is already set up 
```
<%= "class=facet-toggle--only-on-mobile" unless content_item.hide_facets_by_default %>
```
so we only need `hide_facets_by_default` config value to be set to `false`

[Trello ticket](https://trello.com/c/iraWOoq5/1176-switch-showing-the-search-filter-by-default-on-mobile-for-1-week)