### PR TITLE
Implement SageMaker healthcheck

### DIFF
--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -23,18 +23,17 @@ module LearnToRank
     attr_reader :feature_sets
 
     def fetch_new_scores(examples)
-      endpoint = ENV["TENSORFLOW_SAGEMAKER_ENDPOINT"]
-      if endpoint
-        fetch_new_scores_from_sagemaker(examples, endpoint)
+      if sagemaker_endpoint
+        fetch_new_scores_from_sagemaker(examples)
       else
         fetch_new_scores_from_serving(examples)
       end
     end
 
-    def fetch_new_scores_from_sagemaker(examples, endpoint)
+    def fetch_new_scores_from_sagemaker(examples)
       begin
         response = Aws::SageMakerRuntime::Client.new.invoke_endpoint(
-          endpoint_name: endpoint,
+          endpoint_name: sagemaker_endpoint,
           body: {
             "signature_name": "regression",
             "examples": examples,

--- a/lib/learn_to_rank/ranker_api_helper.rb
+++ b/lib/learn_to_rank/ranker_api_helper.rb
@@ -1,5 +1,9 @@
 module LearnToRank
   module RankerApiHelper
+    def sagemaker_endpoint
+      ENV["TENSORFLOW_SAGEMAKER_ENDPOINT"]
+    end
+
     def tensorflow_container_url
       "http://#{tensorflow_serving_ip}:8501/v1/models/ltr"
     end

--- a/lib/learn_to_rank/ranker_status.rb
+++ b/lib/learn_to_rank/ranker_status.rb
@@ -46,8 +46,7 @@ module LearnToRank
     class ModelStatusUnhealthy < RankerServerError; end
 
     def reranker_healthy
-      endpoint = ENV["TENSORFLOW_SAGEMAKER_ENDPOINT"]
-      endpoint ? sagemaker_healthy? : container_healthy?
+      sagemaker_endpoint ? sagemaker_healthy? : container_healthy?
     end
 
     def sagemaker_healthy?

--- a/lib/learn_to_rank/ranker_status.rb
+++ b/lib/learn_to_rank/ranker_status.rb
@@ -21,8 +21,9 @@ module LearnToRank
 
     attr_reader :timeout
 
-    GOOD_STATES = %w(AVAILABLE).freeze
-    GOOD_STATUSES = %w(OK).freeze
+    GOOD_MODEL_STATES = %w(AVAILABLE).freeze
+    GOOD_MODEL_STATUSES = %w(OK).freeze
+    GOOD_ENDPOINT_STATUSES = %w(InService Updating SystemUpdating).freeze
 
     def check_health
       begin
@@ -39,19 +40,30 @@ module LearnToRank
         @message = message # String
       end
     end
+    class EndpointError < StandardError
+      attr_reader :message
+      def initialize(message: nil)
+        @message = message # String
+      end
+    end
     class StatusRequestFailed < RankerServerError; end
     class StatusResponseInvalid < RankerServerError; end
     class ModelUndefined < RankerServerError; end
     class ModelStateUnhealthy < RankerServerError; end
     class ModelStatusUnhealthy < RankerServerError; end
+    class EndpointApiError < EndpointError; end
+    class EndpointStatusUnhealthy < EndpointError; end
 
     def reranker_healthy
       sagemaker_endpoint ? sagemaker_healthy? : container_healthy?
     end
 
     def sagemaker_healthy?
-      # TODO:
+      response = Aws::SageMaker::Client.new.describe_endpoint(endpoint_name: sagemaker_endpoint)
+      validate_endpoint_healthy!(response)
       true
+    rescue Aws::SageMaker::Errors::ServiceError => e
+      raise EndpointApiError.new(message: e.message)
     end
 
     def container_healthy?
@@ -80,15 +92,28 @@ module LearnToRank
       end
 
       state = model.dig("state")
-      unless GOOD_STATES.include?(state)
+      unless GOOD_MODEL_STATES.include?(state)
         raise ModelStateUnhealthy.new(message: "'#{state}' is not a healthy state")
       end
 
       status = model.dig("status", "error_code")
-      unless GOOD_STATUSES.include?(status)
+      unless GOOD_MODEL_STATUSES.include?(status)
         raise ModelStatusUnhealthy.new(
           message: "Status: '#{status}'. Error: #{model.dig('status', 'error_message')}",
         )
+      end
+    end
+
+    def validate_endpoint_healthy!(endpoint)
+      status = endpoint.endpoint_status
+      reason = endpoint.failure_reason
+
+      unless GOOD_ENDPOINT_STATUSES.include?(status)
+        if reason.nil? || reason.empty?
+          raise EndpointStatusUnhealthy.new(message: "Status: '#{status}'.")
+        else
+          raise EndpointStatusUnhealthy.new(message: "Status: '#{status}'. Error: #{reason}.")
+        end
       end
     end
   end


### PR DESCRIPTION
The endpoint can have the following statuses:

- Creating
- Deleting
- Failed
- InService
- OutOfService
- RollingBack
- SystemUpdating
- Updating

For a health state, InServise is obvious.  Updating or SystemUpdating
can happen as part of normal operaiton (in fact Updating will happen
every night when the new model is deployed), so those are fine as
well.  The other states all indicate something has gone wrong: eg, we
shouldn't be creating the endpoint while search-api is trying to use
it.

---

[Trello card](https://trello.com/c/JdueF87E/1341-add-sagemaker-to-reranker-healthcheck)