### PR TITLE
Skip HTML attachments with a missing content ID

### DIFF
--- a/spec/integration/indexer/parts_lookup_spec.rb
+++ b/spec/integration/indexer/parts_lookup_spec.rb
@@ -139,7 +139,6 @@ RSpec.describe "PartslookupDuringIndexingTest" do
         "link" => "/foo",
         "parts" => nil,
         "attachments" => [
-          { "title" => "attachment 1" },
           { "title" => "attachment 2" },
         ],
       },


### PR DESCRIPTION
This seems to happen for a small amount of Welsh attachments (which
make it through the locale filter because they don't have a locale
set).