### PR TITLE
Add countries to protected food & drink names

### DIFF
--- a/config/schema/elasticsearch_types/protected_food_drink_name.json
+++ b/config/schema/elasticsearch_types/protected_food_drink_name.json
@@ -130,6 +130,10 @@
         "value": "france"
       },
       {
+        "label": "Georgia",
+        "value": "georgia"
+      },
+      {
         "label": "Germany",
         "value": "germany"
       },
@@ -152,6 +156,10 @@
       {
         "label": "Guyana",
         "value": "guyana"
+      },
+      {
+        "label": "Honduras",
+        "value": "honduras"
       },
       {
         "label": "Hungary",
@@ -200,6 +208,10 @@
       {
         "label": "Mexico",
         "value": "mexico"
+      },
+      {
+        "label": "Moldova",
+        "value": "moldova"
       },
       {
         "label": "Mongolia",
@@ -288,6 +300,10 @@
       {
         "label": "Turkey",
         "value": "turkey"
+      },
+      {
+        "label": "Ukraine",
+        "value": "ukraine"
       },
       {
         "label": "United States",


### PR DESCRIPTION
These have been requested by the department.

Related to https://github.com/alphagov/govuk-content-schemas/pull/1029 and https://github.com/alphagov/specialist-publisher/pull/1766.

[Trello Card](https://trello.com/c/oedYOWVD/2247-updates-to-protected-food-drink-names-finder)