### PR TITLE
All content finder: Revert to old sort option names

### DIFF
--- a/config/finders/all_content_finder.yml
+++ b/config/finders/all_content_finder.yml
@@ -96,9 +96,9 @@ details:
   - key: "-relevance"
     name: Relevance
   - key: "-public_timestamp"
-    name: Newest
+    name: Updated (newest)
   - key: public_timestamp
-    name: Oldest
+    name: Updated (oldest)
 routes:
 - path: "/search/all"
   type: exact


### PR DESCRIPTION
We wanted to rename these to more user-friendly options, but instead of using the key, Finder Frontend actually uses a dasherised version of the name (!!!) to determine the query parameter.

This means that changing the name of a sort option breaks any links to this sort option (of which there are several for the "updated by" options within GOV.UK, never mind users' bookmarks).

This'll need a proper fix, but for the time being we're happy to go live with the old sort option names.