### PR TITLE
Enable Fields for Get Involved Migration

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -5,6 +5,8 @@
     "attachments",
     "child_organisations",
     "closed_at",
+    "consultation_opening_date",
+    "consultation_closing_date",
     "detailed_format",
     "display_type",
     "document_collections",

--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -25,6 +25,7 @@
     "logo_url",
     "metadata",
     "operational_field",
+    "ordering",
     "organisation_brand",
     "organisation_closed_state",
     "organisation_crest",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -229,6 +229,11 @@
     "description": "When a consultation was, or will be, closed."
   },
 
+  "ordering": {
+    "type":"integer",
+    "description": "The ordering value for take_part pages and other ordered items"
+  },
+
   "latest_change_note": {
     "description": "Note indicating what changed in the last major revision.",
     "type": "unsearchable_text"

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -219,6 +219,16 @@
     "description": "Closing date for closed organisations."
   },
 
+  "consultation_opening_date": {
+    "type": "date",
+    "description": "When a consultation was, or will be, opened."
+  },
+
+  "consultation_closing_date": {
+    "type": "date",
+    "description": "When a consultation was, or will be, closed."
+  },
+
   "latest_change_note": {
     "description": "Note indicating what changed in the last major revision.",
     "type": "unsearchable_text"

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -38,6 +38,14 @@ module GovukIndex
       details.dig("image", "url")
     end
 
+    def consultation_opening_date
+      details["opening_date"]
+    end
+
+    def consultation_closing_date
+      details["closing_date"]
+    end
+
   private
 
     def service_manual

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -46,6 +46,10 @@ module GovukIndex
       details["closing_date"]
     end
 
+    def ordering
+      details["ordering"]
+    end
+
   private
 
     def service_manual

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -29,6 +29,8 @@ module GovukIndex
         closed_date: specialist.closed_date,
         closing_date: specialist.closing_date,
         commodity_type: specialist.commodity_type,
+        consultation_opening_date: details.consultation_opening_date,
+        consultation_closing_date: details.consultation_closing_date,
         contact_groups: details.contact_groups,
         content_id: common_fields.content_id,
         content_purpose_document_supertype: common_fields.content_purpose_document_supertype,

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -92,6 +92,7 @@ module GovukIndex
         medical_specialism: specialist.medical_specialism,
         navigation_document_supertype: common_fields.navigation_document_supertype,
         opened_date: specialist.opened_date,
+        ordering: details.ordering,
         organisation_content_ids: expanded_links.organisation_content_ids,
         organisations: expanded_links.organisations,
         outcome_type: specialist.outcome_type,


### PR DESCRIPTION
Without these fields we need to rely on the Publishing API for retrieving information about the Take Part pages and Consultations for use in the new Get Involved page post-migration from Whitehall to Government Frontend.

Once these fields are in and reindexed we'll be able to use this directly and save a lot of overhead. https://trello.com/c/7BjH9PyC/2083-8-migrate-government-get-involved-to-government-frontend