### PR TITLE
Move stats radio button facet to the top

### DIFF
--- a/config/finders/statistics_finder.yml
+++ b/config/finders/statistics_finder.yml
@@ -44,6 +44,13 @@ details:
     type: text
     display_as_result_metadata: true
     filterable: false
+  - key: content_store_document_type
+    name: Statistics
+    type: research_and_statistics
+    display_as_result_metadata: false
+    filterable: true
+    hide_facet_tag: true
+    preposition: that are
   - key: _unused
     filter_key: all_part_of_taxonomy_tree
     keys:
@@ -63,13 +70,6 @@ details:
     display_as_result_metadata: false
     hide_facet_tag: true
     filterable: true
-  - key: content_store_document_type
-    name: Statistics
-    type: research_and_statistics
-    display_as_result_metadata: false
-    filterable: true
-    hide_facet_tag: true
-    preposition: that are
   - key: organisations
     name: Organisation
     short_name: Organisation

--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -60,7 +60,7 @@ module LearnToRank
     end
 
     def ranker_error(response)
-      response.nil? || response.code != 200
+      response.nil? || response.body.blank? || response.code != 200
     end
 
     def log_response(response)


### PR DESCRIPTION
At present, it looks like the document type field is under the "Topic" heading
in the filters section.  This fixes that, and also makes it nearer the top
on mobile.  It's more used than Topic on the stats finder, so this makes sense.

We'd originally kept topic as the top filter to keep things broadly consistent
between supergroup finders as we expected to build some navigation to allow
users to flip between them.  This hasn't happened, so let's do a small
thing to make life easier for people.

## Before 

<img width="729" alt="Screenshot 2019-12-18 16 35 20" src="https://user-images.githubusercontent.com/773037/71172473-3c28e180-2258-11ea-9c6a-68ea5369915d.png">

## After

<img width="868" alt="Screenshot 2019-12-18 16 35 28" src="https://user-images.githubusercontent.com/773037/71172480-42b75900-2258-11ea-99b7-c4e5364822e6.png">
