### PR TITLE
Use live links when preparing tags

### DIFF
--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -41,7 +41,10 @@ module Indexer
 
     def find_links(content_id)
       GdsApi.with_retries(maximum_number_of_attempts: 5) do
-        Services.publishing_api.get_expanded_links(content_id)["expanded_links"]
+        Services.publishing_api.get_expanded_links(
+          content_id,
+          with_drafts: false,
+        )["expanded_links"]
       end
     rescue GdsApi::TimedOutException => e
       @logger.error("Timeout fetching expanded links for #{content_id}")

--- a/spec/integration/govuk_index/payload_preparer_spec.rb
+++ b/spec/integration/govuk_index/payload_preparer_spec.rb
@@ -25,7 +25,13 @@ RSpec.describe "Payload preparation" do
           "/foo/attachment-3" => "attachment-content-id-3",
         )
 
-        stub_publishing_api_has_expanded_links(content_id: "document-content-id", expanded_links: {})
+        stub_publishing_api_has_expanded_links(
+          {
+            content_id: "document-content-id",
+            expanded_links: {},
+          },
+          with_drafts: false,
+        )
 
         stub_publishing_api_has_item({ content_id: "attachment-content-id-1", publication_state: "published", details: { body: "<strong>body 1</strong>" } })
         stub_publishing_api_has_item({ content_id: "attachment-content-id-2", publication_state: "published", details: { body: "<em>body 2</em>" } })
@@ -75,7 +81,13 @@ RSpec.describe "Payload preparation" do
           "/bar/attachment-3" => "attachment-content-id-3",
         )
 
-        stub_publishing_api_has_expanded_links(content_id: "document-content-id", expanded_links: {})
+        stub_publishing_api_has_expanded_links(
+          {
+            content_id: "document-content-id",
+            expanded_links: {},
+          },
+          with_drafts: false,
+        )
 
         stub_publishing_api_has_item({ content_id: "attachment-content-id-1", publication_state: "published", details: { body: "<strong>body 1</strong>" } })
         stub_publishing_api_has_item({ content_id: "attachment-content-id-2", publication_state: "published", details: { body: "<em>body 2</em>" } })

--- a/spec/integration/indexer/change_notification_processor_spec.rb
+++ b/spec/integration/indexer/change_notification_processor_spec.rb
@@ -7,8 +7,11 @@ RSpec.describe "ChangeNotificationProcessorTest" do
     )
 
     stub_publishing_api_has_expanded_links(
-      content_id: "DOCUMENT-CONTENT-ID",
-      expanded_links: {},
+      {
+        content_id: "DOCUMENT-CONTENT-ID",
+        expanded_links: {},
+      },
+      with_drafts: false,
     )
 
     post "/government_test/documents",
