### PR TITLE
Add rake task to get bets for a query

### DIFF
--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -1,4 +1,5 @@
 require "aws-sdk-s3"
+require "csv"
 require "rummager"
 require "pp"
 require "rainbow"
@@ -74,6 +75,20 @@ namespace :debug do
       if csv.is_a?(Tempfile)
         file.close
         file.unlink
+      end
+    end
+  end
+
+  desc "Get the best bets which match a query"
+  task :fetch_best_bets, [:query] do |_, args|
+    metasearch_index = SearchConfig.default_instance.metasearch_index
+    bets = Search::BestBetsChecker.new(args[:query], metasearch_index)
+    CSV do |out|
+      (bets.best_bets || []).each do |position, links|
+        links.each { |link| out << ["best", link, position] }
+      end
+      (bets.worst_bets || []).each do |link|
+        out << ["worst", link]
       end
     end
   end


### PR DESCRIPTION
With this, we can see why the top two best bets for "marriage tax allowance" have such a huge score:

```
best,/marriage-allowance-guide,1
best,/marriage-allowance,2
best,/income-tax-rates,5000001
best,/government/publications/rates-and-allowances-income-tax/,6000001
best,/government/publications/income-tax-personal-allowance-and-basic-rate-limit-for-2016-to-2017,30000002
worst,/government/topical-events/budget-2016
worst,/government/publications/application-for-a-duplicate-tax-disc
worst,/government/publications/application-for-a-refund-of-vehicle-tax-or-return-of-a-nil-value-tax-disc
```

It's because the best bet boost is `(max_position + 1 - position) * 1000000`, which for result 1 here is `(30000002 + 1 - 1) * 1000000`.