### PR TITLE
Make 'standard' document type non-indexable

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -420,6 +420,7 @@ non_indexable:
 - social_media_use
 - speech
 - staff_update
+- standard
 - statistical_data_set
 - statistics
 - statutory_guidance


### PR DESCRIPTION
Doesn't index the new 'standard' document type in the govuk index as,
like all other Whitehall publications, it will already be indexed in the
government index.

We're planning to migrate all publications over in one go to the
govuk-index in a future piece of work.

Trello:
https://trello.com/c/ugeapNY0/2318-5-create-new-standard-document-sub-type-in-whitehall
