### PR TITLE
Add registered_name field

### DIFF
--- a/config/schema/elasticsearch_types/protected_food_drink_name.json
+++ b/config/schema/elasticsearch_types/protected_food_drink_name.json
@@ -1,5 +1,6 @@
 {
   "fields": [
+    "registered_name",
     "register",
     "status",
     "class_category",

--- a/config/schema/elasticsearch_types/protected_food_drink_name.json
+++ b/config/schema/elasticsearch_types/protected_food_drink_name.json
@@ -12,6 +12,7 @@
     "traditional_term_language",
     "date_application",
     "date_registration",
+    "time_registration",
     "date_registration_eu",
     "internal_notes"
   ],

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -925,6 +925,10 @@
     "description": "The date of UK registration of the name",
     "type": "date"
   },
+  "time_registration": {
+    "description": "The time of UK registration of the name",
+    "type": "identifiers"
+  },
   "date_registration_eu": {
     "description": "The date of EU registration of the name",
     "type": "date"

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -881,6 +881,10 @@
     "type": "identifiers"
   },
 
+  "registered_name": {
+    "description": "The name of the food or drink item in the register.",
+    "type": "identifiers"
+  },
   "register": {
     "description": "The type of protected food or drink name registration e.g: food, spirit drink, wine etc",
     "type": "identifiers"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -43,6 +43,7 @@ module GovukIndex
         date_of_start: specialist.date_of_start,
         date_of_occurrence: specialist.date_of_occurrence,
         date_registration: specialist.date_registration,
+        time_registration: specialist.time_registration,
         date_registration_eu: specialist.date_registration_eu,
         decision_subject: specialist.decision_subject,
         description: common_fields.description,

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -107,6 +107,7 @@ module GovukIndex
         publishing_app: common_fields.publishing_app,
         railway_type: specialist.railway_type,
         reason_for_protection: specialist.reason_for_protection,
+        registered_name: specialist.registered_name,
         role_appointments: expanded_links.role_appointments,
         roles: expanded_links.roles,
         regions: specialist.regions,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -73,6 +73,7 @@ module GovukIndex
     delegate_to_payload :theme
     delegate_to_payload :therapeutic_area
     delegate_to_payload :tiers_or_standalone_items
+    delegate_to_payload :time_registration
     delegate_to_payload :topics
     delegate_to_payload :traditional_term_grapevine_product_category
     delegate_to_payload :traditional_term_type

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -58,6 +58,7 @@ module GovukIndex
     delegate_to_payload :reason_for_protection
     delegate_to_payload :regions
     delegate_to_payload :register
+    delegate_to_payload :registered_name
     delegate_to_payload :registration
     delegate_to_payload :report_type, convert_to_array: true
     delegate_to_payload :research_document_type


### PR DESCRIPTION
This is a new field for the protected food & drink names finder that the department would like to use. At the moment this is currently held in the title of the documents, but it turns out there are some duplicate entries, so they want the "Registered Name" to be the same for those documents and have different titles.

> So I was thinking of replacing the “Registered product name” field in the import spreadsheet, which currently maps to “title”, with a “Title” field which would map to “title” and be unique, and a “Registered name” field which would map to “Registered name” in the metadata. Does that make sense?

Related to https://github.com/alphagov/govuk-content-schemas/pull/1031 and https://github.com/alphagov/specialist-publisher/pull/1770

[Trello Card](https://trello.com/c/oedYOWVD/2247-updates-to-protected-food-drink-names-finder)