### PR TITLE
Remove hide_facet finder configuration setting

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -15,7 +15,6 @@ details:
     link:
       - "/search/all"
   format_name: Documents
-  hide_facets_by_default: true
   facets:
   - key: "_unused"
     display_as_result_metadata: false

--- a/config/finders/citizen_readiness_finder.yml
+++ b/config/finders/citizen_readiness_finder.yml
@@ -12,7 +12,6 @@ title: Detailed EU Exit guidance
 details:
   default_documents_per_page: 20
   document_noun: result
-  hide_facets_by_default: false
   no_index: true
   show_summaries: true
   signup_link: "/email-signup/?topic=/government/brexit-guidance-for-uk-citizens"


### PR DESCRIPTION
Merge and deploy after https://github.com/alphagov/finder-frontend/pull/1870
We will be showing facets by default as shown in https://github.com/alphagov/finder-frontend/pull/1870.

These config flags will no longer be needed.

[Trello ticket](https://trello.com/c/PtSyQ5hi/1285-show-facets-by-default)
