### PR TITLE
Ensure that we scale down the LTR EC2 ASG

### DIFF
--- a/ltr/concourse/after-fetch.sh
+++ b/ltr/concourse/after-fetch.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source search-api-git/ltr/concourse/lib.sh
+
+assume_role
+
+EC2_NAME="govuk-${GOVUK_ENVIRONMENT}-search-ltr-generation"
+AWS_REGION="eu-west-1"
+
+echo "Scaling down ASG..."
+aws autoscaling set-desired-capacity \
+    --region "$AWS_REGION" \
+    --auto-scaling-group-name "$EC2_NAME" \
+    --desired-capacity 0

--- a/ltr/concourse/fetch.sh
+++ b/ltr/concourse/fetch.sh
@@ -77,14 +77,4 @@ ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no "ubuntu@${instance_ip}
   aws s3 cp svm/validate.txt s3://$S3_BUCKET/data/$NOW/validate.txt
 EOF
 
-# the previous assumption may have timed out, so assume again before
-# scaling down the ASG
-assume_role
-
-echo "Scaling down ASG..."
-aws autoscaling set-desired-capacity \
-    --region "$AWS_REGION" \
-    --auto-scaling-group-name "$EC2_NAME" \
-    --desired-capacity 0
-
 echo "$NOW" > "out/${GOVUK_ENVIRONMENT}-${OUTPUT_FILE_NAME}-$(date +%s).txt"

--- a/ltr/concourse/pipeline.yaml
+++ b/ltr/concourse/pipeline.yaml
@@ -109,6 +109,13 @@ jobs:
       trigger: true
     - get: search-api-git
     - task: fetch
+      ensure:
+        params:
+          GOVUK_ENVIRONMENT: integration
+          ROLE_ARN: ((integration-role-arn))
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/after-fetch.sh"]
       config:
         <<: *task-config
         inputs:
@@ -180,6 +187,13 @@ jobs:
       trigger: true
     - get: search-api-git
     - task: fetch
+      ensure:
+        params:
+          GOVUK_ENVIRONMENT: staging
+          ROLE_ARN: ((staging-role-arn))
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/after-fetch.sh"]
       config:
         <<: *task-config
         inputs:
@@ -251,6 +265,13 @@ jobs:
       trigger: true
     - get: search-api-git
     - task: fetch
+      ensure:
+        params:
+          GOVUK_ENVIRONMENT: production
+          ROLE_ARN: ((production-role-arn))
+        run:
+          path: bash
+          args: ["search-api-git/ltr/concourse/after-fetch.sh"]
       config:
         <<: *task-config
         inputs:


### PR DESCRIPTION
The [concourse job](https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/search-learn-to-rank) that runs this script fails occasionally. If this happens at an inopportune moment, then any subsequent jobs will also fail unless someone manually kills the running "search-ltr-generation" EC2 instance.

By using a trap, we can hopefully make it more reliable by ensuring we kill off the failed instance.