### PR TITLE
Add new report type for `Marine Accident Investigation Branch reports`.

### DIFF
--- a/config/schema/elasticsearch_types/maib_report.json
+++ b/config/schema/elasticsearch_types/maib_report.json
@@ -43,6 +43,10 @@
         "value": "investigation-report"
       },
       {
+        "label": "Investigation report on behalf of Red Ensign Group",
+        "value": "investigation-report-on-behalf-of-red-ensign-group"
+      },
+      {
         "label": "Safety bulletin",
         "value": "safety-bulletin"
       },


### PR DESCRIPTION
Added a new report type: 'Investigation report on behalf of Red Ensign Group', following 'Investigation report' type.

[Trello card](https://trello.com/c/GLTNl1B4/2709-add-new-report-type-for-marine-accident-investigation-branch-reports-3)

Related PR's:
https://github.com/alphagov/specialist-publisher/pull/1927
https://github.com/alphagov/govuk-content-schemas/pull/1075