### PR TITLE
Reorder facets on official documents

### DIFF
--- a/config/finders/official_documents_finder.yml
+++ b/config/finders/official_documents_finder.yml
@@ -39,6 +39,13 @@ details:
     type: text
     display_as_result_metadata: true
     filterable: false
+  - key: content_store_document_type
+    name: official documents
+    type: official_documents
+    preposition: Of type
+    display_as_result_metadata: true
+    filterable: true
+    hide_facet_tag: true
   - key: _unused
     filter_key: all_part_of_taxonomy_tree
     keys:
@@ -50,13 +57,6 @@ details:
     display_as_result_metadata: false
     filterable: true
     preposition: about
-  - key: content_store_document_type
-    name: official documents
-    type: official_documents
-    preposition: Of type
-    display_as_result_metadata: true
-    filterable: true
-    hide_facet_tag: true
   - key: organisations
     name: Organisation
     short_name: Organisation


### PR DESCRIPTION
- Non-expandable "of type" facet moved up so that it isn't confused with the Topic drop-down (which is expandable but closed by default so looks like the title of the "of type" radios.

https://trello.com/c/Mg2RDhII/230-confusing-order-of-filters-on-the-official-documents-finder

## Before

![Screenshot 2024-07-08 at 11 18 50](https://github.com/alphagov/search-api/assets/4225737/761d0e7a-3f76-4eb5-896c-fdb20219a535)

## After

![Screenshot 2024-07-08 at 11 20 37](https://github.com/alphagov/search-api/assets/4225737/8cb1d2d4-0afd-4d42-b2fc-5000f60e1093)
