### PR TITLE
Added call for evidence options to policy and engagement finder

### DIFF
--- a/config/finders/policy_and_engagement_email_signup.yml
+++ b/config/finders/policy_and_engagement_email_signup.yml
@@ -30,6 +30,11 @@ details:
       closed_consultations:
       - closed_consultation
       - consultation_outcome
+      open_calls_for_evidence:
+      - open_call_for_evidence
+      closed_calls_for_evidence:
+      - closed_call_for_evidence
+      - call_for_evidence_outcome
   - facet_id: world_locations
     facet_name: world locations
   - facet_id: topic

--- a/config/finders/policy_and_engagement_finder.yml
+++ b/config/finders/policy_and_engagement_finder.yml
@@ -62,6 +62,11 @@ details:
       closed_consultations:
       - closed_consultation
       - consultation_outcome
+      open_calls_for_evidence:
+      - open_call_for_evidence
+      closed_calls_for_evidence:
+      - closed_call_for_evidence
+      - call_for_evidence_outcome
     allowed_values:
     - label: Policy papers
       value: policy_papers
@@ -69,6 +74,10 @@ details:
       value: open_consultations
     - label: Consultations (closed)
       value: closed_consultations
+    - label: Calls for evidence (open)
+      value: open_calls_for_evidence
+    - label: Calls for evidence (closed)
+      value: closed_calls_for_evidence
   - key: organisations
     name: Organisation
     short_name: From


### PR DESCRIPTION
**What**

Required as part of broader scope of introduction of Call For Evidence document type to GOV.UK. Users should be able to quickly filter the returned documents to find calls for evidence.

**Why**

The purpose of the call for evidence type is to avoid confusion for users and legal challenges. User research has identfied that the distinction between consultation and call for evidence isn’t clear, both for departments and users. Departments are currently using the consultation content type for calls for evidence, but this can create problems and legal challenges because they are potentially obliged to publish the outcome of all consultations, whereas that’s not the case for calls for evidence.

Discussion of the original business case can be found here (note in particular the Revised Oct 2022 approach which suggests creating a new content type rather than re-using consultations): https://docs.google.com/document/d/1bC2A9TkddG53UIbLnFs30aznAxeg3HB4Pc0yMFX99es/edit?usp=sharing

See https://trello.com/c/AQn41qyu for more information.