### PR TITLE
Always print code coverage after running tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ group :test do
   gem "rack-test", "~> 1.1.0"
   gem "rspec"
   gem "simplecov", "~> 0.18.5"
-  gem "simplecov-rcov", "~> 0.2.3"
   gem "timecop", "~> 0.9.1"
   gem "webmock", "~> 3.8.3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,8 +292,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.1)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -365,7 +363,6 @@ DEPENDENCIES
   rubyzip (= 2.3.0)
   sidekiq-limit_fetch
   simplecov (~> 0.18.5)
-  simplecov-rcov (~> 0.2.3)
   sinatra (~> 2.0.8)
   statsd-ruby (~> 1.4.0)
   timecop (~> 0.9.1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,8 @@
 ENV["RACK_ENV"] = "test"
 require "pry"
 
-if ENV["USE_SIMPLECOV"]
-  require "simplecov"
-  require "simplecov-rcov"
-  SimpleCov.start do
-    add_filter "/spec/"
-  end
-
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-end
+require "simplecov"
+SimpleCov.start { add_filter "/spec/" }
 
 $LOAD_PATH << File.expand_path("..", __dir__)
 $LOAD_PATH << File.expand_path("../lib", __dir__)


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Note that the RCov formatter is optional, and we can still see a
webpage with the detailed coverage.