### PR TITLE
Remove the focus sector field and facet from AI assurance technique documents and finder

### DIFF
--- a/config/schema/elasticsearch_types/ai_assurance_portfolio_technique.json
+++ b/config/schema/elasticsearch_types/ai_assurance_portfolio_technique.json
@@ -5,8 +5,7 @@
     "principle",
     "key_function",
     "ai_assurance_technique",
-    "assurance_technique_approach",
-    "focus_sector"
+    "assurance_technique_approach"
   ],
   "expanded_search_result_fields": {
     "use_case": [
@@ -243,12 +242,6 @@
       {
         "label": "Educational",
         "value": "educational"
-      }
-    ],
-    "focus_sector": [
-      {
-        "label": "Financial Services",
-        "value": "financial-services"
       }
     ]
   }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1007,10 +1007,6 @@
   "assurance_technique_approach": {
     "type": "identifiers"
   },
-  "focus_sector": {
-    "type": "identifiers"
-  },
-
   "algorithmic_transparency_record_organisation": {
     "description": "The organisation that published the record",
     "type": "identifiers"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -73,7 +73,6 @@ module GovukIndex
         email_document_supertype: common_fields.email_document_supertype,
         first_published_at: specialist.first_published_at,
         flood_and_coastal_erosion_category: specialist.flood_and_coastal_erosion_category,
-        focus_sector: specialist.focus_sector,
         format: common_fields.format,
         fund_state: specialist.fund_state,
         fund_type: specialist.fund_type,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -54,7 +54,6 @@ module GovukIndex
     delegate_to_payload :disease_type, convert_to_array: true
     delegate_to_payload :eligible_entities
     delegate_to_payload :flood_and_coastal_erosion_category
-    delegate_to_payload :focus_sector, convert_to_array: true
     delegate_to_payload :fund_state, convert_to_array: true
     delegate_to_payload :fund_type
     delegate_to_payload :funding_amount


### PR DESCRIPTION
Trello: https://trello.com/c/Gevbmi5F/2828-remove-focus-sector-filter-from-ai-assurance-techniques-finder