### PR TITLE
Only turn attachments into parts if the URL matches the parent

### DIFF
--- a/lib/govuk_index/payload_preparer.rb
+++ b/lib/govuk_index/payload_preparer.rb
@@ -24,7 +24,10 @@ module GovukIndex
     def prepare_parts(payload)
       return payload unless payload["details"].fetch("parts", []).empty?
 
-      details = Indexer::PartsLookup.prepare_parts(payload["details"], return_raw_body: true)
+      details = Indexer::PartsLookup.prepare_parts(
+        payload["details"].merge("link" => payload["base_path"]),
+        return_raw_body: true,
+      )
       return payload if details.fetch("parts", []).empty?
 
       presented_parts = details["parts"].map do |part|

--- a/spec/integration/indexer/parts_lookup_spec.rb
+++ b/spec/integration/indexer/parts_lookup_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe "PartslookupDuringIndexingTest" do
       "/foo/attachment-1" => "attachment-content-id-1",
       "/foo/attachment-2" => "attachment-content-id-2",
       "/foo/attachment-3" => "attachment-content-id-3",
+      "/bar/attachment-4" => "attachment-content-id-4",
+      "/baz/attachment-5" => "attachment-content-id-5",
     )
 
     stub_publishing_api_has_expanded_links(content_id: "document-content-id", expanded_links: {})
@@ -17,6 +19,8 @@ RSpec.describe "PartslookupDuringIndexingTest" do
     stub_publishing_api_has_item({ content_id: "attachment-content-id-1", publication_state: "published", details: { body: "<strong>body 1</strong>" } })
     stub_publishing_api_has_item({ content_id: "attachment-content-id-2", publication_state: "published", details: { body: "<em>body 2</em>" } })
     stub_publishing_api_has_item({ content_id: "attachment-content-id-3", publication_state: "published", details: { body: "<p>body 3</p>" } })
+    stub_publishing_api_has_item({ content_id: "attachment-content-id-4", publication_state: "published", details: { body: "body 4" } })
+    stub_publishing_api_has_item({ content_id: "attachment-content-id-5", publication_state: "published", details: { body: "body 5" } })
   end
 
   it "indexes document with parts unchanged" do
@@ -119,6 +123,32 @@ RSpec.describe "PartslookupDuringIndexingTest" do
         "attachments" => [
           { "title" => "attachment 1", "content" => "body 1" },
           { "title" => "attachment 2", "content" => "body 2" },
+        ],
+      },
+      index: "government_test",
+    )
+  end
+
+  it "ignores attachments where the URL doesn't match the parent/slug format" do
+    post "/government_test/documents", {
+      "link" => "/foo",
+      "attachments" => [
+        { "url" => "/foo/attachment-1", "title" => "attachment 1", "attachment_type" => "html" },
+        { "url" => "/bar/attachment-4", "title" => "attachment 4", "attachment_type" => "html" },
+        { "url" => "/baz/attachment-5", "title" => "attachment 5", "attachment_type" => "html" },
+      ],
+    }.to_json
+
+    expect_document_is_in_rummager(
+      {
+        "link" => "/foo",
+        "parts" => [
+          { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
+        ],
+        "attachments" => [
+          { "title" => "attachment 1", "content" => "body 1" },
+          { "title" => "attachment 4", "content" => "body 4" },
+          { "title" => "attachment 5", "content" => "body 5" },
         ],
       },
       index: "government_test",


### PR DESCRIPTION
We don't index part URLs, only slugs, and assume that all parts have a
URL of the form `{parent_url}/{slug}`.

This is usually correct, but not for HTML attachments on statistics
pages.  There the parent page is under /government/statistics/..., but
the attachment is under /government/publications/....  We could fix
that by storing URLs, but that'd require reindexing a lot of stuff, so
for now let's just go for the simpler solution of rejecting those
attachments.

We'll need to reindex after deploying this.  I think this is the task we want: https://github.com/alphagov/whitehall/blob/master/lib/tasks/search.rake#L80