### PR TITLE
Remove task_list document type

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -50,7 +50,6 @@ statutory_instrument: statutory_instrument # Specialist Publisher
 special_route: edition
 step_by_step_nav: edition
 traffic_commissioner_regulatory_decision: traffic_commissioner_regulatory_decision # Specialist Publisher
-task_list: edition
 tax_tribunal_decision: tax_tribunal_decision # Specialist Publisher
 taxon: edition # Content Tagger
 topic: edition # Collections Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -67,7 +67,6 @@ migrated:
 - service_manual_service_standard
 - service_manual_topic
 - step_by_step_nav
-- task_list
 - taxon:
   - /brexit
   - /transition


### PR DESCRIPTION
This was what step by step pages were originally called. There are no instances of this type anywhere on GOV.UK. It was [removed from govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/commit/46d5d234029a9f857f37876005d477982297f8ca) but sadly, that undoing didn't get as far as here.

I found this by looking at the Elasticsearch slow query logs and noticed that it was included in the list of formats that we filter for.