### PR TITLE
Upgrade to Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Check LTR dependencies install
         run: |
           set -ex

--- a/ltr/scripts/Dockerfile.sagemaker
+++ b/ltr/scripts/Dockerfile.sagemaker
@@ -1,5 +1,5 @@
 # See https://www.tensorflow.org/install/pip?lang=python3#package-location for supported Python versions
-FROM python:3.7
+FROM python:3.8
 
 RUN mkdir govuk
 WORKDIR govuk


### PR DESCRIPTION
## What

Upgrade Python from 3.7 to 3.8

## Why

There are outstanding `dependabot` PR's for `numpy` and `tensorflow` which are failing to build as the versions of these tools requires Python 3.8 and is incompatible with Python 3.7.

`dependabot` issues:

- https://github.com/alphagov/search-api/pull/2407
- https://github.com/alphagov/search-api/pull/2406
- https://github.com/alphagov/search-api/pull/2396

[Trello](https://trello.com/c/VwBT9uFl/163-upgrade-python-in-search-api)