### PR TITLE
Remove related_to_brexit from email signup facets

### DIFF
--- a/config/finders/news_and_communications_email_signup.yml
+++ b/config/finders/news_and_communications_email_signup.yml
@@ -33,10 +33,6 @@ details:
   - facet_id: level_two_taxon
     filter_key: all_part_of_taxonomy_tree
     facet_name: topics
-  - facet_id: related_to_brexit
-    filter_key: all_part_of_taxonomy_tree
-    filter_value: d6c2de5d-ef90-45d1-82d4-5f2438369eea
-    facet_name: topics
 routes:
 - path: "/search/news-and-communications/email-signup"
   type: exact


### PR DESCRIPTION
This isn't used any more.

https://trello.com/c/3bvFaQQv/1361-remove-relatedtobrexit-from-news-comms-email-signup