### PR TITLE
Don't try to turn attachments with missing URLs into parts

### DIFF
--- a/lib/indexer/parts_lookup.rb
+++ b/lib/indexer/parts_lookup.rb
@@ -12,7 +12,7 @@ module Indexer
     def prepare_parts(doc_hash, return_raw_body)
       return doc_hash unless doc_hash["parts"].nil?
 
-      attachments = doc_hash.fetch("attachments", []).select { |a| a.key? "content" }
+      attachments = doc_hash.fetch("attachments", []).select { |a| !a["url"].nil? && !a["content"].nil? }
       return doc_hash if attachments.empty?
 
       doc_hash.merge("parts" => attachments.map { |a| present_part(a, return_raw_body) })


### PR DESCRIPTION
Until the whitehall part of this PR is deployed, whitehall will
continue to send attachments that have content but no URL.  So we need
to be resilient to that.

One option would be to just deploy the changes in quick succession and
reindex any documents published in the gap, but being resilient to
unexpected input is good practice anyway.

---

[Trello card](https://trello.com/c/fouzQRyD/1465-index-html-attachments-as-parts-of-their-parent-documents)