### PR TITLE
Update HMRC manual test to add manual title in section

### DIFF
--- a/spec/integration/govuk_index/hmrc_manuals_spec.rb
+++ b/spec/integration/govuk_index/hmrc_manuals_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "HMRC manual publishing" do
         section_id: "some_section_id",
         manual: {
           "base_path": "/parent/manual/path",
+          "title": "Parent Manual Title",
         },
       },
     )


### PR DESCRIPTION
HMRC Manual sections now have the parent manual title as an optional item in the manual block (this will become required soon)

https://trello.com/c/NToovfjr/1349-add-parent-manuals-title-to-the-hmrc-section-content-item