### PR TITLE
Add timing metrics to all top-level stages of reranking

### DIFF
--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -15,9 +15,7 @@ module LearnToRank
     def ranks
       return nil unless feature_sets.any?
 
-      GovukStatsd.time("reranker.fetch_scores") do
-        fetch_new_scores(feature_sets)
-      end
+      fetch_new_scores(feature_sets)
     end
 
   private

--- a/lib/learn_to_rank/reranker.rb
+++ b/lib/learn_to_rank/reranker.rb
@@ -11,9 +11,8 @@ module LearnToRank
     include Errors
     # Reranker re-orders elasticsearch results using a pre-trained model
     def rerank(query: "", es_results: [])
-      feature_sets = FeatureSets.new.call(query, es_results)
-      new_scores   = Ranker.new(feature_sets).ranks
-
+      feature_sets = fetch_feature_sets(query, es_results)
+      new_scores = fetch_new_scores(feature_sets)
       return nil if new_scores.nil?
 
       log_reranking
@@ -27,10 +26,21 @@ module LearnToRank
 
     MAX_MODEL_SCORE = QueryComponents::BestBets::MIN_BEST_BET_SCORE - 1
 
+    def fetch_feature_sets(query, es_results)
+      GovukStatsd.time("reranker.fetch_feature_sets") do
+        FeatureSets.new.call(query, es_results)
+      end
+    end
+
+    def fetch_new_scores(feature_sets)
+      GovukStatsd.time("reranker.fetch_scores") do
+        Ranker.new(feature_sets).ranks
+      end
+    end
+
     def reorder_results(search_results, new_scores)
-      ranked = search_results
-        .map
-        .with_index { |result, index|
+      GovukStatsd.time("reranker.reorder_results") do
+        ranked = search_results.map.with_index do |result, index|
           m_score = [new_scores[index], MAX_MODEL_SCORE].min
           es_score = result.fetch("_score", 0)
           result.merge(
@@ -39,9 +49,10 @@ module LearnToRank
             # keep best bet scores
             "combined_score" => es_score > MAX_MODEL_SCORE ? es_score : m_score,
           )
-        }
+        end
 
-      ranked.sort_by { |res| -res["combined_score"] }
+        ranked.sort_by { |res| -res["combined_score"] }
+      end
     end
 
     def log_reranking


### PR DESCRIPTION
Logging only the time to fetch new scores from TensorFlow doesn't give us the whole picture.