### PR TITLE
Add required to two facets

### DIFF
--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -15,6 +15,7 @@ details:
   email_filter_facets:
   - facet_id: content_store_document_type
     facet_name: Research and statistics
+    required: true
     facet_choices:
     - key: statistics_published
       filter_values:

--- a/config/finders/transparency_email_signup.yml
+++ b/config/finders/transparency_email_signup.yml
@@ -16,6 +16,7 @@ details:
   email_filter_facets:
   - facet_id: content_store_document_type
     facet_name: All releases
+    required: true
     facet_choices:
     - topic_name: Corporate report
       key: corporate_report


### PR DESCRIPTION
We want users to select a release type and statistic type on transparency and statistics finder email
signups respectively.

Related: https://github.com/alphagov/govuk-content-schemas/pull/952

https://trello.com/c/NS1ZPbBF/1249