### PR TITLE
Use 6 months of data to train model

### DIFF
--- a/lib/learn_to_rank/data_pipeline/bigquery.rb
+++ b/lib/learn_to_rank/data_pipeline/bigquery.rb
@@ -4,7 +4,7 @@ module LearnToRank::DataPipeline
   module Bigquery
     def self.fetch(credentials)
       now = Time.now
-      before = now - 300 * 24 * 60 * 60
+      before = now - 6 * 30 * 24 * 60 * 60 # Around 6 months
       sql = "SELECT * FROM (
   SELECT
   searchTerm,


### PR DESCRIPTION
Pre-December 2019 we used a different field for search links in
Google Analytics (not product.v2ProductName AS link).

The current code for fetching searches from BigQuery does not
account for this, so fetching query document pairs from pre-2020
using the current query will return "(not set)" as the document
link. The query should be amended so that 2019 data can be used.

This is a quick fix to ensure that we only use the newer field
for generating training data for the model.