### PR TITLE
Change reranker address

### DIFF
--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -34,6 +34,7 @@ module LearnToRank
       begin
         response = HTTParty.post(url, options)
       rescue SocketError
+        Services.statsd_client.increment("learn_to_rank.errors.socket_error")
         return nil
       end
 

--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -21,7 +21,7 @@ module LearnToRank
     attr_reader :feature_sets
 
     def fetch_new_scores(examples)
-      url = "http://reranker:8501/v1/models/ltr:regress"
+      url = "http://0.0.0.0:8501/v1/models/ltr:regress"
       options = {
         method: "POST",
         body: {

--- a/spec/unit/helpers/ranker_test_helpers.rb
+++ b/spec/unit/helpers/ranker_test_helpers.rb
@@ -29,7 +29,7 @@ module RankerTestHelpers
   end
 
   def stub_request_to_ranker(examples, rank_response)
-    stub_request(:post, "http://reranker:8501/v1/models/ltr:regress")
+    stub_request(:post, "http://0.0.0.0:8501/v1/models/ltr:regress")
       .with(
         body: {
           signature_name: "regression",
@@ -43,7 +43,7 @@ module RankerTestHelpers
   end
 
   def stub_ranker_is_unavailable
-    stub_request(:post, "http://reranker:8501/v1/models/ltr:regress")
+    stub_request(:post, "http://0.0.0.0:8501/v1/models/ltr:regress")
       .to_return(status: 500)
   end
 end


### PR DESCRIPTION
The docker container is going to live on the bridge network on search machines, which doesn't permit using an alias, but does expose `0.0.0.0`. See https://github.com/alphagov/govuk-puppet/pull/9867