### PR TITLE
Revert REDIS_URL changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,22 @@ FROM ruby:2.7.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean
 RUN gem install foreman
 
-ENV RACK_ENV production
 ENV GOVUK_APP_NAME search-api
+ENV REDIS_HOST redis
 ENV ELASTICSEARCH_URI http://elasticsearch6:9200
 ENV PORT 3233
 ENV RABBITMQ_HOSTS rabbitmq
 ENV RABBITMQ_VHOST /
 ENV RABBITMQ_USER guest
 ENV RABBITMQ_PASSWORD guest
+ENV RACK_ENV development
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
-RUN bundle config set deployment 'true'
-RUN bundle config set without 'development test'
-RUN bundle install --jobs 4
+RUN bundle install
 ADD . $APP_HOME
 
 CMD foreman run web

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,8 @@
 
 library("govuk")
 
+govuk.setEnvar("PUBLISHING_E2E_TESTS_APP_PARAM", "RUMMAGER_COMMITISH")
+
 node('elasticsearch-6.7') {
   govuk.buildProject(
     publishingE2ETests: true,

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,24 @@
 require "govuk_sidekiq/sidekiq_initializer"
 
-GovukSidekiq::SidekiqInitializer.setup_sidekiq(
-  ENV.fetch("GOVUK_APP_NAME", "search-api"),
-  {},
-)
+if ENV["RACK_ENV"] == "test"
+  redis_config = {
+    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
+    port: ENV.fetch("REDIS_PORT", 6379),
+    namespace: "search-api-test",
+  }
+
+  Sidekiq.configure_server do |config|
+    config.redis = redis_config
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = redis_config
+  end
+else
+  redis_config = {
+    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
+    port: ENV.fetch("REDIS_PORT", 6379),
+  }
+
+  GovukSidekiq::SidekiqInitializer.setup_sidekiq("search-api", redis_config)
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ require "pp"
 require "timecop"
 require "pry-byebug"
 
-require "govuk_sidekiq/testing"
+require "sidekiq/testing"
 require "sidekiq/testing/inline" # Make all queued jobs run immediately
 require "bunny-mock"
 require "govuk_schemas"


### PR DESCRIPTION
Something in https://github.com/alphagov/search-api/pull/2244 has caused a problem with the publishing-e2e-tests and I'm not sure what. It turns out the e2e tests haven't been running against Search API correctly since it was renamed from Rummager so this problem wasn't caught until the app was deployed to production.

This is a rather hasty revert to get the tests working again before the weekend.