### PR TITLE
2nd-line workaround for failing sitemap.xml generator

### DIFF
--- a/lib/sitemap/presenter.rb
+++ b/lib/sitemap/presenter.rb
@@ -23,7 +23,11 @@ private
     if document["link"].start_with?("http")
       document["link"]
     else
-      URI.join(base_url, document["link"]).to_s
+      begin
+        URI.join(base_url, document["link"]).to_s
+      rescue URI::InvalidURIError
+        URI.join(base_url, URI::DEFAULT_PARSER.escape(document["link"])).to_s
+      end
     end
   end
 


### PR DESCRIPTION
In the 2nd-line we had an incident with sitemap.xml not being generated. This is a quick fix of that issue.