### PR TITLE
Make smart answer schema indexable

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -47,6 +47,7 @@ service_manual_service_toolkit: edition
 service_manual_topic: service_manual_topic
 service_standard_report: service_standard_report # Specialist Publisher
 simple_smart_answer: edition
+smart_answer: edition
 statutory_instrument: statutory_instrument # Specialist Publisher
 special_route: edition
 step_by_step_nav: edition

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -23,6 +23,8 @@ migrated:
 - place
 - transaction
 - simple_smart_answer
+# Smart Answers
+- smart_answer
 # Specialist Publisher
 - aaib_report
 - asylum_support_decision
@@ -312,7 +314,6 @@ non_indexable_path:
 non_indexable:
 - calculator
 - license_finder
-- smart_answer # this is the format for the `/<path>/y` flow landing page for smart answers
 - special_route:
   - '/homepage'
   - '/tour'

--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -5,6 +5,7 @@ base:
     service_manual_topic: 0.3
     step_by_step_nav: 2.5
     transaction: 1.5
+    smart_answer: 1.5
     # Should appear below govuk (mainstream) content
     aaib_report: 0.2
     research_for_development_output: 0.2

--- a/lib/learn_to_rank/format_enums.rb
+++ b/lib/learn_to_rank/format_enums.rb
@@ -80,6 +80,7 @@ module LearnToRank
         "protected_food_drink_name" => 76,
         "flood_and_coastal_erosion_risk_management_research_report" => 77,
         "service_manual_service_toolkit" => 78,
+        "smart_answer" => 79,
       }
     end
   end

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -119,14 +119,14 @@ RSpec.describe "GovukIndex::PublishingEventProcessorTest" do
       allow(worker).to receive(:logger).and_return(logger)
 
       random_example = generate_random_example(
-        schema: "generic_with_external_related_links",
-        payload: { document_type: "smart_answer", payload_version: 123 },
+        schema: "special_route",
+        payload: { document_type: "special_route", payload_version: 123, base_path: "/tour" },
       )
 
       worker.perform([["test.route", random_example]])
       commit_index "govuk_test"
 
-      expect(logger).to have_received(:info).with("test.route -> BLOCKLISTED #{random_example['base_path']} 'unmapped type'")
+      expect(logger).to have_received(:info).with("test.route -> BLOCKLISTED #{random_example['base_path']} edition")
       expect {
         fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
       }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)

--- a/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
@@ -115,36 +115,16 @@ RSpec.describe GovukIndex::IndexableContentPresenter do
     end
   end
 
-  context "transaction with hidden_search_terms (smart answer start page)" do
-    let(:format) { "transaction" }
+  context "smart_answer format" do
+    let(:format) { "smart_answer" }
     let(:details) do
       {
-        "introductory_paragraph" => [
-          {
-            "content" => "intro\n",
-            "content_type" => "text/govspeak",
-          },
-          {
-            "content_type" => "text/html",
-            "content" => "<p>intro</p>\n",
-          },
-        ],
-        "more_information" => [
-          {
-            "content" => "more<\n",
-            "content_type" => "text/govspeak",
-          },
-          {
-            "content_type" => "text/html",
-            "content" => "<p>more</p>\n",
-          },
-        ],
         "hidden_search_terms" => ["hidden 1", "hidden 2"],
       }
     end
 
     it "hidden_search_terms is correctly indexed" do
-      expect(subject.indexable_content).to eq("hidden 1\n\n\nhidden 2\n\n\nintro\n\n\n\nmore")
+      expect(subject.indexable_content).to eq("hidden 1\n\n\nhidden 2")
     end
   end
 end


### PR DESCRIPTION
Previously, Smart Answer start pages were represented by the transaction content schema. We have since created a new schema `smart_answer` to represent Smart Answers. This adds in support for this new schema so search results behave when they were transaction pages. The start page body content is no longer in the separate fields `introduction` and `more_information` and will now be included within the `hidden_search_terms` section.

This should result in no user facing changes.