### PR TITLE
Fix gds-api-adapters deprecation warnings

### DIFF
--- a/spec/integration/indexer/change_notification_processor_spec.rb
+++ b/spec/integration/indexer/change_notification_processor_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 RSpec.describe "ChangeNotificationProcessorTest" do
   it "triggering a reindex" do
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/foo" => "DOCUMENT-CONTENT-ID",
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: "DOCUMENT-CONTENT-ID",
       expanded_links: {},
     )
@@ -26,7 +26,7 @@ RSpec.describe "ChangeNotificationProcessorTest" do
       index: "government_test",
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: "DOCUMENT-CONTENT-ID",
       expanded_links: {
         mainstream_browse_pages: [{

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "ElasticsearchIndexingTest" do
   end
 
   it "adds a document to the search index" do
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: "6b965b82-2e33-4587-a70c-60204cbb3e29",
       expanded_links: {},
     )
@@ -60,7 +60,7 @@ RSpec.describe "ElasticsearchIndexingTest" do
   end
 
   it "defaults the type to 'edition' if not specified" do
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
       expanded_links: {},
     )
@@ -187,7 +187,7 @@ RSpec.describe "ElasticsearchIndexingTest" do
       expect(stubbed_client).to receive(:bulk).and_call_original
       allow_any_instance_of(SearchIndices::Index).to receive(:build_client).and_return(stubbed_client)
 
-      publishing_api_has_expanded_links(
+      stub_publishing_api_has_expanded_links(
         content_id: "6b965b82-2e33-4587-a70c-60204cbb3e29",
         expanded_links: {},
       )

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "TaglookupDuringIndexingTest" do
   include GdsApi::TestHelpers::PublishingApi
 
   it "indexes document without publishing api content unchanged" do
-    publishing_api_has_lookups({})
+    stub_publishing_api_has_lookups({})
 
     post "/government_test/documents", {
       "link" => "/something-not-in-publishing-api",
@@ -18,7 +18,7 @@ RSpec.describe "TaglookupDuringIndexingTest" do
   end
 
   it "indexes document with external url unchanged" do
-    publishing_api_has_lookups({})
+    stub_publishing_api_has_lookups({})
 
     post "/government_test/documents", {
       "link" => "http://example.com/some-link",
@@ -31,11 +31,11 @@ RSpec.describe "TaglookupDuringIndexingTest" do
   end
 
   it "indexes documents with links from publishing api" do
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/foo/bar" => "DOCUMENT-CONTENT-ID",
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: "DOCUMENT-CONTENT-ID",
       expanded_links: {
         topics: [
@@ -111,7 +111,7 @@ RSpec.describe "TaglookupDuringIndexingTest" do
   end
 
   it "skips content id lookup if it already has a content_id" do
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: "CONTENT-ID-OF-DOCUMENT",
       expanded_links: {
         topics: [
@@ -196,11 +196,11 @@ RSpec.describe "TaglookupDuringIndexingTest" do
       },
     }
 
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/foo/bar" => "DOCUMENT-CONTENT-ID",
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: "DOCUMENT-CONTENT-ID",
       expanded_links: {
         taxons: [taxon1, taxon2],

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -26,7 +26,7 @@ module SpecHelpers
 
   # This works because we first try to look up the content id for the base path.
   def stub_tagging_lookup
-    publishing_api_has_lookups({})
+    stub_publishing_api_has_lookups({})
   end
 
   # need to add additional page_traffic data in order to set maximum allowed ranking value


### PR DESCRIPTION
[Trello card](https://trello.com/c/Xh6cL5bS/1266-fix-a-bunch-of-deprecation-warnings-in-search-api-tests)