### PR TITLE
Update news and coms finder from transition to brexit

### DIFF
--- a/config/finders/news_and_communications_finder.yml
+++ b/config/finders/news_and_communications_finder.yml
@@ -31,8 +31,8 @@ details:
   - key: related_to_brexit
     filter_key: all_part_of_taxonomy_tree
     filter_value: d6c2de5d-ef90-45d1-82d4-5f2438369eea
-    name: Show only Brexit results
-    short_name: Brexit
+    name: Show only transition period results
+    short_name: transition period
     type: checkbox
     display_as_result_metadata: false
     filterable: true

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -31,7 +31,7 @@ namespace :publishing_api do
     Publish finder and email signup content items
 
     Usage:
-    FINDER_CONFIG=news_and_communications.yml EMAIL_SIGNUP_CONFIG=news_and_communications_email_signup.yml rake publishing_api:publish_finder
+    FINDER_CONFIG=news_and_communications_finder.yml EMAIL_SIGNUP_CONFIG=news_and_communications_email_signup.yml rake publishing_api:publish_finder
   "
   task :publish_finder do
     finder_config = ENV["FINDER_CONFIG"]


### PR DESCRIPTION
Trello: https://trello.com/c/Uanimli2/415-change-brexit-to-transition-period-on-search-checkboxes

News and communications finders have a special checkbox to limit all searches to brexit materials.
The brexit taxon has now been moved to transition. Whilst the check continues to work it is now mis-labelled.

This work re-lables the checkbox in search API so that it can be displayed with the new text in finder-frontend.