### PR TITLE
Defend against links without a base_path

### DIFF
--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -99,9 +99,9 @@ module GovukIndex
     end
 
     def slugs(type, path_prefix)
-      expanded_links_item(type).map do |content_item|
-        content_item["base_path"].gsub(%r{^#{path_prefix}}, "")
-      end
+      expanded_links_item(type)
+        .reject { |content_item| content_item["base_path"].nil? }
+        .map { |content_item| content_item["base_path"].gsub(%r{^#{path_prefix}}, "") }
     end
 
     def organisation_slugs(type)


### PR DESCRIPTION
Some things which are in the links hash of a content item do not have a `base_path`. Typical examples are [roles which are catered for in some circumstances](https://github.com/alphagov/search-api/blob/4ecc88cebed0d81947d6d0c589b4add6b33cb32d/lib/govuk_index/publishing_event_worker.rb#L11) already.

Organisations all have base_paths because they are all pages, so we don't need to worry about the `organisation_slugs` method.

Resolves: https://sentry.io/organizations/govuk/issues/1386443327/?environment=staging&project=1461905&query=is%3Aunresolved 
and therefore: https://govuk.zendesk.com/agent/tickets/3920536