### PR TITLE
Report ndcg to graphite

### DIFF
--- a/lib/tasks/relevancy.rake
+++ b/lib/tasks/relevancy.rake
@@ -25,24 +25,7 @@ namespace :relevancy do
 
   desc "Compute nDCG for a set of relevancy judgements (search performance metric)"
   task :ndcg, [:datafile, :ab_tests] do |_, args|
-    csv = args.datafile || relevancy_judgements_from_s3
-    begin
-      judgements = Relevancy::LoadJudgements.from_csv(csv)
-      evaluator = Evaluate::Ndcg.new(judgements, args.ab_tests)
-      results = evaluator.compute_ndcg
-
-      maxlen = results.keys.map { |query, _| query.length }.max
-      results.map do |(query, score)|
-        puts "#{(query + ':').ljust(maxlen + 1)} #{score}"
-      end
-      puts "---"
-      puts "overall score: #{results['average_ndcg']}"
-    ensure
-      if csv.is_a?(Tempfile)
-        file.close
-        file.unlink
-      end
-    end
+    report_ndcg(datafile: args.datafile, ab_tests: args.ab_tests)
   end
 
   desc "Send Google Analytics relevancy data to Graphite
@@ -52,6 +35,27 @@ namespace :relevancy do
     puts "Sending overall CTR to graphite"
     report_overall_ctr
     puts "Finished"
+  end
+end
+
+def report_ndcg(datafile: nil, ab_tests: nil)
+  csv = datafile || relevancy_judgements_from_s3
+  begin
+    judgements = Relevancy::LoadJudgements.from_csv(csv)
+    evaluator = Evaluate::Ndcg.new(judgements, ab_tests)
+    results = evaluator.compute_ndcg
+
+    maxlen = results.keys.map { |query, _| query.length }.max
+    results.map do |(query, score)|
+      puts "#{(query + ':').ljust(maxlen + 1)} #{score}"
+    end
+    puts "---"
+    puts "overall score: #{results['average_ndcg']}"
+  ensure
+    if csv.is_a?(Tempfile)
+      file.close
+      file.unlink
+    end
   end
 end
 


### PR DESCRIPTION
https://trello.com/c/eLOxX370/1215

This adds a new rake task `relevancy:send_metrics_to_graphite` that will run on a schedule. It will send NDCG to graphite, to populate a new metric.

This is necessary since it uses the new Evaluate::NDCG class that computes NDCG manually (rather than using the rank_eval endpoint provided by Elasticsearch), and that we can use to compare the Learning To Rank model to our existing search relevancy performance.

The Elasticsearch rank eval endpoint computes NDCG internally, so we can't use it with the dockerised Reranker.