### PR TITLE
Add summaries to parts

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -165,7 +165,8 @@
     "children": {
       "slug": { "type": "searchable_identifier" },
       "title": { "type": "searchable_text" },
-      "body": { "type": "searchable_text" }
+      "body": { "type": "searchable_text" },
+      "summary": { "type": "searchable_text" }
     }
   },
 


### PR DESCRIPTION
Ahead of merging 2432596 we need to re-index with the new schema.

This should be merged and deployed, then we'll need to re-index, before starting to index parts with summaries.

https://trello.com/c/szgqkAGr/1263-generate-part-summaries-at-index-time