### PR TITLE
Remove filters that aren't being used

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -74,20 +74,6 @@ details:
     short_name: From
     type: text
     show_option_select_filter: true
-  - display_as_result_metadata: false
-    filterable: true
-    key: people
-    name: Person
-    preposition: from
-    type: text
-    show_option_select_filter: true
-  - display_as_result_metadata: true
-    filterable: true
-    key: world_locations
-    name: World location
-    preposition: in
-    type: text
-    show_option_select_filter: true
   - display_as_result_metadata: true
     filterable: true
     key: public_timestamp


### PR DESCRIPTION
Analytics indicate that people tend not to use the World Location or Person filters. This quick small fix removes those options from the search filtering on ONLY the search/all page - as other finders show that they are used in those places.

The search/all page will need to be republished after merge.

Trello: https://trello.com/c/fvGNflxv/1240-remove-filters-that-arent-being-used