### PR TITLE
Fix Python dependency conflicts & add a check to stop it re-occurring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: search-api
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Check LTR dependencies install
+        run: |
+          set -ex
+          # deps are needed even for just downloading the python packages
+          sudo apt-get update
+          sudo apt-get install -y liblapack-dev
+          pip download --no-deps -r ltr/concourse/requirements.txt
+          pip download --no-deps -r ltr/scripts/requirements.txt

--- a/ltr/concourse/requirements.txt
+++ b/ltr/concourse/requirements.txt
@@ -15,7 +15,7 @@ protobuf==3.11.2
 protobuf3-to-dict==0.1.5
 pyasn1==0.4.8
 python-dateutil==2.8.1
-PyYAML==5.4
+PyYAML==5.2
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.2.1

--- a/ltr/concourse/requirements.txt
+++ b/ltr/concourse/requirements.txt
@@ -17,7 +17,7 @@ pyasn1==0.4.8
 python-dateutil==2.8.1
 PyYAML==5.4
 requests==2.22.0
-rsa==4.1
+rsa==3.4.2
 s3transfer==0.2.1
 sagemaker==1.50.1
 scipy==1.4.1

--- a/ltr/scripts/requirements.txt
+++ b/ltr/scripts/requirements.txt
@@ -21,7 +21,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 requests==2.22.0
 requests-oauthlib==1.3.0
-rsa==4.1
+rsa==4.0
 six==1.14.0
 tensorboard==2.0.2
 tensorflow==2.4.0


### PR DESCRIPTION
Without at least a test that the dependencies install, Dependabot will happily raise PRs with version conflicts, which is what happened here:

> ERROR: Cannot install -r requirements.txt (line 4) and rsa==4.1 because these package versions have conflicting dependencies.

> ERROR: Cannot install -r requirements.txt (line 4) and PyYAML==5.4 because these package versions have conflicting dependencies.

I've reverted the recent version bumps and added a workflow to check the packages install, so future such PRs will fail.

I decided to use GitHub Actions for this because we have [an accepted RFC for using GitHub Actions for CI](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-123-github-actions-ci.md) where we don't need the wider platform integration of Jenkins.