### PR TITLE
Revert "Bump certifi from 2022.12.7 to 2023.7.22 in /ltr/sagemaker"

### DIFF
--- a/ltr/sagemaker/requirements-freeze.txt
+++ b/ltr/sagemaker/requirements-freeze.txt
@@ -5,7 +5,7 @@ sagemaker==2.129.0
 attrs==22.2.0
 boto3==1.26.57
 botocore==1.29.57
-certifi==2023.7.22
+certifi==2022.12.7
 charset-normalizer==3.0.1
 colorama==0.4.4
 contextlib2==21.6.0


### PR DESCRIPTION
Reverts alphagov/search-api#2602

Updating dependencies has broken Learn to Rank. Until we figure out which dependencies are at fault, we need to revert all of the LTR dependabot updates.