### PR TITLE
Increase sidekiq concurrency for integration

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 tag: search-api.publishing.service.gov.uk
-:concurrency: 5
+:concurrency: 12
 staging:
   :concurrency:  12
 production:


### PR DESCRIPTION
Increase the sidekiq concurrency for integration to aid with processing the GA4 data and not hitting memory limit.