### PR TITLE
Serve model variant b

### DIFF
--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -74,7 +74,7 @@ resources:
   source:
     bucket: ((readonly_private_bucket_name))
     region_name: eu-west-2
-    regexp: search-learn-to-rank/integration-model-(.*).txt
+    regexp: search-learn-to-rank/integration-model-([0-9]*).txt
 - name: staging-model
   type: s3-iam
   source:
@@ -153,6 +153,22 @@ jobs:
           GOVUK_ENVIRONMENT: integration
           ROLE_ARN: ((integration-role-arn))
           INPUT_FILE_NAME: model
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
+- name: integration-deploy-model-variant-b
+  plan:
+    - get: search-api-git
+    - task: Deploy
+      config:
+        <<: *task-config
+        inputs:
+          - name: search-api-git
+        params:
+          GOVUK_ENVIRONMENT: integration
+          ROLE_ARN: ((integration-role-arn))
+          # MODEL_TAG should already exist in s3 e.g. at *-relevancy/models/variant-b
+          MODEL_TAG: variant-b
         run:
           path: bash
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]


### PR DESCRIPTION
This enables deploying a model using a model's tag name, which will create a separate new sagemaker endpoint, keeping the others intact.

It doesn't handle removing old sagemaker endpoints though. So we still need to figure out how that'd happen.

I see a deploy of a new candidate model & graceful migration to the new model working like this:

1. Make necessary changes to the search api application.
2. Train a new model (ideally with the data pipeline) and upload it to s3.
3. Add a new concourse deploy job to the pipeline that takes a `model_tag` for your model
4. Run the concourse job to deploy your model.
5. Once an AB test is completed confirming we want to migrate to the candidate model, send all traffic to this model, remove the old endpoint, and amend the concourse pipeline to train the new model on a schedule.

Some extra work needs to be done in Search API to permit training/serving different models e.g. those with different features (possibly by passing a model_variant param in the training / query requests).

This change should suffice for comparing two pre-trained models we have ready to AB test.

https://trello.com/c/1EjO05Dj/1333