### PR TITLE
Remove popularity AB test implementations

### DIFF
--- a/lib/search/query_components/popularity.rb
+++ b/lib/search/query_components/popularity.rb
@@ -6,10 +6,6 @@ module QueryComponents
     def wrap(boosted_query)
       return boosted_query if search_params.disable_popularity?
 
-      return logarithmic_boost(boosted_query) if search_params.use_logarithmic_popularity?
-
-      return logarithmic_boost_using_view_count(boosted_query) if search_params.use_view_count_popularity_boost?
-
       default_popularity_boost(boosted_query)
     end
 
@@ -25,36 +21,6 @@ module QueryComponents
               lang: "painless",
               source: "doc['popularity'].value + #{POPULARITY_OFFSET}",
             },
-          },
-        },
-      }
-    end
-
-    def logarithmic_boost(boosted_query)
-      {
-        function_score: {
-          boost_mode: :multiply,
-          max_boost: 5,
-          query: boosted_query,
-          field_value_factor: {
-            field: "popularity_b",
-            modifier: "log1p",
-            factor: POPULARITY_WEIGHT,
-          },
-        },
-      }
-    end
-
-    def logarithmic_boost_using_view_count(boosted_query)
-      {
-        function_score: {
-          boost_mode: :multiply,
-          max_boost: 5,
-          query: boosted_query,
-          field_value_factor: {
-            field: "view_count",
-            modifier: "log1p",
-            factor: 1,
           },
         },
       }

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -41,14 +41,6 @@ module Search
       debug[:disable_popularity]
     end
 
-    def use_logarithmic_popularity?
-      ab_tests[:popularity] == "B"
-    end
-
-    def use_view_count_popularity_boost?
-      ab_tests[:popularity] == "C"
-    end
-
     def disable_synonyms?
       debug[:disable_synonyms]
     end

--- a/spec/unit/query_components/popularity_spec.rb
+++ b/spec/unit/query_components/popularity_spec.rb
@@ -20,29 +20,4 @@ RSpec.describe QueryComponents::Popularity do
       expect(result).not_to be_key(:function_score)
     end
   end
-
-  context "with b variant of popularity" do
-    it "makes popularity logarithmic" do
-      builder = described_class.new(
-        search_query_params(ab_tests: { popularity: "B" }),
-      )
-
-      result = builder.wrap({ some: "query" })
-
-      expect(result).to eq(
-        function_score: {
-          boost_mode: :multiply,
-          max_boost: 5,
-          field_value_factor: {
-            factor: described_class::POPULARITY_WEIGHT,
-            field: "popularity_b",
-            modifier: "log1p",
-          },
-          query: {
-            some: "query",
-          },
-        },
-      )
-    end
-  end
 end


### PR DESCRIPTION
https://trello.com/c/y5XDfrFX/1192-remove-popularity-test-code-from-search-api