### PR TITLE
Apply format migration per-publishing app filter

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -4,15 +4,6 @@ migrated:
 - mainstream_browse_page
 # Contacts
 - contact
-# Content Publisher - formats not indexable when published by Whitehall
-- government_response:
-    publishing_app: content-publisher
-- news_story:
-    publishing_app: content-publisher
-- press_release:
-    publishing_app: content-publisher
-- world_news_story:
-    publishing_app: content-publisher
 # Publisher
 - answer
 - guide
@@ -315,7 +306,22 @@ migrated:
   - '/help/cookies'
   - '/find-local-council'
 
-indexable: []
+partially_migrated:
+  # Content Publisher - formats not indexable when published by Whitehall
+  government_response: content-publisher
+  news_story: content-publisher
+  press_release: content-publisher
+  world_news_story: content-publisher
+
+indexable:
+- government_response: # indexable when published by Content Publisher
+    publishing_app: content-publisher
+- news_story: # indexable when published by Content Publisher
+    publishing_app: content-publisher
+- press_release: # indexable when published by Content Publisher
+    publishing_app: content-publisher
+- world_news_story: # indexable when published by Content Publisher
+    publishing_app: content-publisher
 
 non_indexable_path:
 - '/help/cookie-details'

--- a/lib/govuk_index/migrated_formats.rb
+++ b/lib/govuk_index/migrated_formats.rb
@@ -29,6 +29,10 @@ module GovukIndex
       @migrated_formats ||= convert_to_allowed_hash(data_file["migrated"])
     end
 
+    def partially_migrated_formats
+      @partially_migrated_formats ||= data_file["partially_migrated"]
+    end
+
   private
 
     def data_file

--- a/lib/search/format_migrator.rb
+++ b/lib/search/format_migrator.rb
@@ -9,7 +9,7 @@ module Search
       {
         bool: {
           minimum_should_match: 1,
-          should: [excluding_formats, only_formats],
+          should: [excluding_formats, only_formats] + partially_migrated_formats,
         },
       }
     end
@@ -54,6 +54,21 @@ module Search
           ],
         },
       }
+    end
+
+    def partially_migrated_formats
+      GovukIndex::MigratedFormats.partially_migrated_formats.keys.map do |format|
+        {
+          bool: {
+            must: [
+              base_query,
+              { terms: { _index: migrated_indices } },
+              { term: { format: format } },
+              { term: { publishing_app: GovukIndex::MigratedFormats.partially_migrated_formats[format] } },
+            ],
+          },
+        }
+      end
     end
 
     def base_query

--- a/spec/unit/search/aggregate_example_fetcher_spec.rb
+++ b/spec/unit/search/aggregate_example_fetcher_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Search::AggregateExampleFetcher do
   context "one aggregate with global scope" do
     before do
       allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
+      allow(GovukIndex::MigratedFormats).to receive(:partially_migrated_formats).and_return({})
       @index = stub_index("content index")
       @example_fields = %w[link title other_field]
       main_query_response = { "aggregations" => {


### PR DESCRIPTION
Whilst the migrated section of the migrated_formats.yaml config file did specify that news article formats could only be considered migrated if they were published by content publisher, this logic was not actually applied by the format migrator. The format migrator only applies publishing app restrictions for indexing.

This behaviour was a blocker to migrating news article formats published by Whitehall to the govuk index, because without applying the migrated filter to Whitehall-published documents, duplicate search results will appear in GOV.UK finders once we start allowing indexing of Whitehall news article formats in the GOVUK index. We need to be able to filter out the Whitehall documents indexed on the govuk index until we are confident that all the data has been migrated over safely.

There is an alternative, more straightforward approach that may be more appropriate here. We could add a "migrated_apps" key to the config file and simply say that any document with a publishing app of "content-publisher" in the govuk index must appear in the search results. This would have the advantage of not adding an Elasticsearch condition to evaluate per app/format combination, but isn't true to the original intention of the format migrator (which is intended to work on a format-by-format basis rather than for an entire app). 

Trello: https://trello.com/c/pUo3imKD