### PR TITLE
Disable Sidekiq processing on `search_api_govuk_index` queue

### DIFF
--- a/lib/indexer/amend_job.rb
+++ b/lib/indexer/amend_job.rb
@@ -2,15 +2,19 @@ module Indexer
   class AmendJob < BaseJob
     notify_of_failures
 
-    def perform(index_name, document_link, updates)
+    def perform(index_name, document_link, updates, reschedule_on_failure: true)
       logger.info "Amending document '#{document_link}' in '#{index_name}'"
       logger.info "Amending fields #{updates.keys.join(', ')}"
       logger.debug "Amendments: #{updates}"
       begin
         indexes(index_name).each { |index| index.amend(document_link, updates) }
-      rescue SearchIndices::IndexLocked
-        logger.info "Index #{index_name} is locked; rescheduling"
-        self.class.perform_in(LOCK_DELAY, index_name, document_link, updates)
+      rescue SearchIndices::IndexLocked => e
+        if reschedule_on_failure
+          logger.info "Index #{index_name} is locked; rescheduling"
+          self.class.perform_in(LOCK_DELAY, index_name, document_link, updates)
+        else
+          raise e
+        end
       end
     end
   end

--- a/lib/indexer/change_notification_processor.rb
+++ b/lib/indexer/change_notification_processor.rb
@@ -15,7 +15,7 @@ module Indexer
       index_name = document["real_index_name"]
       document_id = document["_id"]
       updates = {}
-      Indexer::AmendJob.perform_async(index_name, document_id, updates)
+      Indexer::AmendJob.new.perform(index_name, document_id, updates, reschedule_on_failure: false)
       :accepted
     end
 

--- a/lib/retryable_queue_message.rb
+++ b/lib/retryable_queue_message.rb
@@ -1,0 +1,36 @@
+# This class should be used as a wrapper around GovukMessageQueueConsumer::Message
+# whenever we use an exchange that uses a dead letter exchange (dlx) as a retry
+# mechanism. Using a dlx in this way means sending counter intuitive responses to
+# RabbitMQ. Where an ack is the approach to mark a job as completed AND to mark a
+# job as failed, whereas discard actually signifies that we're going to retry the job.
+
+# You should only use this class if you're planning to retry via a dlx otherwise
+# it'll be very confusing!
+
+class RetryableQueueMessage
+  delegate :payload, :headers, :status, :delivery_info, to: :queue_message
+
+  def initialize(queue_message)
+    @queue_message = queue_message
+  end
+
+  def done
+    queue_message.ack
+  end
+
+  def retry
+    queue_message.discard
+  end
+
+  def retries
+    # headers doesn't return a hash but a hash like object (Bunny::MessageProperties)
+    deaths = (headers[:headers] || {}).fetch("x-death", [])
+    # we expect each retry to flag as two deaths (1 for the initial discard,
+    # the other for a timeout to delay the retry)
+    deaths.sum { |d| d["count"] } / 2
+  end
+
+private
+
+  attr_reader :queue_message
+end

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -189,5 +189,6 @@ require "services"
 require "sitemap/property_boost_calculator"
 require "sitemap/generator"
 require "sitemap/presenter"
+require "retryable_queue_message"
 
 require "core_extensions/time/to_string"

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -7,7 +7,22 @@ namespace :message_queue do
 
     channel = bunny.start.create_channel
     exch = Bunny::Exchange.new(channel, :topic, "published_documents")
-    channel.queue("search_api_to_be_indexed").bind(exch, routing_key: "*.links")
+
+    search_api_to_be_indexed_retry_dlx = channel.fanout("search_api_to_be_indexed_retry_dlx")
+    search_api_to_be_indexed_discarded_dlx = channel.fanout("search_api_to_be_indexed_discarded_dlx")
+
+    channel
+      .queue("search_api_to_be_indexed", arguments: { "x-dead-letter-exchange" => search_api_to_be_indexed_retry_dlx.name })
+      .bind(exch, routing_key: "*.links")
+    # messages are queued on search_api_to_be_indexed_discarded_dlx for 30s before their
+    # ttl completes then are routed to the search_api_to_be_indexed_retry_dlx
+    channel.queue("search_api_to_be_indexed_wait_to_retry",
+                  arguments: { "x-dead-letter-exchange" => search_api_to_be_indexed_discarded_dlx.name, "x-message-ttl" => 30 * 1000 })
+           .bind(search_api_to_be_indexed_retry_dlx)
+
+    # messages on the search_api_to_be_indexed_discarded_dlx are routed back to the original queue
+    channel.queue("search_api_to_be_indexed").bind(search_api_to_be_indexed_discarded_dlx)
+
     channel.queue("search_api_bulk_reindex").bind(exch, routing_key: "*.bulk.reindex")
     channel.queue("search_api_govuk_index").bind(exch, routing_key: "*.*")
   end

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -14,9 +14,14 @@ namespace :message_queue do
 
   desc "Index documents that are published to the publishing-api"
   task :listen_to_publishing_queue do
