### PR TITLE
Reset Sidekiq concurrency limits to sensible defaults

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -121,7 +121,7 @@ index:
     # will still work fine, though.
     number_of_replicas: 2
     number_of_shards: 3
-    refresh_interval: '1s'
+    refresh_interval: '30s'
     search:
       slowlog:
         threshold:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,7 +4,7 @@ tag: search-api.publishing.service.gov.uk
 staging:
   :concurrency:  12
 production:
-  :concurrency:  18
+  :concurrency:  12
 :require: ./lib/rummager.rb
 <% if ENV.key?('SIDEKIQ_LOGFILE') %>
 :logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
@@ -13,5 +13,5 @@ production:
   - default
   - bulk
 :limits:
-  bulk: 4
-  default: 144
+  bulk: 12
+  default: 12


### PR DESCRIPTION
We are going to revert the helm config to the original two replicas running Sidekiq, with 12 threads each. We now know we can safely use them all without overburdening Elasticsearch, so this offers 12 threads to the default queue and 12 to the bulk queue. There is an argument that we don't really need the limits at all, but it is probably worthwhile to reserve some threads for each queue. We should re-evaluate this choice at a later date.

One thing that helped speed up indexing was to reduce Elasticsearch's refresh interval to once every 30 seconds. Refreshing is the process by which Elasticsearch makes indexed data available for searching and it is moderately resource intensive. It doesn't make sense to run this every second and reducing the frequency helps to improve indexing throughput.