### PR TITLE
Add CDEI Assurance Techniques finder

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -2,6 +2,7 @@
 # the value represents the elasticsearch_type defined in config/schema/elasticsearch_types
 
 aaib_report: aaib_report # Specialist Publisher
+ai_assurance_portfolio_technique: ai_assurance_portfolio_technique # Specialist Publisher
 animal_disease_case: animal_disease_case # Specialist Publisher
 answer: edition
 asylum_support_decision: asylum_support_decision # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -27,6 +27,7 @@ migrated:
 - smart_answer
 # Specialist Publisher
 - aaib_report
+- ai_assurance_portfolio_technique
 - animal_disease_case
 - asylum_support_decision
 - business_finance_support_scheme

--- a/config/schema/elasticsearch_types/ai_assurance_portfolio_technique.json
+++ b/config/schema/elasticsearch_types/ai_assurance_portfolio_technique.json
@@ -1,0 +1,229 @@
+{
+  "fields": [
+    "use_case",
+    "sector",
+    "principle",
+    "key_function",
+    "ai_assurance_technique"
+  ],
+  "expanded_search_result_fields": {
+    "use_case": [
+      {
+        "label": "Big data analytics",
+        "value": "big-data-analytics"
+      },
+      {
+        "label": "Data-driven profiling",
+        "value": "data-driven-profiling"
+      },
+      {
+        "label": "Natural language processing and generation",
+        "value": "natural-language-processing-and-generation"
+      },
+      {
+        "label": "Image recognition and video processing",
+        "value": "image-recognition-and-video-processing"
+      },
+      {
+        "label": "Machine learning",
+        "value": "machine-learning"
+      },
+      {
+        "label": "Deep learning",
+        "value": "deep-learning"
+      },
+      {
+        "label": "Virtual agents or artificial conversational interfaces",
+        "value": "virtual-agents-or-artificial-conversational-interfaces"
+      },
+      {
+        "label": "Robotic process automation and decision management",
+        "value": "robotic-process-automation-and-decision-management"
+      },
+      {
+        "label": "Robotics and autonomous vehicles/systems",
+        "value": "robotics-and-autonomous-vehicles-systems"
+      }
+    ],
+    "sector": [
+      {
+        "label": "Agriculture, Forestry and Fishing (SIC Code Section A)",
+        "value": "agriculture-forestry-and-fishing"
+      },
+      {
+        "label": "Mining and Quarrying (SIC Code Section B)",
+        "value": "mining-and-quarrying"
+      },
+      {
+        "label": "Manufacturing (SIC Code Section C)",
+        "value": "manufacturing"
+      },
+      {
+        "label": "Energy & Utilities (SIC Code Sections D & E)",
+        "value": "energy-and-utilities"
+      },
+      {
+        "label": "Construction (SIC Code Section F)",
+        "value": "construction"
+      },
+      {
+        "label": "Retail (SIC Code Section G)",
+        "value": "retail"
+      },
+      {
+        "label": "Transportation & Storage (SIC Code Section H)",
+        "value": "transportation-and-storage"
+      },
+      {
+        "label": "Accommodation and Food Service (SIC Code Section I)",
+        "value": "accommodation-and-food-service"
+      },
+      {
+        "label": "Digital & Comms (SIC Code Section J)",
+        "value": "digital-and-comms"
+      },
+      {
+        "label": "Financial and Insurance (SIC Code Section K)",
+        "value": "financial-and-insurance"
+      },
+      {
+        "label": "Real Estate (SIC Code Section L)",
+        "value": "real-estate"
+      },
+      {
+        "label": "Professional, Scientific & Professional Activities (SIC Code Section M)",
+        "value": "professional-scientific-and-professional-activities"
+      },
+      {
+        "label": "Administrative & Support Services (SIC Code Section N)",
+        "value": "administrative-and-support-services"
+      },
+      {
+        "label": "Public Administration & Defence (SIC Code Section O)",
+        "value": "public-administration-and-defence"
+      },
+      {
+        "label": "Education (SIC Code Section P)",
+        "value": "education"
+      },
+      {
+        "label": "Healthcare & Social Work (SIC Code Section Q)",
+        "value": "healthcare-and-social-work"
+      },
+      {
+        "label": "Arts, Entertainment & Recreation (SIC Code Section R)",
+        "value": "arts-entertainment-and-recreation"
+      },
+      {
+        "label": "Other Services (SIC Code Section S)",
+        "value": "other-services"
+      }
+    ],
+    "principle": [
+      {
+        "label": "Safety, security and robustness",
+        "value": "safety-security-and-robustness"
+      },
+      {
+        "label": "Appropriate transparency and explainability",
+        "value": "appropriate-transparency-and-explainability"
+      },
+      {
+        "label": "Fairness",
+        "value": "fairness"
+      },
+      {
+        "label": "Accountability and governance",
+        "value": "accountability-and-governance"
+      },
+      {
+        "label": "Contestability and redress",
+        "value": "contestability-and-redress"
+      }
+    ],
+    "key_function": [
+      {
+        "label": "R&D",
+        "value": "r-and-d"
+      },
+      {
+        "label": "Product and service development",
+        "value": "product-and-service-development"
+      },
+      {
+        "label": "Manufacturing",
+        "value": "manufacturing"
+      },
+      {
+        "label": "Service operations",
+        "value": "service-operations"
+      },
+      {
+        "label": "Supply chain management",
+        "value": "supply-chain-management"
+      },
+      {
+        "label": "Human Resources",
+        "value": "human-resources"
+      },
+      {
+        "label": "Marketing and sales",
+        "value": "marketing-and-sales"
+      },
+      {
+        "label": "Customer services",
+        "value": "customer-services"
+      },
+      {
+        "label": "Risk management",
+        "value": "risk-management"
+      },
+      {
+        "label": "Strategy and corporate finance",
+        "value": "strategy-and-corporate-finance"
+      }
+    ],
+    "ai_assurance_technique": [
+      {
+        "label": "Data assurance",
+        "value": "data-assurance"
+      },
+      {
+        "label": "Compliance audit",
+        "value": "compliance-audit"
+      },
+      {
+        "label": "Formal verification",
+        "value": "formal-verification"
+      },
+      {
+        "label": "Performance testing",
+        "value": "performance-testing"
+      },
+      {
+        "label": "Certification",
+        "value": "certification"
+      },
+      {
+        "label": "Risk Assessment",
+        "value": "risk-assessment"
+      },
+      {
+        "label": "Impact Assessment",
+        "value": "impact-assessment"
+      },
+      {
+        "label": "Impact Evaluation",
+        "value": "impact-evaluation"
+      },
+      {
+        "label": "Conformity Assessment",
+        "value": "conformity-assessment"
+      },
+      {
+        "label": "Bias Audit",
+        "value": "bias-audit"
+      }
+    ]
+  }
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1046,5 +1046,21 @@
   },
   "keyword": {
     "type": "searchable_text"
+  },
+  
+  "use_case": {
+    "type": "identifiers"
+  },
+  "sector": {
+    "type": "identifiers"
+  },
+  "principle": {
+    "type": "identifiers"
+  },
+  "key_function": {
+    "type": "identifiers"
+  },
+  "ai_assurance_technique": {
+    "type": "identifiers"
   }
 }

