### PR TITLE
Add common alternate transliterations for Hezbollah

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -1114,3 +1114,6 @@
 # Country changes
 - search: burma => burma, myanmar
 - search: myanmar => burma, myanmar
+
+# Common transliterations
+- search: hezbollah, hizballah, hizbullah => hezbollah, hizballah, hizbullah


### PR DESCRIPTION
Add common alternate transliterations for Hezbollah. Wel'll be able to close this one-year-old PR:  https://github.com/alphagov/search-api/pull/1386, as part of cleaning up PRs.

Common transliterations of the same word should be treated as equivalent. Currently a GOV.UK search for [Hezbollah](https://www.gov.uk/search?q=Hezbollah) returns 33 results, [Hizballah](https://www.gov.uk/search?q=Hizballah) 19 results, and [Hizbullah](https://www.gov.uk/search?q=Hizbullah) 4 results.