### PR TITLE
Amend Transition page metadescription

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -10,7 +10,7 @@ module GovukIndex
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "title" => "Transition period",
-      "description" => "The UK has left the EU.",
+      "description" => "The UK’s transition period after Brexit comes to an end this year. Find out how to get ready for new rules from January 2021.",
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     presenter = common_fields_presenter(payload)
 
     expect(presenter.title).to eq("Transition period")
-    expect(presenter.description).to eq("The UK has left the EU.")
+    expect(presenter.description).to eq("The UK’s transition period after Brexit comes to an end this year. Find out how to get ready for new rules from January 2021.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
I'm going to check why this isn't read from the content item. Will make a new story to sort this (and the search index entry) out if they can be.

https://trello.com/c/zYugZiMJ/288-update-meta-description-for-transition-landing-page-for-site-search-purposes