### PR TITLE
Add requested label/value changes and additions to TCRD finder

### DIFF
--- a/config/schema/elasticsearch_types/traffic_commissioner_regulatory_decision.json
+++ b/config/schema/elasticsearch_types/traffic_commissioner_regulatory_decision.json
@@ -55,24 +55,76 @@
 
     "outcome_type": [
       {
-        "label": "No action",
-        "value": "no-action"
-      },
-      {
-        "label": "Curtailment",
-        "value": "curtailment"
-      },
-      {
-        "label": "Formal warning",
-        "value": "formal-warning"
+        "label": "Licence revoked",
+        "value": "revocation"
       },
       {
         "label": "Loss of repute",
         "value": "loss-of-repute"
       },
       {
-        "label": "Revocation",
-        "value": "revocation"
+        "label": "Licence holder disqualified",
+        "value": "licence-holder-disqualified"
+      },
+      {
+        "label": "Transport manager disqualified",
+        "value": "transport-manager-disqualified"
+      },
+      {
+        "label": "Licence suspended",
+        "value": "licence-suspended"
+      },
+      {
+        "label": "Licence curtailed or authorisation reduced",
+        "value": "curtailment"
+      },
+      {
+        "label": "Conditions imposed on licence",
+        "value": "conditions-imposed-on-licence"
+      },
+      {
+        "label": "Formal warning",
+        "value": "formal-warning"
+      },
+      {
+        "label": "No action taken",
+        "value": "no-action"
+      },
+      {
+        "label": "Application granted as applied for",
+        "value": "application-granted-as-applied-for"
+      },
+      {
+        "label": "Application granted in part",
+        "value": "application-granted-in-part"
+      },
+      {
+        "label": "Application granted with conditions",
+        "value": "application-granted-with-conditions"
+      },
+      {
+        "label": "Application refused",
+        "value": "application-refused"
+      },
+      {
+        "label": "Application withdrawn",
+        "value": "application-withdrawn"
+      },
+      {
+        "label": "Restrictions imposed under Transport Act 1985",
+        "value": "restrictions-imposed-under-transport-act-1985"
+      },
+      {
+        "label": "Penalty imposed under Transport Act 2000",
+        "value": "penalty-imposed-under-transport-act-2000"
+      },
+      {
+        "label": "Impounding application granted",
+        "value": "impounding-application-granted"
+      },
+      {
+        "label": "Impounding application refused",
+        "value": "impounding-application-refused"
       }
     ]
   }


### PR DESCRIPTION
https://trello.com/c/QUZiTIcs/3268-changes-to-the-specialist-publisher-page-traffic-commissioner-regulatory-decisions-govt-agency-general-issue

When adding a new decision, I request the following changes to be made –

Decision Subject – We need to be able to select multiple options. Options to expand and include Driver Conduct

Region – southeast should be separated and capitalised for consistency South East.

Case Type – need to be able to select multiple options.

Regulatory decision – need to be able to select multiple options and options to be the following:

Licence revoked
Licence holder disqualified
Transport manager disqualified
Licence suspended
Licence curtailed or authorisation reduced
Conditions imposed on licence
Formal warning
No action taken
Application granted as applied for
Application granted in part
Application granted with conditions
Application refused
Application withdrawn
Restrictions imposed under Transport Act 1985
Penalty imposed under Transport Act 2000
Impounding application granted
Impounding application refused