### PR TITLE
Add migrated app configuration to Search API and always include results from migrated apps

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -4,15 +4,6 @@ migrated:
 - mainstream_browse_page
 # Contacts
 - contact
-# Content Publisher - formats not indexable when published by Whitehall
-- government_response:
-    publishing_app: content-publisher
-- news_story:
-    publishing_app: content-publisher
-- press_release:
-    publishing_app: content-publisher
-- world_news_story:
-    publishing_app: content-publisher
 # Publisher
 - answer
 - guide
@@ -315,7 +306,15 @@ migrated:
   - '/help/cookies'
   - '/find-local-council'
 
-indexable: []
+# Below configuration can be removed once government_response, news_story, press_release and world_news_story are migrated
+migrated_publishing_apps:
+  - content-publisher
+
+indexable:
+  - government_response
+  - news_story
+  - press_release
+  - world_news_story
 
 non_indexable_path:
 - '/help/cookie-details'
@@ -388,8 +387,6 @@ non_indexable:
 #- finder # migrated
 - foi_release
 - form
-- government_response: # indexable when published by Content Publisher
-    publishing_app: whitehall
 - guidance
 - html_publication
 - impact_assessment
@@ -402,8 +399,6 @@ non_indexable:
 - modern_slavery_statement
 - national_statistics
 - national_statistics_announcement
-- news_story: # indexable when published by Content Publisher
-    publishing_app: whitehall
 - notice
 - official_statistics
 - official_statistics_announcement
@@ -415,8 +410,6 @@ non_indexable:
 - petitions_and_campaigns
 - policy_area
 - policy_paper
-- press_release: # indexable when published by Content Publisher
-    publishing_app: whitehall
 - procurement
 - promotional
 - publication
@@ -440,7 +433,5 @@ non_indexable:
 - welsh_language_scheme
 - working_group
 - world_location
-- world_news_story: # indexable when published by Content Publisher
-    publishing_app: whitehall
 - worldwide_organisation
 - written_statement

--- a/lib/govuk_index/migrated_formats.rb
+++ b/lib/govuk_index/migrated_formats.rb
@@ -2,10 +2,9 @@ module GovukIndex
   module MigratedFormats
     extend self
 
-    def non_indexable?(format, path, app)
-      non_indexable_formats[format] &&
-        (non_indexable_formats[format] == :all || non_indexable_formats[format].include?(path) ||
-          published_by_non_indexable_app?(format, app)) || non_indexable_path.include?(path)
+    def non_indexable?(format, path)
+      non_indexable_path.include?(path) || non_indexable_formats[format] &&
+        (non_indexable_formats[format] == :all || non_indexable_formats[format].include?(path))
     end
 
     def non_indexable_formats
@@ -16,9 +15,8 @@ module GovukIndex
       @non_indexable_path ||= data_file["non_indexable_path"]
     end
 
-    def indexable?(format, path, app)
-      indexable_formats[format] && (indexable_formats[format] == :all ||
-        indexable_formats[format].include?(path) || published_by_indexable_app?(format, app))
+    def indexable?(format, path)
+      indexable_formats[format] && (indexable_formats[format] == :all || indexable_formats[format].include?(path))
     end
 
     def indexable_formats
@@ -27,6 +25,10 @@ module GovukIndex
 
     def migrated_formats
       @migrated_formats ||= convert_to_allowed_hash(data_file["migrated"])
+    end
+
+    def migrated_publishing_apps
+      @migrated_publishing_apps ||= data_file["migrated_publishing_apps"] || []
     end
 
   private
@@ -44,18 +46,6 @@ module GovukIndex
           hash
         end
       end
-    end
-
-    def published_by_indexable_app?(format, app)
-      return false unless indexable_formats[format].is_a?(Hash)
-
-      indexable_formats[format]["publishing_app"] == app
-    end
-
-    def published_by_non_indexable_app?(format, app)
-      return false unless non_indexable_formats[format].is_a?(Hash)
-
-      non_indexable_formats[format]["publishing_app"] == app
     end
   end
 end

