### PR TITLE
Add air-quality as a land_use

### DIFF
--- a/config/schema/elasticsearch_types/countryside_stewardship_grant.json
+++ b/config/schema/elasticsearch_types/countryside_stewardship_grant.json
@@ -32,6 +32,10 @@
 
     "land_use": [
       {
+        "label": "Air quality",
+        "value": "air-quality"
+      },
+      {
         "label": "Arable land",
         "value": "arable-land"
       },


### PR DESCRIPTION
This is available as an option in specialist-publisher but it's missing from govuk-content-schemas: https://github.com/alphagov/specialist-publisher/blob/4000e6dec54bafd1b8af4516c3eed1abbb874a50/lib/documents/schemas/countryside_stewardship_grants.json#L43

This means that users can't create documents with that option. See https://govuk.zendesk.com/agent/tickets/4431297 for more details.