+    logger = Logging.logger[Indexer::MessageProcessor]
+
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "search_api_to_be_indexed",
       processor: Indexer::MessageProcessor.new,
+      logger:,
+      worker_threads: 10,
+      prefetch: 10,
     ).run
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ require "govuk_sidekiq/testing"
 require "sidekiq/testing/inline" # Make all queued jobs run immediately
 require "bunny-mock"
 require "govuk_schemas"
+require "govuk_message_queue_consumer/test_helpers"
 
 # Silence log output
 Logging.logger.root.appenders = nil

--- a/spec/unit/indexer/change_notification_processor_spec.rb
+++ b/spec/unit/indexer/change_notification_processor_spec.rb
@@ -61,7 +61,10 @@ RSpec.describe Indexer::ChangeNotificationProcessor do
     )
     expect(IndexFinder).to receive(:content_index).and_return(index_mock)
 
-    expect(Indexer::AmendJob).to receive(:perform_async).with("index_name-123", "document_id_345", {})
+    job_double = instance_double(Indexer::AmendJob)
+    expect(Indexer::AmendJob).to receive(:new).and_return(job_double)
+    expect(job_double).to receive(:perform).with("index_name-123", "document_id_345", {}, { reschedule_on_failure: false })
+
     result = described_class.trigger(message_payload)
 
     expect(:accepted).to eq(result)

