### PR TITLE
Separate reranker & diskspace checks, add RFC 141 healthcheck endpoints

### DIFF
--- a/lib/healthcheck/elasticsearch_index_diskspace_check.rb
+++ b/lib/healthcheck/elasticsearch_index_diskspace_check.rb
@@ -30,6 +30,13 @@ module Healthcheck
       true # false if the check is not relevant at this time
     end
 
+    def to_hash
+      {
+        status: status,
+        message: message,
+      }.merge(details)
+    end
+
   private
 
     # Tune this to affect the amount of free space we need available as a minimum % before we alert

--- a/lib/healthcheck/reranker_healthcheck.rb
+++ b/lib/healthcheck/reranker_healthcheck.rb
@@ -25,6 +25,17 @@ module Healthcheck
       !%w[development].include? ENV["RACK_ENV"]
     end
 
+    def to_hash
+      if enabled?
+        {
+          status: status,
+          message: message,
+        }.merge(details)
+      else
+        { status: :ok }
+      end
+    end
+
   private
 
     def reranker_status

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -319,6 +319,17 @@ class Rummager < Sinatra::Application
     GovukHealthcheck.healthcheck(checks).to_json
   end
 
+  get "/healthcheck/live" do
+    [200, { "Content-Type" => "text/plain" }, "OK"]
+  end
+
+  get "/healthcheck/ready" do
+    GovukHealthcheck.rack_response(
+      GovukHealthcheck::SidekiqRedis,
+      Healthcheck::ElasticsearchConnectivityCheck,
+    ).call
+  end
+
   get "/healthcheck/reranker" do
     Healthcheck::RerankerHealthcheck.new.to_hash.to_json
   end

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -319,6 +319,14 @@ class Rummager < Sinatra::Application
     GovukHealthcheck.healthcheck(checks).to_json
   end
 
+  get "/healthcheck/reranker" do
+    Healthcheck::RerankerHealthcheck.new.to_hash.to_json
+  end
+
+  get "/healthcheck/elasticsearch-diskspace" do
+    Healthcheck::ElasticsearchIndexDiskspaceCheck.new.to_hash.to_json
+  end
+
   get "/sitemap.xml" do
     serve_from_s3("sitemap.xml")
   end

--- a/spec/integration/app/healthcheck_spec.rb
+++ b/spec/integration/app/healthcheck_spec.rb
@@ -43,16 +43,15 @@ RSpec.describe "HealthcheckTest" do
       end
 
       it "returns a warning status" do
-        get "/healthcheck"
-        expect(parsed_response.dig("checks", "reranker_healthcheck", "status")).to eq "warning"
+        get "/healthcheck/reranker"
+        expect(parsed_response["status"]).to eq "warning"
       end
     end
 
     context "when reranker healthcheck passes" do
       it "returns an OK status" do
-        get "/healthcheck"
+        get "/healthcheck/reranker"
         expect(parsed_response["status"]).to eq "ok"
-        expect(parsed_response.dig("checks", "reranker_healthcheck", "status")).to eq "ok"
       end
     end
   end
@@ -88,19 +87,17 @@ RSpec.describe "HealthcheckTest" do
       end
 
       it "returns a critical status" do
-        get "/healthcheck"
+        get "/healthcheck/elasticsearch-diskspace"
 
         expect(parsed_response["status"]).to eq "critical"
-        expect(parsed_response.dig("checks", "elasticsearch_diskspace", "status")).to eq "critical"
       end
     end
 
     context "when elasticsearch disk image has more than 20% free" do
       it "returns an OK status" do
-        get "/healthcheck"
+        get "/healthcheck/elasticsearch-diskspace"
 
         expect(parsed_response["status"]).to eq "ok"
-        expect(parsed_response.dig("checks", "elasticsearch_diskspace", "status")).to eq "ok"
       end
     end
   end

--- a/spec/integration/app/healthcheck_spec.rb
+++ b/spec/integration/app/healthcheck_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "HealthcheckTest" do
       end
 
       it "returns a critical status" do
-        get "/healthcheck"
+        get "/healthcheck/ready"
 
         expect(parsed_response["status"]).to eq "critical"
       end
@@ -63,7 +63,7 @@ RSpec.describe "HealthcheckTest" do
       end
 
       it "returns a critical status" do
-        get "/healthcheck"
+        get "/healthcheck/ready"
 
         expect(parsed_response["status"]).to eq "critical"
         expect(parsed_response.dig("checks", "elasticsearch_connectivity", "status")).to eq "critical"
@@ -72,7 +72,7 @@ RSpec.describe "HealthcheckTest" do
 
     context "when elasticsearch CAN be connected to" do
       it "returns an OK status" do
-        get "/healthcheck"
+        get "/healthcheck/ready"
 
         expect(parsed_response["status"]).to eq "ok"
         expect(parsed_response.dig("checks", "elasticsearch_connectivity", "status")).to eq "ok"
@@ -98,46 +98,6 @@ RSpec.describe "HealthcheckTest" do
         get "/healthcheck/elasticsearch-diskspace"
 
         expect(parsed_response["status"]).to eq "ok"
-      end
-    end
-  end
-
-  describe "#sidekiq_queue_latency check" do
-    before do
-      allow(Sidekiq).to receive(:redis_info).and_return({})
-    end
-
-    context "when queue latency is 2 (seconds)" do
-      let(:queue_latency) { 2.seconds }
-
-      it "retuns an OK status" do
-        get "/healthcheck"
-
-        expect(last_response).to be_ok
-
-        expect(parsed_response.dig("checks", "sidekiq_queue_latency", "status")).to eq "ok"
-      end
-    end
-
-    context "when queue latency is high" do
-      let(:queue_latency) { 32.seconds }
-
-      it "retuns a warning status" do
-        get "/healthcheck"
-
-        expect(parsed_response["status"]).to eq "warning"
-        expect(parsed_response.dig("checks", "sidekiq_queue_latency", "status")).to eq "warning"
-      end
-    end
-
-    context "when queue latency is very high" do
-      let(:queue_latency) { 2.minutes }
-
-      it "retuns a critical status" do
-        get "/healthcheck"
-
-        expect(parsed_response["status"]).to eq("critical")
-        expect(parsed_response.dig("checks", "sidekiq_queue_latency", "status")).to eq "critical"
       end
     end
   end


### PR DESCRIPTION
The reranker & ElasticSearch disk space checks have value,
because we want to know if either of these things occurs, but
it's not a fatal error and the app can keep running.

Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)