### PR TITLE
Include document collection slugs in govuk documents

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -73,6 +73,7 @@ module GovukIndex
         disease_case_opened_date: specialist.disease_case_opened_date,
         disease_type: specialist.disease_type,
         display_type: details.document_type_label,
+        document_collections: expanded_links.document_collections,
         document_type: type,
         eligible_entities: specialist.eligible_entities,
         email_document_supertype: common_fields.email_document_supertype,

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -66,6 +66,10 @@ module GovukIndex
       organisation[0].dig("details", "default_news_image", "url") unless organisation.empty?
     end
 
+    def document_collections
+      slugs("document_collections", "/government/collections/")
+    end
+
   private
 
     attr_reader :expanded_links

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -292,6 +292,21 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.default_news_image).to eq(default_news_image_url)
   end
 
+  it "document_collections" do
+    slugs = %w[test-1 test-2]
+    expanded_links = {
+      "document_collections" => slugs.map do |slug|
+        {
+          "base_path" => "/government/collections/#{slug}",
+        }
+      end,
+    }
+
+    presenter = expanded_links_presenter(expanded_links)
+
+    expect(presenter.document_collections).to eq(slugs)
+  end
+
   def expanded_links_presenter(expanded_links)
     described_class.new(expanded_links)
   end


### PR DESCRIPTION
This field was present on the government index, but was dropped during the migration of Whitehall content to the govuk index because it was not used in any of the finders.

However, a team from the MoJ depended on the field for one of their applications, which consumes Search API, so we're reinstating it.

Trello: https://trello.com/c/hdyJ0gJq