### PR TITLE
Ensure official document status is included in the govuk index

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -87,14 +87,7 @@ module GovukIndex
 
     def attachments
       (payload.dig("details", "attachments") || []).map do |attachment|
-        {
-          "content" => attachment["content"],
-          "title" => attachment["title"],
-          "isbn" => attachment["isbn"],
-          "unique_reference" => attachment["unique_reference"],
-          "command_paper_number" => attachment["command_paper_number"],
-          "hoc_paper_number" => attachment["hoc_paper_number"],
-        }.compact
+        attachment.slice("content", "title", "isbn", "unique_reference", "command_paper_number", "hoc_paper_number").compact
       end
     end
 

--- a/lib/indexer/attachments_lookup.rb
+++ b/lib/indexer/attachments_lookup.rb
@@ -31,15 +31,16 @@ module Indexer
         return unless content
       end
 
-      {
-        "url" => attachment["url"],
-        "title" => attachment["title"],
-        "isbn" => attachment["isbn"],
-        "unique_reference" => attachment["unique_reference"],
-        "command_paper_number" => attachment["command_paper_number"],
-        "hoc_paper_number" => attachment["hoc_paper_number"],
-        "content" => content,
-      }.compact
+      attachment.slice(
+        "url",
+        "title",
+        "isbn",
+        "unique_reference",
+        "command_paper_number",
+        "hoc_paper_number",
+        "unnumbered_command_paper",
+        "unnumbered_hoc_paper",
+      ).merge({ "content" => content }).compact
     end
 
     def fetch_attachment_content(attachment)


### PR DESCRIPTION
The document preparer was stripping the unnumbered paper data from the attachments before the elasticsearch presenter could use the information to derive the official document state. This commit makes sure that data is preserved.

This also includes a small refactor to make use of `Hash.slice` where appropriate rather than mapping attachment values across using object assigment.

Trello: https://trello.com/c/upZnqIOL