--- a/lib/govuk_index/publishing_event_job.rb
+++ b/lib/govuk_index/publishing_event_job.rb
@@ -85,9 +85,9 @@ module GovukIndex
       if type_mapper.unpublishing_type?
         logger.info("#{routing_key} -> DELETE #{identifier}")
         processor.delete(presenter)
-      elsif payload.fetch("locale", "en") != "en" || MigratedFormats.non_indexable?(presenter.format, presenter.base_path, presenter.publishing_app)
+      elsif payload.fetch("locale", "en") != "en" || MigratedFormats.non_indexable?(presenter.format, presenter.base_path)
         logger.info("#{routing_key} -> BLOCKLISTED #{identifier}")
-      elsif MigratedFormats.indexable?(presenter.format, presenter.base_path, presenter.publishing_app)
+      elsif MigratedFormats.indexable?(presenter.format, presenter.base_path)
         logger.info("#{routing_key} -> INDEX #{identifier}")
         processor.save(presenter)
       else

--- a/lib/search/format_migrator.rb
+++ b/lib/search/format_migrator.rb
@@ -9,7 +9,7 @@ module Search
       {
         bool: {
           minimum_should_match: 1,
-          should: [excluding_formats, only_formats],
+          should: [excluding_formats, only_formats, migrated_publishing_apps].compact,
         },
       }
     end
@@ -51,6 +51,20 @@ module Search
             base_query,
             { terms: { _index: migrated_indices } },
             { terms: { format: migrated_formats } },
+          ],
+        },
+      }
+    end
+
+    def migrated_publishing_apps
+      return nil if GovukIndex::MigratedFormats.migrated_publishing_apps.empty?
+
+      {
+        bool: {
+          must: [
+            base_query,
+            { terms: { _index: migrated_indices } },
+            { terms: { publishing_app: GovukIndex::MigratedFormats.migrated_publishing_apps } },
           ],
         },
       }

--- a/spec/unit/govuk_index/migrated_formats_spec.rb
+++ b/spec/unit/govuk_index/migrated_formats_spec.rb
@@ -28,25 +28,7 @@ RSpec.describe GovukIndex::MigratedFormats do
       non_indexable_path = described_class.non_indexable_path
 
       expect(non_indexable_path.include?("/help/cookie-details")).to be true
-      expect(described_class.non_indexable?("help_page", "/help/cookie-details", "publisher")).to be true
-    end
-  end
-
-  describe "content that can be published by both Content Publisher and Whitehall" do
-    it "#non_indexable? returns false if content is published by Content Publisher" do
-      expect(described_class.non_indexable?("news_story", "/a-path", "content-publisher")).to be false
-    end
-
-    it "#non_indexable? returns true if content is published by Whitehall" do
-      expect(described_class.non_indexable?("news_story", "/a-path", "whitehall")).to be true
-    end
-
-    it "#indexable? returns true if content is published by Content Publisher" do
-      expect(described_class.indexable?("news_story", "/a-path", "content-publisher")).to be true
-    end
-
-    it "#indexable? returns false if content is published by Whitehall" do
-      expect(described_class.indexable?("news_story", "/a-path", "whitehall")).to be false
+      expect(described_class.non_indexable?("help_page", "/help/cookie-details")).to be true
     end
   end
 end

--- a/spec/unit/search/aggregate_example_fetcher_spec.rb
+++ b/spec/unit/search/aggregate_example_fetcher_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Search::AggregateExampleFetcher do
                     },
                   },
                   { bool: { must_not: { match_all: {} } } },
+                  { bool: { must: [
+                    { match_all: {} },
+                    { terms: { _index: %w[govuk_test] } },
+                    { terms: { publishing_app: %w[content-publisher] } },
+                  ] } },
                 ],
               },
             },
@@ -78,6 +83,7 @@ RSpec.describe Search::AggregateExampleFetcher do
     allow(index).to receive(:schema).and_return(schema)
     index
   end
+
   before do
     allow_any_instance_of(LegacyClient::IndexForSearch).to receive(:real_index_names).and_return(%w[govuk_test])
   end

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -103,58 +103,6 @@ RSpec.describe Search::FormatMigrator do
         ).call).to eq(expected)
       end
 
