### PR TITLE
Show role search results from govuk index

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -52,6 +52,8 @@ migrated:
 - hmrc_manual_section
 - manual
 - manual_section
+- minister # from Whitehall, should be `ministerial_role`
+- ministerial_role
 - person
 - policy
 - recommended-link # Search admin
@@ -295,8 +297,7 @@ migrated:
   - '/help/cookies'
   - '/find-local-council'
 
-indexable:
-- ministerial_role
+indexable: []
 
 non_indexable_path:
 - '/help/cookie-details'


### PR DESCRIPTION
We've migrated person pages so now they are being picked up by search-api from the message queue. This PR changes it so search results are now coming from that new index rather than the old government index.