### PR TITLE
Update the Brexit description

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -10,7 +10,7 @@ module GovukIndex
     BREXIT_PAGE = {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "title" => "Brexit",
-      "description" => "The Brexit transition period has ended - Check how the new rules affect you.",
+      "description" => "The Brexit transition period has ended. Check how the new rules affect you.",
     }.freeze
     extend MethodBuilder
 

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     presenter = common_fields_presenter(payload)
 
     expect(presenter.title).to eq("Brexit")
-    expect(presenter.description).to eq("The Brexit transition period has ended - Check how the new rules affect you.")
+    expect(presenter.description).to eq("The Brexit transition period has ended. Check how the new rules affect you.")
   end
 
   it "withdrawn when withdrawn notice present" do


### PR DESCRIPTION
We can use multiple sentences now that description truncation has been moved from finder-frontend.

We'll hopefully remove this soon: https://trello.com/c/maZEDGMH/404-update-brexit-taxon-title-and-description-in-content-tagger