### PR TITLE
Update link to Search API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Search API also provides a public API: https://www.gov.uk/api/search.json?q=taxe
 ## API documentation
 
 If you would like to use the Search API, please see the
-[Search API documentation](https://docs.publishing.service.gov.uk/apis/search/search-api.html).
+[Search API documentation](https://docs.publishing.service.gov.uk/apps/search-api/using-the-search-api.html).
 
 You can also find some examples in the blog post:
 ["Use the search API to get useful information about GOV.UK content"](https://gdsdata.blog.gov.uk/2016/05/26/use-the-search-api-to-get-useful-information-about-gov-uk-content/).


### PR DESCRIPTION
The link redirected to https://docs.publishing.service.gov.uk/apps/search-api.html, which has the same content as the original link. However, it does lead to a confusing UX, as readers who are already on the Developer Docs page could keep clicking through to the same page as they are already on.

A more appropriate link is the "Using the search API" page, which seems to be the intention behind the link text.

Zendesk: https://govuk.zendesk.com/agent/tickets/4788958