### PR TITLE
Add Canada as an option for protected foods

### DIFF
--- a/config/schema/elasticsearch_types/protected_food_drink_name.json
+++ b/config/schema/elasticsearch_types/protected_food_drink_name.json
@@ -76,6 +76,10 @@
         "value": "cambodia"
       },
       {
+        "label": "Canada",
+        "value": "canada"
+      },
+      {
         "label": "Chile",
         "value": "chile"
       },


### PR DESCRIPTION
Add an option for Canada to be the country of origin for a protected food.

Trello card: https://trello.com/c/F3HaBQBp/2258-2-further-changes-to-protected-food-drink-names-finder