### PR TITLE
Allow expansion of role facets

### DIFF
--- a/lib/search/presenters/entity_expander.rb
+++ b/lib/search/presenters/entity_expander.rb
@@ -38,6 +38,7 @@ module Search
       Mapping.new(:world_locations),
       Mapping.new(:specialist_sectors),
       Mapping.new(:people),
+      Mapping.new(:roles),
       Mapping.new(
         :topic_content_ids,
         new_field_name: :expanded_topics,

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -22,6 +22,7 @@ module Search
         document_collections: registry_for_document_format("document_collection"),
         world_locations: registry_for_document_format("world_location"),
         people: registry_for_document_format("person"),
+        roles: registry_for_document_format("ministerial_role"),
       }
     end
 

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -22,7 +22,7 @@ module Search
         document_collections: registry_for_document_format("document_collection"),
         world_locations: registry_for_document_format("world_location"),
         people: registry_for_document_format("person"),
-        roles: registry_for_document_format("ministerial_role"),
+        roles: roles,
       }
     end
 
@@ -58,6 +58,14 @@ module Search
         search_server.index_for_search([SearchConfig.govuk_index_name]),
         field_definitions,
         "specialist_sector",
+      )
+    end
+
+    def roles
+      BaseRegistry.new(
+        search_server.index_for_search([SearchConfig.govuk_index_name]),
+        field_definitions,
+        "ministerial_role",
       )
     end
 


### PR DESCRIPTION
This adds a registry for ministerial roles (as they are the only kinds of roles you can tag documents to) and adds it to the entity expanders.

This means that when seeing results for a document tagged to a role, we can see the expanded fields for it.

For example at the moment you can only see the `slug` (https://www.gov.uk/api/search.json?facet_roles=1500,examples:0,order:value.title&count=0):

```json
{
  "value": {
    "slug": "attorney-general"
  },
  "documents": 1
},
```