### PR TITLE
Add document parts to sitemap

### DIFF
--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -43,9 +43,9 @@ module Sitemap
         xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
           documents.each do |document|
             xml.url do
-              xml.loc document.url
-              xml.lastmod document.last_updated if document.last_updated
-              xml.priority document.priority
+              xml.loc document[:url]
+              xml.lastmod document[:last_updated] if document[:last_updated]
+              xml.priority document[:priority]
             end
           end
         end
@@ -81,7 +81,7 @@ module Sitemap
         next if documents.empty? && chunk.empty?
 
         documents.map do |document|
-          presented_base_document = SitemapPresenter.new(document["_source"], property_boost_calculator)
+          presented_base_document = SitemapPresenter.new(document["_source"], property_boost_calculator).to_h
 
           parts = document["_source"]["parts"] || []
 
@@ -91,7 +91,7 @@ module Sitemap
               "link" => document["_source"]["link"] + "/" + part["slug"],
             )
 
-            SitemapPresenter.new(part_document, property_boost_calculator)
+            SitemapPresenter.new(part_document, property_boost_calculator).to_h
           end
 
           (presented_parts << presented_base_document).each do |presented|
@@ -155,10 +155,11 @@ module Sitemap
       SearchConfig.content_index_names + [SearchConfig.govuk_index_name]
     end
 
-    StaticDocumentPresenter = Struct.new(:url, :last_updated, :priority)
-
     def homepage
-      StaticDocumentPresenter.new(Plek.current.website_root + "/", nil, 0.5)
+      {
+        url: Plek.current.website_root + "/",
+        priority: 0.5,
+      }
     end
 
     def property_boost_calculator

--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -83,7 +83,23 @@ module Sitemap
         documents.map do |document|
           chunk << SitemapPresenter.new(document["_source"], property_boost_calculator)
 
-          if chunk.size == SITEMAP_LIMIT
+          parts = document["_source"]["parts"] || []
+
+          parts.each do |part|
+            part_document = document["_source"].merge(
+              "is_part" => true,
+              "link" => document["_source"]["link"] + "/" + part["slug"],
+            )
+
+            chunk << SitemapPresenter.new(part_document, property_boost_calculator)
+
+            if chunk.size >= SITEMAP_LIMIT
+              yielder << chunk
+              chunk = []
+            end
+          end
+
+          if chunk.size >= SITEMAP_LIMIT
             yielder << chunk
             chunk = []
           end

--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -81,27 +81,26 @@ module Sitemap
         next if documents.empty? && chunk.empty?
 
         documents.map do |document|
-          chunk << SitemapPresenter.new(document["_source"], property_boost_calculator)
+          presented_base_document = SitemapPresenter.new(document["_source"], property_boost_calculator)
 
           parts = document["_source"]["parts"] || []
 
-          parts.each do |part|
+          presented_parts = parts.map do |part|
             part_document = document["_source"].merge(
               "is_part" => true,
               "link" => document["_source"]["link"] + "/" + part["slug"],
             )
 
-            chunk << SitemapPresenter.new(part_document, property_boost_calculator)
+            SitemapPresenter.new(part_document, property_boost_calculator)
+          end
+
+          (presented_parts << presented_base_document).each do |presented|
+            chunk << presented
 
             if chunk.size >= SITEMAP_LIMIT
               yielder << chunk
               chunk = []
             end
-          end
-
-          if chunk.size >= SITEMAP_LIMIT
-            yielder << chunk
-            chunk = []
           end
         end
 

--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -147,7 +147,7 @@ module Sitemap
     end
 
     def property_boost_calculator
-      PropertyBoostCalculator.new
+      @property_boost_calculator ||= PropertyBoostCalculator.new
     end
 
     def base_url

--- a/lib/sitemap/presenter.rb
+++ b/lib/sitemap/presenter.rb
@@ -33,7 +33,7 @@ class SitemapPresenter
   end
 
   def priority
-    withdrawn_status_boost * property_boost_calculator.boost(document)
+    property_boost_calculator.boost(document)
   end
 
 private
