### PR TITLE
Remove fuzziness from completion query

### DIFF
--- a/lib/search/query_components/autocomplete.rb
+++ b/lib/search/query_components/autocomplete.rb
@@ -10,10 +10,6 @@ module QueryComponents
             "field" => AUTOCOMPLETE_FIELD,
             "size" => 8,
             "skip_duplicates" => true,
-            "fuzzy" => {
-              # For completion API we have to explicitly state this
-              "fuzziness" => "AUTO",
-            },
           },
         },
       }

--- a/spec/unit/query_components/autocomplete_spec.rb
+++ b/spec/unit/query_components/autocomplete_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe QueryComponents::Autocomplete do
             "field" => AUTOCOMPLETE_FIELD,
             "size" => 8,
             "skip_duplicates" => true,
-            "fuzzy" => {
-              "fuzziness" => "AUTO",
-            },
           },
         },
         )


### PR DESCRIPTION
Fuzziness was a good idea in theory, allowing for misspellings to
be accounted for in suggestions. In reality it just gave us bad results,
so this pull request turns them off.