### PR TITLE
Introduce smarter autocomplete results through popularity weighting

### DIFF
--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -1,6 +1,7 @@
 {
   "fields": [
     "all_searchable_text",
+    "autocomplete",
     "content_id",
     "content_purpose_document_supertype",
     "content_purpose_subgroup",

--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -85,19 +85,7 @@ index:
           filter: [trim, lowercase]
           char_filter: [normalize_quotes, strip_quotes]
 
-        edge_ngram_analyzer:
-          filter: [lowercase]
-          tokenizer: edge_ngram_tokenizer
-
-        edge_ngram_search_analyzer:
-          tokenizer: lowercase
-
       tokenizer:
-        edge_ngram_tokenizer:
-            type: edge_ngram
-            min_gram: 1
-            max_gram: 20
-            token_chars: [letter]
 
       char_filter:
         strip_quotes:

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -4,6 +4,11 @@
     "type": "all_searchable_text_type"
   },
 
+  "autocomplete": {
+    "description": "This field allows us to create autocomplete suggestions based off title headings",
+    "type": "autocomplete_result"
+  },
+
   "format": {
     "description": "This field is less specific than content_store_document_type but is mandatory for every document. May be deprecated in future.",
     "type": "identifier"

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -111,11 +111,6 @@
           "index": true,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
-        },
-        "edgengram": {
-          "type": "text",
-          "analyzer": "edge_ngram_analyzer",
-          "search_analyzer": "edge_ngram_search_analyzer"
         }
       }
     }
@@ -153,6 +148,18 @@
       "type": "text",
       "index": true,
       "analyzer": "best_bet_stemmed_match"
+    }
+  },
+
+  "autocomplete_result" : {
+    "description": "Type used to apply autocomplete suggestions to a given document based on title headings",
+    "es_config": {
+      "type": "completion",
+      "preserve_separators": false,
+      "preserve_position_increments": false,
+      "max_input_length": 20,
+      "analyzer": "searchable_text",
+      "search_analyzer": "searchable_text"
     }
   },
 

--- a/lib/govuk_index/popularity_worker.rb
+++ b/lib/govuk_index/popularity_worker.rb
@@ -19,12 +19,17 @@ module GovukIndex
 
     def process_record(record, popularities)
       base_path = record["identifier"]["_id"]
