### PR TITLE
Update cacher_dir location

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -6,7 +6,7 @@ require "sinatra"
 set :root, File.dirname(__FILE__)
 
 Bootsnap.setup(
-  cache_dir: "tmp/cache",
+  cache_dir: "/tmp/cache",
   development_mode: ENV["RACK_ENV"] == "development",
   load_path_cache: true,
   autoload_paths_cache: true,


### PR DESCRIPTION
While Replatforming search-api and disabling root containers from running in EKS - we detected an error:

**error message:**
_Errno::EACCES: Permission denied @ dir_s_mkdir - tmp
/usr/local/lib/ruby/2.7.0/fileutils.rb:250:in mkdir'_

To resolve this issue i have updated to use `/tmp` rather than `tmp`.

https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot