### PR TITLE
Allow ministerial roles to be indexed

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -27,6 +27,7 @@ mainstream_browse_page: edition # Collections Publisher
 manual: manual
 manual_section: manual_section
 medical_safety_alert: medical_safety_alert # Specialist Publisher
+ministerial_role: edition
 news_story: edition
 person: person
 place: edition

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -295,6 +295,7 @@ migrated:
 
 indexable:
 - person
+- ministerial_role
 
 non_indexable_path:
 - '/help/cookie-details'
@@ -391,7 +392,6 @@ non_indexable:
 - map
 - media_enquiries
 - membership
-- ministerial_role
 - national_statistics
 - national_statistics_announcement
 - news_story: # indexable when published by Content Publisher

--- a/spec/integration/govuk_index/ministerial_role_spec.rb
+++ b/spec/integration/govuk_index/ministerial_role_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+RSpec.describe "Ministerial role publishing" do
+  before do
+    bunny_mock = BunnyMock.new
+    @channel = bunny_mock.start.channel
+
+    consumer = GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "ministerial_roles.test",
+      processor: GovukIndex::PublishingEventProcessor.new,
+      rabbitmq_connection: bunny_mock,
+    )
+
+    @queue = @channel.queue("ministerial_roles.test")
+    consumer.run
+  end
+
+  it "indexes a ministerial role" do
+    random_example = generate_random_example(
+      schema: "role",
+      payload: {
+        document_type: "ministerial_role",
+        base_path: "/government/ministers/prime-minister",
+        description: "An important person.",
+      },
+    )
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("ministerial_role" => :all)
+
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = {
+      "link" => random_example["base_path"],
+      "description" => "An important person.",
+      "slug" => "prime-minister",
+    }
+
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
+  end
+end


### PR DESCRIPTION
This will allow us to start indexing ministerial roles directly from the Publishing API rather than from Whitehall.