### PR TITLE
Combine results at the same rank for relevancy scoring

### DIFF
--- a/lib/learn_to_rank/data_pipeline/relevancy_judgements.rb
+++ b/lib/learn_to_rank/data_pipeline/relevancy_judgements.rb
@@ -36,8 +36,7 @@ module LearnToRank::DataPipeline
     # a set of judgements between 0 and 3.
     def judgements(query, documents)
       clicks_above_position = 0
-      ranked_documents = documents.sort_by { |doc| doc[:rank] }
-      ranked_documents.lazy.map do |document|
+      preprocess(documents).lazy.map do |document|
         views = Float(document[:views]) - clicks_above_position
         clicks = Float(document[:clicks])
         views = clicks unless views >= clicks
@@ -55,6 +54,19 @@ module LearnToRank::DataPipeline
           link: document[:link],
         }
       end
+    end
+
+    # order the docs by rank and combine part-results with the page-results
+    def preprocess(documents)
+      combined_docs = documents.group_by { |doc| doc[:rank] }.map do |rank, doc_group|
+        {
+          link: doc_group.map { |doc| doc[:link] }.min_by(&:length),
+          rank: rank,
+          views: doc_group.map { |doc| doc[:views] }.max,
+          clicks: doc_group.map { |doc| doc[:clicks] }.sum,
+        }
+      end
+      combined_docs.sort_by { |doc| doc[:rank] }
     end
 
     # Turn an estimated click-through-rate@1 into an estimated score

--- a/spec/unit/learn_to_rank/relevancy_judgements_spec.rb
+++ b/spec/unit/learn_to_rank/relevancy_judgements_spec.rb
@@ -40,5 +40,38 @@ RSpec.describe LearnToRank::DataPipeline::RelevancyJudgements do
         { link: "2", query: "vehicle tax", score: 1 },
       ])
     end
+
+    context "with parts" do
+      let(:queries) {
+        {
+          "micropig" => [
+            { link: "1", rank: 1, views: 100, clicks: 5 },
+            { link: "1/a", rank: 1, views: 100, clicks: 5 },
+            { link: "1/b", rank: 1, views: 100, clicks: 5 },
+            { link: "1/c", rank: 1, views: 100, clicks: 5 },
+            { link: "2", rank: 2, views: 100, clicks: 15 },
+          ],
+          "vehicle tax" => [
+            { link: "1", rank: 1, views: 100, clicks: 5 },
+            { link: "1/a", rank: 2, views: 100, clicks: 5 },
+            { link: "1/b", rank: 3, views: 100, clicks: 5 },
+            { link: "1/c", rank: 4, views: 100, clicks: 5 },
+            { link: "2", rank: 5, views: 100, clicks: 15 },
+          ],
+        }
+      }
+
+      it "combines the results with the same rank" do
+        expect(judgements).to eq([
+          { link: "1", query: "micropig", score: 3 },
+          { link: "2", query: "micropig", score: 2 },
+          { link: "1", query: "vehicle tax", score: 1 },
+          { link: "1/a", query: "vehicle tax", score: 1 },
+          { link: "1/b", query: "vehicle tax", score: 1 },
+          { link: "1/c", query: "vehicle tax", score: 1 },
+          { link: "2", query: "vehicle tax", score: 2 },
+        ])
+      end
+    end
   end
 end


### PR DESCRIPTION
A set of results will only appear at the same rank for the same query
if 1 of them is a page and the rest of them are parts on that
page (eg, a guide).

Parts aren't separate entities in elasticsearch, so their relevancy
needs attributing to the parent page.

First, work out the URL of the parent page (this is easy because part
URLs are always of the form "{parent url}/{slug}"), and sum all the
clicks.  For the views, take the max.

---

[Trello card](https://trello.com/c/9EfcgjHZ/1415-get-parts-in-results-shipped-disabled-behind-a-feature-flag)