### PR TITLE
Change report type for Marine Accident Investigation Branch reports

### DIFF
--- a/config/schema/elasticsearch_types/maib_report.json
+++ b/config/schema/elasticsearch_types/maib_report.json
@@ -52,7 +52,7 @@
       },
       {
         "label": "Completed preliminary assessment",
-        "value": "completed-preliminary-assessment"
+        "value": "completed-preliminary-examination"
       },
       {
         "label": "Overseas report",


### PR DESCRIPTION
Changing label only (partially reverting previous PR)
 [Trello card](https://trello.com/c/6OoRo5vK/708-change-report-type-for-marine-accident-investigation-branch-reports)
