### PR TITLE
Remove topic boost

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -17,7 +17,6 @@ base:
     minister: 1.7
     operational_field: 1.5
     organisation: 2.5
-    topic: 1.5
     topical_event: 1.5
     # Hide mainstream browse pages
     mainstream_browse_page: 0

--- a/spec/unit/query_components/booster_spec.rb
+++ b/spec/unit/query_components/booster_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe QueryComponents::Booster do
 
     expect_format_boost(result, "minister", 1.7)
     expect_format_boost(result, "organisation", 2.5)
-    expect_format_boost(result, "topic", 1.5)
   end
 
   it "boost services content" do


### PR DESCRIPTION
There is no content that matches ["format = topic"](https://www.gov.uk/api/search.json?filter_format=topic) so this boost adds weight to queries without actually modifying anything.

Related: https://github.com/alphagov/whitehall/pull/5666