### PR TITLE
Remove allow list from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,30 +4,6 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Security updates
-      - dependency-name: brakeman
-        dependency-type: direct
-      # Internal gems
-      - dependency-name: "govuk*"
-        dependency-type: direct
-      - dependency-name: "rubocop-govuk"
-        dependency-type: direct
-      - dependency-name: gds-api-adapters
-        dependency-type: direct
-      - dependency-name: gds-sso
-        dependency-type: direct
-      - dependency-name: plek
-        dependency-type: direct
-      # Framework gems
-      - dependency-name: mongo
-        dependency-type: direct
-      - dependency-name: factory_bot_rails
-        dependency-type: direct
-      - dependency-name: rails
-        dependency-type: direct
-      - dependency-name: rspec-rails
-        dependency-type: direct
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
In [RFC-153](https://github.com/alphagov/govuk-rfcs/pull/153), we proposed and agreed to remove 'allow lists' from all [GOV.UK](http://gov.uk/) Dependabot configs, in order to re-enable security updates.

Trello card: https://trello.com/c/DuA0q9Ck/2966-remove-allow-lists-from-dependabot-configs-2