### PR TITLE
Add models Hippo and Elephant

### DIFF
--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -156,22 +156,6 @@ jobs:
         run:
           path: bash
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
-- name: integration-deploy-model-variant-b
-  plan:
-    - get: search-api-git
-    - task: Deploy
-      config:
-        <<: *task-config
-        inputs:
-          - name: search-api-git
-        params:
-          GOVUK_ENVIRONMENT: integration
-          ROLE_ARN: ((integration-role-arn))
-          # MODEL_TAG should already exist in s3 e.g. at *-relevancy/models/variant-b
-          MODEL_TAG: variant-b
-        run:
-          path: bash
-          args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
 - name: staging-fetch
   plan:
     - get: at-10pm
@@ -312,3 +296,93 @@ jobs:
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
       on_failure:
         <<: *notify-failure
+- name: integration-deploy-model-hippo
+  plan:
+    - get: search-api-git
+    - task: Deploy Hippo Model
+      config:
+        <<: *task-config
+        inputs:
+          - name: search-api-git
+        params:
+          GOVUK_ENVIRONMENT: integration
+          ROLE_ARN: ((integration-role-arn))
+          MODEL_TAG: hippo
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
+- name: integration-deploy-model-elephant
+  plan:
+    - get: search-api-git
+    - task: Deploy Elephant Model
+      config:
+        <<: *task-config
+        inputs:
+          - name: search-api-git
+        params:
+          GOVUK_ENVIRONMENT: integration
+          ROLE_ARN: ((integration-role-arn))
+          MODEL_TAG: elephant
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
+- name: staging-deploy-model-hippo
+  plan:
+    - get: search-api-git
+    - task: Deploy Hippo Model
+      config:
+        <<: *task-config
+        inputs:
+          - name: search-api-git
+        params:
+          GOVUK_ENVIRONMENT: staging
+          ROLE_ARN: ((staging-role-arn))
+          MODEL_TAG: hippo
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
+- name: staging-deploy-model-elephant
+  plan:
+    - get: search-api-git
+    - task: Deploy Elephant Model
+      config:
+        <<: *task-config
+        inputs:
+          - name: search-api-git
+        params:
+          GOVUK_ENVIRONMENT: staging
+          ROLE_ARN: ((staging-role-arn))
+          MODEL_TAG: elephant
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
+- name: production-deploy-model-hippo
+  plan:
+    - get: search-api-git
+    - task: Deploy Hippo Model
+      config:
+        <<: *task-config
+        inputs:
+          - name: search-api-git
+        params:
+          GOVUK_ENVIRONMENT: production
+          ROLE_ARN: ((production-role-arn))
+          MODEL_TAG: hippo
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
+- name: production-deploy-model-elephant
+  plan:
+    - get: search-api-git
+    - task: Deploy Elephant Model
+      config:
+        <<: *task-config
+        inputs:
+          - name: search-api-git
+        params:
+          GOVUK_ENVIRONMENT: production
+          ROLE_ARN: ((production-role-arn))
+          MODEL_TAG: elephant
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/task.sh", "deploy"]


### PR DESCRIPTION
This adds two new deploy jobs per environment, which will create endpoints for two models stored in S3.

The models are named 'Elephant' and 'Hippo'. Elephant was trained on 3 months of data, Hippo with 1 month (also known as '1 model').

These will be AB tested with the model we have running already.

https://trello.com/c/1EjO05Dj/1333