### PR TITLE
Modifies output of Autocomplete to remove extra data from the JSON

### DIFF
--- a/lib/search/presenters/autocomplete_presenter.rb
+++ b/lib/search/presenters/autocomplete_presenter.rb
@@ -13,7 +13,9 @@ module Search
     end
 
     def suggestions
-      es_response["autocomplete"]
+      es_response["autocomplete"]["hits"].map do |hit|
+        hit["_source"]["title"]
+      end
     end
   end
 end


### PR DESCRIPTION
Previous version of this presenter would return all the information
available for a given list of suggestion hits. This is unneeded and
proves confusing when compared with the simpler return of the spelling
suggestion presenter.

PR in relation to https://trello.com/c/eRITjGeX/1253-implement-autocomplete