### PR TITLE
Remove appear_in_find_eu_exit_guidance_business_finder

### DIFF
--- a/config/schema/elasticsearch_types/aaib_report.json
+++ b/config/schema/elasticsearch_types/aaib_report.json
@@ -2,7 +2,6 @@
   "fields": [
     "aircraft_category",
     "aircraft_type",
-    "appear_in_find_eu_exit_guidance_business_finder",
     "date_of_occurrence",
     "business_activity",
     "employ_eu_citizens",

--- a/config/schema/elasticsearch_types/asylum_support_decision.json
+++ b/config/schema/elasticsearch_types/asylum_support_decision.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/business_finance_support_scheme.json
+++ b/config/schema/elasticsearch_types/business_finance_support_scheme.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_sizes",
     "business_stages",
     "business_activity",

--- a/config/schema/elasticsearch_types/cma_case.json
+++ b/config/schema/elasticsearch_types/cma_case.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "case_state",
     "case_type",
     "closed_date",

--- a/config/schema/elasticsearch_types/countryside_stewardship_grant.json
+++ b/config/schema/elasticsearch_types/countryside_stewardship_grant.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "funding_amount",

--- a/config/schema/elasticsearch_types/dfid_research_output.json
+++ b/config/schema/elasticsearch_types/dfid_research_output.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "country",
     "dfid_authors",
     "dfid_document_type",

--- a/config/schema/elasticsearch_types/drug_safety_update.json
+++ b/config/schema/elasticsearch_types/drug_safety_update.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "first_published_at",

--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -2,7 +2,6 @@
   "fields": [
     "acronym",
     "analytics_identifier",
-    "appear_in_find_eu_exit_guidance_business_finder",
     "attachments",
     "child_organisations",
     "closed_at",

--- a/config/schema/elasticsearch_types/employment_appeal_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/employment_appeal_tribunal_decision.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/employment_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/employment_tribunal_decision.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/european_structural_investment_fund.json
+++ b/config/schema/elasticsearch_types/european_structural_investment_fund.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "closing_date",
     "business_activity",
     "employ_eu_citizens",

--- a/config/schema/elasticsearch_types/export_health_certificate.json
+++ b/config/schema/elasticsearch_types/export_health_certificate.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "certificate_status",
     "commodity_type",
     "destination_country",

--- a/config/schema/elasticsearch_types/hmrc_manual.json
+++ b/config/schema/elasticsearch_types/hmrc_manual.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/hmrc_manual_section.json
+++ b/config/schema/elasticsearch_types/hmrc_manual_section.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "hmrc_manual_section_id",

--- a/config/schema/elasticsearch_types/international_development_fund.json
+++ b/config/schema/elasticsearch_types/international_development_fund.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "development_sector",
     "business_activity",
     "eligible_entities",

--- a/config/schema/elasticsearch_types/maib_report.json
+++ b/config/schema/elasticsearch_types/maib_report.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "date_of_occurrence",
     "business_activity",
     "employ_eu_citizens",

--- a/config/schema/elasticsearch_types/manual.json
+++ b/config/schema/elasticsearch_types/manual.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/manual_section.json
+++ b/config/schema/elasticsearch_types/manual_section.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/medical_safety_alert.json
+++ b/config/schema/elasticsearch_types/medical_safety_alert.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "alert_type",
     "business_activity",
     "employ_eu_citizens",

--- a/config/schema/elasticsearch_types/raib_report.json
+++ b/config/schema/elasticsearch_types/raib_report.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "date_of_occurrence",
     "business_activity",
     "employ_eu_citizens",

--- a/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/residential_property_tribunal_decision.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/service_standard_report.json
+++ b/config/schema/elasticsearch_types/service_standard_report.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "assessment_date",
     "business_activity",
     "employ_eu_citizens",

--- a/config/schema/elasticsearch_types/statutory_instrument.json
+++ b/config/schema/elasticsearch_types/statutory_instrument.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/tax_tribunal_decision.json
+++ b/config/schema/elasticsearch_types/tax_tribunal_decision.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/elasticsearch_types/utaac_decision.json
+++ b/config/schema/elasticsearch_types/utaac_decision.json
@@ -1,6 +1,5 @@
 {
   "fields": [
-    "appear_in_find_eu_exit_guidance_business_finder",
     "business_activity",
     "employ_eu_citizens",
     "intellectual_property",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -816,11 +816,6 @@
     "type": "identifiers"
   },
 
-  "appear_in_find_eu_exit_guidance_business_finder": {
-    "description": "Flag to control if this document should appear in the finder, as it is not restricted by document type.",
-    "type": "identifier"
-  },
-
   "sector_business_area": {
     "description": "The sector or business area",
     "type": "identifiers"


### PR DESCRIPTION
Trello: https://trello.com/c/qBM5QLID/482-business-finder-tech-debt

`appear_in_find_eu_exit_guidance_business_finder` is old technical debt surfaced [as part of removing the business finder](https://github.com/alphagov/search-api/pull/1967).

>It looks like the appear_in_find_eu_exit_guidance_business_finder checkbox approach was >replaced the facet_groups approach:
>
>    alphagov/finder-frontend@6f484a6
>    https://github.com/alphagov/search-api/pull/1535/files
>
>The finder content schema needs to have appear_in_find_eu_exit_guidance_business_finder removed too: https://github.com/alphagov/govuk-content-schemas/blob/master/formats/shared/definitions/finder.jsonnet#L51.

This PR cleans out the field_defintion and every time it is used.