### PR TITLE
Remove text filter from Content Type selection in search/all

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -43,7 +43,7 @@ details:
     preposition: in
     short_name: In
     type: text
-    show_option_select_filter: true
+    show_option_select_filter: false
     allowed_values:
     - label: Services
       value: services


### PR DESCRIPTION
It was causing issues for screen readers and was determined to be unneeded for such a small option set.

https://trello.com/c/ktDSbGXC/1596-set-showoptionselectfilter-to-false-on-content-item-facet-filtered-results-of-option-select-autocomplete-difficult-to-find-for-s