--- a/spec/unit/indexer/message_processor_spec.rb
+++ b/spec/unit/indexer/message_processor_spec.rb
@@ -1,0 +1,88 @@
+require "spec_helper"
+
+RSpec.describe Indexer::MessageProcessor do
+  let(:content_item) { generate_random_example }
+  let(:message) { GovukMessageQueueConsumer::MockMessage.new(content_item) }
+  let(:logger) { Logging.logger[described_class] }
+
+  context "when successful" do
+    before do
+      expect(Indexer::ChangeNotificationProcessor)
+        .to receive(:trigger)
+        .with(message.payload)
+        .and_return(:accepted)
+    end
+
+    it "logs some messages" do
+      expected_messages = [
+        /Processing message \[\]: {"content_id":"#{content_item['content_id']}"/,
+        /Finished processing message/,
+      ]
+
+      expected_messages.each do |message|
+        expect(logger).to receive(:info).with(message)
+      end
+
+      described_class.new.process(message)
+    end
+
+    it "increments the statsd counter" do
+      expect(Services.statsd_client).to receive(:increment).with("message_queue.indexer.accepted")
+      described_class.new.process(message)
+    end
+
+    it "acknowledges the message" do
+      expect(message).to receive(:ack)
+      described_class.new.process(message)
+    end
+  end
+
+  context "when an error is raised" do
+    before do
+      expect(Indexer::ChangeNotificationProcessor)
+        .to receive(:trigger)
+        .with(message.payload)
+        .and_raise("oh no")
+    end
+
+    context "and the message is retryable" do
+      it "logs the error" do
+        expect(logger).to receive(:error).with(
+          /#{content_item['content_id']} scheduled for retry due to error: RuntimeError oh no/,
+        )
+
+        described_class.new.process(message)
+      end
+
+      it "retries the message" do
+        # RetryableQueueMessage#retry calls GovukMessageQueueConsumer::Message#discard, so we need to assert the `discard` method is called
+        expect(message).to receive(:discard)
+        described_class.new.process(message)
+      end
+    end
+
+    context "and the message is not retryable" do
+      before do
+        message.headers[:headers] = { "x-death" => 30.times.map { { "count" => 1 } } }
+      end
+
+      it "logs the error" do
+        expect(logger).to receive(:error).with(
+          /#{content_item['content_id']} ignored after #{described_class::MAX_RETRIES} retries/,
+        )
+
+        described_class.new.process(message)
+      end
+
+      it "reports the error" do
+        expect(GovukError).to receive(:notify).with(RuntimeError, extra: message.payload)
+        described_class.new.process(message)
+      end
+
+      it "acks the message so it does not retry" do
+        expect(message).to receive(:ack)
+        described_class.new.process(message)
+      end
+    end
+  end
+end

--- a/spec/unit/retryable_queue_message_spec.rb
+++ b/spec/unit/retryable_queue_message_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe RetryableQueueMessage do
+  describe "#done" do
+    it "sets the queue message to acked" do
+      queue_message = create_mock_message("message")
+      instance = described_class.new(queue_message)
+      expect { instance.done }.to change(queue_message, :acked?).to(true)
+    end
+  end
+
+  describe "#retry" do
+    it "sets the queue message to discarded" do
+      queue_message = create_mock_message("message")
+      instance = described_class.new(queue_message)
+      expect { instance.retry }.to change(queue_message, :discarded?).to(true)
+    end
+  end
+
+  describe "#retries" do
+    it "returns 0 for a queue message with no x-death headers" do
+      queue_message = create_mock_message("message")
+      instance = described_class.new(queue_message)
+      expect(instance.retries).to eq(0)
+    end
+
+    it "collates the counts from x-death headers and divides by 2 to get actual retries count" do
+      queue_message = create_mock_message("message", {
+        headers: {
+          "x-death" => [
+            { "count" => 2, "reason" => "expired", "queue" => "govuk_chat_published_documents_delay_retry" },
+            { "count" => 2, "reason" => "rejected", "queue" => "govuk_chat_published_documents" },
+          ],
+        },
+      })
+      instance = described_class.new(queue_message)
+      expect(instance.retries).to eq(2)
+    end
+  end
+
+  def create_mock_message(...)
+    GovukMessageQueueConsumer::MockMessage.new(...)
+  end
+end

--- a/spec/unit/tasks/message_queue_spec.rb
+++ b/spec/unit/tasks/message_queue_spec.rb
@@ -3,8 +3,8 @@ require "rake"
 load "tasks/message_queue.rake"
 
 RSpec.describe Indexer::MessageProcessor, "RakeTest" do
-  context "when indexing published documents to publishing-api" do
-    it "use GovukMessageQueueConsumer::Consumer" do
+  describe "message_queue:listen_to_publishing_queue" do
+    it "uses GovukMessageQueueConsumer::Consumer" do
       indexer = described_class.new
       expect(described_class).to receive(:new).and_return(indexer)
 
@@ -23,6 +23,79 @@ RSpec.describe Indexer::MessageProcessor, "RakeTest" do
         ).and_return(consumer)
 
       Rake::Task["message_queue:listen_to_publishing_queue"].invoke
