### PR TITLE
Enable LTR as default for NDCG

### DIFF
--- a/lib/evaluate/ndcg.rb
+++ b/lib/evaluate/ndcg.rb
@@ -28,7 +28,7 @@ module Evaluate
 
   private
 
-    DEFAULT_PARAMS = { "count" => %w[20], "fields" => %w[link content_id] }.freeze
+    DEFAULT_PARAMS = { "count" => %w[20], "fields" => %w[link content_id], "ab_tests" => %w(relevance:B) }.freeze
 
     attr_reader :data, :field
 


### PR DESCRIPTION
This will use the reranker when computing NDCG, since it is turned on by default now.

The intent is to make the NDCG metric reflect the effect LTR has: https://grafana.blue.production.govuk.digital/dashboard/file/search_relevancy.json?panelId=7&fullscreen