### PR TITLE
Tweak replica count

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -118,9 +118,8 @@ index:
     # If the elasticsearch cluster is unable to allocate all of the replicas
     # (because you cannot host more than one replica of an index on a particular
     # node) then the cluster will show as being in a "yellow" state. The cluster
-    # will still work fine, though. This number of replicas is able to be allocated
-    # to our production cluster, though not to integration for example.
-    number_of_replicas: 5
+    # will still work fine, though.
+    number_of_replicas: 2
     number_of_shards: 3
     refresh_interval: '1s'
     search:


### PR DESCRIPTION
We're using this cluster less these days, so we don't need to run it at such a large capacity. Because we have fewer elasticsearch data nodes, we should reduce the number of replicas too.

The number of replicas has already been changed in all environments, so updating this config to match. This value is used during a reindex.