### PR TITLE
Use PublishingApi not deprecated PublishingApiV2

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -16,7 +16,7 @@ private
   attr_reader :schema, :logger, :timestamp
 
   def publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(
+    @publishing_api ||= GdsApi::PublishingApi.new(
       Plek.new.find("publishing-api"),
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
       timeout: 10,

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,7 +2,7 @@ require "active_support/cache"
 
 module Services
   def self.publishing_api
-    GdsApi::PublishingApiV2.new(
+    GdsApi::PublishingApi.new(
       Plek.find("publishing-api"),
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
 

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -7,7 +7,7 @@ class SpecialRoutePublisher
   end
 
   def take_ownership_of_search_routes
-    publishing_api = GdsApi::PublishingApiV2.new(
+    publishing_api = GdsApi::PublishingApi.new(
       Plek.new.find("publishing-api"),
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
     )

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe "ElasticsearchIndexingTest" do
-  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::PublishingApi
 
   SAMPLE_DOCUMENT = {
     "title" => "TITLE",

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "gds_api/test_helpers/publishing_api_v2"
 
 RSpec.describe "TaglookupDuringIndexingTest" do
-  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::PublishingApi
 
   it "indexes document without publishing api content unchanged" do
     publishing_api_has_lookups({})

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -1,7 +1,7 @@
 require "gds_api/test_helpers/publishing_api_v2"
 
 module SpecHelpers
-  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::PublishingApi
   EXAMPLE_GENERATOR_RETRIES = 5
 
   def self.included(base)

--- a/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_publisher_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "gds_api/test_helpers/publishing_api_v2"
 
 RSpec.describe ContentItemPublisher::FinderEmailSignupPublisher do
-  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::PublishingApi
 
   signups_glob = File.join(Dir.pwd, "config", "finders", "*_email_signup.yml")
 
@@ -20,7 +20,7 @@ RSpec.describe ContentItemPublisher::FinderEmailSignupPublisher do
       end
 
       describe "#call" do
-        let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+        let(:publishing_api) { instance_double("GdsApi::PublishingApi") }
         let(:payload) {
           ContentItemPublisher::FinderEmailSignupPresenter.new(finder, timestamp).present
         }

--- a/spec/unit/content_item_publisher/finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_publisher_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ContentItemPublisher::FinderPublisher do
       end
 
       describe "#call" do
-        let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+        let(:publishing_api) { instance_double("GdsApi::PublishingApi") }
         let(:payload) {
           ContentItemPublisher::FinderPresenter.new(finder, timestamp).present
         }

--- a/spec/unit/indexer/links_lookup_spec.rb
+++ b/spec/unit/indexer/links_lookup_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Indexer::LinksLookup do
-  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::PublishingApi
 
   let(:content_id) { "DOCUMENT_CONTENT_ID" }
   let(:endpoint) { Plek.current.find("publishing-api") + "/v2" }

--- a/spec/unit/publishing_api_finder_publisher_spec.rb
+++ b/spec/unit/publishing_api_finder_publisher_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PublishingApiFinderPublisher do
     end
 
     describe "#call" do
-      let(:publishing_api) { instance_double("GdsApi::PublishingApiV2") }
+      let(:publishing_api) { instance_double("GdsApi::PublishingApi") }
       let(:payload) {
         FinderContentItemPresenter.new(finder, timestamp).present
       }
@@ -29,7 +29,7 @@ RSpec.describe PublishingApiFinderPublisher do
 
       before do
         allow(logger).to receive(:info)
-        allow(GdsApi::PublishingApiV2).to receive(:new).and_return(publishing_api)
+        allow(GdsApi::PublishingApi).to receive(:new).and_return(publishing_api)
         allow(publishing_api).to receive(:put_content)
         allow(publishing_api).to receive(:patch_links)
         allow(publishing_api).to receive(:publish)


### PR DESCRIPTION
PublishingApiV2 is deprecated, so this moves us to use PublishingApi.