### PR TITLE
Train LTR model on 300 days

### DIFF
--- a/lib/learn_to_rank/data_pipeline/bigquery.rb
+++ b/lib/learn_to_rank/data_pipeline/bigquery.rb
@@ -4,7 +4,7 @@ module LearnToRank::DataPipeline
   module Bigquery
     def self.fetch(credentials)
       now = Time.now
-      before = now - 90 * 24 * 60 * 60
+      before = now - 300 * 24 * 60 * 60
       sql = "SELECT * FROM (
   SELECT
   searchTerm,


### PR DESCRIPTION
This uses 300 days of data to train the model on. The assumption is that more data is better, and that data between August (when we began collecting this data) and December was of greater volume and potentially higher quality. We'll monitor our online and offline metrics to see if this change has an impact.