### PR TITLE
Adjust sagemaker instance type and count

### DIFF
--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -156,6 +156,7 @@ jobs:
           GOVUK_ENVIRONMENT: integration
           ROLE_ARN: ((integration-role-arn))
           INPUT_FILE_NAME: model
+          INSTANCE_COUNT: 2
         run:
           path: bash
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]
@@ -301,7 +302,7 @@ jobs:
           GOVUK_ENVIRONMENT: production
           ROLE_ARN: ((production-role-arn))
           INPUT_FILE_NAME: model
-          INSTANCE_TYPE: ml.c5.xlarge
+          INSTANCE_TYPE: ml.c5.large
         run:
           path: bash
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]


### PR DESCRIPTION
At present, the sagemaker instance type will always be whatever was set originally. This changes things so that the instance type will be updated if the configuration changes. The current live machine type is a t2.medium.

We're changing production's desired type back from c5.xlarge to c5.large so that we can go up in increments and save a bit of cash.

I want to test how this works in integration/staging before moving to production, as it would need to handle in-flight upgrades gracefully, or we'll have to do some more work.

Learning to rank is currently disabled in Puppet, so I'll need to turn that on first to do testing, but that does mean we can deploy this to production without worrying too much.