### PR TITLE
Add a roles facet

### DIFF
--- a/config/finders/news_and_communications_email_signup.yml
+++ b/config/finders/news_and_communications_email_signup.yml
@@ -18,6 +18,8 @@ details:
   email_filter_facets:
   - facet_id: people
     facet_name: people
+  - facet_id: roles
+    facet_name: roles
   - facet_id: organisations
     facet_name: organisations
   - facet_id: world_locations

--- a/config/finders/news_and_communications_finder.yml
+++ b/config/finders/news_and_communications_finder.yml
@@ -71,6 +71,13 @@ details:
     display_as_result_metadata: false
     filterable: true
     show_option_select_filter: true
+  - key: roles
+    name: Roles
+    preposition: from
+    type: hidden
+    display_as_result_metadata: false
+    filterable: true
+    show_option_select_filter: true
   - key: world_locations
     name: World location
     preposition: in


### PR DESCRIPTION
This adds support for being able to search for documents tagged to roles so we can display the announcements list.

So that we can fully migrate roles away from Whitehall (we need to be able to display a list of announcements on each role page).

[Trello Card](https://trello.com/c/yTYIqjiA/1699-5-support-searching-for-documents-tagged-to-roles)