### PR TITLE
Update mapped document type for product_safety_alert_report_recalls

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -1,3 +1,6 @@
+# the key represents the publishing_api document type
+# the value represents the elasticsearch_type defined in config/schema/elasticsearch_types
+
 aaib_report: aaib_report # Specialist Publisher
 answer: edition
 asylum_support_decision: asylum_support_decision # Specialist Publisher
@@ -38,7 +41,7 @@ person: person
 place: edition
 policy: policy # Policy Publisher
 press_release: edition
-product_safety_alert: product_safety_alert_report_recall # Specialist Publisher
+product_safety_alert_report_recall: product_safety_alert_report_recall # Specialist Publisher
 protected_food_drink_name: protected_food_drink_name # Specialist Publisher
 raib_report: raib_report # Specialist Publisher
 research_for_development_output: research_for_development_output # Specialist Publisher


### PR DESCRIPTION
There is a bug where `produect_safety_alert_report_recalls` published from the Specialist Publisher UI are not being returned from search. Eg

- [Page](https://www.integration.publishing.service.gov.uk/product-safety-alerts-reports-recalls/product-safety-report-the-mini-mermaids-dolls-toy-2101-0112) on GOV.UK 
- [Content Item](https://www.integration.publishing.service.gov.uk/api/content/product-safety-alerts-reports-recalls/product-safety-report-the-mini-mermaids-dolls-toy-2101-0112)
- But nothing from [search](https://www.integration.publishing.service.gov.uk/api/search.json?filter_link=/product-safety-alerts-reports-recalls/product-safety-report-the-mini-mermaids-dolls-toy-2101-0112)

See commit message for more information. 

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4903370
