### PR TITLE
Use metadata.project_code for generating indexable content

### DIFF
--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -7,6 +7,7 @@ module GovukIndex
       "local_transaction" => %w[introduction more_information need_to_know],
       "transaction" => %w[introductory_paragraph more_information],
       "travel_advice" => %w[summary],
+      "flood_and_coastal_erosion_risk_management_research_report" => %w[metadata.project_code],
     }.freeze
 
     def initialize(format:, details:, sanitiser:)

--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -35,7 +35,7 @@ module GovukIndex
 
     def indexable_content_parts
       indexable_content_keys.flat_map do |field|
-        indexable_values = details[field] || []
+        indexable_values = details.dig(*field.split(".")) || []
         field == "parts" ? parts(indexable_values) : [indexable_values]
       end
     end

--- a/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
@@ -56,21 +56,38 @@ RSpec.describe GovukIndex::IndexableContentPresenter do
   end
 
   context "additional specified indexable content keys" do
-    let(:format) { "transaction" }
-    let(:details) do
-      {
-        "external_related_links" => [],
-        "introductory_paragraph" => [
-          { "content_type" => "text/govspeak", "content" => "**introductory paragraph**" },
-          { "content_type" => "text/html", "content" => "<strong>introductory paragraph</strong>" },
-        ],
-        "more_information" => "more information",
-        "start_button_text" => "Start now",
-      }
+    context "transaction format" do
+      let(:format) { "transaction" }
+      let(:details) do
+        {
+          "external_related_links" => [],
+          "introductory_paragraph" => [
+            { "content_type" => "text/govspeak", "content" => "**introductory paragraph**" },
+            { "content_type" => "text/html", "content" => "<strong>introductory paragraph</strong>" },
+          ],
+          "more_information" => "more information",
+          "start_button_text" => "Start now",
+        }
+      end
+
+      it "extracts additional indexable content keys when they have been specified" do
+        expect(subject.indexable_content).to eq("introductory paragraph\n\nmore information")
+      end
     end
 
-    it "extracts additional indexable content keys when they have been specified" do
-      expect(subject.indexable_content).to eq("introductory paragraph\n\nmore information")
+    context "flood_and_coastal_erosion_risk_management_research_report format" do
+      let(:format) { "flood_and_coastal_erosion_risk_management_research_report" }
+      let(:details) do
+        {
+          "metadata" => {
+            "project_code" => "ABC",
+          },
+        }
+      end
+
+      it "extracts additional indexable content keys when they have been specified" do
+        expect(subject.indexable_content).to eq("ABC")
+      end
     end
   end
 


### PR DESCRIPTION
This is only relevant for the `flood_and_coastal_erosion_risk_management_research_report` format where they'd like it so be possible to search for a report using the project code which isn't in the title or the description.

https://www.gov.uk/api/content/flood-and-coastal-erosion-risk-management-research-reports/flood-hydrology-roadmap is an example content item that contains the `project_code`.

[Trello Card](https://trello.com/c/b60ohJYh/2380-1st-march-make-flood-and-coastal-erosion-risk-management-research-report-finder-live)