### PR TITLE
Add finder for latest documents

### DIFF
--- a/config/finders/latest_finder.yml
+++ b/config/finders/latest_finder.yml
@@ -1,0 +1,15 @@
+---
+base_path: "/search/latest"
+content_id: eb56dbca-be0b-4381-8dac-0c9de8a3ed7e
+document_type: finder
+locale: en
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder
+title: Search
+description: Find content from government
+details:
+  default_documents_per_page: 20
+routes:
+- path: "/search/latest"
+  type: exact


### PR DESCRIPTION
In https://github.com/alphagov/finder-frontend/pull/2800, a new finder was introduced the replace the "Latest Documents" page that is currently rendered by Whitehall.

This adds the content item, so the finder can be accessed.

[Trello card](https://trello.com/c/93adHMBQ)