### PR TITLE
Add choices to document type facet on transparency finder

### DIFF
--- a/config/finders/transparency_email_signup.yml
+++ b/config/finders/transparency_email_signup.yml
@@ -15,7 +15,20 @@ details:
     content_purpose_supergroup: transparency
   email_filter_facets:
   - facet_id: content_store_document_type
-    facet_name: document type
+    facet_name: All releases
+    facet_choices:
+    - topic_name: Corporate report
+      key: corporate_report
+      radio_button_name: Corporate report
+      prechecked: false
+    - topic_name: FOI release
+      key: foi_release
+      radio_button_name: FOI release
+      prechecked: false
+    - topic_name: Transparency data
+      key: transparency
+      radio_button_name: Transparency data
+      prechecked: false
   - facet_id: people
     facet_name: people
   - facet_id: organisations


### PR DESCRIPTION
These choices are necessary so that we can validate the input for this facet.

As a result of this, users can amend their choices of transparency releases on the signup page.

<img width="354" alt="Screenshot 2019-12-31 at 16 30 11" src="https://user-images.githubusercontent.com/8124374/71627547-fb7f7f80-2bea-11ea-9633-ee3df7701a6d.png">


https://trello.com/c/LMsj6yPk/1247