### PR TITLE
Remove ability to filter by facet groups and facet values

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -374,9 +374,6 @@ non_indexable:
 - document_collection
 - equality_and_diversity
 - facet
-- facet_group
-- facet_value
-- facet_values
 - fatality_notice
 - field_of_operation
 #- finder # migrated

--- a/config/schema/base_elasticsearch_type.json
+++ b/config/schema/base_elasticsearch_type.json
@@ -8,8 +8,6 @@
     "content_store_document_type",
     "description",
     "email_document_supertype",
-    "facet_groups",
-    "facet_values",
     "format",
     "government_document_supertype",
     "government_name",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -164,16 +164,6 @@
     "type": "identifiers"
   },
 
-  "facet_groups": {
-      "description": "Facet groups associated the the documents. Used for tagging documents to finders",
-      "type": "identifiers"
-  },
-
-  "facet_values": {
-      "description": "Facet values associated the the documents. Used for modelling facets in finders",
-      "type": "identifiers"
-  },
-
   "updated_at": {
     "description": "Time of the last indexing. May be significantly newer than `public_timestamp`, as that usually only reflects major updates and not minor ones.",
     "type": "date"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -54,8 +54,6 @@ module GovukIndex
         document_type: type,
         eligible_entities: specialist.eligible_entities,
         email_document_supertype: common_fields.email_document_supertype,
-        facet_groups: expanded_links.facet_groups,
-        facet_values: expanded_links.facet_values,
         first_published_at: specialist.first_published_at,
         flood_and_coastal_erosion_category: specialist.flood_and_coastal_erosion_category,
         format: common_fields.format,

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -40,14 +40,6 @@ module GovukIndex
       content_ids("taxons")
     end
 
-    def facet_groups
-      content_ids("facet_groups")
-    end
-
-    def facet_values
-      content_ids("facet_values")
-    end
-
     def topic_content_ids
       content_ids("topics")
     end

--- a/lib/indexer/links_lookup.rb
+++ b/lib/indexer/links_lookup.rb
@@ -114,8 +114,6 @@ module Indexer
         "topic_content_ids" => content_ids_for(links, "topics"),
         "mainstream_browse_page_content_ids" => content_ids_for(links, "mainstream_browse_pages"),
         "organisation_content_ids" => content_ids_for(links, "organisations"),
-        "facet_groups" => content_ids_for(links, "facet_groups"),
-        "facet_values" => content_ids_for(links, "facet_values"),
         "part_of_taxonomy_tree" => parts_of_taxonomy_for_all_taxons(links),
       }
     end

--- a/spec/integration/indexer/links_lookup_spec.rb
+++ b/spec/integration/indexer/links_lookup_spec.rb
@@ -79,14 +79,6 @@ RSpec.describe "TaglookupDuringIndexingTest" do
               "base_path" => "/alpha-taxonomy/my-taxon-1",
             },
           ],
-          facet_values: [
-            { "content_id" => "TAG-1" },
-            { "content_id" => "TAG-2" },
-          ],
-          facet_groups: [
-            { "content_id" => "TGRP-1" },
-            { "content_id" => "TGRP-2" },
-          ],
         },
       },
       with_drafts: false,
@@ -109,8 +101,6 @@ RSpec.describe "TaglookupDuringIndexingTest" do
         "topic_content_ids" => %w[TOPIC-CONTENT-ID-1 TOPIC-CONTENT-ID-2],
         "mainstream_browse_page_content_ids" => %w[BROWSE-1],
         "organisation_content_ids" => %w[ORG-1 ORG-2],
-        "facet_groups" => %w[TGRP-1 TGRP-2],
-        "facet_values" => %w[TAG-1 TAG-2],
       },
       index: "government_test",
     )

--- a/spec/integration/search/batch_search_spec.rb
+++ b/spec/integration/search/batch_search_spec.rb
@@ -490,40 +490,6 @@ RSpec.describe "BatchSearchTest" do
     expect_results_includes_ministry_of_magic(results, 1, 0)
   end
 
-  it "can filter by facet groups" do
-    commit_treatment_of_dragons_document
-    commit_ministry_of_magic_document(
-      {
-        "facet_groups" => %w[eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c],
-      },
-    )
-
-    get build_get_url([{ filter_facet_groups: %w[eb2093ef-778c-4105-9f33-9aa03d14bc5c] }, { filter_facet_groups: %w[aa2093ef-778c-4105-9f33-9aa03d14bc5c] }])
-    results = parsed_response["results"]
-
-    expect_search_has_result_count(results[0], 1)
-    expect_results_includes_ministry_of_magic(results, 0, 0)
-    expect_search_has_result_count(results[1], 1)
-    expect_results_includes_ministry_of_magic(results, 1, 0)
-  end
-
-  it "can filter by facet values" do
-    commit_treatment_of_dragons_document
-    commit_ministry_of_magic_document(
-      {
-        "facet_values" => %w[eb2093ef-778c-4105-9f33-9aa03d14bc5c aa2093ef-778c-4105-9f33-9aa03d14bc5c],
-      },
-    )
-
-    get build_get_url([{ filter_facet_values: %w[eb2093ef-778c-4105-9f33-9aa03d14bc5c] }, { filter_facet_values: %w[aa2093ef-778c-4105-9f33-9aa03d14bc5c] }])
-    results = parsed_response["results"]
-
-    expect_search_has_result_count(results[0], 1)
-    expect_results_includes_ministry_of_magic(results, 0, 0)
-    expect_search_has_result_count(results[1], 1)
-    expect_results_includes_ministry_of_magic(results, 1, 0)
-  end
-
   it "will allow ten searches" do
     commit_ministry_of_magic_document
     searches = 10.times.map do

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -619,46 +619,6 @@ RSpec.describe "SearchTest" do
     expect(parsed_response.fetch("total")).to eq(1)
   end
 
