### PR TITLE
All content finder: Change `date` facet short_name

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -20,7 +20,7 @@ details:
     filterable: true
     key: public_timestamp
     name: Date
-    short_name: Date
+    short_name: Updated
     preposition: Updated
     type: date
   - key: "_unused"


### PR DESCRIPTION
This is used to display the facet value as part of metadata, and when used in that context, "Updated: ___" sounds better than "Date: ___".

<img width="657" alt="image" src="https://github.com/user-attachments/assets/51ce2847-b234-4f44-b3a3-fe4d20ad14f3">

---

<img width="652" alt="image" src="https://github.com/user-attachments/assets/90972a61-7c86-4a20-ab46-a61b7ab28fe6">
