### PR TITLE
Add OIM Project and SAU Referral case types

### DIFF
--- a/config/schema/elasticsearch_types/cma_case.json
+++ b/config/schema/elasticsearch_types/cma_case.json
@@ -43,6 +43,10 @@
         "value": "mergers"
       },
       {
+        "label": "OIM Project",
+        "value": "oim-project"
+      },
+      {
         "label": "Consumer enforcement",
         "value": "consumer-enforcement"
       },
@@ -53,6 +57,10 @@
       {
         "label": "Reviews of orders and undertakings",
         "value": "review-of-orders-and-undertakings"
+      },
+      {
+        "label": "SAU Referral",
+        "value": "sau-referral"
       },
       {
         "label": "State aid",
@@ -147,6 +155,10 @@
       {
         "label": "Motor industry",
         "value": "motor-industry"
+      },
+      {
+        "label": "Not applicable",
+        "value": "not-applicable"
       },
       {
         "label": "Oil and gas refining and petrochemicals",


### PR DESCRIPTION
The Competition and Markets Authority have recently added Office for the Internal Market projects and Subsidy Advice Unit referrals as new case types to their CMA case specialist document type. This adds the new case types to the search API, and also adds a "Not Applicable" market sector because the market sector field does not apply to the new case types.

Trello: https://trello.com/c/r7sZCKI4