### PR TITLE
Remove email_filter_name from email signup content items

### DIFF
--- a/config/finders/all_content_email_signup.yml
+++ b/config/finders/all_content_email_signup.yml
@@ -10,7 +10,6 @@ title: Search
 description: You'll get an email when content is published.
 details:
   email_filter_by:
-  email_filter_name:
   subscription_list_title_prefix: 'All content'
   reject:
     content_purpose_supergroup: other

--- a/config/finders/guidance_and_regulation_email_signup.yml
+++ b/config/finders/guidance_and_regulation_email_signup.yml
@@ -10,7 +10,6 @@ title: Guidance and regulation
 description: You'll get an email when guidance and regulation is published.
 details:
   email_filter_by:
-  email_filter_name:
   subscription_list_title_prefix: 'Guidance and regulation'
   filter:
     content_purpose_supergroup: guidance_and_regulation

--- a/config/finders/news_and_communications_email_signup.yml
+++ b/config/finders/news_and_communications_email_signup.yml
@@ -14,7 +14,6 @@ details:
     - news
     - speeches_and_statements
   email_filter_by:
-  email_filter_name:
   subscription_list_title_prefix: 'News and communications ' # whitespace intended
   email_filter_facets:
   - facet_id: people

--- a/config/finders/policy_and_engagement_email_signup.yml
+++ b/config/finders/policy_and_engagement_email_signup.yml
@@ -10,7 +10,6 @@ title: Policy papers and consultations
 description: You'll get an email each time content is published.
 details:
   email_filter_by:
-  email_filter_name:
   subscription_list_title_prefix: Policy papers and consultations
   filter:
     content_purpose_supergroup: policy_and_engagement

--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -10,7 +10,6 @@ title: Research and statistics
 description: <p>You can't subscribe to get email notifications about upcoming statistics.</p><p>Subscribe to published statistics to get an email every time statistics are published or updated.</p>
 details:
   email_filter_by:
-  email_filter_name:
   subscription_list_title_prefix: Statistics
   filter: {}
   email_filter_facets:

--- a/config/finders/transparency_email_signup.yml
+++ b/config/finders/transparency_email_signup.yml
@@ -10,7 +10,6 @@ title: Transparency and freedom of information releases
 description: You'll get an email when transparency and freedom of information releases are published.
 details:
   email_filter_by:
-  email_filter_name:
   subscription_list_title_prefix: 'Transparency and freedom of information'
   filter:
     content_purpose_supergroup: transparency


### PR DESCRIPTION
https://trello.com/c/otcTG22f/1246-email-alert-signup-tech-debt

Related to https://github.com/alphagov/specialist-publisher/pull/1555

This field is no longer used.