@@ -42,9 +42,5 @@ private
 
   def base_url
     Plek.current.website_root
-  end
-
-  def withdrawn_status_boost
-    document["is_withdrawn"] ? 0.25 : 1
   end
 end

--- a/lib/sitemap/presenter.rb
+++ b/lib/sitemap/presenter.rb
@@ -7,6 +7,18 @@ class SitemapPresenter
     @logger = Logging.logger[self]
   end
 
+  def to_h
+    {
+      url: url,
+      last_updated: last_updated,
+      priority: priority,
+    }
+  end
+
+private
+
+  attr_reader :document, :property_boost_calculator
+
   def url
     if document["link"].start_with?("http")
       document["link"]
@@ -35,10 +47,6 @@ class SitemapPresenter
   def priority
     property_boost_calculator.boost(document)
   end
-
-private
-
-  attr_reader :document, :property_boost_calculator
 
   def base_url
     Plek.current.website_root

--- a/lib/sitemap/property_boost_calculator.rb
+++ b/lib/sitemap/property_boost_calculator.rb
@@ -16,7 +16,9 @@ class PropertyBoostCalculator
 
     overall_boost = raw_boosts.inject(:*)
 
-    withdrawn_status_boost(document) * map_boost_to_priority(overall_boost).round(2)
+    withdrawn_status_boost(document) *
+      part_boost(document) *
+      map_boost_to_priority(overall_boost).round(2)
   end
 
 private
@@ -36,5 +38,9 @@ private
 
   def withdrawn_status_boost(document)
     document["is_withdrawn"] ? 0.25 : 1
+  end
+
+  def part_boost(document)
+    document["is_part"] ? 0.75 : 1
   end
 end

--- a/lib/sitemap/property_boost_calculator.rb
+++ b/lib/sitemap/property_boost_calculator.rb
@@ -16,7 +16,7 @@ class PropertyBoostCalculator
 
     overall_boost = raw_boosts.inject(:*)
 
-    map_boost_to_priority(overall_boost).round(2)
+    withdrawn_status_boost(document) * map_boost_to_priority(overall_boost).round(2)
   end
 
 private
@@ -32,5 +32,9 @@ private
   # https://www.wolframalpha.com/input/?i=plot+1+-+2%5E(-x),+x+%3D+0+to+5
   def map_boost_to_priority(boost)
     (1 - 2**-boost).to_f
+  end
+
+  def withdrawn_status_boost(document)
+    document["is_withdrawn"] ? 0.25 : 1
   end
 end

--- a/spec/integration/sitemap/generator_spec.rb
+++ b/spec/integration/sitemap/generator_spec.rb
@@ -171,6 +171,8 @@ RSpec.describe Sitemap::Generator do
   end
 
   it "includes parts of documents" do
