### PR TITLE
Increase Sidekiq throughput again

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,7 +4,7 @@ tag: search-api.publishing.service.gov.uk
 staging:
   :concurrency:  12
 production:
-  :concurrency:  12
+  :concurrency:  18
 :require: ./lib/rummager.rb
 <% if ENV.key?('SIDEKIQ_LOGFILE') %>
 :logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
@@ -14,4 +14,4 @@ production:
   - bulk
 :limits:
   bulk: 4
-  default: 84
+  default: 144


### PR DESCRIPTION
Sidekiq workers can be effective with more than 12 threads, so let's see if we can squeeze a little bit more throughput from our 8 processes.