### PR TITLE
Automate deletion of old unused indexes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,3 +60,13 @@ def index_names
     raise "You must specify an index name in SEARCH_INDEX, or 'all'"
   end
 end
+
+def max_index_age
+  max_age_in_days = ENV["MAX_INDEX_AGE"]
+  case max_age_in_days
+  when String
+    max_age_in_days
+  else
+    raise "You must specify the MAX_INDEX_AGE (e.g. MAX_INDEX_AGE=3)"
+  end
+end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -186,6 +186,15 @@ this task will run against all active clusters.
     end
   end
 
+  desc "Cleans out unused indices older than the number of days given by the MAX_INDEX_AGE flag"
+  task :timed_clean do
+    Clusters.active.each do |cluster|
+      index_names.each do |index_name|
+        search_server(cluster: cluster).index_group(index_name).timed_clean(max_index_age)
+      end
+    end
+  end
+
   desc "Check whether a restored index has recovered"
   task :check_recovery, [:index_name, :clusters] do |_, args|
     raise "An 'index_name' must be supplied" unless args.index_name

--- a/spec/unit/time_based_index_cleanup_spec.rb
+++ b/spec/unit/time_based_index_cleanup_spec.rb
@@ -1,0 +1,185 @@
+require "spec_helper"
+
+RSpec.describe SearchIndices::IndexGroup do
+  ELASTICSEARCH_OK = {
+    status: 200,
+    body: { "ok" => true, "acknowledged" => true }.to_json,
+    headers: { "Content-Type" => "application/json" },
+  }.freeze
+
+  BASE_URI = "http://example.com:9200".freeze
+
+  before do
+    @schema = SearchConfig.default_instance.search_server.schema
+    @server = SearchIndices::SearchServer.new(
+      BASE_URI,
+      @schema,
+      %w(government custom),
+      "govuk",
+      %w[government],
+      SearchConfig.default_instance,
+    )
+  end
+
+  # Will error if we try to call the delete due to lack of stub
+  it "timed clean with only one live index does not delete the index" do
+    live_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
+
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          live_name => { "aliases" => { "test" => {} } },
+        }.to_json,
+      )
+
+    expected_response_body = {
+      "hits" => {
+        "hits" => {
+          live_name => { "updated_at" => "1" },
+        },
+      },
+    }
+
+    stub_request(:get, %r{#{BASE_URI}/test(.*?)/_search})
+      .with(
+        body: expected_timed_delete_body,
+      ).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: expected_response_body.to_json,
+      )
+
+    @server.index_group("test").timed_clean(0)
+  end
+
+  # Will error if we try to call the delete due to lack of stub
+  it "timed clean with only one dead index does not delete the index" do
+    dead_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
+
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          dead_name => { "aliases" => {} },
+        }.to_json,
+      )
+
+    expected_response_body = {
+      "hits" => {
+        "hits" => {
+          dead_name => { "updated_at" => "1" },
+        },
+      },
+    }
+
+    stub_request(:get, %r{#{BASE_URI}/test(.*?)/_search})
+      .with(
+        body: expected_timed_delete_body,
+      ).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: expected_response_body.to_json,
+      )
+
+    @server.index_group("test").timed_clean(0)
+  end
+
+  # Will error if we try to call the delete due to lack of stub
+  it "timed clean with one live and one dead index does not delete either index" do
+    live_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
+    dead_name = "test-2012-02-01t12:00:00z-87654321-4321-4321-4321-210987654321"
+
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          live_name => { "aliases" => { "test" => {} } },
+          dead_name => { "aliases" => {} },
+        }.to_json,
+      )
+
+    expected_response_body = {
+      "hits" => {
+        "hits" => {
+          live_name => { "updated_at" => "1" },
+          dead_name => { "updated_at" => "2" },
+        },
+      },
+    }
+
+    stub_request(:get, %r{#{BASE_URI}/test(.*?)/_search})
+      .with(
+        body: expected_timed_delete_body,
+      ).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: expected_response_body.to_json,
+      )
+
+    @server.index_group("test").timed_clean(0)
+  end
+
+  # Will error if we try to delete anything that is not the oldest index due to lack of stub
+  it "timed clean with one live and two dead indexes only deletes oldest dead index" do
+    live_name = "test-2012-03-01t12:00:00z-12345678-1234-1234-1234-123456789012"
+    dead_name = "test-2012-02-01t12:00:00z-87654321-4321-4321-4321-210987654321"
+    dead_name_two = "test-2012-01-01t12:00:00z-87654321-4321-4321-4321-210987654321"
+
+    stub_request(:get, %r{#{BASE_URI}/test\*\?.*})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          live_name => { "aliases" => { "test" => {} } },
+          dead_name => { "aliases" => {} },
+          dead_name_two => { "aliases" => {} },
+        }.to_json,
+      )
+
+    expected_response_body = {
+      "hits" => {
+        "hits" => {
+          live_name => { "updated_at" => "1" },
+          dead_name => { "updated_at" => "2" },
+          dead_name_two => { "updated_at" => "3" },
+        },
+      },
+    }
+
+    stub_request(:get, %r{#{BASE_URI}/test(.*?)/_search})
+      .with(
+        body: expected_timed_delete_body,
+      ).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: expected_response_body.to_json,
+      )
+
+    delete_stub = stub_request(:delete, "#{BASE_URI}/#{dead_name_two}")
+      .to_return(ELASTICSEARCH_OK)
+
+    @server.index_group("test").timed_clean(0)
+
+    assert_requested delete_stub
+  end
+
+  def expected_timed_delete_body
+    {
+      "_source" => "updated_at",
+      "size" => 1,
+      "sort" => [
+        {
+          "updated_at" =>
+          {
+            "order" => "desc",
+            "unmapped_type" => "date",
+          },
+        },
+      ],
+    }
+  end
+end


### PR DESCRIPTION
We were having issues wherein the reliance on manual deletion of old
indexes from the Elasticsearch system was clogging up the storage space
of our cluster. This commit adds a Rake task designed to mitigate this
problem.

The task is designed to be run on schedule in Jenkins. It relies on the
ability to source the "updated_at" value from the last edited record on
a given index. With this in mind, we have two steps.

**1. We gather all indices under the given index name, ignoring the last
two that were created, into a map. The last two that were created are
almost universally guaranteed to be the currently used index, and
the index it replaced.**

**2. Based on whether we have access to an "updated_at" field on the given
index, we either:**

- Check if the age of the index as given by the most recent "updated_at"
 value is older than or equal to N days as given by the environment variable
 MAX_INDEX_AGE and if it is, delete it. Current indexes: government,
 govuk, detailed

- If we do not have access to the field, we simply remove the extra
wasted indexes as we have no way to accurately gauge the age of them.
Current indexes: metasearch, page-traffic

This should effectively manage overall storage use on our cluster, once
the relevant Jenkins job is created.

https://trello.com/c/spNtyEbO/1403-automate-deletion-of-old-unused-indexes