### PR TITLE
Update synonyms for FCDO

### DIFF
--- a/config/schema/synonyms.yml
+++ b/config/schema/synonyms.yml
@@ -219,7 +219,7 @@
 - search: ecs, employer checking service => ecs, employer checking service
 - search: eis, enterprise investment scheme => eis, enterprise investment scheme
 - search: esa, employment and support allowance => esa, employment and support allowance
-- search: fco, foreign commonwealth office => fco, foreign commonwealth office
+- search: fco, foreign commonwealth office => fco, fcdo, foreign commonwealth development office
 - search: fcoc, future character of conflict => fcoc, future character of conflict
 - search: foi, freedom of information => foi, freedom of information
 - search: gae => gae, government authorised exchange


### PR DESCRIPTION
The Foreign & Commonwealth Office (FCO) has been replaced by the Foreign, Commonwealth & Development Office (FCDO).