### PR TITLE
Stop passing statsd (deprecated) to MQ client.

### DIFF
--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -17,7 +17,6 @@ namespace :message_queue do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "search_api_to_be_indexed",
       processor: Indexer::MessageProcessor.new,
-      statsd_client: Services.statsd_client,
     ).run
   end
 
@@ -26,7 +25,6 @@ namespace :message_queue do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "search_api_govuk_index",
       processor: GovukIndex::PublishingEventProcessor.new,
-      statsd_client: Services.statsd_client,
     ).run
   end
 
@@ -35,7 +33,6 @@ namespace :message_queue do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "search_api_bulk_reindex",
       processor: GovukIndex::PublishingEventProcessor.new,
-      statsd_client: Services.statsd_client,
     ).run
   end
 end

--- a/spec/unit/tasks/message_queue_spec.rb
+++ b/spec/unit/tasks/message_queue_spec.rb
@@ -5,9 +5,6 @@ load "tasks/message_queue.rake"
 RSpec.describe Indexer::MessageProcessor, "RakeTest" do
   context "when indexing published documents to publishing-api" do
     it "use GovukMessageQueueConsumer::Consumer" do
-      statsd_client = Statsd.new
-      expect(Services).to receive(:statsd_client).and_return(statsd_client)
-
       indexer = described_class.new
       expect(described_class).to receive(:new).and_return(indexer)
 
@@ -18,7 +15,6 @@ RSpec.describe Indexer::MessageProcessor, "RakeTest" do
         .with(
           queue_name: "search_api_to_be_indexed",
           processor: indexer,
-          statsd_client:,
         ).and_return(consumer)
 
       Rake::Task["message_queue:listen_to_publishing_queue"].invoke


### PR DESCRIPTION
search-api is the only app that's still using the optional statsd parameter to the `GovukMessageQueueConsumer::Consumer` constructor.

We don't use statsd any more. This unblocks deleting the defunct code from govuk_message_queue_consumer.