### PR TITLE
Remove coronavirus taxon boost

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -35,8 +35,6 @@ base:
     devolved: 0.3
   is_historic:
     true: 0.5
-  part_of_taxonomy_tree:
-    5b7b9532-a775-4bd2-a3aa-6ce380184b6c: 2.5 # /coronavirus-taxon
 # Overrides to apply to the sitemap priorities in external search
 external_search:
   format:


### PR DESCRIPTION
Content shouldn't need this arbitrary boost. We should allow elasticsearch relevance a bit more influence on what to return.