### PR TITLE
Allow setting the log level via the environment.

### DIFF
--- a/config/logging_setup.rb
+++ b/config/logging_setup.rb
@@ -3,5 +3,5 @@ Logging.logger.root.add_appenders Logging.appenders.stdout
 Logging.logger.root.level = if ENV["DEBUG"] || $DEBUG
                               :debug
                             else
-                              :info
+                              ENV.fetch("LOG_LEVEL", :info)
                             end

--- a/lib/govuk_index/page_traffic_loader.rb
+++ b/lib/govuk_index/page_traffic_loader.rb
@@ -3,7 +3,7 @@ module GovukIndex
     def initialize(cluster: Clusters.default_cluster, iostream_batch_size: 250)
       @iostream_batch_size = iostream_batch_size
       @logger = Logging.logger[self]
-      @logger.level = :info
+      @logger.level = ENV.fetch("LOG_LEVEL", :info)
       @cluster = cluster
     end
 


### PR DESCRIPTION
Keep the same default log level (`info`) but allow this to be changed by setting the `LOG_LEVEL` environment variable.

We want to be able to control the log level this way so that:

- we don't have to rebuild just to change the log level
- we can enable debug logging if we need it to investigate a problem that's hard to reproduce
- we can tune the log level so as not to waste resources logging things that we don't care about the rest of the time
- if a change introduces a problem with logspew, we can just dial down the log level while someone tracks down the underlying issue

See also https://github.com/alphagov/whitehall/pull/7898 (equivalent change for Rails apps).

Tested: rolled out in staging from the PR branch, verified working with/without `LOG_LEVEL` being set and the verbosity setting takes effect as expected.