### PR TITLE
Remove dependency on deprecated RabbitMQ config

### DIFF
--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -1,15 +1,9 @@
-# The following environment variables need to be set
-# RABBITMQ_HOSTS
-# RABBITMQ_VHOST
-# RABBITMQ_USER
-# RABBITMQ_PASSWORD
 require "rummager"
 
 namespace :message_queue do
   desc "Create the queues that Rummager uses with Rabbit MQ"
   task :create_queues do
-    config = GovukMessageQueueConsumer::RabbitMQConfig.from_environment(ENV)
-    bunny = Bunny.new(config)
+    bunny = Bunny.new
 
     channel = bunny.start.create_channel
     exch = Bunny::Exchange.new(channel, :topic, "published_documents")


### PR DESCRIPTION
The `govuk_message_queue_consumer` gem has deprecated the use of its "proprietary" `RABBITMQ_*` environment variables and `RabbitMQConfig.from_environment` setup process in favour of Bunny just being set up through the conventional `RABBITMQ_URL`.

see also: https://github.com/alphagov/govuk-docker/pull/688