### PR TITLE
Don't index the Brexit taxon (whatever its name is)

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -74,8 +74,6 @@ migrated:
 - service_manual_topic
 - step_by_step_nav
 - taxon:
-  - /brexit
-  - /transition
   - /world/all
   - /world/afghanistan
   - /world/albania


### PR DESCRIPTION
The landing page has been replaced by https://www.gov.uk/government/collections/brexit-guidance so we don't need to index these topic pages any more.