### PR TITLE
Update email subscription title texts

### DIFF
--- a/config/finders/statistics_email_signup.yml
+++ b/config/finders/statistics_email_signup.yml
@@ -10,11 +10,12 @@ title: Research and statistics
 description: <p>You can't subscribe to get email notifications about upcoming statistics.</p><p>Subscribe to published statistics to get an email every time statistics are published or updated.</p>
 details:
   email_filter_by:
-  subscription_list_title_prefix: Statistics
+  subscription_list_title_prefix: ""
   filter: {}
   email_filter_facets:
   - facet_id: content_store_document_type
-    facet_name: Research and statistics
+    facet_name: All documents
+    facet_connector: filtered by
     required: true
     facet_choices:
     - key: statistics_published

--- a/config/finders/transparency_email_signup.yml
+++ b/config/finders/transparency_email_signup.yml
@@ -10,12 +10,13 @@ title: Transparency and freedom of information releases
 description: You'll get an email when transparency and freedom of information releases are published.
 details:
   email_filter_by:
-  subscription_list_title_prefix: 'Transparency and freedom of information'
+  subscription_list_title_prefix: ""
   filter:
     content_purpose_supergroup: transparency
   email_filter_facets:
   - facet_id: content_store_document_type
     facet_name: All releases
+    facet_connector: filtered by
     required: true
     facet_choices:
     - topic_name: Corporate report


### PR DESCRIPTION
Transparency and Statistics finder email signups will have slightly more clear subscriber list titles as a result of this change.

Before:
Transparency and freedom of information with All releases of FOI release
Statistics with 1 Research and statistic

After:
All releases filtered by FOI release
All documents filtered by Statistics (published)

https://trello.com/c/UX2Cd7vr/1211

Should be deployed before the finder-frontend change