### PR TITLE
Make LTR Sagemaker instance types larger

### DIFF
--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -94,7 +94,7 @@ jobs:
     - get: sundays-at-10pm
       trigger: true
     - get: search-api-git
-    - task: Fetch
+    - task: fetch
       config:
         <<: *task-config
         inputs:
@@ -120,7 +120,7 @@ jobs:
       passed: [integration-fetch]
       trigger: true
     - get: search-api-git
-    - task: Train
+    - task: train
       config:
         <<: *task-config
         inputs:
@@ -146,7 +146,7 @@ jobs:
       passed: [integration-train]
       trigger: true
     - get: search-api-git
-    - task: Deploy
+    - task: deploy
       config:
         <<: *task-config
         inputs:
@@ -164,7 +164,7 @@ jobs:
     - get: sundays-at-10pm
       trigger: true
     - get: search-api-git
-    - task: Fetch
+    - task: fetch
       config:
         <<: *task-config
         inputs:
@@ -190,7 +190,7 @@ jobs:
       passed: [staging-fetch]
       trigger: true
     - get: search-api-git
-    - task: Train
+    - task: train
       config:
         <<: *task-config
         inputs:
@@ -216,7 +216,7 @@ jobs:
       passed: [staging-train]
       trigger: true
     - get: search-api-git
-    - task: Deploy
+    - task: deploy
       config:
         <<: *task-config
         inputs:
@@ -235,7 +235,7 @@ jobs:
     - get: sundays-at-10pm
       trigger: true
     - get: search-api-git
-    - task: Fetch
+    - task: fetch
       config:
         <<: *task-config
         inputs:
@@ -263,7 +263,7 @@ jobs:
       passed: [production-fetch]
       trigger: true
     - get: search-api-git
-    - task: Train
+    - task: train
       config:
         <<: *task-config
         inputs:
@@ -291,7 +291,7 @@ jobs:
       passed: [production-train]
       trigger: true
     - get: search-api-git
-    - task: Deploy
+    - task: deploy
       config:
         <<: *task-config
         inputs:

--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -226,6 +226,7 @@ jobs:
           GOVUK_ENVIRONMENT: staging
           ROLE_ARN: ((staging-role-arn))
           INPUT_FILE_NAME: model
+          INSTANCE_TYPE: ml.c5.large
         run:
           path: bash
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
@@ -300,6 +301,7 @@ jobs:
           GOVUK_ENVIRONMENT: production
           ROLE_ARN: ((production-role-arn))
           INPUT_FILE_NAME: model
+          INSTANCE_TYPE: ml.c5.xlarge
         run:
           path: bash
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]


### PR DESCRIPTION
We could do with a little more headroom in production. Moving to a C5 type removes the CPU credit quota. LTR is more compute heavy than anything else. We'll monitor for a bit, and move back down to C5.large if it seems overkill.

The env var is used in the [deploy script](https://github.com/alphagov/search-api/blob/master/ltr/concourse/deploy.py#L19)

I've changed staging too so that I can test the deploy.