### PR TITLE
Use the bulk Sidekiq queue for bulk reindexing jobs

### DIFF
--- a/lib/govuk_index/publishing_event_processor.rb
+++ b/lib/govuk_index/publishing_event_processor.rb
@@ -4,7 +4,13 @@ module GovukIndex
       messages = Array(messages) # treat a single message as an array with one value
 
       Services.statsd_client.increment("govuk_index.rabbit-mq-consumed")
-      PublishingEventJob.perform_async(messages.map { |msg| [msg.delivery_info[:routing_key], msg.payload] })
+
+      bulk_reindex_messages, default_messages = messages.partition do |msg|
+        msg.delivery_info[:routing_key].end_with?(".bulk.reindex")
+      end
+
+      PublishingEventJob.set(queue: "bulk").perform_async(bulk_reindex_messages.map { |msg| [msg.delivery_info[:routing_key], msg.payload] })
+      PublishingEventJob.perform_async(default_messages.map { |msg| [msg.delivery_info[:routing_key], msg.payload] })
       messages.each(&:ack)
     end
   end

--- a/spec/unit/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_processor_spec.rb
@@ -49,4 +49,40 @@ RSpec.describe GovukIndex::PublishingEventProcessor do
 
     subject.process([message1, message2])
   end
+
+  it "will route bulk reindex messages to the bulk queue" do
+    message1 = double(
+      payload: {
+        "base_path" => "/cheese",
+        "document_type" => "help_page",
+        "title" => "We love cheese",
+      },
+      delivery_info: {
+        routing_key: "document.bulk.reindex",
+      },
+    )
+    message2 = double(
+      payload: {
+        "base_path" => "/crackers",
+        "document_type" => "help_page",
+        "title" => "We love crackers",
+      },
+      delivery_info: {
+        routing_key: "document.publish",
+      },
+    )
+
+    bulk_job = double(GovukIndex::PublishingEventJob)
+    expect(GovukIndex::PublishingEventJob).to receive(:set).with(queue: "bulk").and_return(bulk_job)
+    expect(bulk_job).to receive(:perform_async).with(
+      [["document.bulk.reindex", message1.payload]],
+    )
+    expect(GovukIndex::PublishingEventJob).to receive(:perform_async).with(
+      [["document.publish", message2.payload]],
+    )
+    expect(message1).to receive(:ack)
+    expect(message2).to receive(:ack)
+
+    subject.process([message1, message2])
+  end
 end


### PR DESCRIPTION
We have a separate "bulk" sidekiq queue for running bulk reindexing loads so that publisher-driven indexing will not be blocked in production.

However, the GOVUK index publishing event processor was not respecting the routing key provided in the RabbitMQ queue message, and therefore the default Sidekiq queue was being blocked by reindexing operations.

This commit fixes the issue at the cost of an extra loop through the message batch to partition the messages into bulk and non-bulk messages.

This will help me to not need to run indexing jobs for [this ticket](https://trello.com/c/upZnqIOL) out of hours. Some publication types need 20 minutes or so to clear the queue.