### PR TITLE
Migrate Whitehall news article formats to GOVUK index

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -4,7 +4,6 @@ migrated:
 - mainstream_browse_page
 # Contacts
 - contact
-# Content Publisher - formats not indexable when published by Whitehall
 - government_response:
     publishing_app: content-publisher
 - news_story:
@@ -388,8 +387,6 @@ non_indexable:
 #- finder # migrated
 - foi_release
 - form
-- government_response: # indexable when published by Content Publisher
-    publishing_app: whitehall
 - guidance
 - html_publication
 - impact_assessment
@@ -402,8 +399,6 @@ non_indexable:
 - modern_slavery_statement
 - national_statistics
 - national_statistics_announcement
-- news_story: # indexable when published by Content Publisher
-    publishing_app: whitehall
 - notice
 - official_statistics
 - official_statistics_announcement
@@ -415,8 +410,6 @@ non_indexable:
 - petitions_and_campaigns
 - policy_area
 - policy_paper
-- press_release: # indexable when published by Content Publisher
-    publishing_app: whitehall
 - procurement
 - promotional
 - publication
@@ -440,7 +433,5 @@ non_indexable:
 - welsh_language_scheme
 - working_group
 - world_location
-- world_news_story: # indexable when published by Content Publisher
-    publishing_app: whitehall
 - worldwide_organisation
 - written_statement

--- a/spec/unit/govuk_index/migrated_formats_spec.rb
+++ b/spec/unit/govuk_index/migrated_formats_spec.rb
@@ -31,22 +31,4 @@ RSpec.describe GovukIndex::MigratedFormats do
       expect(described_class.non_indexable?("help_page", "/help/cookie-details", "publisher")).to be true
     end
   end
-
-  describe "content that can be published by both Content Publisher and Whitehall" do
-    it "#non_indexable? returns false if content is published by Content Publisher" do
-      expect(described_class.non_indexable?("news_story", "/a-path", "content-publisher")).to be false
-    end
-
-    it "#non_indexable? returns true if content is published by Whitehall" do
-      expect(described_class.non_indexable?("news_story", "/a-path", "whitehall")).to be true
-    end
-
-    it "#indexable? returns true if content is published by Content Publisher" do
-      expect(described_class.indexable?("news_story", "/a-path", "content-publisher")).to be true
-    end
-
-    it "#indexable? returns false if content is published by Whitehall" do
-      expect(described_class.indexable?("news_story", "/a-path", "whitehall")).to be false
-    end
-  end
 end


### PR DESCRIPTION
Because news articles from Content Publisher were already indexed using Publishing API events, we don't seem to need to add any additional fields to the search presenters.

Trello: https://trello.com/c/A5uNzU3G