-  it "can filter by facet value" do
-    commit_ministry_of_magic_document({ "facet_values" => %w[fe2fc3b5-a71b-4063-9605-12c3e6e179d6] })
-    commit_treatment_of_dragons_document({ "facet_values" => %w[e602eb34-a870-46ff-8ba4-de36689fb028] })
-    get "/search?filter_facet_values=fe2fc3b5-a71b-4063-9605-12c3e6e179d6"
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
-    expect_result_includes_ministry_of_magic_for_key(
-      parsed_response,
-      "results",
-      {
-        "_id" => "/ministry-of-magic-site",
-        "document_type" => "edition",
-        "elasticsearch_type" => "edition",
-        "es_score" => nil,
-        "index" => "government_test",
-        "link" => "/ministry-of-magic-site",
-      },
-    )
-  end
-
-  it "can filter by facet group" do
-    commit_ministry_of_magic_document({ "facet_groups" => %w[fe2fc3b5-a71b-4063-9605-12c3e6e179d6] })
-    commit_treatment_of_dragons_document({ "facet_groups" => %w[e602eb34-a870-46ff-8ba4-de36689fb028] })
-    get "/search?filter_facet_groups=fe2fc3b5-a71b-4063-9605-12c3e6e179d6"
-    expect(last_response).to be_ok
-    expect(parsed_response.fetch("total")).to eq(1)
-    expect_result_includes_ministry_of_magic_for_key(
-      parsed_response,
-      "results",
-      {
-        "_id" => "/ministry-of-magic-site",
-        "document_type" => "edition",
-        "elasticsearch_type" => "edition",
-        "es_score" => nil,
-        "index" => "government_test",
-        "link" => "/ministry-of-magic-site",
-      },
-    )
-  end
-
   it "can filter by roles" do
     commit_ministry_of_magic_document("roles" => %w[prime-minister])
     commit_treatment_of_dragons_document("roles" => %w[some-other-role])

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -112,42 +112,6 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     end
   end
 
-  describe "facet fields" do
-    let(:expanded_links) do
-      {
-        "facet_groups" => [{ "content_id" => "3501d07d-12f7-4f7e-97f9-0de008d556cd" }],
-        "facet_values" => [
-          { "content_id" => "4577e252-45c3-4c91-a040-c9f8568d0150" },
-          { "content_id" => "5e326667-0d05-4453-b3a0-a1c6e797171e" },
-        ],
-      }
-    end
-
-    let(:payload) do
-      payload = generate_random_example(payload: { payload_version: 1 })
-      payload["expanded_links"] = expanded_links
-      payload
-    end
-    let(:presenter) { elasticsearch_presenter(payload, payload["document_type"]) }
-    let(:popularity_instance) { instance_double(Indexer::PopularityLookup, lookup_popularities: {}) }
-
-    before do
-      allow(Indexer::PopularityLookup).to receive(:new).and_return(popularity_instance)
-    end
-
-    it "returns facet_groups" do
-      expect(presenter.document).to include(
-        facet_groups: %w[3501d07d-12f7-4f7e-97f9-0de008d556cd],
-      )
-    end
-
-    it "returns facet_values" do
-      expect(presenter.document).to include(
-        facet_values: %w[4577e252-45c3-4c91-a040-c9f8568d0150 5e326667-0d05-4453-b3a0-a1c6e797171e],
-      )
-    end
-  end
-
   def elasticsearch_presenter(payload, type = "aaib_report")
     type_mapper = GovukIndex::DocumentTypeMapper.new(payload)
     allow(type_mapper).to receive(:type).and_return(type)

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -204,34 +204,6 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.taxons).to eq(expected_taxons)
   end
 
-  it "facet_values" do
-    expanded_links = {
-      "facet_values" => [
-        { "content_id" => "ec58ec61-71a6-475a-8df5-da5f866990b5" },
-        { "content_id" => "dd71726f-3fe5-4e5f-8d29-8f668e32a659" },
-      ],
-    }
-
-    presenter = expanded_links_presenter(expanded_links)
-    expected_facet_values = %w[ec58ec61-71a6-475a-8df5-da5f866990b5 dd71726f-3fe5-4e5f-8d29-8f668e32a659]
-
-    expect(presenter.facet_values).to eq(expected_facet_values)
-  end
-
-  it "facet_groups" do
-    expanded_links = {
-      "facet_groups" => [
-        { "content_id" => "ec58ec61-71a6-475a-8df5-da5f866990b5" },
-        { "content_id" => "dd71726f-3fe5-4e5f-8d29-8f668e32a659" },
-      ],
-    }
-
-    presenter = expanded_links_presenter(expanded_links)
-    expected_facet_groups = %w[ec58ec61-71a6-475a-8df5-da5f866990b5 dd71726f-3fe5-4e5f-8d29-8f668e32a659]
-
-    expect(presenter.facet_groups).to eq(expected_facet_groups)
-  end
-
   it "topics" do
     expanded_links = {
       "topics" => [


### PR DESCRIPTION
Related to: 
* https://github.com/alphagov/finder-frontend/pull/2835

Trello: https://trello.com/c/EOLde8PE

`facet_groups` and `facet_values` were created to support the EU Exit Business Support Finder [1].
This finder was decommissioned in February 2020 [2], so support for these filter items is no longer needed.

[1]: https://github.com/alphagov/content-tagger/blob/main/docs/arch/adr-001-links-based-facets.md
[2]: https://github.com/alphagov/finder-frontend/pull/1949