### PR TITLE
Revert "Mark consultations and calls for evidence as migrated to the GOVUK index

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -307,21 +307,21 @@ migrated:
   - '/help/cookies'
   - '/find-local-council'
 # Whitehall
+- government_response
+- news_article
+- news_story
+- press_release
+- world_news_story
+
+indexable:
 - call_for_evidence
 - call_for_evidence_outcome
 - closed_call_for_evidence
 - closed_consultation
 - consultation
 - consultation_outcome
-- government_response
-- news_article
-- news_story
 - open_call_for_evidence
 - open_consultation
-- press_release
-- world_news_story
-
-indexable: []
 
 non_indexable_path:
 - '/help/cookie-details'


### PR DESCRIPTION
This reverts commit d7029ecbd68f6f9be6ba10c5bdcaf7774863f2bd. The original commit caused an error on https://www.gov.uk/government/get-involved because the opening and closing dates for the consultations weren't included in the search data