### PR TITLE
Revert "Bump certifi from 2022.12.7 to 2023.7.22 in /ltr/scripts"

### DIFF
--- a/ltr/scripts/requirements-freeze.txt
+++ b/ltr/scripts/requirements-freeze.txt
@@ -7,7 +7,7 @@ tensorflow-ranking==0.5.1
 ## The following requirements were added by pip freeze:
 astunparse==1.6.3
 cachetools==5.3.0
-certifi==2023.7.22
+certifi==2022.12.7
 charset-normalizer==3.0.1
 flatbuffers==23.1.21
 gast==0.4.0


### PR DESCRIPTION
Reverts alphagov/search-api#2664

Updating dependencies has broken Learn to Rank. Until we figure out which dependencies are at fault, we need to revert all of the LTR dependabot updates.