### PR TITLE
Use Listwise loss function for LTR

### DIFF
--- a/ltr_scripts/tf_ranking_libsvm.py
+++ b/ltr_scripts/tf_ranking_libsvm.py
@@ -81,7 +81,7 @@ flags.DEFINE_string("output_dir", None, "Output directory for models.")
 flags.DEFINE_integer("train_batch_size", 32, "The batch size for training.")
 flags.DEFINE_integer("num_train_steps", 100000, "Number of steps for training.")
 
-flags.DEFINE_float("learning_rate", 0.01, "Learning rate for optimizer.")
+flags.DEFINE_float("learning_rate", 0.1, "Learning rate for optimizer.")
 flags.DEFINE_float("dropout_rate", 0.5, "The dropout rate before output layer.")
 flags.DEFINE_list("hidden_layer_dims", ["256", "128", "64"],
                   "Sizes for hidden layers.")
@@ -90,7 +90,7 @@ flags.DEFINE_integer("num_features", 136, "Number of features per document.")
 flags.DEFINE_integer("list_size", 100, "List size used for training.")
 flags.DEFINE_integer("group_size", 1, "Group size used in score function.")
 
-flags.DEFINE_string("loss", "pairwise_logistic_loss",
+flags.DEFINE_string("loss", "list_mle_loss",
                     "The RankingLossKey for the primary loss function.")
 flags.DEFINE_string(
     "secondary_loss", None, "The RankingLossKey for the secondary loss for "
@@ -356,6 +356,7 @@ def get_eval_metric_fns():
   metric_fns.update({
       "metric/%s" % name: tfr.metrics.make_ranking_metric_fn(name) for name in [
           tfr.metrics.RankingMetricKey.ARP,
+          tfr.metrics.RankingMetricKey.MRR, # Mean Reciprocal Rank
           tfr.metrics.RankingMetricKey.ORDERED_PAIR_ACCURACY,
       ]
   })

--- a/ltr_scripts/train.sh
+++ b/ltr_scripts/train.sh
@@ -4,7 +4,7 @@ OUTPUT_DIR=${OUTPUT_DIR:-../tmp/libsvm}
 TRAIN=${TRAIN:-../tmp/ltr_data/train.txt}
 VALI=${VALI:-../tmp/ltr_data/validate.txt}
 TEST=${TEST:-../tmp/ltr_data/test.txt}
-STEPS=${STEPS:-50000} # runs at ~1,000 rounds per minute. 50,000 steps = 50 mins.
+STEPS=${STEPS:-100000} # runs at ~1,000 rounds per minute. 50,000 steps = 50 mins.
 
 if [[ -d $OUTPUT_DIR ]]; then
   rm -rf $OUTPUT_DIR


### PR DESCRIPTION
This changes the loss function to LIST_MLE_LOSS [1].

This loss function leads to a better NDCG score (about 1% better).

From Wikipedia [2]:
> In practice, listwise approaches often outperform pairwise approaches

Demonstration of improvement (red line is with this new loss function) using a month of training data:

<img width="723" alt="Screenshot 2019-12-02 at 11 56 50" src="https://user-images.githubusercontent.com/8124374/69957742-2e0a5f80-14fb-11ea-88fe-df800938d372.png">


[1] https://github.com/tensorflow/ranking/blob/v0.2.0/tensorflow_ranking/python/losses.py#L44
[2] https://en.wikipedia.org/wiki/Learning_to_rank#Approaches

More details on the loss function in the paper that released it: http://icml2008.cs.helsinki.fi/papers/167.pdf

https://trello.com/c/XGxd6mNO