### PR TITLE
Ensure reranker errors can't prevent a result from being served

### DIFF
--- a/lib/learn_to_rank/features.rb
+++ b/lib/learn_to_rank/features.rb
@@ -71,7 +71,7 @@ module LearnToRank
     def get_format(format)
       return 0 if format.nil? || format.empty?
 
-      format_enums[format]
+      format_enums[format] || 0
     end
 
     def get_timestamp(timestamp)

--- a/lib/learn_to_rank/reranker.rb
+++ b/lib/learn_to_rank/reranker.rb
@@ -18,6 +18,8 @@ module LearnToRank
       log_reranking
 
       reorder_results(es_results, new_scores)
+    rescue StandardError => e
+      GovukError.notify(e, extra: { query: query })
     end
 
   private

--- a/spec/unit/learn_to_rank/features_spec.rb
+++ b/spec/unit/learn_to_rank/features_spec.rb
@@ -67,5 +67,22 @@ RSpec.describe LearnToRank::Features do
         )
       end
     end
+
+    context "with an unknown format or organisation" do
+      subject(:features) {
+        described_class.new(
+          format: "grimoire",
+          organisation_content_ids: ["department of magic"],
+        )
+      }
+
+      it "returns a default format value" do
+        expect(features.as_hash["11"]).to eq(0.0)
+      end
+
+      it "returns a default organisation value" do
+        expect(features.as_hash["12"]).to eq(0.0)
+      end
+    end
   end
 end


### PR DESCRIPTION
1. Add a default for the format type
2. Swallow any errors which come out of trying to rerank

---

[Trello card](https://trello.com/c/DFZ569Yq/1275-provide-defaults-on-ltr-to-stop-errors)