### PR TITLE
Replace require for gds_api/rummager

### DIFF
--- a/lib/tasks/report_inconsistent_aggregate_values.rake
+++ b/lib/tasks/report_inconsistent_aggregate_values.rake
@@ -1,4 +1,4 @@
-require "gds_api/rummager"
+require "gds_api/search"
 
 class DataInconsistencyError < StandardError
 end
@@ -18,7 +18,7 @@ task :report_inconsistent_aggregate_values do
     people
   )
 
-  rummager = GdsApi::Rummager.new(Plek.new.find("search-api"))
+  rummager = GdsApi::Search.new(Plek.new.find("search-api"))
   aggregate_values_to_report = {}
 
   aggregates.each do |aggregate|


### PR DESCRIPTION
`gds_api/rummager` was removed in a breaking change in https://github.com/alphagov/gds-api-adapters/pull/966.  This was preventing search-api from being built with govuk-docker.

Therefore updating to use `gds_search` to keep this task working.