### PR TITLE
Add Healthcheck for Elasticsearch node drive space

### DIFF
--- a/lib/healthcheck/elasticsearch_index_diskspace_check.rb
+++ b/lib/healthcheck/elasticsearch_index_diskspace_check.rb
@@ -1,0 +1,57 @@
+require "govuk_app_config"
+
+module Healthcheck
+  # This is a custom check that is called by GovukHealthcheck
+  # See GovukHealthcheck (govuk_app_config/docs/healthchecks.md) for usage info
+  class ElasticsearchIndexDiskspaceCheck
+    def name
+      :elasticsearch_diskspace
+    end
+
+    def status
+      low_diskspace? ? :critical : :ok
+    end
+
+    def message
+      if low_diskspace?
+        "there is not enough diskspace for the elasticsearch indices! Consider running index cleanup rake task"
+      else
+        "there is enough diskspace for the elasticsearch indices"
+      end
+    end
+
+    def details
+      low_diskspace?
+      { "extra" => "total free space remaining on nodes: #{percentage_free}%" }
+    end
+
+    # Optional
+    def enabled?
+      true # false if the check is not relevant at this time
+    end
+
+  private
+
+    # Tune this to affect the amount of free space we need available as a minimum % before we alert
+    LOW_SPACE_THRESHOLD = 20 # percent
+
+    def cluster_stats
+      @cluster_stats ||= begin
+        client = Services.elasticsearch(cluster: Clusters.default_cluster)
+        es_stats = client.perform_request "GET", "_nodes/stats/fs?pretty=true"
+        es_stats.body.dig("nodes").each_with_object({ total: 0, avail: 0 }) do |(_, node_stat), hsh|
+          hsh[:total] += node_stat.dig("fs", "total", "total_in_bytes")
+          hsh[:avail] += node_stat.dig("fs", "total", "available_in_bytes")
+        end
+      end
+    end
+
+    def percentage_free
+      cluster_stats[:avail] / (cluster_stats[:total] / 100)
+    end
+
+    def low_diskspace?
+      percentage_free < LOW_SPACE_THRESHOLD
+    end
+  end
+end

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -20,6 +20,7 @@ require "govuk_app_config"
 require "healthcheck/sidekiq_queue_latencies_check"
 require "healthcheck/elasticsearch_connectivity_check"
 require "healthcheck/reranker_healthcheck"
+require "healthcheck/elasticsearch_index_diskspace_check.rb"
 
 class Rummager < Sinatra::Application
   class AttemptToUseDefaultMainstreamIndex < StandardError; end
@@ -357,6 +358,7 @@ class Rummager < Sinatra::Application
       Healthcheck::SidekiqQueueLatenciesCheck,
       Healthcheck::ElasticsearchConnectivityCheck,
       Healthcheck::RerankerHealthcheck,
+      Healthcheck::ElasticsearchIndexDiskspaceCheck,
     ]
 
     GovukHealthcheck.healthcheck(checks).to_json

--- a/spec/support/diskspace_test_helpers.rb
+++ b/spec/support/diskspace_test_helpers.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+module DiskspaceTestHelpers
+  def stub_diskspace_check
+    es_source = ENV["ELASTICSEARCH_URI"] || "http://localhost:9200"
+    stub_request(:any, "#{es_source}/_nodes/stats/fs?pretty=true")
+    .to_return(
+      status: 200,
+      body: {
+        "nodes": {
+          "node": {
+            "fs": {
+              "total": {
+                "total_in_bytes": 200,
+                "available_in_bytes": 100,
+              },
+            },
+          },
+        },
+      }.to_json,
+      headers: {
+        "Content-Type" => "application/json",
+      },
+    )
+  end
+
+  def stub_diskspace_fail_check
+    es_source = ENV["ELASTICSEARCH_URI"] || "http://localhost:9200"
+    stub_request(:any, "#{es_source}/_nodes/stats/fs?pretty=true")
+    .to_return(
+      status: 200,
+      body: {
+        "nodes": {
+          "node": {
+            "fs": {
+              "total": {
+                "total_in_bytes": 200,
+                "available_in_bytes": 20,
+              },
+            },
+          },
+        },
+      }.to_json,
+      headers: {
+        "Content-Type" => "application/json",
+      },
+    )
+  end
+end


### PR DESCRIPTION
Typically we only discover that Elasticsearch has run out of diskspace
when we start to see errors. This usually happens because there are old
Elasticsearch indices that have not been removed with the relevant
rake task clogging up the system.

This healthcheck will test the overall space available and cause an
alert if we have less than 20% free on the disks. A percentage decided upon based on current usage trends.

https://trello.com/c/NREu7dvS/1380-alerts-for-duplicate-elasticsearch-indices