### PR TITLE
Bugfix: Improve quality of training/nDCG data retrieved from BigQuery

### DIFF
--- a/lib/learn_to_rank/data_pipeline/bigquery.rb
+++ b/lib/learn_to_rank/data_pipeline/bigquery.rb
@@ -14,9 +14,7 @@ module LearnToRank::DataPipeline
   COUNTIF(observationType = 'click') AS clicks
   FROM (
     SELECT
-    CONCAT(fullVisitorId,'|',CAST(visitId AS STRING)) AS sessionId,
     customDimensions.value AS searchTerm,
-    hits.hitNumber AS hitNumber, -- This is the hit number of the results page (for impressions) or the page itself (for clicks)
     product.v2ProductName AS link,
     product.productListPosition AS linkPosition,
     CASE
@@ -33,10 +31,11 @@ module LearnToRank::DataPipeline
     AND product.productListPosition <= 20
     AND customDimensions.index = 71 -- has search term
   ) AS action
-  GROUP BY searchTerm, link, linkPosition
-  ORDER BY views desc, searchTerm, linkPosition
-) AS res
-WHERE views > #{viewcount}"
+  GROUP BY searchTerm, link
+  )
+  WHERE views > #{viewcount}
+  ORDER BY views desc
+  LIMIT 500000"
 
       bigquery = Google::Cloud::Bigquery.new(credentials: credentials)
       bigquery.query sql, standard_sql: true


### PR DESCRIPTION
We train our Learning To Rank model (see docs/learning-to-rank.md) using
implicit query:document:rank data derived from click-through-rates, which
we obtain from opt-in Google Analytics tracking on search pages.

This fixes a bug in the query that retrieves the data from BigQuery.

The consequence of this change is:

* The volume of data for training increases by ~5x to 500,000 query:doc pairs
* The quality of data for training and our nDCG metric improves
  substantially
* The volume of data autogenerated for online nDCG has increased by ~7x

The bug has been present since we introduced Learning To Rank (LTR).

The bug:

query:document pairs were duplicated in the export since we grouped
on [query, document, rank]. Therefore it was possible to have a query:document
pair occur multiple times but with different ranks. This is because results
in a query's result set can move around a fair bit.

E.g.

query,document,rank
tax return,/company-tax-returns,6
tax return,/company-tax-returns,7

The fix:

Grouping by query and document, and averaging/summing the avg_rank, views,
and clicks.

This ensures that a query:document:rank appears just once in the dataset.

The date range has not increased, so why has the number of query:document pairs?
It's because we now filter by views after the summing the _total_ view count for a query:document
pair, therefore more queries that we previously considered unpopular (due to the above bug)
are included in the results.

Caveats:

* Problems remain in the dataset. For example, document 'parts' are
  included in the dataset like any other document, despite LTR not
  being able to re-rank parts since in Elasticsearch document parts
  are not individual documents, rather parts are attributes of documents.
* I believe we grouped by [query,document,rank] because we wanted to use the CTR for a given
  query:document pair at a given rank, which is more accurate than just averaging the rank for a query.
  We can explore this in future once the rest of the data pipeline supports this.