### PR TITLE
Remove tensorflow/serving stuff for production

### DIFF
--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -24,9 +24,10 @@ module LearnToRank
     attr_reader :feature_sets, :model_variant
 
     def fetch_new_scores(examples)
-      if sagemaker_endpoint(variant: model_variant)
+      case which_reranker
+      when :sagemaker
         fetch_new_scores_from_sagemaker(examples)
-      else
+      when :container
         fetch_new_scores_from_serving(examples)
       end
     end

--- a/lib/learn_to_rank/ranker_api_helper.rb
+++ b/lib/learn_to_rank/ranker_api_helper.rb
@@ -1,5 +1,13 @@
 module LearnToRank
   module RankerApiHelper
+    def which_reranker
+      if sagemaker_endpoint
+        :sagemaker
+      elsif tensorflow_container_url
+        :container
+      end
+    end
+
     def sagemaker_endpoint(variant: nil)
       envvar = ENV["TENSORFLOW_SAGEMAKER_ENDPOINT"]
       return envvar unless envvar.present? && variant.present?
@@ -8,15 +16,17 @@ module LearnToRank
     end
 
     def tensorflow_container_url
-      "http://#{tensorflow_serving_ip}:8501/v1/models/ltr"
+      if tensorflow_container_host
+        "http://#{tensorflow_container_host}:8501/v1/models/ltr"
+      end
     end
 
-    def tensorflow_serving_ip
-      return ENV["TENSORFLOW_SERVING_IP"] if ENV["TENSORFLOW_SERVING_IP"].present?
-
-      return "reranker" if %w(development).include? ENV["RACK_ENV"]
-
-      "0.0.0.0"
+    def tensorflow_container_host
+      if ENV["TENSORFLOW_SERVING_IP"]
+        ENV["TENSORFLOW_SERVING_IP"]
+      elsif ENV["RACK_ENV"] == "development"
+        "reranker"
+      end
     end
   end
 end

--- a/lib/learn_to_rank/ranker_status.rb
+++ b/lib/learn_to_rank/ranker_status.rb
@@ -55,7 +55,14 @@ module LearnToRank
     class EndpointStatusUnhealthy < EndpointError; end
 
     def reranker_healthy
-      sagemaker_endpoint ? sagemaker_healthy? : container_healthy?
+      case which_reranker
+      when :sagemaker
+        sagemaker_healthy?
+      when :container
+        container_healthy?
+      else
+        true
+      end
     end
 
     def sagemaker_healthy?

--- a/spec/integration/app/healthcheck_spec.rb
+++ b/spec/integration/app/healthcheck_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "HealthcheckTest" do
     # We only check for cannot connect because govuk_app_config has tests for this
     context "when reranker healthcheck fails" do
       before do
+        make_use_tensorflow_serving
         stub_ranker_container_doesnt_exist
       end
 

--- a/spec/support/ranker_test_helpers.rb
+++ b/spec/support/ranker_test_helpers.rb
@@ -28,6 +28,15 @@ module RankerTestHelpers
     ]
   end
 
+  def make_ranker_unconfigured
+    ENV["TENSORFLOW_SAGEMAKER_ENDPOINT"] = nil
+    ENV["TENSORFLOW_SERVING_IP"] = nil
+  end
+
+  def make_use_tensorflow_serving
+    ENV["TENSORFLOW_SERVING_IP"] = "0.0.0.0"
+  end
+
   def stub_request_to_ranker(examples, rank_response)
     stub_request(:post, "http://0.0.0.0:8501/v1/models/ltr:regress")
       .with(

--- a/spec/unit/learn_to_rank/ranker_spec.rb
+++ b/spec/unit/learn_to_rank/ranker_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe LearnToRank::Ranker do
   end
 
   describe "#ranks" do
+    before do
+      make_use_tensorflow_serving
+    end
+
     context "when there are no search results" do
       let(:query) { nil }
       let(:search_results) { [] }

--- a/spec/unit/learn_to_rank/ranker_status_spec.rb
+++ b/spec/unit/learn_to_rank/ranker_status_spec.rb
@@ -10,7 +10,21 @@ RSpec.describe LearnToRank::RankerStatus do
     stub_request(:any, "http://0.0.0.0:8501/v1/models/ltr")
   end
 
-  context "when TENSORFLOW_SAGEMAKER_ENDPOINT envvar is unset" do
+  context "when not reranking at all" do
+    before do
+      make_ranker_unconfigured
+    end
+
+    it "is healthy" do
+      expect(status).to be_healthy
+    end
+  end
+
+  context "when reranking with the container" do
+    before do
+      make_use_tensorflow_serving
+    end
+
     context "when the reranker is not available" do
       it "is unhealthy" do
         stub_ranker_container_doesnt_exist

--- a/spec/unit/learn_to_rank/reranker_spec.rb
+++ b/spec/unit/learn_to_rank/reranker_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe LearnToRank::Reranker do
   end
 
   describe "#reranked" do
+    before do
+      make_use_tensorflow_serving
+    end
+
     context "when there are no search results" do
       let(:query) { nil }
       let(:search_results) { [] }


### PR DESCRIPTION
Previously, when sagemaker isn't configured, search-api would assume it can talk to a tensorflow serving container, on 0.0.0.0 if all else fails.  This PR makes it instead default to not reranking at all
if neither sagemaker nor serving have their env vars set.

Also removes a now-redundant rake task.

---

[Trello card](https://trello.com/c/iT2Mh8u6/1413-remove-dockerised-model-and-code)