### PR TITLE
Remove redundant unpublish task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -27,14 +27,6 @@ namespace :publishing_api do
     end
   end
 
-  desc "Unpublish special routes"
-  task :unpublish_prepare_business_and_uk_nationals_special_routes do
-    content_ids = %w[7a99da17-e9e1-410b-b67d-c3f6348c595d b9ef4434-761f-49ae-af97-dc7a248499c4]
-    content_ids.each do |content_id|
-      Services.publishing_api.unpublish(content_id, type: "gone")
-    end
-  end
-
   desc "
     Publish finder and email signup content items
 


### PR DESCRIPTION
https://trello.com/c/Nnm7Drqb/318-business-finder-redirect-business-finder-pages-to-the-checker

This removes a rake task to unpublish 'gone' two content items related
to finding Brexit information. Since we intend to redirect the paths for
these content items outside of search-api, this task is not needed.