### PR TITLE
Index history documents

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -50,6 +50,7 @@ migrated:
 # Other
 - calendar
 - finder # Specialist Publisher and Whitehall
+- history
 - hmrc_manual
 - hmrc_manual_section
 - manual


### PR DESCRIPTION
This format only uses standard fields which search-api handles
already, so there is nothing more to be done, and this doesn't need a
reindex.

---

[Trello card](https://trello.com/c/6IveqNKB/1982-3-render-10-downing-street-in-government-frontend)