### PR TITLE
Add chief_scientific_advisor_role to docs without base path

### DIFF
--- a/lib/govuk_index/publishing_event_worker.rb
+++ b/lib/govuk_index/publishing_event_worker.rb
@@ -19,6 +19,7 @@ module GovukIndex
       board_member_role
       chief_professional_officer_role
       chief_scientific_officer_role
+      chief_scientific_advisor_role
       deputy_head_of_mission_role
       governor_role
       high_commissioner_role


### PR DESCRIPTION
This document type is new to search-api since this change:
https://github.com/alphagov/govuk-content-schemas/pull/931.

It's not expected to have a base path. This will resolve the
following errors: https://sentry.io/organizations/govuk/issues/1131951923/?project=1461905&query=is%3Aunresolved, https://sentry.io/organizations/govuk/issues/1134411307/?project=1461905&query=is%3Aunresolved, https://sentry.io/organizations/govuk/issues/1134411307/?project=1461905&query=is%3Aunresolved