### PR TITLE
Change brexit taxon search description to Jan 2020 pre-lords content

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -10,7 +10,7 @@ module GovukIndex
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "title" => "Brexit",
-      "description" => "Brexit information and guidance on how to prepare for a no deal Brexit.",
+      "description" => "The UK and EU have agreed an exit deal. Find out what happens next.",
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     presenter = common_fields_presenter(payload)
 
     expect(presenter.title).to eq("Brexit")
-    expect(presenter.description).to eq("Brexit information and guidance on how to prepare for a no deal Brexit.")
+    expect(presenter.description).to eq("The UK and EU have agreed an exit deal. Find out what happens next.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
Changes the Brexit taxon description to match the Jan 2020 Pre-lords content