### PR TITLE
Increase timeout for bulk indexing

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -95,7 +95,7 @@ module SearchIndices
     # indexing-methods like `add` and `amend` eventually end up
     # calling this method.
     def bulk_index(document_hashes_or_payload, options = {})
-      @client = build_client(options.merge(retry_on_failure: true))
+      @client = build_client(options.merge(retry_on_failure: true, timeout: 10))
 
       with_retries do
         payload_generator = Indexer::BulkPayloadGenerator.new(@index_name, @search_config, @client, @is_content_index)


### PR DESCRIPTION
We currently specify a default 5s timeout for all indexing queries. Bulk indexing may take longer than this (evidenced by `Faraday::TimeoutError` being raised, even after multiple retries), so we should set a higher timeout limit.

10s is an arbitrary choice, based on doubling the current timeout.

Trello card: https://trello.com/c/YDrY6zRx