### PR TITLE
Dedupe boosting further

### DIFF
--- a/config/query/boosting.yml
+++ b/config/query/boosting.yml
@@ -3,17 +3,13 @@ base:
     coronavirus_landing_page: 2.5
     service_manual_guide: 0.3
     service_manual_topic: 0.3
-    step_by_step_nav: 2.5
     transaction: 1.5
-    smart_answer: 1.5
     # Should appear below govuk (mainstream) content
     aaib_report: 0.2
     research_for_development_output: 0.2
     hmrc_manual_section: 0.2
     service_standard_report: 0.05
     # Inside Gov formats
-    contact: 0.3
-    document_collection: 1.3
     minister: 1.7
     operational_field: 1.5
     organisation: 2.5
@@ -23,12 +19,14 @@ base:
     # Topics
     specialist_sector: 2.5
   content_store_document_type:
+    detailed_guide: 2.5
+    document_collection: 2.5
     foi_release: 0.2
+    manual: 2.5
+    regulation: 2.5
+    travel_advice: 2.5
   content_purpose_supergroup:
     services: 2.5
-  content_purpose_subgroup:
-    guidance: 2.5
-    regulation: 2.5
   organisation_state:
     closed: 0.2
     devolved: 0.3

--- a/spec/unit/query_components/booster_spec.rb
+++ b/spec/unit/query_components/booster_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe QueryComponents::Booster do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: "query" })
 
-    expect_format_boost(result, "contact", 0.3)
     expect_format_boost(result, "service_manual_guide", 0.3)
     expect_format_boost(result, "transaction", 1.5)
   end


### PR DESCRIPTION
In https://github.com/alphagov/search-api/pull/2284 I replaced a couple of out of date supertype groups with more current ones, however it wasn't quite equivalent.

In this commit, I remove the content_purpose_subgroups I added, and replace them with direct additions of the content types that were not already present in the content_purpose_supergroup services group, or elsewhere tracked in this file.

I've dropped the boosting of `contact` entirely because it was boosted by 2.5 and also suppressed by 0.3.

I've removed step_by_step_nav and smart_answers as direct references because they're picked up in the boosting of content_purpose_supergroup services group.

I've left transaction as being boosted, as it always was prioritised over other content.

document_collection was duplicated, so I've given it a lift to be equivalent to the others, and removed the duplication.

The other additions are direct copies from the original configuration.