+    end
+  end
+
+  describe "message_queue:create_queues" do
+    let(:session) do
+      instance_double(Bunny::Session, create_channel: channel).tap do |double|
+        allow(double).to receive(:start).and_return(double)
+      end
+    end
+
+    let(:exchange) { instance_double(Bunny::Exchange, name: "published_documents") }
+    let(:search_api_to_be_indexed_retry_dlx) { instance_double(Bunny::Exchange, name: "search_api_to_be_indexed_retry_dlx") }
+    let(:search_api_to_be_indexed_discarded_dlx) { instance_double(Bunny::Exchange, name: "search_api_to_be_indexed_discarded_dlx") }
+    let(:channel) { instance_double(Bunny::Channel) }
+
+    let(:search_api_to_be_indexed_queue) { instance_double(Bunny::Queue, bind: nil) }
+    let(:search_api_to_be_indexed_wait_to_retry_queue) { instance_double(Bunny::Queue, bind: nil) }
+    let(:search_api_to_be_indexed_discarded_queue) { instance_double(Bunny::Queue, bind: nil) }
+    let(:search_api_bulk_reindex_queue) { instance_double(Bunny::Queue, bind: nil) }
+    let(:search_api_govuk_index_queue) { instance_double(Bunny::Queue, bind: nil) }
+
+    before do
+      allow(Bunny).to receive(:new).and_return(session)
+      allow(Bunny::Exchange).to receive(:new).with(channel, :topic, "published_documents").and_return(exchange)
+      allow(channel).to receive(:fanout).with("search_api_to_be_indexed_retry_dlx")
+        .and_return(search_api_to_be_indexed_retry_dlx)
+      allow(channel).to receive(:fanout).with("search_api_to_be_indexed_discarded_dlx")
+        .and_return(search_api_to_be_indexed_discarded_dlx)
+    end
+
+    it "creates exchanges and queues" do
+      allow(channel)
+        .to receive(:queue).with("search_api_to_be_indexed", anything)
+        .and_return(search_api_to_be_indexed_queue)
+
+      allow(channel)
+        .to receive(:queue).with("search_api_to_be_indexed")
+        .and_return(search_api_to_be_indexed_discarded_queue)
+
+      allow(channel)
+        .to receive(:queue).with("search_api_to_be_indexed_wait_to_retry", anything)
+        .and_return(search_api_to_be_indexed_wait_to_retry_queue)
+
+      allow(channel)
+        .to receive(:queue).with("search_api_bulk_reindex")
+        .and_return(search_api_bulk_reindex_queue)
+
+      allow(channel)
+        .to receive(:queue).with("search_api_govuk_index")
+        .and_return(search_api_govuk_index_queue)
+
+      Rake::Task["message_queue:create_queues"].invoke
+
+      expect(channel).to have_received(:queue).with(
+        "search_api_to_be_indexed",
+        arguments: { "x-dead-letter-exchange" => "search_api_to_be_indexed_retry_dlx" },
+      )
+      expect(channel).to have_received(:queue).with(
+        "search_api_to_be_indexed",
+      )
+      expect(channel).to have_received(:queue).with(
+        "search_api_to_be_indexed_wait_to_retry",
+        arguments: { "x-dead-letter-exchange" => "search_api_to_be_indexed_discarded_dlx",
+                     "x-message-ttl" => 30_000 },
+      )
+      expect(channel).to have_received(:queue).with("search_api_bulk_reindex")
+      expect(channel).to have_received(:queue).with("search_api_govuk_index")
+
+      expect(search_api_to_be_indexed_queue).to have_received(:bind).with(exchange, routing_key: "*.links")
+      expect(search_api_bulk_reindex_queue).to have_received(:bind).with(exchange, routing_key: "*.bulk.reindex")
+      expect(search_api_govuk_index_queue).to have_received(:bind).with(exchange, routing_key: "*.*")
+      expect(search_api_to_be_indexed_wait_to_retry_queue).to have_received(:bind).with(search_api_to_be_indexed_retry_dlx)
+      expect(search_api_to_be_indexed_discarded_queue).to have_received(:bind).with(search_api_to_be_indexed_discarded_dlx)
     end
   end
 end

--- a/spec/unit/tasks/message_queue_spec.rb
+++ b/spec/unit/tasks/message_queue_spec.rb
@@ -11,10 +11,15 @@ RSpec.describe Indexer::MessageProcessor, "RakeTest" do
       consumer = double("consumer")
       expect(consumer).to receive(:run).and_return(true)
 
+      logger = Logging.logger[described_class]
+
       expect(GovukMessageQueueConsumer::Consumer).to receive(:new)
         .with(
           queue_name: "search_api_to_be_indexed",
           processor: indexer,
+          logger:,
+          worker_threads: 10,
+          prefetch: 10,
         ).and_return(consumer)
 
       Rake::Task["message_queue:listen_to_publishing_queue"].invoke


### PR DESCRIPTION

https://trello.com/c/U9M9Og06/2276

This removes the logic to enqueue Sidekiq jobs for messages pulled from the `search_api_govuk_index` queue and instead processes them synchronously.

It adds retrying logic to the consumer to retry a message 5 times, with a 60s delay between retries that is already configured on RabbitMQ (https://github.com/alphagov/govuk-infrastructure/pull/1848).

It also configures the consumer to use multiple threads for concurrent processing, as opposed to the serial processing it does now.

Rather than extract logic out of the `AmendJob` class, I decided to just call it synchronously instead. If other parts of the app didn't use that class to enqueue Sidekiq jobs, I'd have made it a non-Sidekiq class instead, but it feels like doing it this way is the path of least resistance.

See commit messages for more detail.
