### PR TITLE
Make re-indexing more robust

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -245,7 +245,7 @@ module SearchIndices
       begin
         yield
       rescue HTTPClient::TimeoutError, Faraday::TimeoutError
-        raise if (retries += 1) > 3
+        raise if (retries += 1) > 10
 
         logger.info "Retrying after #{retries} timeout errors"
         sleep 2**retries


### PR DESCRIPTION
This increases the number of attempts and time spent retrying to hopefully recover from these failures.

The schema migration process at the moment fails due to timeouts quite frequently, so increasing timeouts and retrying is a reasonable quick fix.

https://deploy.blue.staging.govuk.digital/job/search_api_reindex_with_new_schema/25