### PR TITLE
Switch to Levenshtein distance for spelling suggestions

### DIFF
--- a/lib/search/query_components/suggest.rb
+++ b/lib/search/query_components/suggest.rb
@@ -13,6 +13,7 @@ module QueryComponents
             direct_generator: [{
               field: SPELLING_FIELD,
               suggest_mode: "missing",
+              string_distance: "levenshtein",
               sort: "score",
             }],
           }.merge(highlight),


### PR DESCRIPTION
We've noticed this making an improvement for some particularly
questionable spelling suggestions, even in cases where the default
distance metric (Damerau-Levenshtein) assigns the same distance score.
In such cases the DL and L distances normalise to different values,
and that seems to be what tips the balance.

---

[Trello card](https://trello.com/c/sBHFFUnH/1273-switch-spelling-suggestions-to-what-was-in-b-variant)