### PR TITLE
Extend default rake task with rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ rescue LoadError
 end
 # rubocop:enable Lint/SuppressedException
 
-task default: %i[spec]
+task default: %i[spec lint]
 
 def logger
   Logging.logger.root

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Lint Ruby"
+task :lint do
+  sh "bundle exec rubocop"
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks)