### PR TITLE
[spike] Increase top-k size to 40 by default for relevance queries

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -6,6 +6,7 @@ class SearchParameterParser < BaseParameterParser
     expanded_organisations
   ].freeze
   MAX_RESULTS = 1500
+  MAX_K = 40
 
   # We currently have 375,000 items in Rummager.  Anything over around 900_000
   # results in 5XX errors
@@ -42,6 +43,7 @@ private
     @parsed_params = {
       start: capped_start,
       count: capped_count,
+      rerankable_k: capped_k,
       cluster: cluster,
       search_config: SearchConfig.instance(cluster),
       query: query,
@@ -95,6 +97,14 @@ private
     else
       specified_count
     end
+  end
+
+  def capped_k
+    k = single_integer_param("k", capped_count)
+    return k unless k > MAX_K
+
+    @errors << "Cannot re-rank k of size #{k}. Maximum K (as specified in 'k') is #{MAX_K}"
+    capped_count
   end
 
   def parse_query(query)

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -94,7 +94,7 @@ module Search
 
       return { reranked: false, es_response: es_response } if reranked.nil?
 
-      es_response["hits"]["hits"] = reranked
+      es_response["hits"]["hits"] = reranked.first(search_params.count)
       { reranked: true, es_response: es_response }
     end
 

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -14,7 +14,7 @@ module Search
     def payload
       hash_without_blank_values(
         from: search_params.start,
-        size: search_params.count,
+        size: size,
         _source: {
           includes: fields.uniq,
         },
@@ -122,6 +122,10 @@ module Search
           min_doc_freq: 0, # Revert to the ES 1.7 default
         },
       }
+    end
+
+    def size
+      search_params.fetch_larger_k? ? search_params.rerankable_k : search_params.count
     end
   end
 end

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -7,6 +7,7 @@ module Search
                   :order,
                   :start,
                   :count,
+                  :rerankable_k,
                   :return_fields,
                   :aggregates,
                   :aggregate_name,
@@ -72,6 +73,10 @@ module Search
 
     def suggest_spelling?
       query && (suggest.include?("spelling") || suggest.include?("spelling_with_highlighting"))
+    end
+
+    def fetch_larger_k?
+      rerankable_k > count && rerank
     end
 
     def rerank


### PR DESCRIPTION
Queries will by default fetch 40 documents from Elasticsearch,
or the K documents specifies by the `k` query parameter (max: 40).
The reranker will re-rank K documents, and return only the top-k
specified through the `count` parameter.

This will put greater load on the Elasticsearch cluster but should
improve search quality for relevance queries.