### PR TITLE
Add HTML attachment content to indexable_content

### DIFF
--- a/lib/indexer/attachments_lookup.rb
+++ b/lib/indexer/attachments_lookup.rb
@@ -11,7 +11,13 @@ module Indexer
     def prepare_attachments(doc_hash)
       return doc_hash if doc_hash["attachments"].nil?
 
-      doc_hash.merge("attachments" => doc_hash["attachments"].map { |a| present_attachment(a) }.compact)
+      attachments = doc_hash["attachments"].map { |a| present_attachment(a) }.compact
+      indexable_content_parts = [doc_hash["indexable_content"]]
+      attachments.each { |a| indexable_content_parts << a["content"] }
+      doc_hash.merge(
+        "attachments" => attachments,
+        "indexable_content" => indexable_content_parts.compact.join(" "),
+      )
     end
 
   private

--- a/spec/integration/indexer/parts_lookup_spec.rb
+++ b/spec/integration/indexer/parts_lookup_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "PartslookupDuringIndexingTest" do
           { "title" => "attachment 2", "content" => "body 2" },
           { "title" => "attachment 3", "content" => "body 3" },
         ],
+        "indexable_content" => "body 1 body 2 body 3",
       },
       index: "government_test",
     )
@@ -73,6 +74,7 @@ RSpec.describe "PartslookupDuringIndexingTest" do
           { "title" => "attachment 2", "content" => "body 2" },
           { "title" => "attachment 3", "content" => "body 3" },
         ],
+        "indexable_content" => "body 1 body 2 body 3",
       },
       index: "government_test",
     )
@@ -101,6 +103,7 @@ RSpec.describe "PartslookupDuringIndexingTest" do
           { "title" => "attachment 2", "content" => "body 2" },
           { "title" => "attachment 3" },
         ],
+        "indexable_content" => "body 1 body 2",
       },
       index: "government_test",
     )
@@ -128,6 +131,7 @@ RSpec.describe "PartslookupDuringIndexingTest" do
           { "title" => "attachment 1", "content" => "body 1" },
           { "title" => "attachment 2", "content" => "body 2" },
         ],
+        "indexable_content" => "body 1 body 2",
       },
       index: "government_test",
     )
@@ -155,6 +159,7 @@ RSpec.describe "PartslookupDuringIndexingTest" do
           { "title" => "attachment 4", "content" => "body 4" },
           { "title" => "attachment 5", "content" => "body 5" },
         ],
+        "indexable_content" => "body 1 body 4 body 5",
       },
       index: "government_test",
     )


### PR DESCRIPTION
Quoted search queries don't consider the all_searchable_text field.
This normally makes sense, because that contains all sorts of
metadata, but we do want quoted queries to look inside attachment
contents.

We don't need to do this for the govuk index because that uses the
full bodies of parts (rather than summarised parts), and its
indexable_content presenter copies over part bodies.

---

[Trello card](https://trello.com/c/5H63U71h/1988-investigate-potential-html-attachments-search-incident)