### PR TITLE
Add option to case_types in cma_case

### DIFF
--- a/config/schema/elasticsearch_types/cma_case.json
+++ b/config/schema/elasticsearch_types/cma_case.json
@@ -31,6 +31,10 @@
         "value": "criminal-cartels"
       },
       {
+        "label": "Information and advice to government",
+        "value": "information-and-advice-to-government"
+      },
+      {
         "label": "Markets",
         "value": "markets"
       },


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/RqdVvCSV/548-add-a-new-option-to-case-type-filter-on-cma-cases-specialist-finder)

This PR adds "Information and Advice to Government" as another option in the case_type field in cma_cases