### PR TITLE
Remove deprecation marker on expanded search result field configuration and explain usage

### DIFF
--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -86,8 +86,7 @@ The files contain JSON object with the following keys:
  - `fields`: An array of field names which are allowed in documents of this
    type.  The field names must be defined in the `field_definitions.json` file.
 
- - `expanded_search_result_fields`: DEPRECATED. Sets up field "expansion" for a
-    field. This is used by the search result presenter to replace a raw value.
+ - `expanded_search_result_fields`: This is used by the search result presenter to replace a raw value with other data.
 
     For example:
 
@@ -105,9 +104,10 @@ The files contain JSON object with the following keys:
       ],
     ```
 
-    Will return make the presenter replace the `foo` with value `bar`
+    Will make the search result presenter replace values of `bar`
     with the hash `{ "label": "Bar the bar", "value": "bar" }`. This can be used
     when displaying the search results.
+    For example, finder frontend depends on this behaviour to display readable labels in search result metadata.
 
 Even though we have different schemas for different "elasticsearch
 document types", in practice elasticsearch only knows about one


### PR DESCRIPTION
Given that we don't know why this behaviour was marked deprecated, and downstream apps depend on it, it seems reasonable to remove the deprecation notice.

This commit also adds a usage example from Finder Frontend to make it clear what purposes the configuration can be used for. Arguably finder frontend could look up the label from the finder content item instead of requiring the label to be part of the search result, which might explain why this was deprecated, but that is unlikely to be a simple change.