### PR TITLE
Replace deprecated supertypes in boosting

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -14,7 +14,6 @@ base:
     # Inside Gov formats
     contact: 0.3
     document_collection: 1.3
-    document_series: 1.3
     minister: 1.7
     operational_field: 1.5
     organisation: 2.5

--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -26,10 +26,11 @@ base:
     specialist_sector: 2.5
   content_store_document_type:
     foi_release: 0.2
-  navigation_document_supertype:
+  content_purpose_supergroup:
+    services: 2.5
+  content_purpose_subgroup:
     guidance: 2.5
-  search_user_need_document_supertype:
-    core: 1.5
+    regulation: 2.5
   organisation_state:
     closed: 0.2
     devolved: 0.3

--- a/spec/unit/query_components/booster_spec.rb
+++ b/spec/unit/query_components/booster_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe QueryComponents::Booster do
     expect_format_boost(result, "topic", 1.5)
   end
 
-  it "boost guidance content" do
+  it "boost services content" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: "query" })
 
-    expect_boost_for_field(result, :navigation_document_supertype, "guidance", 2.5)
+    expect_boost_for_field(result, :content_purpose_supergroup, "services", 2.5)
   end
 
   it "downweight service assessments by large amount" do


### PR DESCRIPTION
[navigation_document_supertype](https://github.com/alphagov/govuk_document_types/blob/fc4e1110b24ba5aebbf84b7fec245d4cf27e9ef5/data/supertypes.yml#L1-L26) and [search_user_need_document_supertype](https://github.com/alphagov/govuk_document_types/blob/fc4e1110b24ba5aebbf84b7fec245d4cf27e9ef5/data/supertypes.yml#L1-L26)  have not been updated much in recent years and several new content types have arrived since. They are not really used around the system so it makes sense to replace them with equivalent content_purpose_supertype references.

I've updated the spec too. Guidance content is still boosted, but I think this spec was more about asserting that _something_ was boosted correctly rather than worrying about exactly what it was. With that in mind, I've switched the spec to checking that services get a bump.

Also removed a format that no longer exists on the system

https://trello.com/c/hp5BJD2i/117-unused-incorrect-supertypes-in-content-items
