### PR TITLE
Update bootsnap cache dir location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,25 @@ COPY . /app
 
 FROM $base_image
 
-ENV RAILS_ENV=production GOVUK_APP_NAME=search-api LOG_TO_STDOUT=true
+ENV RAILS_ENV=production \
+    GOVUK_APP_NAME=search-api \
+    LOG_TO_STDOUT=true
 
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y nodejs && \
     apt-get clean
 
+RUN mkdir /app && ln -fs /tmp /app
+
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 
 WORKDIR /app
+
+RUN groupadd -g 1001 app && \
+    useradd app -u 1001 -g 1001 --home /app
+
+USER app
 
 CMD bundle exec puma

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -6,7 +6,7 @@ require "sinatra"
 set :root, File.dirname(__FILE__)
 
 Bootsnap.setup(
-  cache_dir: "/tmp/cache",
+  cache_dir: "tmp/cache",
   development_mode: ENV["RACK_ENV"] == "development",
   load_path_cache: true,
   autoload_paths_cache: true,

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -6,7 +6,7 @@ require "sinatra"
 set :root, File.dirname(__FILE__)
 
 Bootsnap.setup(
-  cache_dir: "tmp/cache",
+  cache_dir: "/tmp/cache",
   development_mode: ENV["RACK_ENV"] == "development",
   load_path_cache: true,
   autoload_paths_cache: true,


### PR DESCRIPTION
 Updating Dockerfile to soft link /tmp as Bootsnap tmp cache location for GOVUK
 kubernetes deploymenit.
 
 This change symlinks /tmp to /app/tmp

I also attempted to use `BOOTSNAP_CACHE_DIR=/tmp/cache ` as ENV value - which seems to not have any affect on the app.