### PR TITLE
Use govuk index for people registry

### DIFF
--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -21,7 +21,7 @@ module Search
         document_series: registry_for_document_format("document_series"),
         document_collections: registry_for_document_format("document_collection"),
         world_locations: registry_for_document_format("world_location"),
-        people: registry_for_document_format("person"),
+        people: govuk_registry_for_document_format("person"),
         roles: govuk_registry_for_document_format("ministerial_role"),
       }
     end

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -54,19 +54,23 @@ module Search
     end
 
     def specialist_sectors
-      BaseRegistry.new(govuk_index, field_definitions, "specialist_sector")
+      govuk_registry_for_document_format("specialist_sector")
     end
 
     def roles
-      BaseRegistry.new(govuk_index, field_definitions, "ministerial_role")
+      govuk_registry_for_document_format("ministerial_role")
     end
 
-    def registry_for_document_format(format)
-      BaseRegistry.new(index, field_definitions, format)
+    def govuk_registry_for_document_format(format)
+      BaseRegistry.new(govuk_index, field_definitions, format)
     end
 
     def govuk_index
       search_server.index_for_search([SearchConfig.govuk_index_name])
+    end
+
+    def registry_for_document_format(format)
+      BaseRegistry.new(index, field_definitions, format)
     end
 
     def index

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -22,7 +22,7 @@ module Search
         document_collections: registry_for_document_format("document_collection"),
         world_locations: registry_for_document_format("world_location"),
         people: registry_for_document_format("person"),
-        roles: roles,
+        roles: govuk_registry_for_document_format("ministerial_role"),
       }
     end
 
@@ -55,10 +55,6 @@ module Search
 
     def specialist_sectors
       govuk_registry_for_document_format("specialist_sector")
-    end
-
-    def roles
-      govuk_registry_for_document_format("ministerial_role")
     end
 
     def govuk_registry_for_document_format(format)

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -54,23 +54,19 @@ module Search
     end
 
     def specialist_sectors
-      BaseRegistry.new(
-        search_server.index_for_search([SearchConfig.govuk_index_name]),
-        field_definitions,
-        "specialist_sector",
-      )
+      BaseRegistry.new(govuk_index, field_definitions, "specialist_sector")
     end
 
     def roles
-      BaseRegistry.new(
-        search_server.index_for_search([SearchConfig.govuk_index_name]),
-        field_definitions,
-        "ministerial_role",
-      )
+      BaseRegistry.new(govuk_index, field_definitions, "ministerial_role")
     end
 
     def registry_for_document_format(format)
       BaseRegistry.new(index, field_definitions, format)
+    end
+
+    def govuk_index
+      search_server.index_for_search([SearchConfig.govuk_index_name])
     end
 
     def index


### PR DESCRIPTION
This changes the registries to use the `govuk` index when finding people as they have been migrated over. This was missed in https://github.com/alphagov/search-api/pull/1852.

The main change is 2ad83d4 but I also did some refactoring in the earlier commits. 

[Trello Card](https://trello.com/c/yTYIqjiA/1699-5-support-searching-for-documents-tagged-to-roles)