### PR TITLE
All content finder: update section names

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -23,7 +23,7 @@ details:
     keys:
     - level_one_taxon
     - level_two_taxon
-    name: topic
+    name: Topic
     preposition: about
     short_name: topic
     type: taxon
@@ -39,7 +39,7 @@ details:
   - display_as_result_metadata: false
     filterable: true
     key: content_purpose_supergroup
-    name: Content type
+    name: Type
     preposition: in
     short_name: In
     type: text


### PR DESCRIPTION
- Change topic section name to properly capitalised `Topic` (the current topic facet in Finder Frontend has this title hardcoded anyway so the name isn't used right now, but we want to fix that)
- Change content type section name to just "Type" to match new designs

> [!NOTE]
> This will need to be applied after merge:
> ```
> kubectl exec -it deployments/search-api -- env FINDER_CONFIG=all_content_finder.yml rake publishing_api:publish_finder
> ```