### PR TITLE
Add with_retries to real index name, and allow retries in client

### DIFF
--- a/lib/legacy_client/index_for_search.rb
+++ b/lib/legacy_client/index_for_search.rb
@@ -65,6 +65,19 @@ module LegacyClient
 
   private
 
+    def with_retries
+      retries ||= 0
+      begin
+        yield
+      rescue HTTPClient::TimeoutError, Faraday::TimeoutError
+        raise if (retries += 1) > 10
+
+        logger.info "Retrying after #{retries} timeout errors"
+        sleep 2**retries
+        retry
+      end
+    end
+
     def logger
       Logging.logger[self]
     end

--- a/lib/legacy_client/index_for_search.rb
+++ b/lib/legacy_client/index_for_search.rb
@@ -18,7 +18,9 @@ module LegacyClient
         # this may throw an exception if the index name isn't found,
         # but we want to propagate the error in that case as it
         # shouldn't happen.
-        @client.indices.get_alias(index: index_name).keys.first
+        with_retries do
+          @client.indices.get_alias(index: index_name).keys.first
+        end
       end
     end
 
@@ -68,7 +70,7 @@ module LegacyClient
     end
 
     def build_client(options = {})
-      Services.elasticsearch(hosts: @base_uri, timeout: options[:timeout] || TIMEOUT_SECONDS)
+      Services.elasticsearch(hosts: @base_uri, timeout: options[:timeout] || TIMEOUT_SECONDS, retry_on_failure: true)
     end
   end
 end


### PR DESCRIPTION
Attempt to mitigate errors like this:
https://sentry.io/organizations/govuk/issues/1711334233/?project=1461905&referrer=slack

https://trello.com/c/1CLYXebu/443-investigate-search-api-timeout-problems-in-integration-staging

Using a similar technique as the one from this card:
https://trello.com/c/YDrY6zRx/446-investigation-faradaytimeouterror-errors-in-search-api-timebox-2-days 