### PR TITLE
Add the none option to disease control zone types

### DIFF
--- a/config/schema/elasticsearch_types/animal_disease_case.json
+++ b/config/schema/elasticsearch_types/animal_disease_case.json
@@ -104,6 +104,10 @@
       {
         "label": "Wild bird monitoring area",
         "value": "wild-bird-monitoring"
+      },
+      {
+        "label": "None",
+        "value": "none"
       }
     ]
   }


### PR DESCRIPTION
Add a new option in the animal disease finder, within the disease control zone types section.

Trello card: https://trello.com/c/wYsvb5vV