### PR TITLE
Retry Concourse fetch check 3 times on 401

### DIFF
--- a/ltr/concourse/fetch.py
+++ b/ltr/concourse/fetch.py
@@ -12,7 +12,7 @@ session = requests.Session()
 session.headers.update({"Authorization": f"Bearer {bearer_token}"})
 
 # despite the name this does both http and https
-session.mount('https://', requests.adapters.HTTPAdapter(max_retries=5))
+session.mount("https://", requests.adapters.HTTPAdapter(max_retries=5))
 
 trigger = session.post(SEARCH_API_TRAIN_URL)
 print(f"POST ({trigger.status_code}) {trigger.text}", file=sys.stderr)


### PR DESCRIPTION
<img width="562" alt="Screenshot 2020-02-13 at 09 39 35" src="https://user-images.githubusercontent.com/75235/74421339-c51d5d00-4e44-11ea-9396-2c108e9e7abd.png">

We've seen sporadic auth failures despite the bearer token not
changing, so I suspect these actually indicate temporary signon
availability issues (whether signon itself, or the network).

---

[Trello card](https://trello.com/c/WpOjmsQU/1385-fix-daily-ltr-training-data-generation-flakyness)