### PR TITLE
Add SFO finder to Search API

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -58,6 +58,7 @@ service_manual_service_standard: service_manual_guide
 service_manual_service_toolkit: edition
 service_manual_topic: service_manual_topic
 service_standard_report: service_standard_report # Specialist Publisher
+sfo_case: sfo_case # Specialist Publisher
 simple_smart_answer: edition
 smart_answer: edition
 statutory_instrument: statutory_instrument # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -54,6 +54,7 @@ migrated:
 - research_for_development_output
 - residential_property_tribunal_decision
 - service_standard_report
+- sfo_case
 - statutory_instrument
 - tax_tribunal_decision
 - traffic_commissioner_regulatory_decision

--- a/config/schema/elasticsearch_types/sfo_case.json
+++ b/config/schema/elasticsearch_types/sfo_case.json
@@ -1,0 +1,17 @@
+{
+	"fields": [
+		"sfo_case_state"
+	],
+	"expanded_search_result_fields": {
+		"sfo_case_state": [
+			{
+				"label": "Open",
+				"value": "open"
+			},
+			{
+				"label": "Closed",
+				"value": "closed"
+			}
+		]
+	}
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1100,5 +1100,9 @@
   },
   "veterans_support_organisation_region_wales": {
     "type": "identifiers"
+  },
+  "sfo_case_state": {
+    "description": "Whether a case is open or closed. Applies to SFO cases.",
+    "type": "identifiers"
   }
 }

--- a/config/schema/indexes/govuk.json
+++ b/config/schema/indexes/govuk.json
@@ -36,12 +36,13 @@
     "raib_report",
     "research_for_development_output",
     "residential_property_tribunal_decision",
-    "traffic_commissioner_regulatory_decision",
     "service_manual_guide",
     "service_manual_topic",
     "service_standard_report",
+    "sfo_case",
     "statutory_instrument",
     "tax_tribunal_decision",
+    "traffic_commissioner_regulatory_decision",
     "utaac_decision",
     "veterans_support_organisation"
   ]

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -156,6 +156,7 @@ module GovukIndex
         roles: expanded_links.roles,
         sector: specialist.sector,
         service_provider: specialist.service_provider,
+        sfo_case_state: specialist.sfo_case_state,
         sift_end_date: specialist.sift_end_date,
         sifting_status: specialist.sifting_status,
         slug:,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -107,6 +107,7 @@ module GovukIndex
     delegate_to_payload :review_status
     delegate_to_payload :sector, convert_to_array: true
     delegate_to_payload :service_provider
+    delegate_to_payload :sfo_case_state
     delegate_to_payload :sift_end_date
     delegate_to_payload :sifting_status
     delegate_to_payload :stage


### PR DESCRIPTION
This document type has been requested by the Serious Fraud Office. The finder will enable users to find fraud, bribery and corruption cases investigated by the SFO.

[Docs for adding a specialist document type](https://docs.publishing.service.gov.uk/repos/specialist-publisher/creating-editing-and-removing-specialist-document-types-and-finders.html)

[Trello](https://trello.com/c/E7KMeGZo/3034-specialist-finder-sfo-cases)