### PR TITLE
Hide the show only Brexit results checkbox

### DIFF
--- a/config/finders/news_and_communications_finder.yml
+++ b/config/finders/news_and_communications_finder.yml
@@ -33,7 +33,7 @@ details:
     filter_value: d6c2de5d-ef90-45d1-82d4-5f2438369eea
     name: Show only Brexit results
     short_name: Brexit
-    type: checkbox
+    type: hidden_clearable
     display_as_result_metadata: false
     filterable: true
     preposition: about


### PR DESCRIPTION
Affects: https://www.gov.uk/search/news-and-communications

We'll follow this up in finder-frontend to formally retire this feature. This particular change just hides the checkbox but leaves the ability to filter if you have an existing URL.

We're retiring it because it has a fair bit of special handling which adds complexity to search. This is a risk when there is no specialist team working in this area, so we've chosen to retire it instead, as not many people are using it.

https://trello.com/c/8Pv2YKzn/1311-retire-show-only-brexit-results-from-finders