### PR TITLE
Replace archived govuk-content-schema-test-helpers with govuk_schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ end
 group :test do
   gem "bunny-mock"
   gem "climate_control"
-  gem "govuk-content-schema-test-helpers"
   gem "rack-test"
   gem "rspec"
   gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,8 +147,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_app_config (4.12.0)
       logstasher (~> 2.1)
       plek (>= 4, < 6)
@@ -427,7 +425,6 @@ DEPENDENCIES
   google-api-client
   google-cloud-bigquery
   googleauth
-  govuk-content-schema-test-helpers
   govuk_app_config
   govuk_document_types
   govuk_message_queue_consumer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,6 @@ require "govuk_sidekiq/testing"
 require "sidekiq/testing/inline" # Make all queued jobs run immediately
 require "bunny-mock"
 require "govuk_schemas"
-require "govuk-content-schema-test-helpers"
-require "govuk-content-schema-test-helpers/validator"
 
 # Silence log output
 Logging.logger.root.appenders = nil

--- a/spec/unit/content_item_publisher/finder_email_signup_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_email_signup_presenter_spec.rb
@@ -4,13 +4,6 @@ require "govuk_schemas/rspec_matchers"
 RSpec.describe ContentItemPublisher::FinderEmailSignupPresenter do
   include GovukSchemas::RSpecMatchers
 
-  before do
-    GovukContentSchemaTestHelpers.configure do |config|
-      config.schema_type = "publisher_v2"
-      config.project_root = File.expand_path(Dir.pwd)
-    end
-  end
-
   signups_glob = File.join(Dir.pwd, "config", "finders", "*_email_signup.yml")
 
   Dir.glob(signups_glob).each do |config_file|

--- a/spec/unit/content_item_publisher/finder_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_presenter_spec.rb
@@ -4,13 +4,6 @@ require "govuk_schemas/rspec_matchers"
 RSpec.describe ContentItemPublisher::FinderPresenter do
   include GovukSchemas::RSpecMatchers
 
-  before do
-    GovukContentSchemaTestHelpers.configure do |config|
-      config.schema_type = "publisher_v2"
-      config.project_root = File.expand_path(Dir.pwd)
-    end
-  end
-
   finders_glob = File.join(Dir.pwd, "config", "finders", "*_finder.yml")
 
   Dir.glob(finders_glob).each do |config_file|

--- a/spec/unit/content_item_publisher/finder_publisher_spec.rb
+++ b/spec/unit/content_item_publisher/finder_publisher_spec.rb
@@ -1,13 +1,6 @@
 require "spec_helper"
 
 RSpec.describe ContentItemPublisher::FinderPublisher do
-  before do
-    GovukContentSchemaTestHelpers.configure do |config|
-      config.schema_type = "publisher_v2"
-      config.project_root = File.expand_path(Dir.pwd)
-    end
-  end
-
   finders_glob = File.join(Dir.pwd, "config", "finders", "*_finder.yml")
   Dir.glob(finders_glob).each do |config_file|
     context "Checking #{File.basename(config_file)}" do

--- a/spec/unit/special_route_publisher_spec.rb
+++ b/spec/unit/special_route_publisher_spec.rb
@@ -1,12 +1,8 @@
 require "spec_helper"
+require "govuk_schemas/validator"
 
 RSpec.describe SpecialRoutePublisher do
   before do
-    GovukContentSchemaTestHelpers.configure do |config|
-      config.schema_type = "publisher_v2"
-      config.project_root = File.expand_path("../..", __dir__)
-    end
-
     @publishing_api = double
 
     logger = Logger.new($stdout)
@@ -30,9 +26,9 @@ RSpec.describe SpecialRoutePublisher do
   end
 
   def assert_valid_content_item(payload)
-    validator = GovukContentSchemaTestHelpers::Validator.new(
+    validator = GovukSchemas::Validator.new(
       "special_route",
-      "schema",
+      "publisher",
       payload,
     )
 


### PR DESCRIPTION
**What**

This is part of the work to replace all occurrences of [govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers) with [govuk_schemas](https://github.com/alphagov/govuk_schemas).

**Why**

[govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers) is deprecated, archived, and is no longer being updated. But is still used by [feedback](https://github.com/alphagov/feedback).

Link to [Trello](https://trello.com/c/mjd0wWvk/239-switch-govuk-content-schema-test-helpers-for-govukschemas-in-search-api) card

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.