### PR TITLE
Configure dependabot to ignore elasticsearch beyond 6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "elasticsearch"
+        versions: ["7.x", "8.x"]
+        # We can't upgrade to version 7 or beyond
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
We can't upgrade `elasticsearch` to version 7.

This PR should stop dependendabot from opening PRs to upgrade.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore