### PR TITLE
Disable Learning to Rank's involvement in queries

### DIFF
--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -77,7 +77,7 @@ module Search
     end
 
     def rerank
-      RelevanceHelpers.ltr_enabled? && [nil, "relevance"].include?(order) && ab_tests[:relevance] != "disable"
+      false
     end
 
     def use_shingles?


### PR DESCRIPTION
Learning to Rank only changes the ordering of results when the query includes keywords and is ordered by relevance.

It can only affect how results rank within a single page. The maximum effect it could have is to reverse the order of a page of results. The results all still appear on the same page.

Site search searches with keywords (the majority of searches) are now served by Vertex AI search. The cost and complexity of running a Learning to Rank training and serving pipeline for the other use cases no longer seems commensurate with the impact.

In addition to this, the training of our model has not been supervised effectively for a while, leading to a drop in the quality of the model.

I therefore propose disabling the use of Learning to Rank in Search-API (this change) which allows the removal of the code to invoke the model, the pipeline that builds and deploys the model and the Terraform to support the deployment.