### PR TITLE
Increase training data for LTR model

### DIFF
--- a/lib/learn_to_rank/data_pipeline/bigquery.rb
+++ b/lib/learn_to_rank/data_pipeline/bigquery.rb
@@ -4,7 +4,7 @@ module LearnToRank::DataPipeline
   module Bigquery
     def self.fetch(credentials)
       now = Time.now
-      before = now - 2 * 7 * 24 * 60 * 60
+      before = now - 90 * 24 * 60 * 60
       sql = "SELECT * FROM (
   SELECT
   searchTerm,

--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -11,7 +11,7 @@ notify-failure: &notify-failure
   put: govuk-searchandnav-slack
   params:
     channel: '#govuk-searchandnav'
-    username: 'Daily LTR'
+    username: 'Weekly LTR'
     icon_emoji: ':concourse:'
     silent: true
     text: |
@@ -38,10 +38,10 @@ resource_types:
     tag: latest
 
 resources:
-- name: at-10pm
+- name: sundays-at-10pm
   type: cron-resource
   source:
-    expression: "00 22 * * *"
+    expression: "00 22 * * SUN"
     location: "Europe/London"
 - name: search-api-git
   type: git
@@ -91,7 +91,7 @@ resources:
 jobs:
 - name: integration-fetch
   plan:
-    - get: at-10pm
+    - get: sundays-at-10pm
       trigger: true
     - get: search-api-git
     - task: Fetch
@@ -161,7 +161,7 @@ jobs:
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
 - name: staging-fetch
   plan:
-    - get: at-10pm
+    - get: sundays-at-10pm
       trigger: true
     - get: search-api-git
     - task: Fetch
@@ -231,7 +231,7 @@ jobs:
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
 - name: production-fetch
   plan:
-    - get: at-10pm
+    - get: sundays-at-10pm
       trigger: true
     - get: search-api-git
     - task: Fetch


### PR DESCRIPTION
This will train the model on substantially more data (90 days), which
we believe will make it more accurate at reranking results.
We ran an AB test (Elephant) which increased click through
rate on the top 1,3,5 results, so this ships that model.

This intends to train the model on Sundays at 10pm.

Since we are now training the model with substantially
more data, this takes a lot longer so it's better to
do this at the weekend.