### PR TITLE
Change covid synonyms

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -269,7 +269,7 @@
 - search: british citizenship => british citizenship, british citizen
 - search: health check, health checks => nhs health check
 - search: job share, job sharing => job share, job sharing, flexible working
-- search: covid 19, covid-19, covid19, covid, coronavirus => covid-19, coronavirus, covid19
+- search: covid 19, covid-19, covid19, covid, coronavirus => covid, coronavirus, covid19
 
 # Removing terms to return relevant content
 - search: flood areas => flood


### PR DESCRIPTION
Giving "covid-19" as an option means that all covid-related searches
match documents which contain the string "19" in them, which isn't
great.  Since "covid" matches documents that contain "covid",
"covid-19", and "covid 19", I think we should use that instead.