### PR TITLE
Fix queue name in spec

### DIFF
--- a/spec/unit/retryable_queue_message_spec.rb
+++ b/spec/unit/retryable_queue_message_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe RetryableQueueMessage do
       queue_message = create_mock_message("message", {
         headers: {
           "x-death" => [
-            { "count" => 2, "reason" => "expired", "queue" => "govuk_chat_published_documents_delay_retry" },
-            { "count" => 2, "reason" => "rejected", "queue" => "govuk_chat_published_documents" },
+            { "count" => 2, "reason" => "expired", "queue" => "search_api_to_be_indexed_wait_to_retry" },
+            { "count" => 2, "reason" => "rejected", "queue" => "search_api_to_be_indexed" },
           ],
         },
       })


### PR DESCRIPTION
Most of this spec was copy-pasted from the govuk-chat repo, and so the
queue names reflect that. This updates the names so they're relevant to
this repo.
