### PR TITLE
Update transition description

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -10,7 +10,7 @@ module GovukIndex
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "title" => "Transition period",
-      "description" => "The UK’s transition period after Brexit comes to an end this year. Find out how to get ready for new rules from January 2021.",
+      "description" => "The UK’s transition period after Brexit comes to an end this year - find out how to get ready for new rules from January 2021.",
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     presenter = common_fields_presenter(payload)
 
     expect(presenter.title).to eq("Transition period")
-    expect(presenter.description).to eq("The UK’s transition period after Brexit comes to an end this year. Find out how to get ready for new rules from January 2021.")
+    expect(presenter.description).to eq("The UK’s transition period after Brexit comes to an end this year - find out how to get ready for new rules from January 2021.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
We want to make this one sentence to appease the finder-frontend presentation gods.  At present, it's truncated after the first `. `.  (Note the space after the dot which doesn't seem to show up in the rendered code block)