### PR TITLE
Fix sidekiq worker boot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
     puma (6.0.2)
       nio4r (~> 2.0)
     racc (1.6.2)
-    rack (2.2.3.1)
+    rack (2.2.6.2)
     rack-logstasher (1.0.2)
       logstash-event
       rack (~> 2.0)
@@ -357,9 +357,8 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
-    sidekiq-limit_fetch (4.1.0)
-      redis (>= 4.6.0)
-      sidekiq (>= 4)
+    sidekiq-limit_fetch (4.4.1)
+      sidekiq (>= 6)
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)


### PR DESCRIPTION
Sidekiq workers are failing to start with the following error:

> 2023-01-30T11:27:42.852Z pid=32 tid=17q8 WARN: NameError: undefined local variable or method `options' for #<Sidekiq::Manager:0x0000556eaa78f550>
> 2023-01-30T11:27:42.855Z pid=32 tid=17q8 WARN: /root/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sidekiq-limit_fetch-4.1.0/lib/sidekiq/extensions/manager.rb:9:in `start'
>  /root/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sidekiq-6.5.8/lib/sidekiq/launcher.rb:36:in `run'
>  /root/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sidekiq-6.5.8/lib/sidekiq/cli.rb:132:in `launch'
>  /root/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sidekiq-6.5.8/lib/sidekiq/cli.rb:121:in `run'
>  /root/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sidekiq-6.5.8/bin/sidekiq:31:in `<top (required)>'
>  /root/.rbenv/versions/2.7.6/bin/sidekiq:23:in `load'
>  /root/.rbenv/versions/2.7.6/bin/sidekiq:23:in `<main>'

This is a problem with [the version of the sidekiq-limit_fetch gem](https://github.com/deanpcmad/sidekiq-limit_fetch/issues/131) that we're running, once we hit sidekiq 6.5.

It's [fixed](https://github.com/deanpcmad/sidekiq-limit_fetch/pull/135) in [version 4.3 of this gem](https://github.com/deanpcmad/sidekiq-limit_fetch/issues/131)