### PR TITLE
Add ability to boost custom fields

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1023,7 +1023,7 @@
     "type": "identifiers"
   },
   "licence_transaction_industry": {
-    "type": "searchable_identifiers"
+    "type": "searchable_multivalued_text"
   },
   "licence_transaction_licence_identifier": {
     "type": "identifiers"

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -39,6 +39,35 @@
     }
   },
 
+  "searchable_multivalued_text": {
+    "description": "Plain text that can occur multiple times in a single document and considered in searches",
+    "filter_type": "text",
+    "multivalued": true,
+    "es_config": {
+      "type": "keyword",
+      "index": true,
+      "copy_to": ["spelling_text", "all_searchable_text"],
+      "fields": {
+        "no_stop": {
+          "type": "text",
+          "index": true,
+          "analyzer": "searchable_text"
+        },
+        "shingles": {
+          "type": "text",
+          "index": true,
+          "analyzer": "with_shingles"
+        },
+        "synonym": {
+          "type": "text",
+          "index": true,
+          "analyzer": "with_index_synonyms",
+          "search_analyzer": "with_search_synonyms"
+        }
+      }
+    }
+  },
+
   "searchable_text": {
     "description": "A piece of plain text that should be split into words and considered in searches",
     "es_config": {

--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -55,6 +55,7 @@ private
       debug: debug_options,
       suggest: character_separated_param("suggest"),
       ab_tests:,
+      boost_fields: character_separated_param("boost_fields"),
     }
 
     # Search can be run either with a text query or a base_path to find

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -16,7 +16,8 @@ module Search
                   :is_quoted_phrase,
                   :ab_tests,
                   :cluster,
-                  :search_config
+                  :search_config,
+                  :boost_fields
 
     # starts and ends with quotes with no quotes in between, with or without
     # leading or trailing whitespace
@@ -31,6 +32,7 @@ module Search
         ab_tests: {},
         cluster: Clusters.default_cluster,
         search_config: SearchConfig.default_instance,
+        boost_fields: [],
       }.merge(params)
       params.each do |k, v|
         public_send("#{k}=", v)

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe SearchParameterParser do
       debug: {},
       suggest: [],
       ab_tests: {},
+      boost_fields: [],
     }.merge(params)
   end
 

--- a/spec/unit/query_components/core_query_spec.rb
+++ b/spec/unit/query_components/core_query_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe QueryComponents::CoreQuery do
       query = builder.minimum_should_match("_all", "text to search over")
       expect(query.to_s).to match(/"2<2 3<3 7<50%"/)
     end
+
+    it "includes field boosts for unquoted query" do
+      builder = described_class.new(
+        search_query_params(boost_fields: %w[custom_field]),
+      )
+
+      query = builder.unquoted_phrase_query("income tax")
+
+      expect(query.to_s).to include("custom_field.synonym")
+    end
+
+    it "includes field boosts for quoted query" do
+      builder = described_class.new(
+        search_query_params(boost_fields: %w[custom_field]),
+      )
+
+      query = builder.quoted_phrase_query("income tax")
+
+      expect(query.to_s).to include("custom_field.no_stop")
+    end
   end
 
   context "the search query with synonyms disabled" do


### PR DESCRIPTION
We want to boost licence_transaction_industry field for the new licence finder. As we're putting more onus / importance on the industries the it seems reasonable to assume that a search match against an industry name should be weight higher than, at least, the body of the licence pages. 

This change isn't tied specifically to our use case and can be used against any field with a compatible field type. Currently the weighting is just below the description as this seems a reasonable start.  

I've tested the new field type in Staging and it works as expected (includes industry in main search, weights industries over indexable _content, facet filters work). 

This change requires reindexing of the `govuk` index. 

More info in the commits ->

Sister PR: 
- https://github.com/alphagov/finder-frontend/pull/3030

Trello:
https://trello.com/c/VhsBND5i/1888-boost-industry-field