### PR TITLE
Add Assurance Warrantee to the AI Assurance Facet

### DIFF
--- a/config/schema/elasticsearch_types/ai_assurance_portfolio_technique.json
+++ b/config/schema/elasticsearch_types/ai_assurance_portfolio_technique.json
@@ -224,6 +224,10 @@
       {
         "label": "Bias Audit",
         "value": "bias-audit"
+      },
+      {
+        "label": "Assurance Warrantee",
+        "value": "assurance-warrantee"
       }
     ],
     "assurance_technique_approach": [


### PR DESCRIPTION
## Description

We’ve got a requirement from Dept of Science, Innovation & Technology to add a new facet to their Specialist Finder:

https://www.gov.uk/ai-assurance-techniques?use_case%5B%5D=robotic-process-automation-and-decision-management

The area to be updated is under Assurance Techniques and the new addition is Assurance Warrantee.

This field was updated for content schemas in this [PR](alphagov/publishing-api#2550) on Publishing API.

And to the finder in this [PR](https://github.com/alphagov/specialist-publisher/pull/2437) on Specialist Publisher.

## Trello card

https://trello.com/c/jhkaBdEK/2187-update-specialist-finder-facet