### PR TITLE
Add new facet to SFO finder

### DIFF
--- a/config/schema/elasticsearch_types/sfo_case.json
+++ b/config/schema/elasticsearch_types/sfo_case.json
@@ -1,6 +1,7 @@
 {
 	"fields": [
-		"sfo_case_state"
+		"sfo_case_state",
+		"sfo_case_opened_date"
 	],
 	"expanded_search_result_fields": {
 		"sfo_case_state": [

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1104,5 +1104,9 @@
   "sfo_case_state": {
     "description": "Whether a case is open or closed. Applies to SFO cases.",
     "type": "identifiers"
+  },
+  "sfo_case_opened_date": {
+    "description": "Open date of a SFO case",
+    "type": "date"
   }
 }

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -156,6 +156,7 @@ module GovukIndex
         roles: expanded_links.roles,
         sector: specialist.sector,
         service_provider: specialist.service_provider,
+        sfo_case_opened_date: specialist.sfo_case_opened_date,
         sfo_case_state: specialist.sfo_case_state,
         sift_end_date: specialist.sift_end_date,
         sifting_status: specialist.sifting_status,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -107,6 +107,7 @@ module GovukIndex
     delegate_to_payload :review_status
     delegate_to_payload :sector, convert_to_array: true
     delegate_to_payload :service_provider
+    delegate_to_payload :sfo_case_opened_date
     delegate_to_payload :sfo_case_state
     delegate_to_payload :sift_end_date
     delegate_to_payload :sifting_status


### PR DESCRIPTION
Adds an additional facet to the new to SFO Finder specialist finder. As per documentation found [here](https://docs.publishing.service.gov.uk/repos/specialist-publisher/creating-editing-and-removing-specialist-document-types-and-finders.html#editing-a-specialist-document-type)

[First PR](https://github.com/alphagov/search-api/pull/3038)
[Trello](https://trello.com/c/E7KMeGZo/3034-specialist-finder-sfo-cases)
[Zendesk](https://govuk.zendesk.com/agent/tickets/5958029)