### PR TITLE
Add Ordering field to Edition

### DIFF
--- a/config/schema/elasticsearch_types/edition.json
+++ b/config/schema/elasticsearch_types/edition.json
@@ -23,6 +23,7 @@
     "logo_url",
     "metadata",
     "operational_field",
+    "ordering",
     "organisation_brand",
     "organisation_closed_state",
     "organisation_crest",

--- a/lib/parameter_parser/base_parameter_parser.rb
+++ b/lib/parameter_parser/base_parameter_parser.rb
@@ -23,6 +23,8 @@ class BaseParameterParser
     title
     tribunal_decision_decision_date
     start_date
+    end_date
+    ordering
     assessment_date
     popularity
     release_timestamp


### PR DESCRIPTION
We now store the order of Take Part pages in the publishing API, however we need
access to this information in the Search API as well. As Take Part pages are of
the Edition type in Elasticsearch, we need the field enabled here.

Related to https://trello.com/c/7BjH9PyC/2083-8-migrate-government-get-involved-to-government-frontend