### PR TITLE
Update world location news document type name

### DIFF
--- a/lib/learn_to_rank/format_enums.rb
+++ b/lib/learn_to_rank/format_enums.rb
@@ -41,7 +41,7 @@ module LearnToRank
         "licence" => 37,
         "specialist_sector" => 38,
         "transaction" => 39,
-        "world_location_news_page" => 40,
+        "world_location_news" => 40,
         "statutory_instrument" => 41,
         "countryside_stewardship_grant" => 42,
         "taxon" => 43,


### PR DESCRIPTION
We have recently renamed the name of the format we send to search, to remove some confusing differences in naming in our stack. This change should ensure that the search results are ranked in the same place as when they were published under the previously named format.

Merged whitehall PR in which we update the search presenter to reflect the new doc type [here](https://github.com/alphagov/whitehall/pull/6747)

[Trello ](https://trello.com/c/5vpV1JUu/194-update-world-news-location-document-type)