### PR TITLE
Remove explicit irb dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "govuk_message_queue_consumer"
 gem "govuk_schemas"
 gem "govuk_sidekiq"
 gem "httparty"
-gem "irb", require: false
 gem "logging"
 gem "loofah"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,10 +184,6 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    io-console (0.6.0)
-    irb (1.8.1)
-      rdoc
-      reline (>= 0.3.8)
     jmespath (1.6.2)
     json (2.6.3)
     json-schema (4.0.0)
@@ -448,8 +444,6 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    psych (5.1.0)
-      stringio
     public_suffix (5.0.3)
     puma (6.3.1)
       nio4r (~> 2.0)
@@ -487,8 +481,6 @@ GEM
     rb-kqueue (0.2.8)
       ffi (>= 0.5.0)
     rbtree (0.4.6)
-    rdoc (6.5.0)
-      psych (>= 4.0.0)
     redis (5.0.6)
       redis-client (>= 0.9.0)
     redis-client (0.14.1)
@@ -496,8 +488,6 @@ GEM
     redis-namespace (1.10.0)
       redis (>= 4)
     regexp_parser (2.8.1)
-    reline (0.3.8)
-      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -601,7 +591,6 @@ GEM
       rbtree
       set (~> 1.0)
     statsd-ruby (1.5.0)
-    stringio (3.0.8)
     thor (1.2.2)
     tilt (2.2.0)
     timecop (0.9.8)
@@ -650,7 +639,6 @@ DEPENDENCIES
   govuk_schemas
   govuk_sidekiq
   httparty
-  irb
   logging
   loofah
   mr-sparkle


### PR DESCRIPTION
For the last two weeks deployments to integration haven't been working because the irb gem has a sub-dependency that requires lib-yaml to be installed in the docker container, which it isn't.

The irb gem probably isn't required as it is part of the default Ruby install. An explicit dependency on irb was introduced in [this commit](https://github.com/alphagov/search-api/commit/e75c233bbd5e8aa9c840babf91ec0b33bd82058c) which states it was removed from Ruby in Ruby 2.6, but presumably that decision was reversed according to the [gem's readme](https://github.com/ruby/irb)

I deployed this branch to integration and it fixed the build: https://github.com/alphagov/search-api/actions/runs/6221593937