### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -305,20 +305,6 @@ class Rummager < Sinatra::Application
     status.to_json
   end
 
-  # Healthcheck using govuk_app_config for Icinga alerts
-  # See govuk_app_config/healthcheck for guidance on adding checks.
-  get "/healthcheck" do
-    checks = [
-      GovukHealthcheck::SidekiqRedis,
-      Healthcheck::SidekiqQueueLatenciesCheck,
-      Healthcheck::ElasticsearchConnectivityCheck,
-      Healthcheck::RerankerHealthcheck,
-      Healthcheck::ElasticsearchIndexDiskspaceCheck,
-    ]
-
-    GovukHealthcheck.healthcheck(checks).to_json
-  end
-
   get "/healthcheck/live" do
     [200, { "Content-Type" => "text/plain" }, "OK"]
   end


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
