### PR TITLE
Show new 'value_of_funding' options

### DIFF
--- a/config/schema/elasticsearch_types/international_development_fund.json
+++ b/config/schema/elasticsearch_types/international_development_fund.json
@@ -241,7 +241,8 @@
     ],
 
     "value_of_funding": [
-      {"label": "Up to £100,000", "value": "up-to-100000"},
+      {"label": "Up to £10,000", "value": "up-to-10000"},
+      {"label": "£10,001 to £100,000", "value": "10001-to-100000"},
       {"label": "£100,001 to £500,000", "value": "100001-500000"},
       {"label": "£500,001 to £1,000,000", "value": "500001-to-1000000"},
       {"label": "More than £1,000,000", "value": "more-than-1000000"}


### PR DESCRIPTION
Dependent on https://github.com/alphagov/specialist-publisher/pull/1818 (for defining the option for new funds) and https://github.com/alphagov/publishing-api/pull/1901 (for fixing up the old funds).

Trello: https://trello.com/c/eDFwuCFY/2356-5-changes-to-international-development-funding-finder