### PR TITLE
Mark detailed guide documents indexable

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -21,7 +21,7 @@ contact: contact
 coronavirus_landing_page: edition
 countryside_stewardship_grant: countryside_stewardship_grant # Specialist Publisher
 data_ethics_guidance_document: data_ethics_guidance_document # Specialist Publisher
-detailed_guidance: edition
+detailed_guide: edition
 drcf_digital_markets_research: drcf_digital_markets_research # Specialist Publisher
 drug_safety_update: drug_safety_update # Specialist Publisher
 employment_appeal_tribunal_decision: employment_appeal_tribunal_decision # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -324,7 +324,7 @@ migrated:
 
 indexable:
 - case_study
-- detailed_guidance
+- detailed_guide
 - fatality_notice
 - statistical_data_set
 


### PR DESCRIPTION
When indexed via Publishing API, the format is `detailed_guide` instead of `detailed_guidance`.