-      it "when no base query without migrated formats" do
-        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
-        expected = {
-          bool: {
-            minimum_should_match: 1,
-            should: [
-              {
-                bool: {
-                  must: { match_all: {} },
-                  must_not: { terms: { _index: %w[govuk_test] } },
-                },
-              },
-              { bool: { must_not: { match_all: {} } } },
-            ],
-          },
-        }
-        expect(described_class.new(
-          SearchConfig.default_instance,
-        ).call).to eq(expected)
-      end
-
-      it "when no base query with migrated formats" do
-        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("help_page" => :all)
-        expected = {
-          bool:
-          { minimum_should_match: 1,
-            should: [
-              {
-                bool: {
-                  must: { match_all: {} },
-                  must_not: [
-                    { terms: { _index: %w[govuk_test] } },
-                    { terms: { format: %w[help_page] } },
-                  ],
-                },
-              },
-              {
-                bool: {
-                  must: [
-                    { match_all: {} },
-                    { terms: { _index: %w[govuk_test] } },
-                    { terms: { format: %w[help_page] } },
-                  ],
-                },
-              },
-            ] },
-        }
-        expect(described_class.new(
-          SearchConfig.default_instance,
-        ).call).to eq(expected)
-      end
-
       it "uses a default match all query when no base query is provided" do
         allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
         allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return([])

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Search::FormatMigrator do
     Clusters.active.each do |_cluster|
       it "when base query without migrated formats" do
         allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return([])
         base_query = { filter: "component" }
         expected = {
           bool: {
@@ -36,6 +37,7 @@ RSpec.describe Search::FormatMigrator do
 
       it "when base query with migrated formats" do
         allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("help_page" => :all)
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return([])
         base_query = { filter: "component" }
         expected = {
           bool: {
@@ -56,6 +58,39 @@ RSpec.describe Search::FormatMigrator do
                     base_query,
                     { terms: { _index: %w[govuk_test] } },
                     { terms: { format: %w[help_page] } },
+                  ],
+                },
+              },
+            ],
+          },
+        }
+        expect(described_class.new(
+          SearchConfig.default_instance,
+          base_query:,
+        ).call).to eq(expected)
+      end
+
+      it "when base query with migrated apps" do
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return(%w[content-publisher])
+        base_query = { filter: "component" }
+        expected = {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                bool: {
+                  must: base_query,
+                  must_not: { terms: { _index: %w[govuk_test] } },
+                },
+              },
+              { bool: { must_not: { match_all: {} } } },
+              {
+                bool: {
+                  must: [
+                    base_query,
+                    { terms: { _index: %w[govuk_test] } },
+                    { terms: { publishing_app: %w[content-publisher] } },
                   ],
                 },
               },
@@ -114,6 +149,28 @@ RSpec.describe Search::FormatMigrator do
                 },
               },
             ] },
+        }
+        expect(described_class.new(
+          SearchConfig.default_instance,
+        ).call).to eq(expected)
+      end
+
+      it "uses a default match all query when no base query is provided" do
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
+        allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return([])
+        expected = {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              {
+                bool: {
+                  must: { match_all: {} },
+                  must_not: { terms: { _index: %w[govuk_test] } },
+                },
+              },
+              { bool: { must_not: { match_all: {} } } },
+            ],
+          },
         }
         expect(described_class.new(
           SearchConfig.default_instance,


### PR DESCRIPTION
This allows us to safely migrate document formats to the govuk index in Whitehall. With the current configuration that isn't possible because the format migrator doesn't respect publishing app configuration within the migrated section of the migrated_formats.yaml file.

We have considered maintaining the apparent original intention of the file which was to migrate items on a format by format basis, but applying the format migration for specific publishing apps added substnatial complexity to the Elasticsearch filter which might have affected search performance.

Because we can now just declare an app migrated, we no longer need the configuration for restricting indexable formats based on their publishing app either, so that code has been removed.

The Format Migrator spec unnecessarily tested the default query behaviour for each clause in the Elasticsearch query. Repeating that test another time for the migrated apps clause didn't seem sensible, so we now only test the default query behaviour once.

Trello: https://trello.com/c/pUo3imKD