### PR TITLE
Add native Ruby `debug` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "warden"
 gem "warden-oauth2"
 
 group :development, :test do
+  gem "debug"
   gem "pry-byebug"
   gem "rubocop-govuk", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    debug (1.7.1)
     declarative (0.0.20)
     diff-lcs (1.5.0)
     docile (1.4.0)
@@ -427,6 +428,7 @@ DEPENDENCIES
   bootsnap
   bunny-mock
   climate_control
+  debug
   elasticsearch (~> 6)
   gds-api-adapters
   google-api-client


### PR DESCRIPTION
This is the [current state-of-the-art][1] first-party (extended standard library) Ruby debugging gem with excellent editor and tooling support, replacing the need for e.g. `pry` or `byebug` (except for individual preferences, which is why I'm leaving `pry-byebug` in the Gemfile for now).

[1]: https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/