### PR TITLE
Fix HTTParty response check

### DIFF
--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -60,7 +60,7 @@ module LearnToRank
     end
 
     def ranker_error(response)
-      response.nil? || response.code != 200
+      (response.body.nil? || response.body.empty?) || response.code != 200
     end
 
     def log_response(response)


### PR DESCRIPTION
This resolves a deprecation warning from the HTTParty gem.

> HTTParty will no longer override `response#nil?`. This functionality will be
> removed in future versions. Please, add explicit check `response.body.nil? || response.body.empty?`.
> For more info refer to: https://github.com/jnunemaker/httparty/issues/568.