### PR TITLE
Display parts on top 3 results only

### DIFF
--- a/lib/search/presenters/result_set_presenter.rb
+++ b/lib/search/presenters/result_set_presenter.rb
@@ -55,8 +55,8 @@ module Search
     end
 
     def presented_results
-      es_response.dig("hits", "hits").to_a.map do |raw_result|
-        ResultPresenter.new(raw_result.to_hash, @registries, @schema, search_params).present
+      es_response.dig("hits", "hits").to_a.map.with_index(1) do |raw_result, rank|
+        ResultPresenter.new(raw_result.to_hash, @registries, @schema, search_params, result_rank: rank).present
       end
     end
   end

--- a/spec/unit/search/presenters/result_presenter_spec.rb
+++ b/spec/unit/search/presenters/result_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Search::ResultPresenter do
       "_source" => { "document_type" => "raib_report", "format" => %w[a-string] },
     }
 
-    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[format])).present
+    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[format]), result_rank: 1).present
 
     expect(result["format"]).to eq("a-string")
   end
@@ -20,7 +20,7 @@ RSpec.describe Search::ResultPresenter do
       "_source" => { "document_type" => "raib_report", "railway_type" => %w[heavy-rail light-rail] },
     }
 
-    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[railway_type])).present
+    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[railway_type]), result_rank: 1).present
 
     expect(
       [
@@ -28,5 +28,40 @@ RSpec.describe Search::ResultPresenter do
         { "label" => "Light rail", "value" => "light-rail" },
       ],
     ).to eq(result["railway_type"])
+  end
+
+  it "limits the number of parts to 10" do
+    document = {
+      "_type" => "generic-document",
+      "_index" => "govuk_test",
+      "_source" => { "document_type" => "edition", "parts" => ([{ a: "part" }] * 20) },
+    }
+
+    result = described_class.new(
+      document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w(parts)),
+      result_rank: 1
+    ).present
+
+    expect(result.dig("parts").count).to eq(10)
+  end
+
+  it "only displays parts for the top 3 results" do
+    document = {
+      "_type" => "generic-document",
+      "_index" => "govuk_test",
+      "_source" => { "document_type" => "edition", "parts" => [{ a: "part" }] },
+    }
+
+    (1..5).each { |rank|
+      result = described_class.new(
+        document,
+        nil,
+        sample_schema,
+        Search::QueryParameters.new(return_fields: %w(parts)),
+        result_rank: rank,
+      ).present
+
+      expect(result.dig("parts").count).to eq(rank <= 3 ? 1 : 0)
+    }
   end
 end

--- a/spec/unit/search/presenters/temporary_link_fix_spec.rb
+++ b/spec/unit/search/presenters/temporary_link_fix_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Search::ResultPresenter, "Temporary Link Fix" do
       "_source" => { "document_type" => "raib_report", "link" => ["some/link"] },
     }
 
-    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
+    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link]), result_rank: 1).present
 
     expect(result["link"]).to eq("/some/link")
   end
@@ -20,7 +20,7 @@ RSpec.describe Search::ResultPresenter, "Temporary Link Fix" do
       "_source" => { "document_type" => "raib_report", "link" => ["http://example.org/some-link"] },
     }
 
-    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
+    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link]), result_rank: 1).present
 
     expect(result["link"]).to eq("http://example.org/some-link")
   end
@@ -32,7 +32,7 @@ RSpec.describe Search::ResultPresenter, "Temporary Link Fix" do
       "_source" => { "document_type" => "raib_report", "link" => ["/some-link"] },
     }
 
-    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link])).present
+    result = described_class.new(document, nil, sample_schema, Search::QueryParameters.new(return_fields: %w[link]), result_rank: 1).present
 
     expect(result["link"]).to eq("/some-link")
   end


### PR DESCRIPTION
This will only show parts on the top 3 results, and enforces a limit of 10 parts per result.

The limit could be higher, it was chosen arbitrarily since the average number of parts is 4.

This could also be implemented in `finder-frontend` - doing this in search-api means we can reduce the amount of data unnecessarily returned to finder-frontend.

https://trello.com/c/EMaEQplm/1302-update-display-parts-be-work