### PR TITLE
Remove /uk-nationals-living-eu

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -320,7 +320,6 @@ non_indexable:
   - '/tour'
   - '/help/ab-testing'
   - '/help.json'
-  - '/uk-nationals-living-eu'
   - '/random'
   # from whitehall
   - "/BingSiteAuth.xml"

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -98,14 +98,6 @@ class SpecialRoutePublisher
         description: "The prefix URL under which our XML sitemaps are located.",
         type: "prefix",
       },
-      {
-        rendering_app: "finder-frontend",
-        base_path: "/uk-nationals-living-eu",
-        content_id: "7a99da17-e9e1-410b-b67d-c3f6348c595d",
-        title: "UK nationals living in the EU",
-        description: "Q&A frontend for the country pages affected by EU Exit",
-        type: "exact",
-      },
     ]
   end
 end


### PR DESCRIPTION
This is a custom page that will be redirected to a collection.

We're going to override the content item and route using short-url-manager.

https://trello.com/c/rTwoXCox/1695-redirect-where-do-you-live-tool-to-fcdo-living-in-collection-page