@@ -28,13 +31,18 @@ RSpec.describe "ChangeNotificationProcessorTest" do
     )
 
     stub_publishing_api_has_expanded_links(
-      content_id: "DOCUMENT-CONTENT-ID",
-      expanded_links: {
-        mainstream_browse_pages: [{
-          title: "Bla",
-          base_path: "/browse/my-browse",
-        }],
+      {
+        content_id: "DOCUMENT-CONTENT-ID",
+        expanded_links: {
+          mainstream_browse_pages: [
+            {
+              title: "Bla",
+              base_path: "/browse/my-browse",
+            },
+          ],
+        },
       },
+      with_drafts: false,
     )
 
     Indexer::ChangeNotificationProcessor.trigger({

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -20,8 +20,11 @@ RSpec.describe "ElasticsearchIndexingTest" do
 
   it "adds a document to the search index" do
     stub_publishing_api_has_expanded_links(
-      content_id: "6b965b82-2e33-4587-a70c-60204cbb3e29",
-      expanded_links: {},
+      {
+        content_id: "6b965b82-2e33-4587-a70c-60204cbb3e29",
+        expanded_links: {},
+      },
+      with_drafts: false,
     )
 
     post "/government_test/documents",
@@ -62,8 +65,11 @@ RSpec.describe "ElasticsearchIndexingTest" do
 
   it "defaults the type to 'edition' if not specified" do
     stub_publishing_api_has_expanded_links(
-      content_id: "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
-      expanded_links: {},
+      {
+        content_id: "9d86d339-44c2-474f-8daf-cb64bed6c0d9",
+        expanded_links: {},
+      },
+      with_drafts: false,
     )
 
     post "/government_test/documents",
@@ -193,8 +199,11 @@ RSpec.describe "ElasticsearchIndexingTest" do
       allow_any_instance_of(SearchIndices::Index).to receive(:build_client).and_return(stubbed_client)
 
       stub_publishing_api_has_expanded_links(
-        content_id: "6b965b82-2e33-4587-a70c-60204cbb3e29",
-        expanded_links: {},
+        {
+          content_id: "6b965b82-2e33-4587-a70c-60204cbb3e29",
+          expanded_links: {},
+        },
+        with_drafts: false,
       )
 
       post "/government_test/documents",

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -38,55 +38,58 @@ RSpec.describe "TaglookupDuringIndexingTest" do
     )
 
     stub_publishing_api_has_expanded_links(
-      content_id: "DOCUMENT-CONTENT-ID",
-      expanded_links: {
-        topics: [
-          {
-            "content_id" => "TOPIC-CONTENT-ID-1",
-            "base_path" => "/topic/my-topic/a",
-          },
-          {
-            "content_id" => "TOPIC-CONTENT-ID-2",
-            "base_path" => "/topic/my-topic/b",
-          },
-        ],
-        mainstream_browse_pages: [
-          {
-            "content_id" => "BROWSE-1",
-            "base_path" => "/browse/my-browse/1",
-          },
-        ],
-        organisations: [
-          {
-            "content_id" => "ORG-1",
-            "base_path" => "/government/organisations/my-org/1",
-          },
-          {
-            "content_id" => "ORG-2",
-            "base_path" => "/courts-tribunals/my-court",
-          },
-        ],
-        primary_publishing_organisation: [
-          {
-            "content_id" => "ORG-1",
-            "base_path" => "/government/organisations/my-org/1",
-          },
-        ],
-        taxons: [
-          {
-            "content_id" => "TAXON-1",
-            "base_path" => "/alpha-taxonomy/my-taxon-1",
-          },
-        ],
-        facet_values: [
-          { "content_id" => "TAG-1" },
-          { "content_id" => "TAG-2" },
-        ],
-        facet_groups: [
-          { "content_id" => "TGRP-1" },
-          { "content_id" => "TGRP-2" },
-        ],
+      {
+        content_id: "DOCUMENT-CONTENT-ID",
+        expanded_links: {
+          topics: [
+            {
+              "content_id" => "TOPIC-CONTENT-ID-1",
+              "base_path" => "/topic/my-topic/a",
+            },
+            {
+              "content_id" => "TOPIC-CONTENT-ID-2",
+              "base_path" => "/topic/my-topic/b",
+            },
+          ],
+          mainstream_browse_pages: [
+            {
+              "content_id" => "BROWSE-1",
+              "base_path" => "/browse/my-browse/1",
+            },
+          ],
+          organisations: [
+            {
+              "content_id" => "ORG-1",
+              "base_path" => "/government/organisations/my-org/1",
+            },
+            {
+              "content_id" => "ORG-2",
+              "base_path" => "/courts-tribunals/my-court",
+            },
+          ],
+          primary_publishing_organisation: [
+            {
+              "content_id" => "ORG-1",
+              "base_path" => "/government/organisations/my-org/1",
+            },
+          ],
+          taxons: [
+            {
+              "content_id" => "TAXON-1",
+              "base_path" => "/alpha-taxonomy/my-taxon-1",
+            },
+          ],
+          facet_values: [
+            { "content_id" => "TAG-1" },
+            { "content_id" => "TAG-2" },
+          ],
+          facet_groups: [
+            { "content_id" => "TGRP-1" },
+            { "content_id" => "TGRP-2" },
+          ],
+        },
       },
+      with_drafts: false,
     )
 
     post "/government_test/documents",
@@ -115,15 +118,18 @@ RSpec.describe "TaglookupDuringIndexingTest" do
 
   it "skips content id lookup if it already has a content_id" do
     stub_publishing_api_has_expanded_links(
-      content_id: "CONTENT-ID-OF-DOCUMENT",
-      expanded_links: {
-        topics: [
-          {
-            "content_id" => "TOPIC-CONTENT-ID-1",
-            "base_path" => "/topic/my-topic/a",
-          },
-        ],
+      {
+        content_id: "CONTENT-ID-OF-DOCUMENT",
+        expanded_links: {
+          topics: [
+            {
+              "content_id" => "TOPIC-CONTENT-ID-1",
+              "base_path" => "/topic/my-topic/a",
+            },
+          ],
+        },
       },
+      with_drafts: false,
     )
 
     post "/government_test/documents",
@@ -205,10 +211,13 @@ RSpec.describe "TaglookupDuringIndexingTest" do
     )
 
     stub_publishing_api_has_expanded_links(
-      content_id: "DOCUMENT-CONTENT-ID",
-      expanded_links: {
-        taxons: [taxon1, taxon2],
+      {
+        content_id: "DOCUMENT-CONTENT-ID",
+        expanded_links: {
+          taxons: [taxon1, taxon2],
+        },
       },
+      with_drafts: false,
     )
 
     post "/government_test/documents",

--- a/spec/integration/indexer/parts_lookup_spec.rb
+++ b/spec/integration/indexer/parts_lookup_spec.rb
@@ -14,7 +14,13 @@ RSpec.describe "PartslookupDuringIndexingTest" do
       "/baz/attachment-5" => "attachment-content-id-5",
     )
 
-    stub_publishing_api_has_expanded_links(content_id: "document-content-id", expanded_links: {})
+    stub_publishing_api_has_expanded_links(
+      {
+        content_id: "document-content-id",
+        expanded_links: {},
+      },
+      with_drafts: false,
+    )
 
     stub_publishing_api_has_item({ content_id: "attachment-content-id-1", publication_state: "published", details: { body: "<strong>body 1</strong>" } })
     stub_publishing_api_has_item({ content_id: "attachment-content-id-2", publication_state: "published", details: { body: "<em>body 2</em>" } })

--- a/spec/integration/workers/indexer/amend_worker_spec.rb
+++ b/spec/integration/workers/indexer/amend_worker_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Indexer::AmendWorker do
 
   def stub_request_to_publishing_api(id)
     endpoint = Plek.current.find("publishing-api") + "/v2"
-    expanded_links_url = endpoint + "/expanded-links/" + id
+    expanded_links_url = endpoint + "/expanded-links/" + id + "?with_drafts=false"
 
     stub_request(:get, expanded_links_url).to_return(status: 200, body: {}.to_json)
   end

--- a/spec/unit/indexer/links_lookup_spec.rb
+++ b/spec/unit/indexer/links_lookup_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Indexer::LinksLookup do
 
   let(:content_id) { "DOCUMENT_CONTENT_ID" }
   let(:endpoint) { Plek.current.find("publishing-api") + "/v2" }
-  let(:expanded_links_url) { endpoint + "/expanded-links/" + content_id }
+  let(:expanded_links_url) { endpoint + "/expanded-links/" + content_id + "?with_drafts=false" }
 
   it "retry links on timeout" do
     stub_request(:get, expanded_links_url).to_timeout


### PR DESCRIPTION
Otherwise the Publishing API returns the expanded links for the draft
if one exists, which may be different from the live content. The
Search API is currently just deployed to index live content, so this
should fix issues where Whitehall content is indexed with the
organisations for the draft editions.