+    stub_const("Sitemap::Generator::SITEMAP_LIMIT", 4)
+
     add_sample_documents(
       [
         {
@@ -205,11 +207,6 @@ RSpec.describe Sitemap::Generator do
           <priority>0.5</priority>
         </url>
         <url>
-          <loc>http://www.dev.gov.uk/an-example-answer</loc>
-          <lastmod>2017-07-01T12:41:34+00:00</lastmod>
-          <priority>0.5</priority>
-        </url>
-        <url>
           <loc>http://www.dev.gov.uk/an-example-answer/hummus-weevils</loc>
           <lastmod>2017-07-01T12:41:34+00:00</lastmod>
           <priority>0.375</priority>
@@ -218,6 +215,11 @@ RSpec.describe Sitemap::Generator do
           <loc>http://www.dev.gov.uk/an-example-answer/tasty-badger</loc>
           <lastmod>2017-07-01T12:41:34+00:00</lastmod>
           <priority>0.375</priority>
+        </url>
+        <url>
+          <loc>http://www.dev.gov.uk/an-example-answer</loc>
+          <lastmod>2017-07-01T12:41:34+00:00</lastmod>
+          <priority>0.5</priority>
         </url>
       </urlset>
     HEREDOC

--- a/spec/integration/sitemap/generator_spec.rb
+++ b/spec/integration/sitemap/generator_spec.rb
@@ -170,6 +170,63 @@ RSpec.describe Sitemap::Generator do
     generator.run
   end
 
+  it "includes parts of documents" do
+    add_sample_documents(
+      [
+        {
+          "title" => "Cheese in my face",
+          "description" => "Hummus weevils",
+          "format" => "answer",
+          "link" => "/an-example-answer",
+          "indexable_content" => "I like my badger: he is tasty and delicious",
+          "public_timestamp" => "2017-07-01T12:41:34+00:00",
+          "parts" => [
+            {
+              "slug": "hummus-weevils",
+              "title": "Hummus weevils",
+              "body": "I like my badger",
+            },
+            {
+              "slug": "tasty-badger",
+              "title": "Tasty badger",
+              "body": "he is tasty and delicious",
+            },
+          ],
+        },
+      ],
+      index_name: "govuk_test",
+    )
+
+    expected_xml = <<~HEREDOC
+      <?xml version="1.0" encoding="UTF-8"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url>
+          <loc>http://www.dev.gov.uk/</loc>
+          <priority>0.5</priority>
+        </url>
+        <url>
+          <loc>http://www.dev.gov.uk/an-example-answer</loc>
+          <lastmod>2017-07-01T12:41:34+00:00</lastmod>
+          <priority>0.5</priority>
+        </url>
+        <url>
+          <loc>http://www.dev.gov.uk/an-example-answer/hummus-weevils</loc>
+          <lastmod>2017-07-01T12:41:34+00:00</lastmod>
+          <priority>0.375</priority>
+        </url>
+        <url>
+          <loc>http://www.dev.gov.uk/an-example-answer/tasty-badger</loc>
+          <lastmod>2017-07-01T12:41:34+00:00</lastmod>
+          <priority>0.375</priority>
+        </url>
+      </urlset>
+    HEREDOC
+
+    expect(sitemap_uploader).to receive(:upload).with(file_content: expected_xml, file_name: "sitemap_1.xml")
+
+    generator.run
+  end
+
   it "generates and uploads the sitemap index" do
     add_sample_documents(
       [

--- a/spec/unit/sitemap/generator_spec.rb
+++ b/spec/unit/sitemap/generator_spec.rb
@@ -71,8 +71,7 @@ RSpec.describe Sitemap::Generator do
   end
 
   it "page priority is document priority" do
-    document = build_document("/some-path")
-    allow(document).to receive(:priority).and_return(0.48)
+    document = build_document("/some-path").merge(priority: 0.48)
 
     sitemap_xml = sitemap_generator.generate_sitemap_xml([document])
 
@@ -92,7 +91,7 @@ RSpec.describe Sitemap::Generator do
     SitemapPresenter.new(
       attributes,
       PropertyBoostCalculator.new,
-    )
+    ).to_h
   end
 
   def expect_page_has_no_lastmod(page)

--- a/spec/unit/sitemap/property_boost_calculator_spec.rb
+++ b/spec/unit/sitemap/property_boost_calculator_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe PropertyBoostCalculator do
     expect(calculator.boost(build_document(document_type: "some_doc_type"))).to eq(0.5)
   end
 
+  it "withdrawn status divides the calculated priority by four" do
+    document = build_document(
+      is_withdrawn: true,
+    )
+
+    # default boost is 0.5 as above
+    expect(subject.boost(document)).to eq(0.125)
+  end
+
   it "boosts are rounded" do
     stub_boost_config({
       "format" => {
@@ -147,10 +156,11 @@ RSpec.describe PropertyBoostCalculator do
     allow(YAML).to receive(:load_file).and_return(config)
   end
 
-  def build_document(format: nil, document_type: nil)
+  def build_document(format: nil, document_type: nil, is_withdrawn: nil)
     attributes = {}
     attributes["format"] = format if format
     attributes["content_store_document_type"] = document_type if document_type
+    attributes["is_withdrawn"] = is_withdrawn unless is_withdrawn.nil?
 
     attributes
   end

--- a/spec/unit/sitemap/property_boost_calculator_spec.rb
+++ b/spec/unit/sitemap/property_boost_calculator_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe PropertyBoostCalculator do
     calculator = subject
 
     expect(calculator.boost(build_document(format: "format1"))).to eq(0)
-    expect(0.5).to eq(calculator.boost(build_document(format: "format2")))
-    expect(0.75).to eq(calculator.boost(build_document(format: "format3")))
-    expect(0.88).to eq(calculator.boost(build_document(format: "format4")))
+    expect(calculator.boost(build_document(format: "format2"))).to eq(0.5)
+    expect(calculator.boost(build_document(format: "format3"))).to eq(0.75)
+    expect(calculator.boost(build_document(format: "format4"))).to eq(0.88)
     expect(calculator.boost(build_document(format: "format5"))).to eq(1)
   end
 
@@ -30,7 +30,7 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    expect(0.5).to eq(calculator.boost(build_document(format: "some_format")))
+    expect(calculator.boost(build_document(format: "some_format"))).to eq(0.5)
   end
 
   it "boosts limit is 1" do
@@ -58,7 +58,7 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    expect(0.5).to eq(calculator.boost(build_document(format: "other_format")))
+    expect(calculator.boost(build_document(format: "other_format"))).to eq(0.5)
   end
 
   it "unconfigured property has default boost" do
@@ -70,7 +70,7 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    expect(0.5).to eq(calculator.boost(build_document(document_type: "some_doc_type")))
+    expect(calculator.boost(build_document(document_type: "some_doc_type"))).to eq(0.5)
   end
 
   it "boosts are rounded" do
@@ -83,8 +83,8 @@ RSpec.describe PropertyBoostCalculator do
 
     calculator = subject
 
-    expect(0.08).to eq(calculator.boost(build_document(format: "format1")))
-    expect(0.27).to eq(calculator.boost(build_document(format: "format2")))
+    expect(calculator.boost(build_document(format: "format1"))).to eq(0.08)
+    expect(calculator.boost(build_document(format: "format2"))).to eq(0.27)
   end
 
   it "boosts for different fields are combined" do
@@ -111,7 +111,7 @@ RSpec.describe PropertyBoostCalculator do
     #   1 - 2^(-format boost * document type boost * navigation supertype boost)
     # = 1 - 2^(-0.5 * 0.2 * 1)
     # = 0.07
-    expect(0.07).to eq(calculator.boost(document))
+    expect(calculator.boost(document)).to eq(0.07)
   end
 
   it "external search overrides are applied" do

--- a/spec/unit/sitemap/sitemap_presenter_spec.rb
+++ b/spec/unit/sitemap/sitemap_presenter_spec.rb
@@ -10,20 +10,20 @@ RSpec.describe SitemapPresenter do
 
   it "url is document link if link is http url" do
     document = build_document(url: "http://some.url")
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.url).to eq("http://some.url")
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:url]).to eq("http://some.url")
   end
 
   it "url is document link if link is https url" do
     document = build_document(url: "https://some.url")
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.url).to eq("https://some.url")
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:url]).to eq("https://some.url")
   end
 
   it "url appends host name if link is a path" do
     document = build_document(url: "/some/path")
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.url).to eq("https://website_root/some/path")
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:url]).to eq("https://website_root/some/path")
   end
 
   it "last updated is timestamp if timestamp is date time" do
