### PR TITLE
Reduce Elasticsearch refresh rate

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -121,7 +121,7 @@ index:
     # will still work fine, though.
     number_of_replicas: 2
     number_of_shards: 3
-    refresh_interval: '1s'
+    refresh_interval: '30s'
     search:
       slowlog:
         threshold:


### PR DESCRIPTION
The refresh rate setting in Elasticsearch controls how often Elasticsearch makes data that it has indexed available to search. This is quite a resource intensive process, so performing it less frequently can help improve indexing throughput.