### PR TITLE
Add new fields to UKMCAB specialist document type

### DIFF
--- a/config/schema/elasticsearch_types/uk_market_conformity_assessment_body.json
+++ b/config/schema/elasticsearch_types/uk_market_conformity_assessment_body.json
@@ -9,7 +9,9 @@
     "uk_market_conformity_assessment_body_website",
     "uk_market_conformity_assessment_body_email",
     "uk_market_conformity_assessment_body_phone",
-    "uk_market_conformity_assessment_body_legislative_area"
+    "uk_market_conformity_assessment_body_legislative_area",
+    "uk_market_conformity_assessment_body_notified_body_number",
+    "uk_market_conformity_assessment_body_address"
   ],
   "expanded_search_result_fields": {
     "uk_market_conformity_assessment_body_type": [

--- a/config/schema/elasticsearch_types/uk_market_conformity_assessment_body.json
+++ b/config/schema/elasticsearch_types/uk_market_conformity_assessment_body.json
@@ -32,8 +32,8 @@
         "value": "recognised-third-party-organisation"
       },
       {
-        "label": "Third country body",
-        "value": "third-country-body"
+        "label": "Overseas body",
+        "value": "overseas-body"
       },
       {
         "label": "Notified body (NI)",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -677,6 +677,9 @@
   "uk_market_conformity_assessment_body_number": {
     "type": "searchable_identifier"
   },
+  "uk_market_conformity_assessment_body_notified_body_number": {
+    "type": "identifier"
+  },
   "uk_market_conformity_assessment_body_type": {
     "type": "searchable_identifiers"
   },
@@ -697,6 +700,9 @@
   },
   "uk_market_conformity_assessment_body_legislative_area": {
     "type": "searchable_identifiers"
+  },
+  "uk_market_conformity_assessment_body_address": {
+    "type": "identifier"
   },
   "authors": {
     "description": "A set of author names, which aren't selected from a predefined list and don't repeat",

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -155,6 +155,8 @@ module GovukIndex
         uk_market_conformity_assessment_body_testing_locations: specialist.uk_market_conformity_assessment_body_testing_locations,
         uk_market_conformity_assessment_body_type: specialist.uk_market_conformity_assessment_body_type,
         uk_market_conformity_assessment_body_website: specialist.uk_market_conformity_assessment_body_website,
+        uk_market_conformity_assessment_body_notified_body_number: specialist.uk_market_conformity_assessment_body_notified_body_number,
+        uk_market_conformity_assessment_body_address: specialist.uk_market_conformity_assessment_body_address,
         user_journey_document_supertype: common_fields.user_journey_document_supertype,
         value_of_funding: specialist.value_of_funding,
         vessel_type: specialist.vessel_type,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -97,6 +97,8 @@ module GovukIndex
     delegate_to_payload :uk_market_conformity_assessment_body_testing_locations, convert_to_array: true
     delegate_to_payload :uk_market_conformity_assessment_body_type, convert_to_array: true
     delegate_to_payload :uk_market_conformity_assessment_body_website
+    delegate_to_payload :uk_market_conformity_assessment_body_address
+    delegate_to_payload :uk_market_conformity_assessment_body_notified_body_number
     delegate_to_payload :value_of_funding
     delegate_to_payload :vessel_type
     delegate_to_payload :will_continue_on


### PR DESCRIPTION
## What

We have received a request to add more fields to `uk_market_conformity_assessment_body` document types. 

Related work:
See https://github.com/alphagov/specialist-publisher/pull/1899

Trello: https://trello.com/c/DvVWCPT7/2644-changes-to-ukmcab-specialist-document-and-finder-5
