### PR TITLE
Use maximum number of threads available for Sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,4 +14,4 @@ production:
   - bulk
 :limits:
   bulk: 4
-  default: 48
+  default: 84


### PR DESCRIPTION
We're currently running 8 replicas of the worker pods and Sidekiq is configured to run 12 threads per process, so theoretically we have 84 threads available.

Elasticsearch's indexing rate is looking healthy with the current maximum of 48 threads, so we might as well use the extra threads we have available.