### PR TITLE
Remove title from test

### DIFF
--- a/spec/integration/govuk_index/hmrc_manuals_spec.rb
+++ b/spec/integration/govuk_index/hmrc_manuals_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe "HMRC manual publishing" do
         section_id: "some_section_id",
         manual: {
           "base_path": "/parent/manual/path",
-          "title": "Parent Manual Title",
         },
       },
     )


### PR DESCRIPTION
We're no longer planning to populate the manual title on a section.

Trello:
https://trello.com/c/ItYKGMqF/1464-revert-add-parent-manuals-title-to-the-hmrc-section-content-item