### PR TITLE
Mark call for evidence document type non-indexable

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -369,6 +369,7 @@ non_indexable:
 - accessible_documents_policy
 - access_and_opening
 - authored_article
+- call_for_evidence
 - case_study
 - complaints_procedure
 - consultation


### PR DESCRIPTION
We believe this is required because Whitehall calls the search API directly, so we do not want the publishing API to also attempt to index calls for evidence. This is technical debt and we want to remove this behaviour from Whitehall in the future, at which time we will be able to migrate to the new indexing process.

See this Slack thread for reasoning: https://gds.slack.com/archives/C03D4A72HGE/p1688571445392239

Trello card: https://trello.com/c/gJGbGiCZ