### PR TITLE
Revert "Bump requests from 2.28.2 to 2.31.0 in /ltr/scripts"

### DIFF
--- a/ltr/scripts/requirements-freeze.txt
+++ b/ltr/scripts/requirements-freeze.txt
@@ -28,7 +28,7 @@ packaging==23.0
 protobuf==3.19.6
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-requests==2.31.0
+requests==2.28.2
 requests-oauthlib==1.3.1
 rsa==4.9
 tensorboard-data-server==0.6.1


### PR DESCRIPTION
Reverts alphagov/search-api#2591

Updating dependencies has broken Learn to Rank. Until we figure out which dependencies are at fault, we need to revert all of the LTR dependabot updates.
