### PR TITLE
Remove reference to Search Admin

### DIFF
--- a/docs/documents.md
+++ b/docs/documents.md
@@ -1,6 +1,6 @@
 # Documents API (to be deprecated)
 
-> **Note**: Once whitehall and Search Admin are using the [new indexing process](new-indexing-process.md),
+> **Note**: Once Whitehall is using the [new indexing process](new-indexing-process.md),
 the documents API will be removed and search API will consume only from the publishing API.
 
 ### `POST /:index/documents`


### PR DESCRIPTION
Search Admin no longer uses the Documents API, as of https://github.com/alphagov/search-admin/commit/8d8a372a351ecdd9842525dcbd611450d31de8f6.