### PR TITLE
Re-instate #2244

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,23 @@ FROM ruby:2.7.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean
 RUN gem install foreman
 
+ENV RACK_ENV production
 ENV GOVUK_APP_NAME search-api
-ENV REDIS_HOST redis
 ENV ELASTICSEARCH_URI http://elasticsearch6:9200
 ENV PORT 3233
 ENV RABBITMQ_HOSTS rabbitmq
 ENV RABBITMQ_VHOST /
 ENV RABBITMQ_USER guest
 ENV RABBITMQ_PASSWORD guest
-ENV RACK_ENV development
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
-RUN bundle install
+RUN bundle config set deployment 'true'
+RUN bundle config set without 'development test'
+RUN bundle install --jobs 4
 ADD . $APP_HOME
 
 CMD foreman run web

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,5 @@
 library("govuk")
 
 node('elasticsearch-6.7') {
-  govuk.buildProject(
-    publishingE2ETests: true,
-    rubyLintDiff: false
-  )
+  govuk.buildProject(publishingE2ETests: true)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,6 @@
 
 library("govuk")
 
-govuk.setEnvar("PUBLISHING_E2E_TESTS_APP_PARAM", "RUMMAGER_COMMITISH")
-
 node('elasticsearch-6.7') {
   govuk.buildProject(
     publishingE2ETests: true,

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,24 +1,6 @@
 require "govuk_sidekiq/sidekiq_initializer"
 
-if ENV["RACK_ENV"] == "test"
-  redis_config = {
-    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
-    port: ENV.fetch("REDIS_PORT", 6379),
-    namespace: "search-api-test",
-  }
-
-  Sidekiq.configure_server do |config|
-    config.redis = redis_config
-  end
-
-  Sidekiq.configure_client do |config|
-    config.redis = redis_config
-  end
-else
-  redis_config = {
-    host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
-    port: ENV.fetch("REDIS_PORT", 6379),
-  }
-
-  GovukSidekiq::SidekiqInitializer.setup_sidekiq("search-api", redis_config)
-end
+GovukSidekiq::SidekiqInitializer.setup_sidekiq(
+  "search-api",
+  { url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379") },
+)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ require "pp"
 require "timecop"
 require "pry-byebug"
 
-require "sidekiq/testing"
+require "govuk_sidekiq/testing"
 require "sidekiq/testing/inline" # Make all queued jobs run immediately
 require "bunny-mock"
 require "govuk_schemas"


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

This brings back the changes introduced https://github.com/alphagov/search-api/pull/2244 and reverted in https://github.com/alphagov/search-api/pull/2245. I've since learnt the problem was: https://github.com/alphagov/publishing-e2e-tests/pull/410/commits/0505c46a660545b317c8d25f4e5ec7009a78e4da.

This depends on https://github.com/alphagov/publishing-e2e-tests/pull/410 and I've marked this as a draft because of that.