### PR TITLE
Remove need for REDIS_HOST and REDIS_PORT env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,23 @@ FROM ruby:2.7.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean
 RUN gem install foreman
 
+ENV RACK_ENV production
 ENV GOVUK_APP_NAME search-api
-ENV REDIS_HOST redis
 ENV ELASTICSEARCH_URI http://elasticsearch6:9200
 ENV PORT 3233
 ENV RABBITMQ_HOSTS rabbitmq
 ENV RABBITMQ_VHOST /
 ENV RABBITMQ_USER guest
 ENV RABBITMQ_PASSWORD guest
-ENV RACK_ENV development
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
-RUN bundle install
+RUN bundle config set deployment 'true'
+RUN bundle config set without 'development test'
+RUN bundle install --jobs 4
 ADD . $APP_HOME
 
 CMD foreman run web

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ rescue LoadError
 end
 # rubocop:enable Lint/SuppressedException
 
-task default: %i[spec lint]
+task default: %i[lint spec]
 
 def logger
   Logging.logger.root

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,24 +1,6 @@
 require "govuk_sidekiq/sidekiq_initializer"
 
-if ENV["RACK_ENV"] == "test"
-  redis_config = {
-    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
-    port: ENV.fetch("REDIS_PORT", 6379),
-    namespace: "search-api-test",
-  }
-
-  Sidekiq.configure_server do |config|
-    config.redis = redis_config
-  end
-
-  Sidekiq.configure_client do |config|
-    config.redis = redis_config
-  end
-else
-  redis_config = {
-    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
-    port: ENV.fetch("REDIS_PORT", 6379),
-  }
-
-  GovukSidekiq::SidekiqInitializer.setup_sidekiq("search-api", redis_config)
-end
+GovukSidekiq::SidekiqInitializer.setup_sidekiq(
+  ENV.fetch("GOVUK_APP_NAME", "search-api"),
+  {},
+)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ require "pp"
 require "timecop"
 require "pry-byebug"
 
-require "sidekiq/testing"
+require "govuk_sidekiq/testing"
 require "sidekiq/testing/inline" # Make all queued jobs run immediately
 require "bunny-mock"
 require "govuk_schemas"


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

This is one of the few GOV.UK projects that uses this old approach to
configuring Redis - whereas most of the other ones use the approach
supported natively by the Redis gem [1] of using REDIS_URL. Removing
this will allow us to remove the need for REDIS_HOST and REDIS_PORT env
vars in our architecture and also allows this code to be simplified.

[1]: https://github.com/redis/redis-rb

It also applies a couple of minor tweaks to the Dockerfile and Rakefile.