### PR TITLE
Add unpublishing tasks for business_finder and brexit_campaign_page

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -150,4 +150,20 @@ namespace :publishing_api do
     Services.publishing_api.unpublish(finder["content_id"], "gone")
     Services.publishing_api.unpublish(finder["signup_content_id"], "gone")
   end
+
+  desc "Unpublish business finder results and questions pages"
+  task :unpublish_business_finder do
+    content_ids = %w[b9ef4434-761f-49ae-af97-dc7a248499c4 42ce66de-04f3-4192-bf31-8394538e0734 2818d67a-029a-4899-a438-a543d5c6a20d]
+    content_ids.each do |content_id|
+      Services.publishing_api.unpublish(content_id, type: "redirect", alternative_path: "/transition")
+    end
+  end
+
+  desc "Unpublish prepare eu exit campaign page"
+  task :unpublish_brexit_campaign_page do
+    content_ids = %w[ecb55f9d-0823-43bd-a116-dbfab2b76ef9 3a6d9383-5341-47a8-aaee-860dabd7c4d8 3bf851b-5df7-441b-8813-f0ec849da35f]
+    content_ids.each do |content_id|
+      Services.publishing_api.unpublish(content_id, type: "redirect", alternative_path: "/transition")
+    end
+  end
 end


### PR DESCRIPTION
Trello:
- https://trello.com/c/CLw2wZSV/391-business-finder-unpublish-the-results-email-signup-page
- https://trello.com/c/Nnm7Drqb/390-business-finder-redirect-question-pages-to-brexit-landing-page
- https://trello.com/c/lCl4gypt/450-retire-the-prepare-eu-exit-page-and-redirect-to-the-brexit-landing-page

Hits the publishing API with an unpublish call for the business finder content IDs, and old brexit campaign page content ids

**Tested on integration - it works!**
- https://www.integration.publishing.service.gov.uk/prepare-business-uk-leaving-eu
- https://www.integration.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=2
- https://www.integration.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=3
- https://www.integration.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=4
- https://www.integration.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=5
- https://www.integration.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=6
- https://www.integration.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=7
- https://www.integration.publishing.service.gov.uk/find-eu-exit-guidance-business?
- https://www.integration.publishing.service.gov.uk/find-eu-exit-guidance-business/email-signup

Also:
- https://www.integration.publishing.service.gov.uk/prepare-eu-exit
- https://www.integration.publishing.service.gov.uk/prepare-eu-exit/all
- https://www.integration.publishing.service.gov.uk/email-signup/?topic=/government/brexit-guidance-for-uk-citizens

## Tested on staging

https://www.staging.publishing.service.gov.uk/prepare-business-uk-leaving-eu
https://www.staging.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=2
https://www.staging.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=3
https://www.staging.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=4
https://www.staging.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=5
https://www.staging.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=6
https://www.staging.publishing.service.gov.uk/prepare-business-uk-leaving-eu?page=7
https://www.staging.publishing.service.gov.uk/find-eu-exit-guidance-business?
https://www.staging.publishing.service.gov.uk/find-eu-exit-guidance-business/email-signup

Also:

https://www.staging.publishing.service.gov.uk/prepare-eu-exit
https://www.staging.publishing.service.gov.uk/prepare-eu-exit/all
https://www.staging.publishing.service.gov.uk/email-signup/?topic=/government/brexit-guidance-for-uk-citizens

**Live**

https://gov.uk/prepare-business-uk-leaving-eu
https://gov.uk/prepare-business-uk-leaving-eu?page=2
https://gov.uk/prepare-business-uk-leaving-eu?page=3
https://gov.uk/prepare-business-uk-leaving-eu?page=4
https://gov.uk/prepare-business-uk-leaving-eu?page=5
https://gov.uk/prepare-business-uk-leaving-eu?page=6
https://gov.uk/prepare-business-uk-leaving-eu?page=7
https://gov.uk/find-eu-exit-guidance-business?
https://gov.uk/find-eu-exit-guidance-business/email-signup

Also:

https://gov.uk/prepare-eu-exit
https://gov.uk/prepare-eu-exit/all
https://gov.uk/prepare-eu-exit/email-signup/?topic=/government/brexit-guidance-for-uk-citizens