### PR TITLE
Add "Greater Cambridge Partnership" to Algorithmic Transparency Records

### DIFF
--- a/config/schema/elasticsearch_types/algorithmic_transparency_record.json
+++ b/config/schema/elasticsearch_types/algorithmic_transparency_record.json
@@ -48,6 +48,10 @@
       {
         "label": "Department for Education",
         "value": "department-for-education"
+      },
+      {
+        "label": "Greater Cambridge Partnership",
+        "value": "greater-cambridge-partnership"
       }
     ],
     "algorithmic_transparency_record_organisation_type": [


### PR DESCRIPTION
Trello: https://trello.com/c/pZucErjg/2550-add-a-new-organisation-to-the-arts-finders-organisations-facet