### PR TITLE
Update all content finder facets and sort options

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -96,9 +96,9 @@ details:
   - key: "-relevance"
     name: Relevance
   - key: "-public_timestamp"
-    name: Updated (newest)
+    name: Newest
   - key: public_timestamp
-    name: Updated (oldest)
+    name: Oldest
 routes:
 - path: "/search/all"
   type: exact

--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -16,6 +16,13 @@ details:
       - "/search/all"
   format_name: Documents
   facets:
+  - display_as_result_metadata: true
+    filterable: true
+    key: public_timestamp
+    name: Date
+    short_name: Date
+    preposition: Updated
+    type: date
   - key: "_unused"
     display_as_result_metadata: false
     filter_key: all_part_of_taxonomy_tree
@@ -72,13 +79,6 @@ details:
     preposition: in
     type: hidden_clearable
     show_option_select_filter: false
-  - display_as_result_metadata: true
-    filterable: true
-    key: public_timestamp
-    name: Updated
-    short_name: Updated
-    preposition: Updated
-    type: date
   - display_as_result_metadata: false
     filterable: true
     key: topical_events


### PR DESCRIPTION
This updates the content item source for the "all content" finder to reflect the upcoming design changes.

In particular, it:
* renames the date sort options (from "Updated (oldest/newest)" to just "Oldest/Newest")
* renames the date facet from "Updated" to "Date"
* moves the date facet to be the first facet rather than the last

> [!NOTE]
> This is a pre-emptive PR, and should be merged and applied **roughly when we go live with the new UI** so it doesn't mess up our analytics measurement of the old UI too much.

### Before
![image](https://github.com/user-attachments/assets/e7f36265-e6c2-4d80-910d-765b2ce30421)

### After
![image](https://github.com/user-attachments/assets/65ec186b-cb48-4aa8-8bd2-0c628c1babba)
