### PR TITLE
Be more specific about the LTR model path in S3

### DIFF
--- a/ltr/concourse/deploy.py
+++ b/ltr/concourse/deploy.py
@@ -39,7 +39,7 @@ except Exception:
 
 # find the model
 
-model_location_prefix = f"model/{(model_tag or model_name).strip()}"
+model_location_prefix = f"model/{(model_tag or model_name).strip()}/output"
 print(f"looking with prefix {model_location_prefix}", file=sys.stderr)
 
 try:

--- a/ltr/concourse/train.py
+++ b/ltr/concourse/train.py
@@ -41,6 +41,6 @@ estimator.fit(
     }
 )
 
-print(model_name)
+print(f"{model_name}/{estimator._current_job_name}")
 
 print("done", file=sys.stderr)


### PR DESCRIPTION
The S3 model lives somewhere like this:
> model/1597611974-1597613098.7122111/search-2020-08-16-21-24-58-712/output/model.tar.gz

but we're searching only under the first level:
> model/1597611974-1597613098.7122111

which means, should any other stuff get deployed there, we'll get an error because we can't decide which model to ship. This should increase the path to the specific output of the parent job.