### PR TITLE
Bump up Sidekiq default queue concurrency limit

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,4 +14,4 @@ production:
   - bulk
 :limits:
   bulk: 4
-  default: 8
+  default: 24


### PR DESCRIPTION
We need higher throughput to process a large republishing job. We think Elasticsearch has sufficient capacity to deal with the extra indexing requests.