### PR TITLE
Avoid unnecessary mkdir /app in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,21 +3,18 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
 
 FROM $builder_image AS builder
 
-RUN mkdir /app
-
 WORKDIR /app
-COPY Gemfile* .ruby-version /app/
 
+COPY Gemfile* .ruby-version /app/
 RUN bundle install
 
 COPY . /app
+
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=search-api \
     LOG_TO_STDOUT=true
-
-RUN mkdir /app && ln -fs /tmp /app
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/


### PR DESCRIPTION
This is needed in order to remain compatible with an upcoming change to govuk-ruby-base.