### PR TITLE
Add Pregnancy and Breasfeeding Therapeutic Areas

### DIFF
--- a/config/schema/elasticsearch_types/drug_safety_update.json
+++ b/config/schema/elasticsearch_types/drug_safety_update.json
@@ -19,6 +19,10 @@
         "value": "anaesthesia-intensive-care"
       },
       {
+        "label": "Breastfeeding",
+        "value": "breastfeeding"
+      },
+      {
         "label": "Cancer",
         "value": "cancer"
       },
@@ -85,6 +89,10 @@
       {
         "label": "Pain management and palliation",
         "value": "pain-management-palliation"
+      },
+      {
+        "label": "Pregnancy",
+        "value": "pregnancy"
       },
       {
         "label": "Psychiatry",


### PR DESCRIPTION
This refers to https://www.gov.uk/drug-safety-update which is edited by
MHRA (Medicines and Healthcare products Regulatory Agency) in
https://specialist-publisher.publishing.service.gov.uk/drug-safety-updates

This is needed because they are launching a major new, lengthy project
on medicines and pregnant women, so will have a lot more content in this
area going forward, and wish to allow users to group existing content on
these topics closely together.

The request to add these two Therapeutic Areas came through Zendesk:
https://govuk.zendesk.com/agent/tickets/4099517

Related PRs:
- https://github.com/alphagov/specialist-publisher/pull/1657
- https://github.com/alphagov/govuk-content-schemas/pull/993