### PR TITLE
Mark document collections indexable in GOVUK index

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -23,6 +23,7 @@ coronavirus_landing_page: edition
 countryside_stewardship_grant: countryside_stewardship_grant # Specialist Publisher
 data_ethics_guidance_document: data_ethics_guidance_document # Specialist Publisher
 detailed_guide: edition
+document_collection: edition
 drcf_digital_markets_research: drcf_digital_markets_research # Specialist Publisher
 drug_safety_update: drug_safety_update # Specialist Publisher
 employment_appeal_tribunal_decision: employment_appeal_tribunal_decision # Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -331,7 +331,8 @@ migrated:
 - world_news_story
 - written_statement
 
-indexable: []
+indexable:
+- document_collection
 
 non_indexable_path:
 - '/help/cookie-details'
@@ -390,7 +391,6 @@ non_indexable:
 - corporate_report
 - correspondence
 - decision
-- document_collection
 - equality_and_diversity
 - facet
 - field_of_operation

--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -3,6 +3,7 @@ module GovukIndex
     DEFAULTS = %w[body parts hidden_search_terms].freeze
     BY_FORMAT = {
       "contact" => %w[title description],
+      "document_collection" => %w[collection_groups],
       "licence" => %w[licence_short_description licence_overview],
       "local_transaction" => %w[introduction more_information need_to_know],
       "transaction" => %w[introductory_paragraph more_information],
@@ -37,18 +38,12 @@ module GovukIndex
     def indexable_content_parts
       indexable_content_keys.flat_map do |field|
         indexable_values = details.dig(*field.split(".")) || []
-        field == "parts" ? parts(indexable_values) : [indexable_values]
+        %w[parts collection_groups].include?(field) ? indexable_values.flat_map { |item| [item["title"], item["body"]] } : [indexable_values]
       end
     end
 
     def indexable_content_keys
       DEFAULTS + BY_FORMAT.fetch(format, [])
-    end
-
-    def parts(items)
-      items.flat_map do |item|
-        [item["title"], item["body"]]
-      end
     end
 
     def contact_groups_titles

--- a/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
@@ -55,6 +55,34 @@ RSpec.describe GovukIndex::IndexableContentPresenter do
     end
   end
 
+  context "details with collection groups" do
+    let(:format) { "document_collection" }
+    let(:details) do
+      {
+        "collection_groups" => [
+          {
+            "title" => "title 1",
+            "body" => [
+              { "content_type" => "text/govspeak", "content" => "**hello**" },
+              { "content_type" => "text/html", "content" => "<strong>hello</strong>" },
+            ],
+          },
+          {
+            "title" => "title 2",
+            "body" => [
+              { "content_type" => "text/govspeak", "content" => "**goodbye**" },
+              { "content_type" => "text/html", "content" => "<strong>goodbye</strong>" },
+            ],
+          },
+        ],
+      }
+    end
+
+    it "extracts content from details with collection groups" do
+      expect(subject.indexable_content).to eq("title 1\n\nhello\n\ntitle 2\n\ngoodbye")
+    end
+  end
+
   context "additional specified indexable content keys" do
     context "transaction format" do
       let(:format) { "transaction" }


### PR DESCRIPTION
As part of this commit we ensure that the headings and body content for each group belonging to the collection are also indexed so that search queries can search them for matching tokens.

Trello: https://trello.com/c/pUo3imKD