### PR TITLE
Increase concurrency of Search API default queue again

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,4 +14,4 @@ production:
   - bulk
 :limits:
   bulk: 4
-  default: 24
+  default: 48


### PR DESCRIPTION
We still need more throughput to process the backlog in the queue for republishing all publications