### PR TITLE
Scale sagemaker instances

### DIFF
--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -316,7 +316,8 @@ jobs:
           GOVUK_ENVIRONMENT: production
           ROLE_ARN: ((production-role-arn))
           INPUT_FILE_NAME: model
-          INSTANCE_TYPE: ml.c5.large
+          INSTANCE_COUNT: 6
+          INSTANCE_TYPE: ml.c5.xlarge
         run:
           path: bash
           args: ["search-api-git/ltr/concourse/task.sh", "deploy"]


### PR DESCRIPTION
CPU usage is creeping up on the instances. Bumping to 6 will even out the AZ allocations, and bumping the machine type will give us some headroom.

The variables are used in [deploy.py](https://github.com/alphagov/search-api/blob/master/ltr/concourse/deploy.py#L18-L19)