### PR TITLE
Update 'show only' section in finders

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -47,7 +47,7 @@ details:
   - display_as_result_metadata: false
     filterable: true
     key: content_purpose_supergroup
-    name: Show only
+    name: Content type
     preposition: in
     short_name: In
     type: text


### PR DESCRIPTION
- this allows the user to limit the search to a particular kind of result, such as services or news and communications
- 'show only' caused an accessibility failure because the text did not convey the meaning of the control
- after much discussion with the content community, the alternative 'Content type' was chosen

Before:

<img width="742" alt="Screenshot 2020-09-08 at 09 37 48" src="https://user-images.githubusercontent.com/861310/92453593-5ecca300-f1b7-11ea-8171-61c9c1e1d920.png">

After:

<img width="711" alt="Screenshot 2020-09-08 at 10 13 04" src="https://user-images.githubusercontent.com/861310/92457263-ea483300-f1bb-11ea-9191-ff9e3ec881c7.png">

Trello card: https://trello.com/c/vv1XryWY/361-search-results-meaningless-heading-and-label
