### PR TITLE
Mark news article formats as migrated

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -306,16 +306,14 @@ migrated:
   - '/help'
   - '/help/cookies'
   - '/find-local-council'
+# Whitehall
+- government_response
+- news_article
+- news_story
+- press_release
+- world_news_story
 
-# Below configuration can be removed once government_response, news_story, press_release and world_news_story are migrated
-migrated_publishing_apps:
-  - content-publisher
-
-indexable:
-  - government_response
-  - news_story
-  - press_release
-  - world_news_story
+indexable: []
 
 non_indexable_path:
 - '/help/cookie-details'

--- a/lib/govuk_index/migrated_formats.rb
+++ b/lib/govuk_index/migrated_formats.rb
@@ -27,10 +27,6 @@ module GovukIndex
       @migrated_formats ||= convert_to_allowed_hash(data_file["migrated"])
     end
 
-    def migrated_publishing_apps
-      @migrated_publishing_apps ||= data_file["migrated_publishing_apps"] || []
-    end
-
   private
 
     def data_file

--- a/lib/search/format_migrator.rb
+++ b/lib/search/format_migrator.rb
@@ -11,7 +11,7 @@ module Search
           minimum_should_match: 1,
           # match documents meeting any of below conditions
           # this query excludes documents that are present in the migrated index, but their format is not yet marked as migrated
-          should: [be_an_unmigrated_document, be_a_migrated_document, be_published_by_a_migrated_app].compact,
+          should: [be_an_unmigrated_document, be_a_migrated_document].compact,
         },
       }
     end
@@ -55,22 +55,6 @@ module Search
             base_query,
             { terms: { _index: migrated_indices } },
             { terms: { format: migrated_formats } },
-          ],
-        },
-      }
-    end
-
-    # This condition captures documents that were published by an app for which all document formats should be considered migrated
-    # This is useful when a format is published by multiple apps but migration is only complete for one of them
-    def be_published_by_a_migrated_app
-      return nil if GovukIndex::MigratedFormats.migrated_publishing_apps.empty?
-
-      {
-        bool: {
-          must: [
-            base_query,
-            { terms: { _index: migrated_indices } },
-            { terms: { publishing_app: GovukIndex::MigratedFormats.migrated_publishing_apps } },
           ],
         },
       }

--- a/spec/unit/search/aggregate_example_fetcher_spec.rb
+++ b/spec/unit/search/aggregate_example_fetcher_spec.rb
@@ -23,11 +23,6 @@ RSpec.describe Search::AggregateExampleFetcher do
                     },
                   },
                   { bool: { must_not: { match_all: {} } } },
-                  { bool: { must: [
-                    { match_all: {} },
-                    { terms: { _index: %w[govuk_test] } },
-                    { terms: { publishing_app: %w[content-publisher] } },
-                  ] } },
                 ],
               },
             },

--- a/spec/unit/search/format_migrator_spec.rb
+++ b/spec/unit/search/format_migrator_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Search::FormatMigrator do
     Clusters.active.each do |_cluster|
       it "when base query without migrated formats" do
         allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
-        allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return([])
         base_query = { filter: "component" }
         expected = {
           bool: {
@@ -37,7 +36,6 @@ RSpec.describe Search::FormatMigrator do
 
       it "when base query with migrated formats" do
         allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return("help_page" => :all)
-        allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return([])
         base_query = { filter: "component" }
         expected = {
           bool: {
@@ -70,42 +68,8 @@ RSpec.describe Search::FormatMigrator do
         ).call).to eq(expected)
       end
 
-      it "when base query with migrated apps" do
-        allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
-        allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return(%w[content-publisher])
-        base_query = { filter: "component" }
-        expected = {
-          bool: {
-            minimum_should_match: 1,
-            should: [
-              {
-                bool: {
-                  must: base_query,
-                  must_not: { terms: { _index: %w[govuk_test] } },
-                },
-              },
-              { bool: { must_not: { match_all: {} } } },
-              {
-                bool: {
-                  must: [
-                    base_query,
-                    { terms: { _index: %w[govuk_test] } },
-                    { terms: { publishing_app: %w[content-publisher] } },
-                  ],
-                },
-              },
-            ],
-          },
-        }
-        expect(described_class.new(
-          SearchConfig.default_instance,
-          base_query:,
-        ).call).to eq(expected)
-      end
-
       it "uses a default match all query when no base query is provided" do
         allow(GovukIndex::MigratedFormats).to receive(:migrated_formats).and_return({})
-        allow(GovukIndex::MigratedFormats).to receive(:migrated_publishing_apps).and_return([])
         expected = {
           bool: {
             minimum_should_match: 1,


### PR DESCRIPTION
Now that these formats are marked as migrated, we no longer require the override that forced all documents published by Content Publisher to be migrated. This was necessary because the Whitehall versions of those document formats were indexable but not migrated.

Trello: https://trello.com/c/pUo3imKD