### PR TITLE
Enable fuzzy queries in autocomplete search

### DIFF
--- a/lib/search/query_components/autocomplete.rb
+++ b/lib/search/query_components/autocomplete.rb
@@ -8,8 +8,12 @@ module QueryComponents
           "prefix" => search_term,
           "completion" => {
             "field" => AUTOCOMPLETE_FIELD,
-            "size" => 10,
+            "size" => 8,
             "skip_duplicates" => true,
+            "fuzzy" => {
+              # For completion API we have to explicitly state this
+              "fuzziness" => "AUTO",
+            },
           },
         },
       }

--- a/spec/unit/query_components/autocomplete_spec.rb
+++ b/spec/unit/query_components/autocomplete_spec.rb
@@ -16,8 +16,11 @@ RSpec.describe QueryComponents::Autocomplete do
           "prefix" => search_query_params.query,
           "completion" => {
             "field" => AUTOCOMPLETE_FIELD,
-            "size" => 10,
+            "size" => 8,
             "skip_duplicates" => true,
+            "fuzzy" => {
+              "fuzziness" => "AUTO",
+            },
           },
         },
         )


### PR DESCRIPTION
Fuzzy queries allow for users to misspell their searches and still
retrieve meaningful autocomplete results. See ES Api:
https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-suggesters-completion.html#fuzzy

This pull request also reduces the maximum return count to that agreed
to in design.

Trello: https://trello.com/c/RRpQJpF9/1323-improve-autocomplete-results