### PR TITLE
Mark consultations and calls for evidence as indexable in the govuk index

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -9,7 +9,13 @@ answer: edition
 asylum_support_decision: asylum_support_decision # Specialist Publisher
 business_finance_support_scheme: business_finance_support_scheme # Specialist Publisher
 calendar: edition
+call_for_evidence: edition
+call_for_evidence_outcome: edition
+closed_call_for_evidence: edition
+closed_consultation: edition
 cma_case: cma_case # Specialist Publisher
+consultation: edition
+consultation_outcome: edition
 contact: contact
 coronavirus_landing_page: edition
 countryside_stewardship_grant: countryside_stewardship_grant # Specialist Publisher
@@ -45,6 +51,8 @@ marine_notice: marine_notice # Specialist Publisher
 medical_safety_alert: medical_safety_alert # Specialist Publisher
 ministerial_role: edition
 news_story: edition
+open_call_for_evidence: edition
+open_consultation: edition
 person: person
 place: edition
 policy: policy # Policy Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -313,7 +313,15 @@ migrated:
 - press_release
 - world_news_story
 
-indexable: []
+indexable:
+- call_for_evidence
+- call_for_evidence_outcome
+- closed_call_for_evidence
+- closed_consultation
+- consultation
+- consultation_outcome
+- open_call_for_evidence
+- open_consultation
 
 non_indexable_path:
 - '/help/cookie-details'
@@ -370,10 +378,8 @@ non_indexable:
 - accessible_documents_policy
 - access_and_opening
 - authored_article
-- call_for_evidence
 - case_study
 - complaints_procedure
-- consultation
 #- contact # migrated
 - corporate_report
 - correspondence


### PR DESCRIPTION
When indexed via Publishing API we end up with more formats because the type key rather than the schema name is used as the format value.