### PR TITLE
Remove redundant signup supergroup reject filter

### DIFF
--- a/config/finders/all_content_email_signup.yml
+++ b/config/finders/all_content_email_signup.yml
@@ -11,8 +11,6 @@ description: You'll get an email when content is published.
 details:
   email_filter_by:
   subscription_list_title_prefix: 'All content'
-  reject:
-    content_purpose_supergroup: other
   email_filter_facets:
   - facet_id: content_purpose_supergroup
     facet_name: content_purpose_supergroup


### PR DESCRIPTION
https://trello.com/c/Qr1IO25y/363-audit-all-email-signup-pages-to-understand-why-they-exist

Support for this "blocklist" approach was added [1] and then
removed [2] in favour of a more granular "safelist" approach [3].

[1]: https://github.com/alphagov/govuk-content-schemas/pull/861
[2]: https://github.com/alphagov/email-alert-api/pull/809
[3]: https://github.com/alphagov/finder-frontend/pull/1030/commits/516d0f5995632c00244943b27a3fc1e5150584c5#diff-2325bcf50557df85fe62018c52682ecfL86

- [x] Republish this content item to remove the redundant config