### PR TITLE
Add device-safety-information

### DIFF
--- a/config/schema/elasticsearch_types/medical_safety_alert.json
+++ b/config/schema/elasticsearch_types/medical_safety_alert.json
@@ -34,6 +34,10 @@
       {
         "label": "National Patient Safety alert",
         "value": "national-patient-safety"
+      },
+      {
+        "label": "Device safety information",
+        "value": "device-safety-information"
       }
     ],
 

--- a/config/schema/elasticsearch_types/medical_safety_alert.json
+++ b/config/schema/elasticsearch_types/medical_safety_alert.json
@@ -32,7 +32,7 @@
         "value": "company-led-drugs"
       },
       {
-        "label": "National Patient Safety alert",
+        "label": "National patient safety alert",
         "value": "national-patient-safety"
       },
       {


### PR DESCRIPTION
This is an alert type for medical safety alerts which MHRA would like to start using with 1c6afad to replace "Medical Device Alert".

Depends on https://github.com/alphagov/govuk-content-schemas/pull/1007

[Trello Card](https://trello.com/c/gnHVgWtw/2131-add-national-patient-safety-alerts) &middot; [Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/4210399)