### PR TITLE
Bump govuk_document_types to 2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
-    govuk_document_types (1.0.1)
+    govuk_document_types (2.0.0)
     govuk_message_queue_consumer (4.1.0)
       bunny (~> 2.17)
     govuk_schemas (4.6.0)


### PR DESCRIPTION
I'm manually updating the govuk_document_types gem dependency because it contains [changes that we need][1] for the new 'Call for evidence' document type.

These changes are required for PR #2634.

[1]: https://github.com/alphagov/govuk_document_types/blob/main/CHANGELOG.md#200