### PR TITLE
Boost content tagged to the coronavirus taxon

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -34,8 +34,6 @@ base:
     devolved: 0.3
   is_historic:
     true: 0.5
-  topical_events:
-    coronavirus-covid-19-uk-government-response: 5
   part_of_taxonomy_tree:
     5b7b9532-a775-4bd2-a3aa-6ce380184b6c: 5 # /coronavirus-taxon
 # Overrides to apply to the sitemap priorities in external search

--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -36,6 +36,8 @@ base:
     true: 0.5
   topical_events:
     coronavirus-covid-19-uk-government-response: 5
+  part_of_taxonomy_tree:
+    5b7b9532-a775-4bd2-a3aa-6ce380184b6c: 5 # /coronavirus-taxon
 # Overrides to apply to the sitemap priorities in external search
 external_search:
   format:


### PR DESCRIPTION
We're gradually moving away from the topical event, but we need to retain
the search strategy.

We'll remove the topical event boost when we actually retire it.

Related to https://github.com/alphagov/search-api/pull/2035