### PR TITLE
Update Dockerfile to use new GOV.UK Ruby base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,21 @@
-ARG base_image=ruby:2.7.6-slim-buster
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
 
-FROM $base_image AS builder
-
-ENV RAILS_ENV=production
-
-# TODO: have a separate build image which already contains the build-only deps.
-RUN apt-get update -qq && \
-    apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs && \
-    apt-get clean
+FROM $builder_image AS builder
 
 RUN mkdir /app
 
 WORKDIR /app
 COPY Gemfile* .ruby-version /app/
 
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install -j8 --retry=2
+RUN bundle install
 
 COPY . /app
 
 FROM $base_image
 
-ENV RAILS_ENV=production \
-    GOVUK_APP_NAME=search-api \
+ENV GOVUK_APP_NAME=search-api \
     LOG_TO_STDOUT=true
-
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs && \
-    apt-get clean
 
 RUN mkdir /app && ln -fs /tmp /app
 
@@ -38,9 +23,6 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 
 WORKDIR /app
-
-RUN groupadd -g 1001 app && \
-    useradd app -u 1001 -g 1001 --home /app
 
 USER app
 


### PR DESCRIPTION
Updates the Dockerfile to use the new [GOV.UK Ruby base images](https://github.com/alphagov/govuk-ruby-images). Also updates the .ruby-version file to not specify a patch version, to allow for easier Ruby patching.

Context: https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles