### PR TITLE
Add a replica to each index

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -115,7 +115,12 @@ index:
     # can't be applied from the nodes, so they have to live here.
     # This means that we can no longer (easily) have ci-agents or the
     # dev VM use no replicas.
-    number_of_replicas: 1
+    # If the elasticsearch cluster is unable to allocate all of the replicas
+    # (because you cannot host more than one replica of an index on a particular
+    # node) then the cluster will show as being in a "yellow" state. The cluster
+    # will still work fine, though. This number of replicas is able to be allocated
+    # to our production cluster, though not to integration for example.
+    number_of_replicas: 5
     number_of_shards: 3
     refresh_interval: '1s'
     search:


### PR DESCRIPTION
We want to have more readonly copies of our elasticsearch indices available to spread the load. We have already provisioned the extra space that we need for this.

This can also be done from a search-api machine by running the following command against each index:

```
govuk_setenv search-api bash -c 'curl -XPUT "$ELASTICSEARCH_URI/govuk/_settings" -H "Content-Type: application/json" -d "
{
    \"index\" : {
        \"number_of_replicas\" : 2
    }
}"'
```

(you'll need to swap out `govuk` for `government`, `detailed` etc.)

This may well slow down reindexing, which we can address if needed by running:

```
govuk_setenv search-api bash -c 'curl -XPUT "$ELASTICSEARCH_URI/govuk/_settings" -H "Content-Type: application/json" -d "
{
    \"index\" : {
        \"refresh_interval\" : "-1"
    }
}"'
```
before running.  We'll need to reset it afterwards by running:

```
govuk_setenv search-api bash -c 'curl -XPUT "$ELASTICSEARCH_URI/govuk/_settings" -H "Content-Type: application/json" -d "
{
    \"index\" : {
        \"refresh_interval\" : "1s"
    }
}"'
```

We'll address that when we come to it, though.