+      title = record["document"]["title"]
       OpenStruct.new(
         identifier: record["identifier"].merge("version_type" => "external_gte", "_type" => "generic-document"),
-        document: record["document"].merge(
+        document: record["document"].merge!(
           "popularity" => popularities.dig(base_path, :popularity_score),
           "popularity_b" => popularities.dig(base_path, :popularity_rank),
           "view_count" => popularities.dig(base_path, :view_count),
+          "autocomplete" => { # Relies on updated popularity. Title is for new records.
+            "input" => title,
+            "weight" => popularities.dig(base_path, :popularity_rank),
+          },
         ),
       )
     end

--- a/lib/search/presenters/autocomplete_presenter.rb
+++ b/lib/search/presenters/autocomplete_presenter.rb
@@ -13,9 +13,15 @@ module Search
     end
 
     def suggestions
-      es_response["autocomplete"]["hits"].map do |hit|
-        hit["_source"]["title"]
+      es_response["autocomplete"]
+      value = es_response["autocomplete"].map do |result|
+        result[1].map do |options|
+          options["options"].map do |suggestion|
+            suggestion["_source"]["autocomplete"].dig("input")
+          end
+        end
       end
+      value.flatten!
     end
   end
 end

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -167,13 +167,13 @@ module Search
 
     def run_autocomplete_query(search_params)
       query = {
-        _source: "title",
-        query: QueryComponents::Autocomplete.new(search_params).payload,
+        _source: "autocomplete", #Removes unneeded response from query
+        suggest: QueryComponents::Autocomplete.new(search_params).payload,
       }
 
       response = index.raw_search(query)
 
-      response["hits"]
+      response["suggest"]
     end
 
     def log_search

--- a/lib/search/query_components/autocomplete.rb
+++ b/lib/search/query_components/autocomplete.rb
@@ -1,30 +1,15 @@
 module QueryComponents
   class Autocomplete < BaseComponent
-    AUTOCOMPLETE_FIELD = "title.edgengram".freeze
+    AUTOCOMPLETE_FIELD = "autocomplete".freeze
 
     def payload
       {
-        "bool" => {
-          "must" => {
-            "match" => {
-              AUTOCOMPLETE_FIELD => {
-                "query" => search_term,
-                "operator" => "and",
-              },
-            },
-          },
-          "must_not" => {
-            # The below are excluded from any autocomplete suggestions
-            # If modified remember to update autocomplete_spec!
-            "terms" => {
-              "format" => [
-                #As referenced from config/govuk_index/mapped_document_types.yaml
-                "hmrc_manual_section",
-                "dfid_research_output",
-                "employment_tribunal_decision",
-                "employment_appeal_tribunal_decision",
-              ],
-            },
+        "suggested_autocomplete" => {
+          "prefix" => search_term,
+          "completion" => {
+            "field" => AUTOCOMPLETE_FIELD,
+            "size" => 10,
+            "skip_duplicates" => true,
           },
         },
       }

--- a/spec/integration/govuk_index/updating_popularity_data_spec.rb
+++ b/spec/integration/govuk_index/updating_popularity_data_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "GovukIndex::UpdatingPopularityDataTest" do
   end
 
   it "updates the popularity when it exists" do
-    id = insert_document("govuk_test", { popularity: 0.222, format: "help_page" }, type: "edition")
+    id = insert_document("govuk_test", { title: "govuk_test_doc", popularity: 0.222, format: "help_page" }, type: "edition")
     commit_index("govuk_test")
 
     document_count = 4
@@ -22,7 +22,7 @@ RSpec.describe "GovukIndex::UpdatingPopularityDataTest" do
   end
 
   it "set the popularity to the lowest popularity when it doesnt exist" do
-    id = insert_document("govuk_test", { popularity: 0.222, format: "help_page" }, type: "edition")
+    id = insert_document("govuk_test", { title: "govuk_test_doc", popularity: 0.222, format: "help_page" }, type: "edition")
     commit_index("govuk_test")
 
     document_count = 4
@@ -36,7 +36,7 @@ RSpec.describe "GovukIndex::UpdatingPopularityDataTest" do
   end
 
   it "ignores popularity update if version has moved on" do
-    id = insert_document("govuk_test", { popularity: 0.222, format: "help_page" }, type: "edition", version: 2)
+    id = insert_document("govuk_test", { title: "govuk_test_doc", popularity: 0.222, format: "help_page" }, type: "edition", version: 2)
     commit_index("govuk_test")
 
     document_count = 4
@@ -55,7 +55,7 @@ RSpec.describe "GovukIndex::UpdatingPopularityDataTest" do
   end
 
   it "copies version information" do
-    id = insert_document("govuk_test", { popularity: 0.222, format: "help_page" }, type: "edition", version: 3)
+    id = insert_document("govuk_test", { title: "govuk_test_doc", popularity: 0.222, format: "help_page" }, type: "edition", version: 3)
     commit_index("govuk_test")
     GovukIndex::PopularityUpdater.update("govuk_test")
 
@@ -73,7 +73,7 @@ RSpec.describe "GovukIndex::UpdatingPopularityDataTest" do
   end
 
   it "does not skips non indexable formats if process all flag is set" do
-    id = insert_document("govuk_test", { popularity: 0.222, format: "edition" }, type: "edition", version: 3)
+    id = insert_document("govuk_test", { title: "govuk_test_doc", popularity: 0.222, format: "edition" }, type: "edition", version: 3)
     commit_index("govuk_test")
 
     document_count = 4

--- a/spec/unit/query_components/autocomplete_spec.rb
+++ b/spec/unit/query_components/autocomplete_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe QueryComponents::Autocomplete do
   context "when enabled in debug options" do
     it "returns a set of autocomplete results" do
-      AUTOCOMPLETE_FIELD = "title.edgengram".freeze
+      AUTOCOMPLETE_FIELD = "autocomplete".freeze
 
       builder = described_class.new(
         search_query_params(suggest: "autocomplete"),
@@ -12,28 +12,14 @@ RSpec.describe QueryComponents::Autocomplete do
       result = builder.payload
 
       expect(result).to eq(
-        "bool" => {
-          "must" => {
-            "match" => {
-              AUTOCOMPLETE_FIELD => {
-                "query" => search_query_params.query,
-                "operator" => "and",
-              },
-            },
+        "suggested_autocomplete" => {
+          "prefix" => search_query_params.query,
+          "completion" => {
+            "field" => AUTOCOMPLETE_FIELD,
+            "size" => 10,
+            "skip_duplicates" => true,
           },
-          "must_not" => {
-          # The below are excluded from any autocomplete suggestions
-            "terms" => {
-              "format" => [
-                #As referenced from config/govuk_index/mapped_document_types.yaml
-                "hmrc_manual_section",
-                "dfid_research_output",
-                "employment_tribunal_decision",
-                "employment_appeal_tribunal_decision",
-                ],
-              },
-            },
-          },
+        },
         )
     end
   end


### PR DESCRIPTION
Unlike the actual search functionality, Elasticsearch suggest API does
not allow automatic results ranking on any "suggest" fields used in
the Elasticsearch schema for autocomplete functionality. This combined
with a need for speed resulted in a "dumb" original implementation.

This pull request improves the previous implementation in the following
key ways:

- Allows us to use the suggestion API as provided by Elasticsearch
- Allows us to use the popularity of a given document to weigh
  autocomplete results
- Allows us an easy means to keep popularity of autocomplete results
  concurrent with the base popularity used for ranking.
- Opens the door for potential improvements in using context-based
  suggestion ranking.

The autocomplete field is updated when the update_popularity script is
called, ensuring concurrent values in both fields.

Servers will need to be reindexed and the update_popularity rake task run for these changes to be fully in effect.

Trello: https://trello.com/c/RRpQJpF9/1323-improve-autocomplete-results