### PR TITLE
Remove publishing e2e tests from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@
 library("govuk")
 
 node('elasticsearch-6.7') {
-  govuk.buildProject(publishingE2ETests: true)
+  govuk.buildProject()
 }


### PR DESCRIPTION
## Context

We're decommissioning the [Publishing E2E tests][] now that GOV.UK apps have transitioned to a model of continuous deployment with contract tests, as outlined in [RFC-128][]. The overall progress of this work is tracked in a [Trello card on the GOV.UK Tech Debt board][tech-debt-card].

[Publishing E2E tests]: https://github.com/alphagov/publishing-e2e-tests
[RFC-128]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#delete-publishing-e2e-tests
[tech-debt-card]: https://trello.com/c/Lbw4TTfD/233-publishing-e2e-tests-still-exist

## What this PR does

This PR removes the E2E tests from this app's CI pipeline. Once merged, the Jenkins CI server will no longer kick off a run of the publishing-e2e-tests job when new PRs are opened.

This change is the first step in the overall decommissioning process, and will be applied to every application currently running the E2E tests.

## Trello card 

https://trello.com/c/qgR41OnR/837-disable-publishing-end-to-end-tests-on-our-apps

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