@@ -31,16 +31,16 @@ RSpec.describe SitemapPresenter do
       url: "/some/path",
       timestamp: "2014-01-28T14:41:50+00:00",
     )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.last_updated).to eq("2014-01-28T14:41:50+00:00")
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:last_updated]).to eq("2014-01-28T14:41:50+00:00")
   end
 
   it "updated_at overrides public_timestamp if both are present" do
     document = build_document(url: "/some/path")
     document["public_timestamp"] = "2014-01-28T14:41:50+00:00"
     document["updated_at"] = "2019-01-28T14:41:50+00:00"
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.last_updated).to eq("2019-01-28T14:41:50+00:00")
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:last_updated]).to eq("2019-01-28T14:41:50+00:00")
   end
 
   it "last updated is timestamp if timestamp is date" do
@@ -48,8 +48,8 @@ RSpec.describe SitemapPresenter do
       url: "/some/path",
       timestamp: "2017-07-12",
     )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.last_updated).to eq("2017-07-12")
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:last_updated]).to eq("2017-07-12")
   end
 
   it "last updated is limited to recent date" do
@@ -57,8 +57,8 @@ RSpec.describe SitemapPresenter do
       url: "/some/path",
       timestamp: "1995-06-01",
     )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.last_updated).to eq("2012-10-17T00:00:00+00:00")
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:last_updated]).to eq("2012-10-17T00:00:00+00:00")
   end
 
   it "last updated is omitted if timestamp is missing" do
