### PR TITLE
Require the "manage_search_indices" permission to do that

### DIFF
--- a/lib/auth/mock_strategy.rb
+++ b/lib/auth/mock_strategy.rb
@@ -10,7 +10,7 @@ module Auth
           "uid" => "e7def478-c626-4d1b-9a4d-8a31e3ecfa0d",
           "name" => "Mock API User",
           "email" => "mock.user@example.com",
-          "permissions" => %w(signin),
+          "permissions" => %w(signin manage_search_indices),
           "organisation_slug" => nil,
           "organisation_content_id" => nil,
           "disabled" => false,

--- a/lib/routes/content.rb
+++ b/lib/routes/content.rb
@@ -9,7 +9,7 @@ class Rummager < Sinatra::Application
 
   delete "/content" do
     begin
-      require_authentication
+      require_authentication "manage_search_indices"
       Clusters.active.map do |cluster|
         search_config = SearchConfig.instance(cluster)
         raw_result = find_result_by_link(params["link"], search_config)


### PR DESCRIPTION
Previously search-api only had one permission: "signin".  We're going
to add an endpoint for Concourse to trigger generation of the LTR
training data.  Concourse shouldn't be able to manage search indices,
nor should apps which can manage search indices be able to trigger an
LTR fetch.  So having one permission is no longer good enough.

I think the only apps which communicate with these endpoints are
search-admin and whitehall.  I've given both of those this permission
in signon.

---

I've tested this by deploying to integration and publishing a new doc from whitehall.

---

[Trello card](https://trello.com/c/ZSkcaF6E/1243-add-api-endpoint-in-search-api-to-generate-training-data)