### PR TITLE
Rename date facet

### DIFF
--- a/config/schema/elasticsearch_types/sfo_case.json
+++ b/config/schema/elasticsearch_types/sfo_case.json
@@ -1,7 +1,7 @@
 {
 	"fields": [
 		"sfo_case_state",
-		"sfo_case_opened_date"
+		"sfo_case_date_announced"
 	],
 	"expanded_search_result_fields": {
 		"sfo_case_state": [

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1105,8 +1105,8 @@
     "description": "Whether a case is open or closed. Applies to SFO cases.",
     "type": "identifiers"
   },
-  "sfo_case_opened_date": {
-    "description": "Open date of a SFO case",
+  "sfo_case_date_announced": {
+    "description": "Date announced of a SFO case",
     "type": "date"
   }
 }

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -156,7 +156,7 @@ module GovukIndex
         roles: expanded_links.roles,
         sector: specialist.sector,
         service_provider: specialist.service_provider,
-        sfo_case_opened_date: specialist.sfo_case_opened_date,
+        sfo_case_date_announced: specialist.sfo_case_date_announced,
         sfo_case_state: specialist.sfo_case_state,
         sift_end_date: specialist.sift_end_date,
         sifting_status: specialist.sifting_status,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -107,7 +107,7 @@ module GovukIndex
     delegate_to_payload :review_status
     delegate_to_payload :sector, convert_to_array: true
     delegate_to_payload :service_provider
-    delegate_to_payload :sfo_case_opened_date
+    delegate_to_payload :sfo_case_date_announced
     delegate_to_payload :sfo_case_state
     delegate_to_payload :sift_end_date
     delegate_to_payload :sifting_status


### PR DESCRIPTION
Renames a facet in the new SFO Finder specialist finder.

[Previous PR](https://github.com/alphagov/search-api/pull/3043)
[Trello](https://trello.com/c/E7KMeGZo/3034-specialist-finder-sfo-cases)
[Zendesk](https://govuk.zendesk.com/agent/tickets/5958029)