### PR TITLE
Revert "Combine results at the same rank for relevancy scoring"

### DIFF
--- a/spec/unit/learn_to_rank/relevancy_judgements_spec.rb
+++ b/spec/unit/learn_to_rank/relevancy_judgements_spec.rb
@@ -40,38 +40,5 @@ RSpec.describe LearnToRank::DataPipeline::RelevancyJudgements do
         { link: "2", query: "vehicle tax", score: 1 },
       ])
     end
-
-    context "with parts" do
-      let(:queries) do
-        {
-          "micropig" => [
-            { link: "1", rank: 1, views: 100, clicks: 5 },
-            { link: "1/a", rank: 1, views: 100, clicks: 5 },
-            { link: "1/b", rank: 1, views: 100, clicks: 5 },
-            { link: "1/c", rank: 1, views: 100, clicks: 5 },
-            { link: "2", rank: 2, views: 100, clicks: 15 },
-          ],
-          "vehicle tax" => [
-            { link: "1", rank: 1, views: 100, clicks: 5 },
-            { link: "1/a", rank: 2, views: 100, clicks: 5 },
-            { link: "1/b", rank: 3, views: 100, clicks: 5 },
-            { link: "1/c", rank: 4, views: 100, clicks: 5 },
-            { link: "2", rank: 5, views: 100, clicks: 15 },
-          ],
-        }
-      end
-
-      it "combines the results with the same rank" do
-        expect(judgements).to eq([
-          { link: "1", query: "micropig", score: 3 },
-          { link: "2", query: "micropig", score: 2 },
-          { link: "1", query: "vehicle tax", score: 1 },
-          { link: "1/a", query: "vehicle tax", score: 1 },
-          { link: "1/b", query: "vehicle tax", score: 1 },
-          { link: "1/c", query: "vehicle tax", score: 1 },
-          { link: "2", query: "vehicle tax", score: 2 },
-        ])
-      end
-    end
   end
 end


### PR DESCRIPTION
I'm investigating why Search CTR and NDCG declined in March 2020. This coincided with changes in user behaviour in response to COVID-19, so changes may be required to support the new behaviour. However, as a first pass I'm investigating whether any releases correlated with the decrease in our offline and online metrics, starting with PRs #2041 and #2044. 

We found that reverting commit c3f14e86205f67895a7810faa052559f2b08ac81 (PR #2041) improves NDCG@1,10,20 by 1-2% and has a neutral effect on NDCG@3,5.

As we don't have a search team at the moment we're not running proper AB tests so will monitor the impact of this on CTR on 100% of traffic.

Graphs ([view in Grafana](https://grafana.integration.publishing.service.gov.uk/dashboard/file/search_relevancy.json?panelId=7&fullscreen&orgId=1&from=now-30d&to=now&edit))

<img width="1146" alt="Screenshot 2020-08-04 at 15 10 05" src="https://user-images.githubusercontent.com/8124374/89303903-b762ca80-d664-11ea-800b-de12b5d50062.png">
<img width="1145" alt="Screenshot 2020-08-04 at 15 10 23" src="https://user-images.githubusercontent.com/8124374/89303909-b7fb6100-d664-11ea-9973-979fd5def7c3.png">
