### PR TITLE
Add Sint Maarten

### DIFF
--- a/config/schema/elasticsearch_types/export_health_certificate.json
+++ b/config/schema/elasticsearch_types/export_health_certificate.json
@@ -206,6 +206,7 @@
       {"label": "Seychelles", "value": "seychelles"},
       {"label": "Sierra Leone", "value": "sierra-leone"},
       {"label": "Singapore", "value": "singapore"},
+      {"label": "Sint Maarten", "value": "sint-maarten"},
       {"label": "Slovakia", "value": "slovakia"},
       {"label": "Slovenia", "value": "slovenia"},
       {"label": "Solomon Islands", "value": "solomon-islands"},


### PR DESCRIPTION
From the [Zendesk](https://govuk.zendesk.com/agent/tickets/6000442) ticket - "We require the addition of "Sint Maarten" to the list of destination countries available to select in the Export Health Certificates section of Specialist Publisher. We have a certificate that needs to be published, but we cannot create a page for it whilst the country does not exist in the system."

[Trello](https://trello.com/c/UuMKP5Si/3289-addition-of-country-to-export-health-certificates-metadata-govt-agency-general-issue)