### PR TITLE
Adding Docker Hub Authentication Details

### DIFF
--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -6,6 +6,8 @@ task-config: &task-config
     source:
       repository: python
       tag: 3.7
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
 notify-failure: &notify-failure
   put: govuk-searchandnav-slack
@@ -26,16 +28,22 @@ resource_types:
   source:
     repository: cftoolsmiths/cron-resource
     tag: latest
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
 - name: s3-iam
   type: docker-image
   source:
     repository: governmentpaas/s3-resource
     tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
 - name: slack-notification
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
 
 resources:
 - name: sundays-at-10pm


### PR DESCRIPTION
This is to address the problem of rate limiting that docker hub is
introducing on un-authenticated accounts.