### PR TITLE
Reduce Sidekiq thread count

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,4 +14,4 @@ production:
   - bulk
 :limits:
   bulk: 4
-  default: 84
+  default: 48


### PR DESCRIPTION
Elasticsearch couldn't cope with the increased thread count, so dropping this down again.