### PR TITLE
Reduce boost applied to coronavirus content

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -36,7 +36,7 @@ base:
   is_historic:
     true: 0.5
   part_of_taxonomy_tree:
-    5b7b9532-a775-4bd2-a3aa-6ce380184b6c: 5 # /coronavirus-taxon
+    5b7b9532-a775-4bd2-a3aa-6ce380184b6c: 2.5 # /coronavirus-taxon
 # Overrides to apply to the sitemap priorities in external search
 external_search:
   format:


### PR DESCRIPTION
The default boost for anything is 1, which is used as a multiplier to promote or demote certain content.

The boost here is cumulative with other boosts in this file, so any covid landing pages also have another 2.5 applied to them, transactions have 1.5 etc.

Our supposition is that artificially boosting all the coronavirus content by such a lot is suppressing other relevant content.

The ideal scenario is that no taxon has any particular precedence over any other, particularly with such a strong "brand" (the inclusion of "covid" or "coronavirus" in the query is an excellent indicator), it should be able to stand on its own two feet with the other settings we have applied.

With that in mind, we don't want to remove it completely, for fear that we might actively hurt coronavirus searches. So we'll start off by reducing it a bit, and monitor the [overall click through rate](https://grafana.blue.production.govuk.digital/dashboard/file/search_relevancy.json?orgId=1&from=now%2FM&to=now%2FM&panelId=6&fullscreen)

If the rate doesn't change, and the coronavirus team are happy, then I'll subsequently remove this boost altogether.