### PR TITLE
Timeout Reranker calls after 1s

### DIFF
--- a/lib/learn_to_rank/ranker.rb
+++ b/lib/learn_to_rank/ranker.rb
@@ -34,7 +34,10 @@ module LearnToRank
 
     def fetch_new_scores_from_sagemaker(examples)
       begin
-        response = Aws::SageMakerRuntime::Client.new.invoke_endpoint(
+        client = Aws::SageMakerRuntime::Client.new(
+          http_read_timeout: 1,
+        )
+        response = client.invoke_endpoint(
           endpoint_name: sagemaker_endpoint(variant: model_variant),
           body: {
             "signature_name": "regression",


### PR DESCRIPTION
Yesterday at peak load we saw a few requests take over 1s to complete.

This reduces the timeout on requests to SageMaker from 60s to 1s (this is the lowest we can go).

`http_read_timeout` is the number of seconds to wait for response data [1].

When a request to SageMaker fails (including timeouts) we return the top-k results without reranking. The results should be lower quality but this is an acceptable trade off for reasonable timeliness.

This shouldn't have a noticeable impact, but should make requests complete a little quicker for some users.

[1] https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SageMakerRuntime/Client.html#invoke_endpoint-instance_method