### PR TITLE
Allow /world/all to be found in search

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -73,6 +73,7 @@ migrated:
 - taxon:
   - /brexit
   - /transition
+  - /world/all
   - /world/afghanistan
   - /world/albania
   - /world/algeria


### PR DESCRIPTION
This is a taxon page so is not available unless explicitly tagged here. It's required so that the page can be added to a mainstream browse page.

https://trello.com/c/Htmtq32N/370-add-world-to-mainstream-browse#comment-60deff5767f324483180a0b1