### PR TITLE
Add National Patient Safety Alert

### DIFF
--- a/config/schema/elasticsearch_types/medical_safety_alert.json
+++ b/config/schema/elasticsearch_types/medical_safety_alert.json
@@ -30,6 +30,10 @@
       {
         "label": "Drug alert: company-led",
         "value": "company-led-drugs"
+      },
+      {
+        "label": "National Patient Safety alert",
+        "value": "national-patient-safety"
       }
     ],
 


### PR DESCRIPTION
This is a new category of medical safety alert that MHRA would like to start using.

[Trello Card](https://trello.com/c/gnHVgWtw/2131-add-national-patient-safety-alerts) &middot; [Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/4210399)