### PR TITLE
Revert "Bump requests from 2.28.2 to 2.31.0 in /ltr/jenkins"

### DIFF
--- a/ltr/sagemaker/requirements-freeze.txt
+++ b/ltr/sagemaker/requirements-freeze.txt
@@ -1,5 +1,5 @@
 awscli==1.27.57
-requests==2.31.0
+requests==2.28.2
 sagemaker==2.129.0
 ## The following requirements were added by pip freeze:
 attrs==22.2.0


### PR DESCRIPTION
Reverts alphagov/search-api#2592

Updating dependencies has broken Learn to Rank. Until we figure out which dependencies are at fault, we need to revert all of the LTR dependabot updates.