--- a/config/schema/indexes/govuk.json
+++ b/config/schema/indexes/govuk.json
@@ -1,6 +1,7 @@
 {
   "elasticsearch_types": [
     "aaib_report",
+    "ai_assurance_portfolio_technique",
     "animal_disease_case",
     "asylum_support_decision",
     "business_finance_support_scheme",

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -13,6 +13,7 @@ module GovukIndex
 
     def document
       {
+        ai_assurance_technique: specialist.ai_assurance_technique,
         aircraft_category: specialist.aircraft_category,
         aircraft_type: specialist.aircraft_type,
         alert_type: specialist.alert_type,
@@ -79,6 +80,7 @@ module GovukIndex
         is_withdrawn: common_fields.withdrawn?,
         issued_date: specialist.issued_date,
         keyword: specialist.keyword,
+        key_function: specialist.key_function,
         laid_date: specialist.laid_date,
         land_use: specialist.land_use,
         latest_change_note: details.latest_change_note,
@@ -114,6 +116,7 @@ module GovukIndex
         popularity: common_fields.popularity,
         popularity_b: common_fields.popularity_b,
         primary_publishing_organisation: expanded_links.primary_publishing_organisation,
+        principle: specialist.principle,
         product_alert_type: specialist.product_alert_type,
         product_category: specialist.product_category,
         product_measure_type: specialist.product_measure_type,
@@ -138,6 +141,7 @@ module GovukIndex
         review_status: specialist.review_status,
         role_appointments: expanded_links.role_appointments,
         roles: expanded_links.roles,
+        sector: specialist.sector,
         service_provider: specialist.service_provider,
         sift_end_date: specialist.sift_end_date,
         sifting_status: specialist.sifting_status,
@@ -180,6 +184,7 @@ module GovukIndex
         uk_market_conformity_assessment_body_type: specialist.uk_market_conformity_assessment_body_type,
         uk_market_conformity_assessment_body_website: specialist.uk_market_conformity_assessment_body_website,
         updated_at: common_fields.updated_at,
+        use_case: specialist.use_case,
         user_journey_document_supertype: common_fields.user_journey_document_supertype,
         value_of_funding: specialist.value_of_funding,
         vessel_type: specialist.vessel_type,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -4,6 +4,7 @@ module GovukIndex
 
     set_payload_method :metadata
 
+    delegate_to_payload :ai_assurance_technique, convert_to_array: true
     delegate_to_payload :aircraft_category
     delegate_to_payload :aircraft_type
     delegate_to_payload :alert_type, convert_to_array: true
@@ -50,6 +51,7 @@ module GovukIndex
     delegate_to_payload :industries
     delegate_to_payload :internal_notes
     delegate_to_payload :issued_date
+    delegate_to_payload :key_function, convert_to_array: true
     delegate_to_payload :keyword
     delegate_to_payload :laid_date
     delegate_to_payload :land_use
@@ -70,6 +72,7 @@ module GovukIndex
     delegate_to_payload :oim_project_type
     delegate_to_payload :opened_date
     delegate_to_payload :outcome_type
+    delegate_to_payload :principle, convert_to_array: true
     delegate_to_payload :product_alert_type
     delegate_to_payload :product_category
     delegate_to_payload :product_measure_type
@@ -89,6 +92,7 @@ module GovukIndex
     delegate_to_payload :research_document_type
     delegate_to_payload :result
     delegate_to_payload :review_status
+    delegate_to_payload :sector, convert_to_array: true
     delegate_to_payload :service_provider
     delegate_to_payload :sift_end_date
     delegate_to_payload :sifting_status
@@ -124,6 +128,7 @@ module GovukIndex
     delegate_to_payload :uk_market_conformity_assessment_body_testing_locations, convert_to_array: true
     delegate_to_payload :uk_market_conformity_assessment_body_type, convert_to_array: true
     delegate_to_payload :uk_market_conformity_assessment_body_website
+    delegate_to_payload :use_case, convert_to_array: true
     delegate_to_payload :value_of_funding
     delegate_to_payload :vessel_type
     delegate_to_payload :virus_strain


### PR DESCRIPTION
For this [Trello card](https://trello.com/c/1LeqkG5a/1245-create-a-cdei-finder). Following the [Developer Docs on creating a specialist finder](https://docs.publishing.service.gov.uk/repos/specialist-publisher/creating-and-editing-specialist-document-types.html#3-configure-search-api), this commit updates the relevant files in search API.