### PR TITLE
Add parts to search index

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -33,6 +33,7 @@
     "organisation_state",
     "organisation_type",
     "organisations",
+    "parts",
     "parent_organisations",
     "people",
     "roles",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -159,6 +159,16 @@
     "type": "identifiers"
   },
 
+  "parts": {
+    "description": "Parts of guidance.",
+    "type": "objects",
+    "children": {
+      "slug": { "type": "searchable_identifier" },
+      "title": { "type": "searchable_text" },
+      "body": { "type": "searchable_text" }
+    }
+  },
+
   "part_of_taxonomy_tree": {
     "description": "Any taxon tagged to the document and any of their ancestor taxons",
     "type": "identifiers"

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -39,6 +39,21 @@ module GovukIndex
       details.dig("image", "url")
     end
 
+    def parts
+      parts = details.fetch("parts", [])
+      return unless parts && parts.any?
+
+      parts.map do |part|
+        body = part.fetch("body", [{}]).first
+        body_content = body["content"]
+        {
+          "slug" => part["slug"],
+          "title" => part["title"],
+          "body" => body_content,
+        }
+      end
+    end
+
   private
 
     def service_manual

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -78,6 +78,7 @@ module GovukIndex
         organisation_content_ids:            expanded_links.organisation_content_ids,
         organisations:                       expanded_links.organisations,
         outcome_type:                        specialist.outcome_type,
+        parts:                               details.parts,
         part_of_taxonomy_tree:               expanded_links.part_of_taxonomy_tree,
         people:                              expanded_links.people,
         policy_groups:                       expanded_links.policy_groups,

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -25,6 +25,33 @@ RSpec.describe GovukIndex::DetailsPresenter do
     end
   end
 
+  context "when there are parts" do
+    let(:format) { "guide" }
+    let(:details) {
+      {
+        "parts" => [
+          {
+            "slug" => "a-part",
+            "title" => "A Part",
+            "body" => [{
+              "content" => "<p>The body of a part.</p>",
+            }],
+          },
+        ],
+      }
+    }
+
+    it "extracts parts" do
+      expect(presented_details.parts).to eq([
+        {
+          "body" => "<p>The body of a part.</p>",
+          "slug" => "a-part",
+          "title" => "A Part",
+        },
+      ])
+    end
+  end
+
   context "images" do
     context "document without an image" do
       let(:format) { "answer" }


### PR DESCRIPTION
Currently guidance parts (sections of guides, such as
'How to claim' in the Universal Credit guide) are indexed
into the blob of indexable_content, and aren't available
to frontend applications for rendering.

This indexes parts separately and makes them available for
returning in responses.

https://trello.com/c/jRP2uUla/1239-display-results-in-parts-be-work