### PR TITLE
Add `host_authorization` setting for dev environment

### DIFF
--- a/lib/rummager/config.rb
+++ b/lib/rummager/config.rb
@@ -3,6 +3,7 @@ require "rummager"
 
 configure :development do
   set :protection, false
+  set :host_authorization, { permitted_hosts: [] }
 end
 
 # Enable custom error handling (eg ``error Exception do;...end``)


### PR DESCRIPTION
Sinatra 4.1 ships with a breaking change that [enables host allowlisting middleware][1] in local development, which in turn breaks running Search API through GOV.UK Docker.
    
This adds an explicit `permitted_hosts` setting for the middleware in the development environment, which allows access with arbitrary host headers.

[1]: https://github.com/sinatra/sinatra/pull/2053