### PR TITLE
Add Albania as an option for protected foods

### DIFF
--- a/config/schema/elasticsearch_types/protected_food_drink_name.json
+++ b/config/schema/elasticsearch_types/protected_food_drink_name.json
@@ -44,6 +44,10 @@
         "value": "united-kingdom"
       },
       {
+        "label": "Albania",
+        "value": "albania"
+      },
+      {
         "label": "Andorra",
         "value": "andorra"
       },


### PR DESCRIPTION
Add an option for Albania to be the country of origin for a protected food.

[Trello](https://trello.com/c/SSBGIovv/2277-add-albania-to-protected-food-drink-names-finder)