### PR TITLE
Auto-update Concourse pipeline

### DIFF
--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -97,6 +97,12 @@ resources:
     regexp: search-learn-to-rank/production-model-(.*).txt
 
 jobs:
+- name: update-pipeline
+  plan:
+    - get: search-api-git
+      trigger: true
+    - set_pipeline: search-learn-to-rank
+      file: search-api-git/ltr/concourse/pipeline.yaml
 - name: integration-fetch
   plan:
     - get: sundays-at-10pm


### PR DESCRIPTION
This adds a new job that will watch GitHub for changes to the search-api repo and automatically set any pipeline changes that have been made, so we don't need to manually make those changes.