### PR TITLE
Change report type for Marine Accident Investigation Branch reports

### DIFF
--- a/config/schema/elasticsearch_types/maib_report.json
+++ b/config/schema/elasticsearch_types/maib_report.json
@@ -51,8 +51,8 @@
         "value": "safety-bulletin"
       },
       {
-        "label": "Completed preliminary examination",
-        "value": "completed-preliminary-examination"
+        "label": "Completed preliminary assessment",
+        "value": "completed-preliminary-assessment"
       },
       {
         "label": "Overseas report",


### PR DESCRIPTION
As requested [Trello card](https://trello.com/c/6OoRo5vK/708-change-report-type-for-marine-accident-investigation-branch-reports)

Related PR:
https://github.com/alphagov/govuk-content-schemas/pull/1120
https://github.com/alphagov/specialist-publisher/pull/2106