### PR TITLE
[WIP] Change facet_name of content_store_document_type filter on Research and Stats finder email signup

### DIFF
--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -15,7 +15,7 @@ details:
   filter: {}
   email_filter_facets:
   - facet_id: content_store_document_type
-    facet_name: Research and statistics
+    facet_name: document types
     facet_choices:
     - key: statistics_published
       filter_values:


### PR DESCRIPTION
https://trello.com/c/UX2Cd7vr/1211-research-and-stats-subscription-descriptions-are-weird

Related to https://github.com/alphagov/finder-frontend/pull/1807

This will change this:
Statistics with 2 Research and statistics
to this:
Statistics with document types of Statistics (published) and Research