### PR TITLE
Add licence_transaction document type and fields

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -28,6 +28,7 @@ hmrc_manual_section: hmrc_manual_section
 international_development_fund: international_development_fund # Specialist Publisher
 flood_and_coastal_erosion_risk_management_research_report: flood_and_coastal_erosion_risk_management_research_report # Specialist Publisher
 licence: edition
+licence_transaction: edition # Specialist Publisher
 local_transaction: edition
 maib_report: maib_report # Specialist Publisher
 mainstream_browse_page: edition # Collections Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -39,6 +39,7 @@ migrated:
 - european_structural_investment_fund # use Rummager name as mapping occurs before validation check
 - export_health_certificate
 - international_development_fund
+- licence_transaction
 - flood_and_coastal_erosion_risk_management_research_report
 - maib_report
 - marine_notice

--- a/config/schema/elasticsearch_types/licence_transaction.json
+++ b/config/schema/elasticsearch_types/licence_transaction.json
@@ -1,0 +1,9 @@
+{
+  "fields": [
+    "country",
+    "sector",
+    "activity",
+    "will_continue_on",
+    "continuation_link"
+  ]
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1017,5 +1017,18 @@
   },
   "zone_type": {
     "type": "identifiers"
+  },
+
+  "activity": {
+    "type": "identifiers"
+  },
+  "sector": {
+    "type": "identifiers"
+  },
+  "will_continue_on": {
+    "type": "identifiers"
+  },
+  "continuation_link": {
+    "type": "identifiers"
   }
 }

--- a/config/schema/indexes/govuk.json
+++ b/config/schema/indexes/govuk.json
@@ -18,6 +18,7 @@
     "hmrc_manual",
     "hmrc_manual_section",
     "international_development_fund",
+    "licence_transaction",
     "maib_report",
     "manual",
     "manual_section",

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -15,6 +15,7 @@ module GovukIndex
       {
         aircraft_category: specialist.aircraft_category,
         aircraft_type: specialist.aircraft_type,
+        activity: specialist.activity,
         alert_type: specialist.alert_type,
         assessment_date: specialist.assessment_date,
         attachments: common_fields.attachments,
@@ -131,6 +132,7 @@ module GovukIndex
         role_appointments: expanded_links.role_appointments,
         roles: expanded_links.roles,
         service_provider: specialist.service_provider,
+        sector: specialist.sector,
         sift_end_date: specialist.sift_end_date,
         sifting_status: specialist.sifting_status,
         slug: slug,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -6,6 +6,7 @@ module GovukIndex
 
     delegate_to_payload :aircraft_category
     delegate_to_payload :aircraft_type
+    delegate_to_payload :activity
     delegate_to_payload :alert_type, convert_to_array: true
     delegate_to_payload :assessment_date
     delegate_to_payload :authors
@@ -81,6 +82,7 @@ module GovukIndex
     delegate_to_payload :research_document_type
     delegate_to_payload :result
     delegate_to_payload :review_status
+    delegate_to_payload :sector
     delegate_to_payload :service_provider
     delegate_to_payload :sift_end_date
     delegate_to_payload :sifting_status

--- a/lib/learn_to_rank/format_enums.rb
+++ b/lib/learn_to_rank/format_enums.rb
@@ -81,6 +81,7 @@ module LearnToRank
         "flood_and_coastal_erosion_risk_management_research_report" => 77,
         "service_manual_service_toolkit" => 78,
         "smart_answer" => 79,
+        "licence_transaction" => 80,
       }
     end
   end

--- a/spec/integration/govuk_index/specialist_formats_spec.rb
+++ b/spec/integration/govuk_index/specialist_formats_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "SpecialistFormatTest" do
       employment_tribunal_decision
       flood_and_coastal_erosion_risk_management_research_report
       international_development_fund
+      licence_transaction
       maib_report
       medical_safety_alert
       protected_food_drink_name


### PR DESCRIPTION
Adds country, sector, activity, will_continue_on and continuation link
fields for the new licence_transaction document type. `country` is
already defined so we don't need to add an extra field definition.

Trello:
https://trello.com/c/mGJ5DIsI/1659-create-licence-document-type-in-specialist-publisher