### PR TITLE
Cache index names for 30s

### DIFF
--- a/lib/index_group.rb
+++ b/lib/index_group.rb
@@ -77,6 +77,8 @@ module SearchIndices
       payload = { "actions" => actions }
 
       @client.indices.update_aliases(body: payload)
+
+      Cache.clear
     end
 
     def current

--- a/lib/legacy_client/index_for_search.rb
+++ b/lib/legacy_client/index_for_search.rb
@@ -15,10 +15,9 @@ module LegacyClient
 
     def real_index_names
       index_names.map do |index_name|
-        # this may throw an exception if the index name isn't found,
-        # but we want to propagate the error in that case as it
-        # shouldn't happen.
-        @client.indices.get_alias(index: index_name).keys.first
+        Cache.getex(index_name, expiration: 30) do
+          @client.indices.get_alias(index: index_name).keys.first
+        end
       end
     end
 


### PR DESCRIPTION
This should reduce load on elasticsearch, as we don't need to fetch
the real name of every alias on every query.  On the other hand,
getting the index name of an alias is a cheap operation, so it may not
save much.

---

[Trello card](https://trello.com/c/5zpvZfi9/1455-see-if-there-are-any-low-hanging-fruit-to-reduce-load-on-elasticsearch)