### PR TITLE
Add healthcheck for dockerised LTR model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 6.0.2"
 gem "aws-sdk-s3", "~> 1.60"
+gem "aws-sdk-sagemaker", "~> 1.49"
 gem "aws-sdk-sagemakerruntime", "~> 1.18"
 gem "elasticsearch", "~> 6"
 gem "gds-api-adapters", "~> 63.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
+    aws-sdk-sagemaker (1.49.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-sagemakerruntime (1.18.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
@@ -317,6 +320,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 6.0.2)
   aws-sdk-s3 (~> 1.60)
+  aws-sdk-sagemaker (~> 1.49)
   aws-sdk-sagemakerruntime (~> 1.18)
   bunny-mock (~> 1.7)
   climate_control (~> 0.2)

--- a/lib/healthcheck/reranker_healthcheck.rb
+++ b/lib/healthcheck/reranker_healthcheck.rb
@@ -1,0 +1,34 @@
+require "govuk_app_config"
+require "learn_to_rank/ranker_status"
+
+module Healthcheck
+  # This is a custom check that is called by GovukHealthcheck
+  # See GovukHealthcheck (govuk_app_config/docs/healthchecks.md) for usage info
+  class RerankerHealthcheck
+    def name
+      :reranker_healthcheck
+    end
+
+    def status
+      reranker_status.healthy? ? :ok : :warning
+    end
+
+    def message
+      reranker_status.healthy? ? "reranker is OK" : "reranker is unhealthy!"
+    end
+
+    def details
+      reranker_status.healthy? ? {} : { extra: { errors: reranker_status.errors } }
+    end
+
+    def enabled?
+      !%w(development).include? ENV["RACK_ENV"]
+    end
+
+  private
+
+    def reranker_status
+      @reranker_status ||= LearnToRank::RankerStatus.new
+    end
+  end
+end

--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -4,6 +4,8 @@ require "httparty"
 module LearnToRank
   class Ranker
     include Errors
+    include RankerApiHelper
+
     # Ranker takes feature sets and requests new scores for them
     # from a pre-trained model.
     def initialize(feature_sets = [])
@@ -60,7 +62,7 @@ module LearnToRank
     end
 
     def fetch_new_scores_from_serving(examples)
-      url = "http://#{tensorflow_serving_ip}:8501/v1/models/ltr:regress"
+      url = "#{tensorflow_container_url}:regress"
       options = {
         method: "POST",
         body: {
@@ -87,16 +89,6 @@ module LearnToRank
       end
 
       JSON.parse(response.body).fetch("results")
-    end
-
-    def tensorflow_serving_ip
-      if ENV["TENSORFLOW_SERVING_IP"].present?
-        ENV["TENSORFLOW_SERVING_IP"]
-      elsif %w(development).include? ENV["RACK_ENV"]
-        "reranker"
-      else
-        "0.0.0.0"
-      end
     end
 
     def logger

--- a/lib/learn_to_rank/ranker_api_helper.rb
+++ b/lib/learn_to_rank/ranker_api_helper.rb
@@ -1,0 +1,15 @@
+module LearnToRank
+  module RankerApiHelper
+    def tensorflow_container_url
+      "http://#{tensorflow_serving_ip}:8501/v1/models/ltr"
+    end
+
+    def tensorflow_serving_ip
+      return ENV["TENSORFLOW_SERVING_IP"] if ENV["TENSORFLOW_SERVING_IP"].present?
+
+      return "reranker" if %w(development).include? ENV["RACK_ENV"]
+
+      "0.0.0.0"
+    end
+  end
+end

--- a/lib/learn_to_rank/ranker_status.rb
+++ b/lib/learn_to_rank/ranker_status.rb
@@ -1,0 +1,96 @@
+require "aws-sdk-sagemaker"
+require "httparty"
+
+module LearnToRank
+  class RankerStatus
+    include RankerApiHelper
+
+    attr_reader :errors
+
+    def initialize(timeout: 0.1)
+      @errors = [] # Strings
+      @timeout = timeout
+      @healthy = check_health
+    end
+
+    def healthy?
+      @healthy && errors.none?
+    end
+
+  private
+
+    attr_reader :timeout
+
+    GOOD_STATES = %w(AVAILABLE).freeze
+    GOOD_STATUSES = %w(OK).freeze
+
+    def check_health
+      begin
+        reranker_healthy
+      rescue StandardError => e
+        @errors << "#{e.class}: #{e.message}"
+        false
+      end
+    end
+
+    class RankerServerError < StandardError
+      attr_reader :message
+      def initialize(message: nil)
+        @message = message # String
+      end
+    end
+    class StatusRequestFailed < RankerServerError; end
+    class StatusResponseInvalid < RankerServerError; end
+    class ModelUndefined < RankerServerError; end
+    class ModelStateUnhealthy < RankerServerError; end
+    class ModelStatusUnhealthy < RankerServerError; end
+
+    def reranker_healthy
+      endpoint = ENV["TENSORFLOW_SAGEMAKER_ENDPOINT"]
+      endpoint ? sagemaker_healthy? : container_healthy?
+    end
+
+    def sagemaker_healthy?
+      # TODO:
+      true
+    end
+
+    def container_healthy?
+      options = {
+        headers: { "Content-Type" => "application/json" },
+        timeout: timeout, # seconds
+      }
+      response = HTTParty.get(tensorflow_container_url, options)
+      validate_response!(response)
+      model = JSON.parse(response.body).fetch("model_version_status", []).last
+      validate_model_healthy!(model)
+      true
+    rescue HTTParty::Error, SocketError, Timeout::Error => e
+      raise RankerServerError.new(message: e.message)
+    end
+
+    def validate_response!(response)
+      return unless response.body.nil? || response.body.empty? || response.code != 200
+
+      raise StatusResponseInvalid.new(message: "Invalid response received from reranker")
+    end
+
+    def validate_model_healthy!(model)
+      unless model.present?
+        raise ModelUndefined.new(message: "No model_version_status model")
+      end
+
+      state = model.dig("state")
+      unless GOOD_STATES.include?(state)
+        raise ModelStateUnhealthy.new(message: "'#{state}' is not a healthy state")
+      end
+
+      status = model.dig("status", "error_code")
+      unless GOOD_STATUSES.include?(status)
+        raise ModelStatusUnhealthy.new(
+          message: "Status: '#{status}'. Error: #{model.dig('status', 'error_message')}",
+        )
+      end
+    end
+  end
+end

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -114,6 +114,7 @@ require "learn_to_rank/errors"
 require "learn_to_rank/explain_scores"
 require "learn_to_rank/feature_sets"
 require "learn_to_rank/features"
+require "learn_to_rank/ranker_api_helper"
 require "learn_to_rank/ranker"
 require "learn_to_rank/reranker"
 

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -8,6 +8,7 @@ require "routes/content"
 require "govuk_app_config"
 require "healthcheck/sidekiq_queue_latencies_check"
 require "healthcheck/elasticsearch_connectivity_check"
+require "healthcheck/reranker_healthcheck"
 
 class Rummager < Sinatra::Application
   class AttemptToUseDefaultMainstreamIndex < StandardError; end
@@ -344,6 +345,7 @@ class Rummager < Sinatra::Application
       GovukHealthcheck::SidekiqRedis,
       Healthcheck::SidekiqQueueLatenciesCheck,
       Healthcheck::ElasticsearchConnectivityCheck,
+      Healthcheck::RerankerHealthcheck,
     ]
 
     GovukHealthcheck.healthcheck(checks).to_json

--- a/spec/support/ranker_test_helpers.rb
+++ b/spec/support/ranker_test_helpers.rb
@@ -46,4 +46,34 @@ module RankerTestHelpers
     stub_request(:post, "http://0.0.0.0:8501/v1/models/ltr:regress")
       .to_return(status: 500)
   end
+
+  def stub_ranker_status_request
+    stub_request(:any, "http://0.0.0.0:8501/v1/models/ltr")
+  end
+
+  def stub_ranker_container_doesnt_exist
+    stub_ranker_status_request.to_return(status: 500)
+  end
+
+  def stub_ranker_requests_timeout
+    stub_ranker_status_request.to_timeout
+  end
+
+  def stub_ranker_status_to_be_ok
+    stub_ranker_status_request.to_return(
+      status: 200,
+      body: {
+        "model_version_status": [
+          {
+            "version": "1",
+            "state": "AVAILABLE",
+            "status": {
+              "error_code": "OK",
+              "error_message": "",
+            },
+          },
+        ],
+      }.to_json,
+    )
+  end
 end

--- a/spec/unit/learn_to_rank/ranker_spec.rb
+++ b/spec/unit/learn_to_rank/ranker_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "spec/unit/helpers/ranker_test_helpers"
+require "spec/support/ranker_test_helpers"
 
 RSpec.describe LearnToRank::Ranker do
   include RankerTestHelpers

--- a/spec/unit/learn_to_rank/ranker_status_spec.rb
+++ b/spec/unit/learn_to_rank/ranker_status_spec.rb
@@ -1,0 +1,103 @@
+require "spec_helper"
+require "spec/support/ranker_test_helpers"
+
+RSpec.describe LearnToRank::RankerStatus do
+  include RankerTestHelpers
+
+  subject(:status) { described_class.new(timeout: 0.001) }
+
+  def stub_ranker_status_request
+    stub_request(:any, "http://0.0.0.0:8501/v1/models/ltr")
+  end
+
+  context "when TENSORFLOW_SAGEMAKER_ENDPOINT envvar is unset" do
+    context "when the reranker is not available" do
+      it "is unhealthy" do
+        stub_ranker_container_doesnt_exist
+
+        expect(status).to_not be_healthy
+        expect(status.errors.first).to include("StatusResponseInvalid")
+      end
+    end
+
+    context "when the reranker takes too long to respond" do
+      it "is unhealthy" do
+        stub_ranker_requests_timeout
+        expect(status).to_not be_healthy
+        expect(status.errors.first).to include("RankerServerError")
+      end
+    end
+
+    context "when the reranker response is invalid" do
+      it "is unhealthy" do
+        stub_ranker_status_request.to_return(status: 400)
+        expect(status.errors.first).to include("StatusResponseInvalid")
+      end
+    end
+
+    context "when there is no model version defined" do
+      it "is unhealthy" do
+        stub_ranker_status_request.to_return(
+          status: 200,
+          body: {
+            "model_version_status": [],
+          }.to_json,
+        )
+        expect(status).to_not be_healthy
+        expect(status.errors.first).to include("ModelUndefined")
+      end
+    end
+
+    context "when the model is not in a healthy state" do
+      it "is unhealthy" do
+        stub_ranker_status_request.to_return(
+          status: 200,
+          body: {
+            "model_version_status": [
+              {
+                "version": "1",
+                "state": "UNAVAILABLE",
+                "status": {
+                  "error_code": "CRITICAL",
+                  "error_message": "It is broken",
+                },
+              },
+            ],
+          }.to_json,
+        )
+        expect(status).to_not be_healthy
+        expect(status.errors.first).to include("ModelStateUnhealthy")
+      end
+    end
+
+    context "when the model does not have a healthy status" do
+      it "is unhealthy" do
+        stub_ranker_status_request.to_return(
+          status: 200,
+          body: {
+            "model_version_status": [
+              {
+                "version": "1",
+                "state": "AVAILABLE",
+                "status": {
+                  "error_code": "CRITICAL",
+                  "error_message": "It is broken",
+                },
+              },
+            ],
+          }.to_json,
+        )
+        expect(status).to_not be_healthy
+        expect(status.errors.first).to include("ModelStatusUnhealthy: Status: 'CRITICAL'. Error: It is broken")
+      end
+    end
+
+    context "when the model is healthy" do
+      it "returns healthy" do
+        stub_ranker_status_to_be_ok
+        expect(status.errors).to be_empty
+        expect(status).to be_healthy
+      end
+    end
+  end
+end

--- a/spec/unit/learn_to_rank/reranker_spec.rb
+++ b/spec/unit/learn_to_rank/reranker_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "spec/unit/helpers/ranker_test_helpers"
+require "spec/support/ranker_test_helpers"
 
 RSpec.describe LearnToRank::Reranker do
   include RankerTestHelpers


### PR DESCRIPTION
This adds a connectivity and model status healthcheck for the model served by the tensorflow serving docker container on search machines.

Still to add: AWS Sagemaker status check

https://trello.com/c/Jgbd0TrY/1255-add-model-status-to-search-api-healthcheck