### PR TITLE
Build learn-to-rank image on release.

### DIFF
--- a/.github/workflows/deploy-ltr.yml
+++ b/.github/workflows/deploy-ltr.yml
@@ -19,6 +19,8 @@ on:
         - staging
         - production
         default: 'integration'
+  release:
+    types: [released]
 
 jobs:
   build-and-publish-image:


### PR DESCRIPTION
Builds of the LTR images have been manual for quite some time and that's been ok, but it's a good idea to ensure that the image is up-to-date.