### PR TITLE
Update the Brexit result

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -9,8 +9,8 @@ module GovukIndex
     }.freeze
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-      "title" => "Transition period",
-      "description" => "The UK’s transition period after Brexit comes to an end this year - check the new rules for January 2021 and take action now.",
+      "title" => "Brexit transition",
+      "description" => "The Brexit transition period ends this year - Check the new rules from January 2021 and act now.",
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     presenter = common_fields_presenter(payload)
 
-    expect(presenter.title).to eq("Transition period")
-    expect(presenter.description).to eq("The UK’s transition period after Brexit comes to an end this year - check the new rules for January 2021 and take action now.")
+    expect(presenter.title).to eq("Brexit transition")
+    expect(presenter.description).to eq("The Brexit transition period ends this year - Check the new rules from January 2021 and act now.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
These terms match the [landing page](gov.uk/transition) except for the hyphen in the description. This is to ensure that search shows the full description and not just the first sentence.