### PR TITLE
Add Ordering field definition

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -219,6 +219,11 @@
     "description": "Closing date for closed organisations."
   },
 
+  "ordering": {
+    "type":"integer",
+    "description": "The ordering value for take_part pages and other ordered items"
+  },
+
   "latest_change_note": {
     "description": "Note indicating what changed in the last major revision.",
     "type": "unsearchable_text"


### PR DESCRIPTION
Allows us to save the ordering of Take Part pages in a searchable format for
use in the Get Involved page post migration from Whitehall to Government-Frontend.

Related to Get Involved migration work: https://trello.com/c/7BjH9PyC/2083-8-migrate-government-get-involved-to-government-frontend