### PR TITLE
Rename GDS SSO env vars

### DIFF
--- a/lib/auth/gds_sso.rb
+++ b/lib/auth/gds_sso.rb
@@ -36,11 +36,11 @@ module Auth
     end
 
     def oauth_id
-      ENV.fetch("OAUTH_ID", "")
+      ENV.fetch("GDS_SSO_OAUTH_ID", "")
     end
 
     def oauth_secret
-      ENV.fetch("OAUTH_SECRET", "")
+      ENV.fetch("GDS_SSO_OAUTH_SECRET", "")
     end
   end
 end


### PR DESCRIPTION
These were renamed in Puppet [1] to better explain usage in their name,
and this change has been deployed to production already. Most applications
don't use these env vars manually and instead use the
gds-sso gem [2], however as Search API is a Sinatra app rather than
Rails it has it's own rather special configuration.

[1]: https://github.com/alphagov/govuk-puppet/pull/10832
[2]: https://github.com/alphagov/gds-sso