### PR TITLE
Update the Brexit result

### DIFF
--- a/config/finders/news_and_communications_finder.yml
+++ b/config/finders/news_and_communications_finder.yml
@@ -31,8 +31,8 @@ details:
   - key: related_to_brexit
     filter_key: all_part_of_taxonomy_tree
     filter_value: d6c2de5d-ef90-45d1-82d4-5f2438369eea
-    name: Show only transition period results
-    short_name: transition period
+    name: Show only Brexit results
+    short_name: Brexit
     type: checkbox
     display_as_result_metadata: false
     filterable: true

--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -9,8 +9,8 @@ module GovukIndex
     }.freeze
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-      "title" => "Brexit transition",
-      "description" => "The Brexit transition period ends this year - Check the new rules from January 2021 and act now.",
+      "title" => "Brexit",
+      "description" => "The Brexit transition period has ended - Check how the new rules affect you.",
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
 
     presenter = common_fields_presenter(payload)
 
-    expect(presenter.title).to eq("Brexit transition")
-    expect(presenter.description).to eq("The Brexit transition period ends this year - Check the new rules from January 2021 and act now.")
+    expect(presenter.title).to eq("Brexit")
+    expect(presenter.description).to eq("The Brexit transition period has ended - Check how the new rules affect you.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
We join the sentences from the [metadescription in the content](https://github.com/alphagov/collections/pull/2195/files) together using a hyphen as a hack to stop them being truncated by the description presenter which only shows the first sentence. 

We're not going to change the underlying description truncation behaviour for this result, partly because [This update broke my workflow](https://xkcd.com/1172/)

I'll need to re-present this to search using:

`sudo -u deploy govuk_setenv publishing-api bundle exec rake represent_downstream:content_id[d6c2de5d-ef90-45d1-82d4-5f2438369eea]`

----

Also relabelled the news and communications finder Brexit checkbox, to reflect the update in language.


https://trello.com/c/vLUxjqKZ/747-deploy-31-12-1115pm-update-landing-page-meta-description-for-1-january