### PR TITLE
Add display type for documents in the GOVUK index

### DIFF
--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -6,6 +6,7 @@ module GovukIndex
 
     set_payload_method :details
 
+    delegate_to_payload :document_type_label
     delegate_to_payload :licence_identifier
     delegate_to_payload :licence_short_description
     delegate_to_payload :url

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -72,6 +72,7 @@ module GovukIndex
         disease_case_closed_date: specialist.disease_case_closed_date,
         disease_case_opened_date: specialist.disease_case_opened_date,
         disease_type: specialist.disease_type,
+        display_type: details.document_type_label,
         document_type: type,
         eligible_entities: specialist.eligible_entities,
         email_document_supertype: common_fields.email_document_supertype,

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -112,6 +112,16 @@ RSpec.describe GovukIndex::DetailsPresenter do
 
   context "publication format" do
     let(:format) { "publication" }
+    let(:details) do
+      {
+        "document_type_label" => "Publication",
+      }
+    end
+
+    it "extracts the document type label" do
+      expect(presented_details.document_type_label).to eq("Publication")
+    end
+
     context "it has an attachment with a command paper number" do
       let(:details) do
         {


### PR DESCRIPTION
The display type attribute is a human friendly document type label that is displayed as metadata on the search results in the [official documents](https://www.gov.uk/official-documents) and [research and statistics](https://www.gov.uk/search/research-and-statistics) finders.

Trello: https://trello.com/c/upZnqIOL