### PR TITLE
Remove Plek.current

### DIFF
--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -157,7 +157,7 @@ module Sitemap
 
     def homepage
       {
-        url: "#{Plek.current.website_root}/",
+        url: "#{Plek.new.website_root}/",
         priority: 0.5,
       }
     end
@@ -167,7 +167,7 @@ module Sitemap
     end
 
     def base_url
-      Plek.current.website_root
+      Plek.new.website_root
     end
   end
 end

--- a/lib/sitemap/presenter.rb
+++ b/lib/sitemap/presenter.rb
@@ -49,6 +49,6 @@ private
   end
 
   def base_url
-    Plek.current.website_root
+    Plek.new.website_root
   end
 end

--- a/spec/integration/workers/indexer/amend_worker_spec.rb
+++ b/spec/integration/workers/indexer/amend_worker_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Indexer::AmendWorker do
   end
 
   def stub_request_to_publishing_api(id)
-    endpoint = "#{Plek.current.find('publishing-api')}/v2"
+    endpoint = "#{Plek.find('publishing-api')}/v2"
     expanded_links_url = "#{endpoint}/expanded-links/#{id}?with_drafts=false"
 
     stub_request(:get, expanded_links_url).to_return(status: 200, body: {}.to_json)

--- a/spec/integration/workers/indexer/bulk_index_worker_spec.rb
+++ b/spec/integration/workers/indexer/bulk_index_worker_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Indexer::BulkIndexWorker do
   end
 
   def stub_request_to_publishing_api
-    endpoint = "#{Plek.current.find('publishing-api')}/lookup-by-base-path"
+    endpoint = "#{Plek.find('publishing-api')}/lookup-by-base-path"
 
     stub_request(:post, endpoint).to_return(status: 200, body: {}.to_json)
   end

--- a/spec/unit/indexer/links_lookup_spec.rb
+++ b/spec/unit/indexer/links_lookup_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Indexer::LinksLookup do
   include GdsApi::TestHelpers::PublishingApi
 
   let(:content_id) { "DOCUMENT_CONTENT_ID" }
-  let(:endpoint) { "#{Plek.current.find('publishing-api')}/v2" }
+  let(:endpoint) { "#{Plek.find('publishing-api')}/v2" }
   let(:expanded_links_url) { "#{endpoint}/expanded-links/#{content_id}?with_drafts=false" }
 
   it "retry links on timeout" do


### PR DESCRIPTION
`Plek.current` was marked as deprecated in alphagov/plek#94. This replaces all uses of `Plek.current` to stop deprecation warnings from filling up the logs with:

"Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead."

[Trello](https://trello.com/c/vdnZ4cBq/233-replace-plekcurrent)