### PR TITLE
NDCG should use score

### DIFF
--- a/lib/evaluate/ndcg.rb
+++ b/lib/evaluate/ndcg.rb
@@ -62,7 +62,7 @@ module Evaluate
       judgements.each_with_object({}) do |judgement, hsh|
         query = judgement[:query]
         hsh[query] = hsh.fetch(query, {})
-        hsh[query][judgement[field.to_sym]] = judgement[:rank].to_i
+        hsh[query][judgement[field.to_sym]] = judgement[:score].to_i
       end
     end
 

--- a/spec/integration/evaluate/ndcg_spec.rb
+++ b/spec/integration/evaluate/ndcg_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe Evaluate::Ndcg do
   end
   let(:relevancy_judgements) do
     [
-      { query: "dog", link: "/dog", rank: 3 },
-      { query: "dog", link: "/dog-walking-dogs", rank: 2 },
-      { query: "dog", link: "/dogs", rank: 3 },
-      { query: "dog", link: "/dog-dog-owner", rank: 1 },
-      { query: "dog", link: "/cat-owners", rank: 0 },
-      { query: "dog", link: "/cat", rank: 0 },
+      { query: "dog", link: "/dog", score: 3 },
+      { query: "dog", link: "/dog-walking-dogs", score: 2 },
+      { query: "dog", link: "/dogs", score: 3 },
+      { query: "dog", link: "/dog-dog-owner", score: 1 },
+      { query: "dog", link: "/cat-owners", score: 0 },
+      { query: "dog", link: "/cat", score: 0 },
 
-      { query: "cat", link: "/cat-cat-cat!", rank: 2 },
-      { query: "cat", link: "/cat-owners", rank: 2 },
-      { query: "cat", link: "/cats", rank: 3 },
-      { query: "cat", link: "/cat-dog-owners", rank: 1 },
-      { query: "cat", link: "/dog", rank: 0 },
+      { query: "cat", link: "/cat-cat-cat!", score: 2 },
+      { query: "cat", link: "/cat-owners", score: 2 },
+      { query: "cat", link: "/cats", score: 3 },
+      { query: "cat", link: "/cat-dog-owners", score: 1 },
+      { query: "cat", link: "/dog", score: 0 },
     ]
   end
 


### PR DESCRIPTION
I broke the rake task relevancy:ndcg in 50c4a71d270cf84d8dbe47121a2451f326855bd2.

This should fix that and bring NDCG into sync with the JudgementsToSvm which expects score.

https://trello.com/c/A3U2R0sf/1447-fix-ndcg-metric-in-search-relevancy-dashboard