### PR TITLE
Changes to the 'product-safety-alert' specialist document type

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -37,7 +37,7 @@ person: person
 place: edition
 policy: policy # Policy Publisher
 press_release: edition
-product_safety_alert: product_safety_alert # Specialist Publisher
+product_safety_alert: product_safety_alert_report_recall # Specialist Publisher
 protected_food_drink_name: protected_food_drink_name # Specialist Publisher
 raib_report: raib_report # Specialist Publisher
 research_for_development_output: research_for_development_output # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -42,7 +42,7 @@ migrated:
 - marine_notice
 - medical_safety_alert
 - oim_project
-- product_safety_alert
+- product_safety_alert_report_recall
 - protected_food_drink_name
 - raib_report
 - research_for_development_output

--- a/config/schema/elasticsearch_types/product_safety_alert_report_recall.json
+++ b/config/schema/elasticsearch_types/product_safety_alert_report_recall.json
@@ -8,9 +8,9 @@
   ],
   "expanded_search_result_fields": {
     "product_alert_type": [
-      {"label": "Safety alert", "value": "safety-alert"},
+      {"label": "Product safety alert", "value": "product-safety-alert"},
       {"label": "Product safety report", "value": "product-safety-report"},
-      {"label": "Recall", "value": "recall"}
+      {"label": "Product recall", "value": "product-recall"}
     ],
     "product_risk_level": [
       {"label": "Serious", "value": "serious"},

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -975,7 +975,7 @@
     "type": "date"
   },
   "product_alert_type":{
-    "description": "Alert type: {safety-alert, product-safety-report, recall}",
+    "description": "Alert type: {product-safety-alert, product-safety-report, product-recall}",
     "type": "identifiers"
   },
   "product_risk_level":{

--- a/config/schema/indexes/govuk.json
+++ b/config/schema/indexes/govuk.json
@@ -24,7 +24,7 @@
     "oim_project",
     "person",
     "policy",
-    "product_safety_alert",
+    "product_safety_alert_report_recall",
     "protected_food_drink_name",
     "raib_report",
     "research_for_development_output",


### PR DESCRIPTION
Name has been changed from 'product-safety-alert' to 'product-safety-alert-report-recall',
this will be pluralised correctly using the locales on the frontend. The product alert types
have also been changed to 'product-safety-alert, product-safety-report, product-recall` for
consistency.

Trello: https://trello.com/c/ojsFViiX/2746-create-new-specialist-document-and-finder-product-safety-alerts-unsafe-products-and-recalls-3-5