### PR TITLE
Create a new database index for search-suggestions

### DIFF
--- a/config/schema/elasticsearch_types/suggestion.json
+++ b/config/schema/elasticsearch_types/suggestion.json
@@ -1,0 +1,6 @@
+{
+  "use_base_type": false,
+  "fields":[
+    "autocomplete"
+  ]
+}

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -157,7 +157,7 @@
       "type": "completion",
       "preserve_separators": false,
       "preserve_position_increments": false,
-      "max_input_length": 20,
+      "max_input_length": 50,
       "analyzer": "searchable_text",
       "search_analyzer": "searchable_text"
     }

--- a/config/schema/indexes/search-metrics.json
+++ b/config/schema/indexes/search-metrics.json
@@ -1,0 +1,5 @@
+{
+  "elasticsearch_types":[
+    "suggestion"
+  ]
+}

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -2,10 +2,11 @@ production: &default
   base_uri: <%= ENV["ELASTICSEARCH_URI"] || 'http://localhost:9200' %>
   content_index_names: ["detailed", "government"]
   govuk_index_name: "govuk"
-  auxiliary_index_names: ["page-traffic", "metasearch"]
+  auxiliary_index_names: ["page-traffic", "metasearch", "search-metrics"]
   registry_index: "government"
   metasearch_index_name: "metasearch"
   page_traffic_index_name: "page-traffic"
+  search_suggestion_index_name: "search-metrics"
   popularity_rank_offset: 10
   # When doing spell checking, which indices to use?
   spelling_index_names:
@@ -23,10 +24,11 @@ test:
   base_uri: <%= ENV.fetch('ELASTICSEARCH_URI', 'http://localhost:9200') %>
   content_index_names: ["government_test"]
   govuk_index_name: "govuk_test"
-  auxiliary_index_names: ["page-traffic_test", "metasearch_test"]
+  auxiliary_index_names: ["page-traffic_test", "metasearch_test", "search-metrics_test"]
   registry_index: "government_test"
   metasearch_index_name: "metasearch_test"
   page_traffic_index_name: "page-traffic_test"
+  search_suggestion_index_name: "search-metrics_test"
   popularity_rank_offset: 10
   spelling_index_names:
     - government_test

--- a/lib/govuk_index/popularity_worker.rb
+++ b/lib/govuk_index/popularity_worker.rb
@@ -19,17 +19,12 @@ module GovukIndex
 
     def process_record(record, popularities)
       base_path = record["identifier"]["_id"]
-      title = record["document"]["title"]
       OpenStruct.new(
         identifier: record["identifier"].merge("version_type" => "external_gte", "_type" => "generic-document"),
         document: record["document"].merge!(
           "popularity" => popularities.dig(base_path, :popularity_score),
           "popularity_b" => popularities.dig(base_path, :popularity_rank),
           "view_count" => popularities.dig(base_path, :view_count),
-          "autocomplete" => { # Relies on updated popularity. Title is for new records.
-            "input" => title,
-            "weight" => popularities.dig(base_path, :popularity_rank),
-          },
         ),
       )
     end

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -5,13 +5,14 @@ module Search
     class NumberOutOfRange < Error; end
     class QueryTooLong < Error; end
 
-    attr_reader :index, :registries, :spelling_index, :suggestion_blocklist
+    attr_reader :index, :registries, :spelling_index, :suggestions_index, :suggestion_blocklist
 
-    def initialize(registries:, content_index:, metasearch_index:, spelling_index:)
+    def initialize(registries:, content_index:, metasearch_index:, spelling_index:, suggestions_index:)
       @index = content_index
       @registries = registries
       @metasearch_index = metasearch_index
       @spelling_index = spelling_index
+      @suggestions_index = suggestions_index
       @suggestion_blocklist = SuggestionBlocklist.new(registries)
     end
 
@@ -177,7 +178,7 @@ module Search
           suggest: QueryComponents::Autocomplete.new(search_params).payload,
         }
 
-        response = index.raw_search(query)
+        response = suggestions_index.raw_search(query)
 
         response["suggest"]
       end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -10,6 +10,7 @@ class SearchConfig
       content_index_names
       spelling_index_names
       govuk_index_name
+      search_suggestion_index_name
       page_traffic_index_name
     ].each do |config_method|
       define_method config_method do
@@ -132,6 +133,10 @@ class SearchConfig
     @metasearch_index ||= search_server.index(SearchConfig.metasearch_index_name)
   end
 
+  def suggestions_index
+    @suggestions_index ||= search_server.index(SearchConfig.search_suggestion_index_name)
+  end
+
   def spelling_index
     @spelling_index ||= search_server.index_for_search(SearchConfig.spelling_index_names)
   end
@@ -173,6 +178,7 @@ private
       registries: registries,
       metasearch_index: metasearch_index,
       spelling_index: spelling_index,
+      suggestions_index: suggestions_index,
     )
   end
 


### PR DESCRIPTION
Creates an index designed to store metrics for search suggestions,
with initial design relying on search terms, unique search occurrences
and search exit percentage.

`./spec/integration/search/batch_search_spec.rb` tests fail currently for an unknown reason, likely not registering something correctly as it's not seeing the new index.

PR made purely for feedback and suggestions.