@@ -66,8 +66,8 @@ RSpec.describe SitemapPresenter do
       url: "/some/path",
       timestamp: nil,
     )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.last_updated).to be_nil
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:last_updated]).to be_nil
   end
 
   it "last updated is omitted if timestamp is invalid" do
@@ -75,8 +75,8 @@ RSpec.describe SitemapPresenter do
       url: "/some/path",
       timestamp: "not-a-date",
     )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.last_updated).to be_nil
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:last_updated]).to be_nil
   end
 
   it "last updated is omitted if timestamp is in invalid format" do
@@ -84,8 +84,8 @@ RSpec.describe SitemapPresenter do
       url: "/some/path",
       timestamp: "01-01-2017",
     )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.last_updated).to be_nil
+    presented = described_class.new(document, @boost_calculator).to_h
+    expect(presented[:last_updated]).to be_nil
   end
 
   it "page with boosted format has adjusted priority" do
@@ -96,8 +96,8 @@ RSpec.describe SitemapPresenter do
     property_boost_calculator = PropertyBoostCalculator.new
     allow(property_boost_calculator).to receive(:boost).with(document).and_return(0.72)
 
-    presenter = described_class.new(document, property_boost_calculator)
-    expect(0.72).to eq(presenter.priority)
+    presented = described_class.new(document, property_boost_calculator).to_h
+    expect(0.72).to eq(presented[:priority])
   end
 
   def build_document(url:, timestamp: nil, format: nil, is_withdrawn: nil)

--- a/spec/unit/sitemap/sitemap_presenter_spec.rb
+++ b/spec/unit/sitemap/sitemap_presenter_spec.rb
@@ -88,32 +88,6 @@ RSpec.describe SitemapPresenter do
     expect(presenter.last_updated).to be_nil
   end
 
-  it "default page priority is maximum value" do
-    document = build_document(
-      url: "/some/path",
-      is_withdrawn: false,
-    )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.priority).to eq(1)
-  end
-
-  it "withdrawn page has lower priority" do
-    document = build_document(
-      url: "/some/path",
-      is_withdrawn: true,
-    )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(0.25).to eq(presenter.priority)
-  end
-
-  it "page with no withdrawn flag has maximum priority" do
-    document = build_document(
-      url: "/some/path",
-    )
-    presenter = described_class.new(document, @boost_calculator)
-    expect(presenter.priority).to eq(1)
-  end
-
   it "page with boosted format has adjusted priority" do
     document = build_document(
       url: "/some/path",


### PR DESCRIPTION
We want to be able to include "parts" in our sitemaps because they are important (and when viewed externally, separate) pages from the pages we present as results in site search.

We also want to be able to give them a priority, so that external searches will hopefully understand how our site is structured better than before.  At present, HTML publications (treated as a `part` within the search index) are not in the sitemap, so when crawled organically (by a crawler following links), they will probably get the default weight applied to them.

This may sometimes be higher than the document they've been linked from (for example, if the "parent" publication is withdrawn, then it is down-weighted).  We want to address this, and ensure that any weighting boost/suppression of a parent doc is also applied to its parts.

There are a couple of performance tweaks in here as well, which (on integration at least), reduce the time to generate the sitemaps from ~9 minutes to less than 4 minutes.

https://trello.com/c/RCkUOYwp/343-check-html-publication-weighting-in-sitemaps