### PR TITLE
Index Welsh "HMRC Contact" specialist documents

### DIFF
--- a/spec/integration/govuk_index/locale_spec.rb
+++ b/spec/integration/govuk_index/locale_spec.rb
@@ -49,7 +49,24 @@ RSpec.describe "locales" do
     expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "edition")
   end
 
-  it "does not index non-English pages" do
+  it "indexes Welsh pages for the hmrc_contact document type" do
+    random_example = generate_random_example(
+      schema: "specialist_document",
+      payload: {
+        document_type: "hmrc_contact",
+        base_path: "/find-hmrc-contacts/welsh-contact",
+      },
+    )
+    random_example["locale"] = "cy"
+
+    allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("hmrc_contact" => :all)
+    @queue.publish(random_example.to_json, content_type: "application/json")
+
+    expected_document = { "link" => random_example["base_path"] }
+    expect_document_is_in_rummager(expected_document, index: "govuk_test", type: "hmrc_contact")
+  end
+
+  it "does not index other non-English pages" do
     random_example = generate_random_example(
       schema: "taxon",
       payload: {

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "GovukIndex::PublishingEventProcessorTest" do
       job.perform([["test.route", random_example]])
       commit_index "govuk_test"
 
-      expect(logger).to have_received(:info).with("test.route -> BLOCKLISTED #{random_example['base_path']} edition")
+      expect(logger).to have_received(:info).with("test.route -> BLOCKLISTED #{random_example['base_path']} edition (non-indexable)")
       expect {
         fetch_document_from_rummager(id: random_example["base_path"], index: "govuk_test")
       }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
@@ -161,7 +161,7 @@ RSpec.describe "GovukIndex::PublishingEventProcessorTest" do
       )
 
       job.perform([["test.route", random_example]])
-      expect(logger).to have_received(:info).with("test.route -> BLOCKLISTED #{random_example['base_path']} edition")
+      expect(logger).to have_received(:info).with("test.route -> BLOCKLISTED #{random_example['base_path']} edition (non-indexable)")
     end
 
     it "can block/safe list specific base_paths within a format" do
@@ -180,7 +180,7 @@ RSpec.describe "GovukIndex::PublishingEventProcessorTest" do
 
       job.perform([["test.route", homepage_example]])
       job.perform([["test.route", help_example]])
-      expect(logger).to have_received(:info).with("test.route -> BLOCKLISTED #{homepage_example['base_path']} edition")
+      expect(logger).to have_received(:info).with("test.route -> BLOCKLISTED #{homepage_example['base_path']} edition (non-indexable)")
       expect(logger).to have_received(:info).with("test.route -> INDEX #{help_example['base_path']} edition")
     end
   end


### PR DESCRIPTION
We're migrating the HMRC Contacts Admin over to a general "HMRC Finder" Specialist Finder. HMRC need to be able to publish both English and Welsh specialist documents (of type `hmrc_contact`) to serve user needs.

Whilst the specialist document itself renders well with a locale of `cy` (Welsh page furniture and correct `lang` attribute set on the `<main>` HTML element), Welsh specialist documents aren't currently surfaced in the HMRC Finder because Search API rejects all non-English documents at the point of indexing. See related PR here:
https://github.com/alphagov/search-api/pull/1810

This means that the "Cymraeg / Welsh" facet we've added to the HMRC Finder (for feature parity with the Contacts Admin) doesn't work: it always returns 0 documents.
https://github.com/alphagov/specialist-publisher/pull/3011

Non-English documents were omitted from Search API because:

> there's no way to filter by language
> our stemming and synonyms are only set up for English
> We have non-English content in Rummager and don't know what language it is as Rummager does not store it
> We show Welsh results on search pages
> We may inadvertently be showing some non-English content in feeds / English pages

That is no longer much of a concern in 2025, because site search uses search-api-v2, which is unaffected by this change. That being said, site search falls back to search-api (v1) if no query param is provided, so anyone looking at <https://www.gov.uk/search/all?order=updated-newest> could see lots of non-English content surfacing if we're not careful about how we make this change.

We're therefore scoping this change to just Welsh, and just HMRC Contact specialist document type. There will only be a few of them, so the chances of these being unexpectedly surfaced outside of the HMRC Finder itself are very slim.

A better solution would be to start indexing the locale of all documents, and then applying a locale filter everywhere in our frontend apps that makes calls to Search API. But that's a pretty sizeable change, especially considering that we generally want to be moving to Search API v2. So this was considered a suitable stop-gap in the meantime.
We've logged the wider issue as a publishing tech debt card to revisit later: https://trello.com/c/ZzszTweH/

Trello for this work: https://trello.com/c/fXxLTdGk/