### PR TITLE
Update "site search" finder result count

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -9,7 +9,7 @@ schema_name: finder
 title: Search
 description: Find content from government
 details:
-  default_documents_per_page: 20
+  default_documents_per_page: 10
   document_noun: result
   reject:
     link:


### PR DESCRIPTION
We will be changing this to 10 results in the upcoming new site search UI, but want to try it out on the existing finder to be able to measure interaction data for a while and make sure our KPIs don't regress.