### PR TITLE
Mark four document types as migrated

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -310,23 +310,24 @@ migrated:
 # Whitehall
 - call_for_evidence
 - call_for_evidence_outcome
+- case_study
 - closed_call_for_evidence
 - closed_consultation
 - consultation
 - consultation_outcome
+- detailed_guidance # Required to prevent detailed guidance from government index appearing in search results, type has been renamed to detailed_guide
+- detailed_guide
+- fatality_notice
 - government_response
 - open_call_for_evidence
 - open_consultation
 - news_article
 - news_story
 - press_release
+- statistical_data_set
 - world_news_story
 
-indexable:
-- case_study
-- detailed_guide
-- fatality_notice
-- statistical_data_set
+indexable: []
 
 non_indexable_path:
 - '/help/cookie-details'

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -462,22 +462,22 @@ RSpec.describe "SearchTest" do
 
     # we DON'T want this document in our search results
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Rules of Quiddich (2017)",
         "link" => "/quiddich-rules-2017",
-        "format" => "detailed_guidance",
+        "format" => "detailed_guide",
         "topical_events" => %w[quiddich-world-cup-2017],
       },
     )
 
     # we DO want this document in our search results
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Rules of Quiddich (2018)",
         "link" => "/quiddich-rules-2018",
-        "format" => "detailed_guidance",
+        "format" => "detailed_guide",
         "topical_events" => [topical_event_of_interest],
       },
     )


### PR DESCRIPTION
These document types can easily be migrated to the GOVUK search index as they do not have sub-types or any substantial changes to how their source data is defined in the govuk indexing process.

Note that the detailed guidance type has been renamed to detailed guide, see https://github.com/alphagov/publishing-api/commit/8594a0af800fab26c376fa49e35d2b61f438ff87. Once the detailed index has been removed we can remove the `detailed_guidance` type from the migrated list.

Trello: https://trello.com/c/vEPHlW1u