### PR TITLE
Fix deploy learn to rank workflow

### DIFF
--- a/.github/workflows/deploy-ltr.yml
+++ b/.github/workflows/deploy-ltr.yml
@@ -39,6 +39,7 @@ jobs:
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
       environment: ${{ inputs.environment || 'integration' }}
+      appName: search-api-learn-to-rank
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}

--- a/.github/workflows/deploy-ltr.yml
+++ b/.github/workflows/deploy-ltr.yml
@@ -19,10 +19,6 @@ on:
         - staging
         - production
         default: 'integration'
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
 
 jobs:
   build-and-publish-image:


### PR DESCRIPTION
- Disables automatic deploys (as most changes to search api aren't to do with learn to rank)
- Updates reference of which image tag file to update