### PR TITLE
Update industry match type to 'searchable_identifiers'

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1023,7 +1023,7 @@
     "type": "identifiers"
   },
   "licence_transaction_industry": {
-    "type": "identifiers"
+    "type": "searchable_identifiers"
   },
   "licence_transaction_licence_identifier": {
     "type": "identifiers"


### PR DESCRIPTION
Previously, 'licence_transaction_industry' field values were not factored into the search query for the new licence finder. Usability testing highlighted multiple instances of when it would've been useful to also query by the industry field when using main search.

Originally, I tried updating the industries field to `searchable_text`, as it was probably more flexible in matching user terms than an identifier (due to splitting query into words) [1]. However, this type broke the facet select:

Kibana:
```
Error
{"error":"\"licence_transaction_industry\" is not a valid filter field"}
```

I then used `searchable_identifiers`, which supports arrays [2]. After reindexing the industries were factored into the main search and the facets worked as expected.

Something to note is that search uses the value [3] vs label [4] to query against as this is the data that exists on the content item.

This doesn’t really make a difference if both include the same words and no special characters. If special characters do exist in the label like hyphens, brackets, commas etc, then these won’t be queried as they’ll be stripped when the value is generated.

We can mitigate this by adding the label we want to use per value in Search [5], however this would include introducing extra config which we’d need to maintain so only advisable if there is a real use case (e.g official licence name has hyphen).

Before we test this again, we'll need to ensure the labels and values are equivalent (excluding special characters). The branch [6] we've used for usability testing currently has different value / labels as this was simpler to implement after content updates, however we’ve started the work [7] to update the values (value == label) as part of the migration.

[1]: https://codecurated.com/blog/elasticsearch-text-vs-keyword/#:~:text=between%20the%20two.-,The%20Differences,will%20behave%20when%20getting%20queried.
[2]: https://github.com/alphagov/search-api/blob/063be596e0bcc7e12c857b0615e83ec7e4e8a52f/config/schema/field_types.json#L32
[3]: https://github.com/alphagov/specialist-publisher/blob/566340da64d2c9e48b0cb93642a27c43c692f0ca/lib/documents/schemas/licence_transactions.json#L58
[4]: https://github.com/alphagov/specialist-publisher/blob/566340da64d2c9e48b0cb93642a27c43c692f0ca/lib/documents/schemas/licence_transactions.json#L57
[5]: https://github.com/alphagov/search-api/blob/063be596e0bcc7e12c857b0615e83ec7e4e8a52f/config/schema/elasticsearch_types/animal_disease_case.json#L10
[6]: https://github.com/alphagov/specialist-publisher/pull/2222
[7]: https://github.com/alphagov/specialist-publisher/pull/2231


## Searching for 'retail' example

### Before 

<img width="669" alt="Screenshot 2023-03-15 at 15 26 48" src="https://user-images.githubusercontent.com/24479188/225358980-69612a55-164d-4766-845a-f69dbf8e48cf.png">

### After 

<img width="1042" alt="Screenshot 2023-03-15 at 15 28 27" src="https://user-images.githubusercontent.com/24479188/225359190-1f76c15d-1d21-4977-ba43-9135b19a6f93.png">

Trello:
https://trello.com/c/WDTCQQ35/1891-include-licence-filter-facets-in-the-main-search-query-for-new-licence-finder