### PR TITLE
Enable LTR using string env variables

### DIFF
--- a/doc/learning-to-rank.md
+++ b/doc/learning-to-rank.md
@@ -30,7 +30,7 @@ database in the `venv` directory.  If you close the shell, you can run
 Using LTR
 ---------
 
-**Set the `ENABLE_LTR` environment variable, or all of this is disabled.**
+**Set the `ENABLE_LTR` environment variable to "true", or all of this is disabled.**
 
 There are several rake tasks for training and serving a TensorFlow
 model in the `learn_to_rank` namespace.
@@ -58,7 +58,7 @@ This task needs to be run with access to Elasticsearch.  If you're
 using govuk-docker the full command will be:
 
 ```sh
-govuk-docker run -e ENABLE_LTR=1 search-api-lite bundle exec rake 'learn_to_rank:generate_training_dataset[judgements.csv]'
+govuk-docker run -e ENABLE_LTR=true search-api-lite bundle exec rake 'learn_to_rank:generate_training_dataset[judgements.csv]'
 ```
 
 Once you have the training dataset you can train and serve a model:
@@ -75,7 +75,7 @@ inside the govuk-docker network at `reranker:8501`.  You can start
 search-api with the `ENABLE_LTR` environment variable with:
 
 ```sh
-govuk-docker run -e ENABLE_LTR=1 search-api-app
+govuk-docker run -e ENABLE_LTR=true search-api-app
 ```
 
 If you now query search-api with `ab_tests=relevance:B` then results

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -151,6 +151,7 @@ require "search/query_components/visibility_filter"
 require "search/query_parameters"
 require "search/registries"
 require "search/registry"
+require "search/relevance_helpers"
 require "search/suggestion_blocklist"
 require "search/timed_cache"
 

--- a/lib/search/presenters/result_presenter.rb
+++ b/lib/search/presenters/result_presenter.rb
@@ -85,7 +85,7 @@ module Search
       # it is.
       result[:es_score] = raw_result["_score"]
       # LearnToRank generated values
-      if ENV["ENABLE_LTR"]
+      if RelevanceHelpers.ltr_enabled?
         result[:model_score] = raw_result["model_score"]
         result[:original_rank] = raw_result["original_rank"]
         result[:combined_score] = raw_result["combined_score"]

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -70,7 +70,7 @@ module Search
     end
 
     def rerank
-      !ENV["ENABLE_LTR"].nil? && [nil, "relevance"].include?(order) && ab_tests[:relevance] == "B"
+      RelevanceHelpers.ltr_enabled? && [nil, "relevance"].include?(order) && ab_tests[:relevance] == "B"
     end
 
   private

--- a/lib/search/relevance_helpers.rb
+++ b/lib/search/relevance_helpers.rb
@@ -1,0 +1,5 @@
+module Search::RelevanceHelpers
+  def self.ltr_enabled?
+    ENV["ENABLE_LTR"].present? && ENV["ENABLE_LTR"] == "true"
+  end
+end

--- a/lib/tasks/learn_to_rank.rake
+++ b/lib/tasks/learn_to_rank.rake
@@ -3,6 +3,7 @@ require "fileutils"
 require "rummager"
 require "analytics/popular_queries"
 require "relevancy/load_judgements"
+require "search/relevance_helpers"
 
 namespace :learn_to_rank do
   desc "Export a CSV of relevancy judgements generated from CTR on popular queries"
@@ -98,7 +99,7 @@ namespace :learn_to_rank do
   end
 
   def assert_ltr!
-    raise "set $ENABLE_LTR to use learn_to_rank" if ENV["ENABLE_LTR"].nil?
+    raise 'set $ENABLE_LTR to "true" to use learn_to_rank' unless Search::RelevanceHelpers.ltr_enabled?
   end
 
   def export_to_csv(hash, filename)


### PR DESCRIPTION
We were previously relying on the truthiness of `ENV["ENABLE_LTR"]` to control enabling learn to rank.  We were trying to set the env var to a boolean in puppet, but that's not possible.

We'll do a check for the string "true" instead (to avoid an env var of "false" accidentally passing the truthiness rules) and convert puppet to setting strings instead.

https://trello.com/c/YL1JhAcm/1190-enable-ltr-in-staging-and-integration