### PR TITLE
Remove references to specialist document finders

### DIFF
--- a/docs/publishing-finders.md
+++ b/docs/publishing-finders.md
@@ -1,9 +1,7 @@
 # Publishing finders
 
-Search API is currently used to publish some finders which do not fit
-the standard specialist document finder pattern. These are:
-
-For new finder content items, use the rake task `publishing_api:publish_finder`. For example:
+Search API is used to publish finders and their corresponding email signup content items.
+For example:
 
 ```
 FINDER_CONFIG=news_and_communications.yml EMAIL_SIGNUP_CONFIG=news_and_communications_email_signup.yml publishing_api:publish_finder


### PR DESCRIPTION
Removes the following text:
"Search API is currently used to publish some finders which do not fit
the standard specialist document finder pattern. These are:"

This text used to be:

"Rummager is currently used to publish two specific finders which do
not fit the standard specialist document finder pattern. These are:"

"two specific finders" was renamed to "some finders" here:
https://github.com/alphagov/search-api/commit/1351ba07451babc1249f62502c668d3941d0a90e#diff-bcd2e3cfb9dbd15522ba6293e991ea0072ccf34d78518fae4d0af939f3a67199L3-L4

...but the number of finders was never more than two. And, in fact, the
first finder was removed from the list here:
https://github.com/alphagov/search-api/commit/5af425415dfc5d9f356408dfe2041157993d0bc3#diff-bcd2e3cfb9dbd15522ba6293e991ea0072ccf34d78518fae4d0af939f3a67199L6
Then the second finder removed here:
https://github.com/alphagov/search-api/commit/699534dd25af1960da753c285501ae3df55ecede#diff-bcd2e3cfb9dbd15522ba6293e991ea0072ccf34d78518fae4d0af939f3a67199L6

...meaning that there are now _no_ non-conforming specialist finders published by Search API.