### PR TITLE
Allow filtering on documents based on attached roles

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -35,6 +35,7 @@
     "organisations",
     "parent_organisations",
     "people",
+    "roles",
     "personal_data",
     "policies",
     "policy_areas",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -327,6 +327,11 @@
     "type": "identifiers"
   },
 
+  "roles": {
+    "description": "Links to roles associated with this page (https://www.gov.uk/government/ministers).",
+    "type": "identifiers"
+  },
+
   "policy_groups": {
     "description": "Links to policy groups (working groups) associated with this page (https://www.gov.uk/government/groups).",
     "type": "identifiers"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -89,6 +89,7 @@ module GovukIndex
         publishing_app:                      common_fields.publishing_app,
         railway_type:                        specialist.railway_type,
         role_appointments:                   expanded_links.role_appointments,
+        roles:                               expanded_links.roles,
         regions:                             specialist.regions,
         registration:                        specialist.registration,
         rendering_app:                       common_fields.rendering_app,

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -191,6 +191,8 @@ module GovukIndex
         base_path.gsub(%r{^/government/policies/}, "")
       elsif format == "person"
         base_path.gsub(%r{^/government/people/}, "")
+      elsif format == "ministerial_role"
+        base_path.gsub(%r{^/government/ministers/}, "")
       end
     end
 

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -20,6 +20,10 @@ module GovukIndex
       slugs("people", "/government/people/")
     end
 
+    def roles
+      slugs("roles", "/government/ministers/")
+    end
+
     def policy_groups
       slugs("working_groups", "/government/groups/")
     end

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -64,6 +64,7 @@ class BaseParameterParser
     primary_publishing_organisation
     publishing_app
     rendering_app
+    roles
     search_format_types
     search_user_need_document_supertype
     specialist_sectors

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -625,6 +625,29 @@ RSpec.describe "SearchTest" do
     })
   end
 
+  it "can filter by roles" do
+    commit_ministry_of_magic_document("roles" => %w[prime-minister])
+    commit_treatment_of_dragons_document("roles" => %w[some-other-role])
+
+    get "/search?filter_roles=prime-minister"
+
+    expect(last_response).to be_ok
+    expect(parsed_response.fetch("total")).to eq(1)
+
+    expect_result_includes_ministry_of_magic_for_key(
+      parsed_response,
+      "results",
+      {
+        "_id" => "/ministry-of-magic-site",
+        "document_type" => "edition",
+        "elasticsearch_type" => "edition",
+        "es_score" => nil,
+        "index" => "government_test",
+        "link" => "/ministry-of-magic-site",
+      },
+    )
+  end
+
 private
 
   def first_result

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -278,9 +278,9 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
       {
         "role_appointments" => [
           {
-              "content_id" => "215f612f-6491-4241-9d91-dd39d1759792",
-              "locale" => "en",
-              "title" => "Prime Minister",
+            "content_id" => "215f612f-6491-4241-9d91-dd39d1759792",
+            "locale" => "en",
+            "title" => "Prime Minister",
           },
         ],
       }

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -291,6 +291,25 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     specify { expect(presenter.role_appointments).to eq(%w[215f612f-6491-4241-9d91-dd39d1759792]) }
   end
 
+  describe "roles" do
+    let(:expanded_links) do
+      {
+        "roles" => [
+          {
+            "base_path" => "/government/ministers/badger-of-deploy",
+            "content_id" => "215f612f-6491-4241-9d91-dd39d1759792",
+            "locale" => "en",
+            "title" => "Prime Minister",
+          },
+        ],
+      }
+    end
+
+    subject(:presenter) { expanded_links_presenter(expanded_links) }
+
+    specify { expect(presenter.roles).to eq(%w[badger-of-deploy]) }
+  end
+
   it "default_news_image" do
     default_news_image_url = "https://www.test.gov.uk/default_news_image.jpg"
     expanded_links = {


### PR DESCRIPTION
This allows users to filter on documents based on any attached roles. Currently you can do https://www.gov.uk/api/search.json?filter_people=boris-johnson to filter all documents tagged to the person "Boris Johnson". This PR should make it possible to filter on all documents tagged to the role "Prime Minister" with https://www.gov.uk/api/search.json?filter_roles=prime-minister.

This is required to support rendering the "Announcements" section here https://www.gov.uk/government/ministers/prime-minister#announcements from Search API rather than from Whitehall's own index.

[Trello Card](https://trello.com/c/6r6CjemK/1404-investigate-how-we-can-support-filtering-on-roles-in-the-search-api)