### PR TITLE
Fetch latest model present on S3 file if none specified

### DIFF
--- a/lib/tasks/learn_to_rank.rake
+++ b/lib/tasks/learn_to_rank.rake
@@ -56,9 +56,11 @@ namespace :learn_to_rank do
       bucket_name = ENV["AWS_S3_RELEVANCY_BUCKET_NAME"]
       raise "Missing required AWS_S3_RELEVANCY_BUCKET_NAME" if bucket_name.blank?
 
-      raise "Please specify the model filename" if args.model_filename.blank?
+      model_files = Aws::S3::Bucket.new(bucket_name).objects.map(&:key)
 
-      model_filename = args.model_filename
+      model_filename = args.model_filename || model_files.max
+
+      puts "Pulling model: #{model_filename} ..."
 
       o = Aws::S3::Object.new(bucket_name: bucket_name, key: "ltr/#{model_filename}")
 

--- a/lib/tasks/learn_to_rank.rake
+++ b/lib/tasks/learn_to_rank.rake
@@ -58,7 +58,7 @@ namespace :learn_to_rank do
 
       model_files = Aws::S3::Bucket.new(bucket_name).objects.map(&:key)
 
-      model_filename = args.model_filename || model_files.max
+      model_filename = args.model_filename || model_files.max_by(&:to_i)
 
       puts "Pulling model: #{model_filename} ..."
 


### PR DESCRIPTION
If no model file name is specified in the rake task command, then the latest model file gets pulled. 

By convention, each model file is named as: `1.zip`, `2.zip`, ..., `n.zip`.

Given a relevancy model bucket with `1.zip`, `2.zip` and `3.zip`, `rake learn_to_rank:reranker:pull` will pull `3.zip`.

--

https://trello.com/c/Azj599Sw/1213-improve-resilience-of-learn-to-rank