### PR TITLE
Explain why boosting announcement curve was chosen

### DIFF
--- a/docs/relevancy.md
+++ b/docs/relevancy.md
@@ -100,17 +100,16 @@ field and its number of page views in the `vc_14` field.
 
 #### Recency
 
-This is an implementation of [this curve][], and is applied to
-documents of the "announcement" type in the [booster.rb][] file.  It
-serves to increase the score of new documents and decrease the score
-of old documents.
+This is an implementation of [this curve](https://solr.apache.org/guide/7_7/function-queries.html#recip-function),
+and is applied to documents of the "announcement" type in the [booster.rb][]
+file.  It serves to increase the score of new documents and decrease 
+the score of old documents.
 
 Only documents of `search_format_types` 'announcement' are affected by
 recency boosting.
 
-The curve came from the solr documentation, but the link to the
-original source is broken, so it is unclear why this particular curve
-was chosen.
+The curve was chosen so that it only applies the boost temporarily (2 
+months moderate decay then a rapid decay after that).
 
 #### Properties
 


### PR DESCRIPTION
I'm familiarising myself with the `seach-api` again, and I know why this curve was chosen because I chose it.

The current solar doc has moved on; it was an extension of https://solr.apache.org/guide/7_7/function-queries.html#recip-function.

Also, the graph of the curve is no longer there due to WolframAlpha changing.

But you can imagine a curve decaying slowly for two months and then rapidly.

This was so that announcements are ranked higher in the search, but old announcements (we arbitrarily chose two months) are not (which was an issue as all announcements were boosted equally, causing poor results).