### PR TITLE
Remove obsolete Jenkinsfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .github
 .gitignore
 Dockerfile
-Jenkinsfile
 Procfile
 README.md
 coverage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,0 @@
-#!/usr/bin/env groovy
-
-library("govuk")
-
-node('elasticsearch-6.7') {
-  govuk.buildProject()
-}


### PR DESCRIPTION
This is a bulk change and will be bulk-approved.

There is no need to review individually.
