### PR TITLE
Fix allowed locations list for international development fund

### DIFF
--- a/config/schema/elasticsearch_types/international_development_fund.json
+++ b/config/schema/elasticsearch_types/international_development_fund.json
@@ -29,116 +29,792 @@
 
     "location": [
       {
-        "label": "Afghanistan",
-        "value": "afghanistan"
+        "value": "afghanistan",
+        "label": "Afghanistan"
       },
       {
-        "label": "Bangladesh",
-        "value": "bangladesh"
+        "value": "albania",
+        "label": "Albania"
       },
       {
-        "label": "Democratic Republic of the Congo",
-        "value": "democratic-republic-of-congo"
+        "value": "algeria",
+        "label": "Algeria"
       },
       {
-        "label": "Ethiopia",
-        "value": "ethiopia"
+        "value": "andorra",
+        "label": "Andorra"
       },
       {
-        "label": "Ghana",
-        "value": "ghana"
+        "value": "angola",
+        "label": "Angola"
       },
       {
-        "label": "India",
-        "value": "india"
+        "value": "antigua-and-barbuda",
+        "label": "Antigua and Barbuda"
       },
       {
-        "label": "Kenya",
-        "value": "kenya"
+        "value": "argentina",
+        "label": "Argentina"
       },
       {
-        "label": "Kyrgyzstan",
-        "value": "kyrgyzstan"
+        "value": "armenia",
+        "label": "Armenia"
       },
       {
-        "label": "Liberia",
-        "value": "liberia"
+        "value": "australia",
+        "label": "Australia"
       },
       {
-        "label": "Malawi",
-        "value": "malawi"
+        "value": "austria",
+        "label": "Austria"
       },
       {
-        "label": "Mozambique",
-        "value": "mozambique"
+        "value": "azerbaijan",
+        "label": "Azerbaijan"
       },
       {
-        "label": "Myanmar",
-        "value": "myanmar"
+        "value": "bahamas",
+        "label": "Bahamas, The"
       },
       {
-        "label": "Nepal",
-        "value": "nepal"
+        "value": "bahrain",
+        "label": "Bahrain"
       },
       {
-        "label": "Nigeria",
-        "value": "nigeria"
+        "value": "bangladesh",
+        "label": "Bangladesh"
       },
       {
-        "label": "The Occupied Palestinian Territories",
-        "value": "the-occupied-palestinian-territories"
+        "value": "barbados",
+        "label": "Barbados"
       },
       {
-        "label": "Pakistan",
-        "value": "pakistan"
+        "value": "belarus",
+        "label": "Belarus"
       },
       {
-        "label": "Rwanda",
-        "value": "rwanda"
+        "value": "belgium",
+        "label": "Belgium"
       },
       {
-        "label": "Sierra Leone",
-        "value": "sierra-leone"
+        "value": "belize",
+        "label": "Belize"
       },
       {
-        "label": "Somalia",
-        "value": "somalia"
+        "value": "benin",
+        "label": "Benin"
       },
       {
-        "label": "South Africa",
-        "value": "south-africa"
+        "value": "bhutan",
+        "label": "Bhutan"
       },
       {
-        "label": "Sudan",
-        "value": "sudan"
+        "value": "bolivia",
+        "label": "Bolivia"
       },
       {
-        "label": "South Sudan",
-        "value": "south-sudan"
+        "value": "bosnia-and-herzegovina",
+        "label": "Bosnia and Herzegovina"
       },
       {
-        "label": "Tajikistan",
-        "value": "tajikistan"
+        "value": "botswana",
+        "label": "Botswana"
       },
       {
-        "label": "Tanzania",
-        "value": "tanzania"
+        "value": "brazil",
+        "label": "Brazil"
       },
       {
-        "label": "Uganda",
-        "value": "uganda"
+        "value": "brunei",
+        "label": "Brunei"
       },
       {
-        "label": "Yemen",
-        "value": "yemen"
+        "value": "bulgaria",
+        "label": "Bulgaria"
       },
       {
-        "label": "Zambia",
-        "value": "zambia"
+        "value": "burkina-faso",
+        "label": "Burkina Faso"
       },
       {
-        "label": "Zimbabwe",
-        "value": "zimbabwe"
+        "value": "burundi",
+        "label": "Burundi"
+      },
+      {
+        "value": "cambodia",
+        "label": "Cambodia"
+      },
+      {
+        "value": "cameroon",
+        "label": "Cameroon"
+      },
+      {
+        "value": "canada",
+        "label": "Canada"
+      },
+      {
+        "value": "cape-verde",
+        "label": "Cape Verde"
+      },
+      {
+        "value": "central-african-republic",
+        "label": "Central African Republic"
+      },
+      {
+        "value": "chad",
+        "label": "Chad"
+      },
+      {
+        "value": "chile",
+        "label": "Chile"
+      },
+      {
+        "value": "china",
+        "label": "China"
+      },
+      {
+        "value": "colombia",
+        "label": "Colombia"
+      },
+      {
+        "value": "comoros",
+        "label": "Comoros"
+      },
+      {
+        "value": "congo",
+        "label": "Congo"
+      },
+      {
+        "value": "democratic-republic-of-congo",
+        "label": "Congo (Democratic Republic)"
+      },
+      {
+        "value": "cook-islands",
+        "label": "Cook Islands"
+      },
+      {
+        "value": "costa-rica",
+        "label": "Costa Rica"
+      },
+      {
+        "value": "croatia",
+        "label": "Croatia"
+      },
+      {
+        "value": "cuba",
+        "label": "Cuba"
+      },
+      {
+        "value": "cyprus",
+        "label": "Cyprus"
+      },
+      {
+        "value": "czech-republic",
+        "label": "Czech Republic"
+      },
+      {
+        "value": "denmark",
+        "label": "Denmark"
+      },
+      {
+        "value": "djibouti",
+        "label": "Djibouti"
+      },
+      {
+        "value": "dominica",
+        "label": "Dominica"
+      },
+      {
+        "value": "dominican-republic",
+        "label": "Dominican Republic"
+      },
+      {
+        "value": "east-timor",
+        "label": "East Timor"
+      },
+      {
+        "value": "ecuador",
+        "label": "Ecuador"
+      },
+      {
+        "value": "egypt",
+        "label": "Egypt"
+      },
+      {
+        "value": "el-salvador",
+        "label": "El Salvador"
+      },
+      {
+        "value": "equatorial-guinea",
+        "label": "Equatorial Guinea"
+      },
+      {
+        "value": "eritrea",
+        "label": "Eritrea"
+      },
+      {
+        "value": "estonia",
+        "label": "Estonia"
+      },
+      {
+        "value": "ethiopia",
+        "label": "Ethiopia"
+      },
+      {
+        "value": "fiji",
+        "label": "Fiji"
+      },
+      {
+        "value": "finland",
+        "label": "Finland"
+      },
+      {
+        "value": "france",
+        "label": "France"
+      },
+      {
+        "value": "gabon",
+        "label": "Gabon"
+      },
+      {
+        "value": "gambia",
+        "label": "Gambia, The"
+      },
+      {
+        "value": "georgia",
+        "label": "Georgia"
+      },
+      {
+        "value": "germany",
+        "label": "Germany"
+      },
+      {
+        "value": "ghana",
+        "label": "Ghana"
+      },
+      {
+        "value": "greece",
+        "label": "Greece"
+      },
+      {
+        "value": "grenada",
+        "label": "Grenada"
+      },
+      {
+        "value": "guatemala",
+        "label": "Guatemala"
+      },
+      {
+        "value": "guinea",
+        "label": "Guinea"
+      },
+      {
+        "value": "guinea-bissau",
+        "label": "Guinea-Bissau"
+      },
+      {
+        "value": "guyana",
+        "label": "Guyana"
+      },
+      {
+        "value": "haiti",
+        "label": "Haiti"
+      },
+      {
+        "value": "honduras",
+        "label": "Honduras"
+      },
+      {
+        "value": "hungary",
+        "label": "Hungary"
+      },
+      {
+        "value": "iceland",
+        "label": "Iceland"
+      },
+      {
+        "value": "india",
+        "label": "India"
+      },
+      {
+        "value": "indonesia",
+        "label": "Indonesia"
+      },
+      {
+        "value": "iran",
+        "label": "Iran"
+      },
+      {
+        "value": "iraq",
+        "label": "Iraq"
+      },
+      {
+        "value": "ireland",
+        "label": "Ireland"
+      },
+      {
+        "value": "israel",
+        "label": "Israel"
+      },
+      {
+        "value": "italy",
+        "label": "Italy"
+      },
+      {
+        "value": "cote-d-ivoire",
+        "label": "Ivory Coast"
+      },
+      {
+        "value": "jamaica",
+        "label": "Jamaica"
+      },
+      {
+        "value": "japan",
+        "label": "Japan"
+      },
+      {
+        "value": "jordan",
+        "label": "Jordan"
+      },
+      {
+        "value": "kazakhstan",
+        "label": "Kazakhstan"
+      },
+      {
+        "value": "kenya",
+        "label": "Kenya"
+      },
+      {
+        "value": "kiribati",
+        "label": "Kiribati"
+      },
+      {
+        "value": "kosovo",
+        "label": "Kosovo"
+      },
+      {
+        "value": "kuwait",
+        "label": "Kuwait"
+      },
+      {
+        "value": "kyrgyzstan",
+        "label": "Kyrgyzstan"
+      },
+      {
+        "value": "laos",
+        "label": "Laos"
+      },
+      {
+        "value": "latvia",
+        "label": "Latvia"
+      },
+      {
+        "value": "lebanon",
+        "label": "Lebanon"
+      },
+      {
+        "value": "lesotho",
+        "label": "Lesotho"
+      },
+      {
+        "value": "liberia",
+        "label": "Liberia"
+      },
+      {
+        "value": "libya",
+        "label": "Libya"
+      },
+      {
+        "value": "liechtenstein",
+        "label": "Liechtenstein"
+      },
+      {
+        "value": "lithuania",
+        "label": "Lithuania"
+      },
+      {
+        "value": "luxembourg",
+        "label": "Luxembourg"
+      },
+      {
+        "value": "madagascar",
+        "label": "Madagascar"
+      },
+      {
+        "value": "malawi",
+        "label": "Malawi"
+      },
+      {
+        "value": "malaysia",
+        "label": "Malaysia"
+      },
+      {
+        "value": "maldives",
+        "label": "Maldives"
+      },
+      {
+        "value": "mali",
+        "label": "Mali"
+      },
+      {
+        "value": "malta",
+        "label": "Malta"
+      },
+      {
+        "value": "marshall-islands",
+        "label": "Marshall Islands"
+      },
+      {
+        "value": "mauritania",
+        "label": "Mauritania"
+      },
+      {
+        "value": "mauritius",
+        "label": "Mauritius"
+      },
+      {
+        "value": "mexico",
+        "label": "Mexico"
+      },
+      {
+        "value": "micronesia",
+        "label": "Micronesia"
+      },
+      {
+        "value": "moldova",
+        "label": "Moldova"
+      },
+      {
+        "value": "monaco",
+        "label": "Monaco"
+      },
+      {
+        "value": "mongolia",
+        "label": "Mongolia"
+      },
+      {
+        "value": "montenegro",
+        "label": "Montenegro"
+      },
+      {
+        "value": "morocco",
+        "label": "Morocco"
+      },
+      {
+        "value": "north-macedonia",
+        "label": "North Macedonia"
+      },
+      {
+        "value": "mozambique",
+        "label": "Mozambique"
+      },
+      {
+        "value": "myanmar",
+        "label": "Myanmar"
+      },
+      {
+        "value": "namibia",
+        "label": "Namibia"
+      },
+      {
+        "value": "nauru",
+        "label": "Nauru"
+      },
+      {
+        "value": "nepal",
+        "label": "Nepal"
+      },
+      {
+        "value": "netherlands",
+        "label": "Netherlands"
+      },
+      {
+        "value": "new-zealand",
+        "label": "New Zealand"
+      },
+      {
+        "value": "nicaragua",
+        "label": "Nicaragua"
+      },
+      {
+        "value": "niger",
+        "label": "Niger"
+      },
+      {
+        "value": "nigeria",
+        "label": "Nigeria"
+      },
+      {
+        "value": "north-korea",
+        "label": "North Korea"
+      },
+      {
+        "value": "norway",
+        "label": "Norway"
+      },
+      {
+        "value": "the-occupied-palestinian-territories",
+        "label": "Occupied Palestinian Territories, The"
+      },
+      {
+        "value": "oman",
+        "label": "Oman"
+      },
+      {
+        "value": "pakistan",
+        "label": "Pakistan"
+      },
+      {
+        "value": "palau",
+        "label": "Palau"
+      },
+      {
+        "value": "panama",
+        "label": "Panama"
+      },
+      {
+        "value": "papua-new-guinea",
+        "label": "Papua New Guinea"
+      },
+      {
+        "value": "paraguay",
+        "label": "Paraguay"
+      },
+      {
+        "value": "peru",
+        "label": "Peru"
+      },
+      {
+        "value": "philippines",
+        "label": "Philippines"
+      },
+      {
+        "value": "poland",
+        "label": "Poland"
+      },
+      {
+        "value": "portugal",
+        "label": "Portugal"
+      },
+      {
+        "value": "qatar",
+        "label": "Qatar"
+      },
+      {
+        "value": "romania",
+        "label": "Romania"
+      },
+      {
+        "value": "russia",
+        "label": "Russia"
+      },
+      {
+        "value": "rwanda",
+        "label": "Rwanda"
+      },
+      {
+        "value": "samoa",
+        "label": "Samoa"
+      },
+      {
+        "value": "san-marino",
+        "label": "San Marino"
+      },
+      {
+        "value": "sao-tome-and-principe",
+        "label": "Sao Tome and Principe"
+      },
+      {
+        "value": "saudi-arabia",
+        "label": "Saudi Arabia"
+      },
+      {
+        "value": "senegal",
+        "label": "Senegal"
+      },
+      {
+        "value": "serbia",
+        "label": "Serbia"
+      },
+      {
+        "value": "seychelles",
+        "label": "Seychelles"
+      },
+      {
+        "value": "sierra-leone",
+        "label": "Sierra Leone"
+      },
+      {
+        "value": "singapore",
+        "label": "Singapore"
+      },
+      {
+        "value": "slovakia",
+        "label": "Slovakia"
+      },
+      {
+        "value": "slovenia",
+        "label": "Slovenia"
+      },
+      {
+        "value": "solomon-islands",
+        "label": "Solomon Islands"
+      },
+      {
+        "value": "somalia",
+        "label": "Somalia"
+      },
+      {
+        "value": "south-africa",
+        "label": "South Africa"
+      },
+      {
+        "value": "south-korea",
+        "label": "South Korea"
+      },
+      {
+        "value": "south-sudan",
+        "label": "South Sudan"
+      },
+      {
+        "value": "spain",
+        "label": "Spain"
+      },
+      {
+        "value": "sri-lanka",
+        "label": "Sri Lanka"
+      },
+      {
+        "value": "st-kitts-and-nevis",
+        "label": "St Kitts and Nevis"
+      },
+      {
+        "value": "st-lucia",
+        "label": "St Lucia"
+      },
+      {
+        "value": "st-vincent",
+        "label": "St Vincent"
+      },
+      {
+        "value": "sudan",
+        "label": "Sudan"
+      },
+      {
+        "value": "suriname",
+        "label": "Suriname"
+      },
+      {
+        "value": "swaziland",
+        "label": "Swaziland"
+      },
+      {
+        "value": "sweden",
+        "label": "Sweden"
+      },
+      {
+        "value": "switzerland",
+        "label": "Switzerland"
+      },
+      {
+        "value": "syria",
+        "label": "Syria"
+      },
+      {
+        "value": "tajikistan",
+        "label": "Tajikistan"
+      },
+      {
+        "value": "tanzania",
+        "label": "Tanzania"
+      },
+      {
+        "value": "thailand",
+        "label": "Thailand"
+      },
+      {
+        "value": "togo",
+        "label": "Togo"
+      },
+      {
+        "value": "tonga",
+        "label": "Tonga"
+      },
+      {
+        "value": "trinidad-and-tobago",
+        "label": "Trinidad and Tobago"
+      },
+      {
+        "value": "tunisia",
+        "label": "Tunisia"
+      },
+      {
+        "value": "turkey",
+        "label": "Turkey"
+      },
+      {
+        "value": "turkmenistan",
+        "label": "Turkmenistan"
+      },
+      {
+        "value": "tuvalu",
+        "label": "Tuvalu"
+      },
+      {
+        "value": "uganda",
+        "label": "Uganda"
+      },
+      {
+        "value": "ukraine",
+        "label": "Ukraine"
+      },
+      {
+        "value": "united-arab-emirates",
+        "label": "United Arab Emirates"
+      },
+      {
+        "value": "united-kingdom",
+        "label": "United Kingdom"
+      },
+      {
+        "value": "united-states",
+        "label": "United States"
+      },
+      {
+        "value": "uruguay",
+        "label": "Uruguay"
+      },
+      {
+        "value": "uzbekistan",
+        "label": "Uzbekistan"
+      },
+      {
+        "value": "vanuatu",
+        "label": "Vanuatu"
+      },
+      {
+        "value": "vatican-city",
+        "label": "Vatican City"
+      },
+      {
+        "value": "venezuela",
+        "label": "Venezuela"
+      },
+      {
+        "value": "vietnam",
+        "label": "Vietnam"
+      },
+      {
+        "value": "yemen",
+        "label": "Yemen"
+      },
+      {
+        "value": "zambia",
+        "label": "Zambia"
+      },
+      {
+        "value": "zimbabwe",
+        "label": "Zimbabwe"
       }
     ],
 


### PR DESCRIPTION
Countries are missing from the allowed list of locations against International Development Fund records, leading to situations where despite multiple countries being available in the search index (so they can be filtered on), they will not be returned in results and cannot be displayed on the results page.

Update this file to match the corresponding file in specialist publisher.

https://govuk.zendesk.com/agent/tickets/5441472