### PR TITLE
Revert "Bump tensorflow from 2.11.0 to 2.11.1 in /ltr/scripts"

### DIFF
--- a/ltr/scripts/requirements-freeze.txt
+++ b/ltr/scripts/requirements-freeze.txt
@@ -2,7 +2,7 @@ absl-py==1.4.0
 numpy==1.24.1
 six==1.16.0
 tensorboard==2.11.2
-tensorflow==2.11.1
+tensorflow==2.11.0
 tensorflow-ranking==0.5.1
 ## The following requirements were added by pip freeze:
 astunparse==1.6.3


### PR DESCRIPTION
Reverts alphagov/search-api#2551

Updating dependencies has broken Learn to Rank. Until we figure out which dependencies are at fault, we need to revert all of the LTR dependabot updates.