### PR TITLE
Retrieve page traffic file from S3 instead of stdin

### DIFF
--- a/bin/load_page_traffic.sh
+++ b/bin/load_page_traffic.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rake page_traffic:load
+
+SEARCH_INDEX=page-traffic rake search:clean

--- a/lib/tasks/page_traffic.rake
+++ b/lib/tasks/page_traffic.rake
@@ -1,0 +1,17 @@
+require "aws-sdk-s3"
+
+namespace :page_traffic do
+  desc "Bulk load data from Google Analytics"
+  task :load, :environment do
+    s3 = Aws::S3::Client.new
+
+    puts "Downloading file from S3..."
+    resp = s3.get_object(bucket: ENV["AWS_SEARCH_ANALYTICS_BUCKET"], key: "page-traffic.dump")
+
+    Clusters.active.each do |cluster|
+      puts "Performing page traffic load for cluster #{cluster.key}..."
+      resp.body.rewind
+      GovukIndex::PageTrafficLoader.new(cluster:).load_from(resp.body)
+    end
+  end
+end


### PR DESCRIPTION
This modified the load_page_traffic script to retrieve the page traffic dump from S3 instead of reading from stdin. This is because the search_analytics now uploads the file to s3 and no longer directly interacts with search-api.

This mirrors the behaviour of [bin/page_traffic_load](https://github.com/alphagov/search-api/blob/main/bin/page_traffic_load)