### PR TITLE
Rename field for flood & coastal erosion report

### DIFF
--- a/config/schema/elasticsearch_types/flood_and_coastal_erosion_risk_management_research_report.json
+++ b/config/schema/elasticsearch_types/flood_and_coastal_erosion_risk_management_research_report.json
@@ -1,6 +1,6 @@
 {
   "fields": [
-    "category",
+    "flood_and_coastal_erosion_category",
     "date_of_start",
     "date_of_completion",
     "project_code",
@@ -9,7 +9,7 @@
   ],
 
   "expanded_search_result_fields": {
-    "category": [
+    "flood_and_coastal_erosion_category": [
       {"label": "Environmental management and sustainability", "value": "environmental-management-and-sustainability"},
       {"label": "Increasing resilience to flooding", "value": "increasing-resilience-to-flooding"},
       {"label": "Managing flood incidents", "value": "managing-flood-incidents"},

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -943,8 +943,8 @@
     "type": "identifiers"
   },
 
-  "category": {
-    "description": "The category of the document.",
+  "flood_and_coastal_erosion_category": {
+    "description": "The category of flood and coastal erosion risk reports e.g: managing flood incidents",
     "type": "identifiers"
   },
   "date_of_start": {

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -23,7 +23,7 @@ module GovukIndex
         business_stages: specialist.business_stages,
         case_state: specialist.case_state,
         case_type: specialist.case_type,
-        category: specialist.category,
+        flood_and_coastal_erosion_category: specialist.flood_and_coastal_erosion_category,
         certificate_status: specialist.certificate_status,
         class_category: specialist.class_category,
         closed_date: specialist.closed_date,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -13,7 +13,7 @@ module GovukIndex
     delegate_to_payload :business_stages
     delegate_to_payload :case_state, convert_to_array: true
     delegate_to_payload :case_type, convert_to_array: true
-    delegate_to_payload :category
+    delegate_to_payload :flood_and_coastal_erosion_category
     delegate_to_payload :certificate_status
     delegate_to_payload :class_category
     delegate_to_payload :closed_date


### PR DESCRIPTION
The `category` field has been [renamed] and so we need to allow this to
be queried through Search API.

[renamed]: https://github.com/alphagov/specialist-publisher/pull/1811

Trello:
https://trello.com/c/rWJ6jhKH/2317-3-add-email-subscription-filters-to-flood-research-report-finder
