### PR TITLE
Add assurance technique approach to AI assurance portfolio technique elasticsearch type

### DIFF
--- a/config/schema/elasticsearch_types/ai_assurance_portfolio_technique.json
+++ b/config/schema/elasticsearch_types/ai_assurance_portfolio_technique.json
@@ -4,7 +4,8 @@
     "sector",
     "principle",
     "key_function",
-    "ai_assurance_technique"
+    "ai_assurance_technique",
+    "assurance_technique_approach"
   ],
   "expanded_search_result_fields": {
     "use_case": [
@@ -223,6 +224,20 @@
       {
         "label": "Bias Audit",
         "value": "bias-audit"
+      }
+    ],
+    "assurance_technique_approach": [
+      {
+        "label": "Technical",
+        "value": "technical"
+      },
+      {
+        "label": "Procedural",
+        "value": "procedural"
+      },
+      {
+        "label": "Educational",
+        "value": "educational"
       }
     ]
   }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1062,5 +1062,8 @@
   },
   "ai_assurance_technique": {
     "type": "identifiers"
+  },
+  "assurance_technique_approach": {
+    "type": "identifiers"
   }
 }

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -18,6 +18,7 @@ module GovukIndex
         aircraft_type: specialist.aircraft_type,
         alert_type: specialist.alert_type,
         assessment_date: specialist.assessment_date,
+        assurance_technique_approach: specialist.assurance_technique_approach,
         attachments: common_fields.attachments,
         authors: specialist.authors,
         business_sizes: specialist.business_sizes,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -9,6 +9,7 @@ module GovukIndex
     delegate_to_payload :aircraft_type
     delegate_to_payload :alert_type, convert_to_array: true
     delegate_to_payload :assessment_date
+    delegate_to_payload :assurance_technique_approach, convert_to_array: true
     delegate_to_payload :authors
     delegate_to_payload :business_sizes
     delegate_to_payload :business_stages


### PR DESCRIPTION
Required as part of addition of new assurance technique approach facet to AI Assurance technique specialist finder

Trello: https://trello.com/c/dk6wY8nD
Zendesk: https://govuk.zendesk.com/agent/tickets/5444446