### PR TITLE
Use env `LOG_TO_STDOUT` to enable stdout logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY . /app
 
 FROM $base_image
 
-ENV RAILS_ENV=production GOVUK_APP_NAME=search-api
+ENV RAILS_ENV=production GOVUK_APP_NAME=search-api LOG_TO_STDOUT=true
 
 RUN apt-get update -qy && \
     apt-get upgrade -y && \

--- a/config.ru
+++ b/config.ru
@@ -20,15 +20,18 @@ end
 
 if log_path
   enable :logging
-  log = File.new(log_path, "a")
-  log.sync = true
-  STDOUT.reopen(log)
-  STDERR.reopen(log)
+  unless ENV["LOG_TO_STDOUT"].present?
+    log = File.new(log_path, "a")
+    log.sync = true
+    STDOUT.reopen(log)
+    STDERR.reopen(log)
+  end
 end
 
 unless in_development
+  logger = ENV["LOG_TO_STDOUT"].present? ? Logger.new($stdout) : Logger.new("log/production.json.log") 
   use Rack::Logstasher::Logger,
-      Logger.new("log/production.json.log"),
+      logger,
       extra_request_headers: { "GOVUK-Request-Id" => "govuk_request_id", "x-varnish" => "varnish_id" }
 end
 


### PR DESCRIPTION
In EKS, we want logging to go to stdout rather than to a logging
file. This commit introduce a new `LOG_TO_STDOUT` env which
when set will log to stdout.

By default, stdout logging is enable in the Docker image as decided
[here](https://github.com/alphagov/govuk-helm-charts/pull/23).
We need to disable that for publishing-e2e.