### PR TITLE
Remove content_store_document_type facet from site search page

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -38,14 +38,6 @@ details:
     allowed_values: []
   - display_as_result_metadata: false
     filterable: true
-    key: content_store_document_type
-    name: Document type
-    preposition: Of type
-    type: hidden_clearable
-    show_option_select_filter: false
-    allowed_values: []
-  - display_as_result_metadata: false
-    filterable: true
     key: content_purpose_supergroup
     name: Content type
     preposition: in


### PR DESCRIPTION
Each query that is made from site search currently[ includes a facet query for content_store_document_type](https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/goto/7d82b3f776e68ff3fe6533af88adbd00).

I can't see that we use this anywhere. I've done a [kibana search](https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/goto/17791b3994f276f0cbd3f8eac632dbd7) over the last week to see if there are some legacy queries that use this, but there aren't any legitimate ones that I can see.

Removing this will reduce the work that search-api has to do on each query and make site search a little snappier.

I'll test it on integration before doing anything courageous. :-)