### PR TITLE
Don't raise exception when base_path is missing

### DIFF
--- a/lib/govuk_index/presenters/elasticsearch_delete_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_delete_presenter.rb
@@ -14,12 +14,6 @@ module GovukIndex
       base_path
     end
 
-    def valid!
-      unless payload["base_path"] || payload["content_id"]
-        raise(NotIdentifiable, "base_path and content_id missing from payload")
-      end
-    end
-
     def type
       raise NotFoundError if existing_document.nil?
 

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -254,12 +254,6 @@ module GovukIndex
       common_fields.publishing_app
     end
 
-    def valid!
-      if format == "recommended-link" && !details.url
-        raise(MissingExternalUrl, "url missing from details section")
-      end
-    end
-
     def image_url
       details.image_url || (expanded_links.default_news_image if newslike?)
     end

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -255,10 +255,8 @@ module GovukIndex
     end
 
     def valid!
-      if format == "recommended-link"
-        details.url || raise(MissingExternalUrl, "url missing from details section")
-      else
-        base_path || raise(NotIdentifiable, "base_path missing from payload")
+      if format == "recommended-link" && !details.url
+        raise(MissingExternalUrl, "url missing from details section")
       end
     end
 

--- a/lib/govuk_index/publishing_event_message_handler.rb
+++ b/lib/govuk_index/publishing_event_message_handler.rb
@@ -63,8 +63,6 @@ module GovukIndex
                     )
                   end
 
-      presenter.valid!
-
       identifier = "#{presenter.link} #{presenter.type || "'unmapped type'"}"
 
       if type_mapper.unpublishing_type?

--- a/spec/integration/govuk_index/external_content_spec.rb
+++ b/spec/integration/govuk_index/external_content_spec.rb
@@ -46,18 +46,18 @@ RSpec.describe "external content publishing" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("recommended-link" => :all)
 
     url = "https://www.nhs.uk"
-    content_id = "b7e993e1-9afa-4235-99a4-479caa240267"
-    document = { "link" => url, "content_id" => content_id }
-    commit_document("govuk_test", document, id: content_id, type: "recommended-link")
-    expect_document_is_in_rummager(document, id: content_id, index: "govuk_test", type: "recommended-link")
+    base_path = "/test"
+    document = { "link" => url, "base_path" => base_path }
+    commit_document("govuk_test", document, id: base_path, type: "recommended-link")
+    expect_document_is_in_rummager(document, id: base_path, index: "govuk_test", type: "recommended-link")
 
     payload = {
       "document_type" => "gone",
       "payload_version" => 15,
-      "content_id" => content_id,
+      "base_path" => base_path,
     }
     @queue.publish(payload.to_json, content_type: "application/json")
 
-    expect_document_missing_in_rummager(id: content_id, index: "govuk_test")
+    expect_document_missing_in_rummager(id: base_path, index: "govuk_test")
   end
 end

--- a/spec/integration/govuk_index/publishing_event_message_handler_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_message_handler_spec.rb
@@ -95,46 +95,6 @@ RSpec.describe GovukIndex::PublishingEventMessageHandler do
         described_class.call("routing.unpublish", payload)
       end
     end
-
-    context "when document type requires a basepath" do
-      let(:actions) { Index::ElasticsearchProcessor.govuk }
-      let(:payload) do
-        {
-          "document_type" => "help_page",
-          "title" => "We love cheese",
-        }
-      end
-
-      it "notify of a validation error for missing basepath" do
-        expect(GovukError).to receive(:notify).with(
-          instance_of(GovukIndex::NotIdentifiable),
-          extra: {
-            message_body: {
-              "document_type" => "help_page",
-              "title" => "We love cheese",
-            },
-          },
-        )
-
-        described_class.call("routing.key", payload)
-      end
-    end
-
-    context "when document type doesn't require a basepath" do
-      let(:actions) { Index::ElasticsearchProcessor.govuk }
-      let(:payload) do
-        {
-          "document_type" => "contact",
-          "title" => "We love cheese",
-        }
-      end
-
-      it "don't notify of a validation error for missing basepath" do
-        expect(GovukError).not_to receive(:notify)
-
-        described_class.call("routing.key", payload)
-      end
-    end
   end
 
   def stub_document_type_mapper

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -57,15 +57,17 @@ RSpec.describe "GovukIndex::PublishingEventProcessorTest" do
     end
 
     it "discards messages that are invalid" do
-      invalid_payload = {
-        "title" => "Pitts S-2B, G-SKYD, 21 June 1996",
-        "document_type" => "help_page",
-      }
+      invalid_example = generate_random_example(
+        schema: "external_content",
+        payload: {
+          title: "Pitts S-2B, G-SKYD, 21 June 1996",
+          document_type: "external_content",
+          details: { url: "" },
+        },
+      )
 
-      expect(GovukError).to receive(:notify)
-      @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
-
-      expect(@queue.message_count).to eq(0)
+      @queue.publish(invalid_example.to_json, content_type: "application/json")
+      expect(@channel.acknowledged_state[:rejected].count).to eq(1)
     end
 
     it "discards messages that are withdrawn and invalid" do
@@ -75,7 +77,7 @@ RSpec.describe "GovukIndex::PublishingEventProcessorTest" do
       }
 
       expect(GovukError).to receive(:notify)
-      @queue.publish(invalid_payload.to_json, extra: { content_type: "application/json" })
+      @queue.publish(invalid_payload.to_json, content_type: "application/json")
 
       expect(@queue.message_count).to eq(0)
     end

--- a/spec/integration/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/integration/govuk_index/publishing_event_processor_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "GovukIndex::PublishingEventProcessorTest" do
       expect(popularity).to eq(document["_source"]["popularity"])
     end
 
-    it "discards messages that are invalid" do
+    it "acks messages that are invalid" do
       invalid_example = generate_random_example(
         schema: "external_content",
         payload: {
@@ -67,18 +67,7 @@ RSpec.describe "GovukIndex::PublishingEventProcessorTest" do
       )
 
       @queue.publish(invalid_example.to_json, content_type: "application/json")
-      expect(@channel.acknowledged_state[:rejected].count).to eq(1)
-    end
-
-    it "discards messages that are withdrawn and invalid" do
-      invalid_payload = {
-        "title" => "Pitts S-2B, G-SKYD, 21 June 1996",
-        "document_type" => "gone",
-      }
-
-      expect(GovukError).to receive(:notify)
-      @queue.publish(invalid_payload.to_json, content_type: "application/json")
-
+      expect(@channel.acknowledged_state[:acked].count).to eq(1)
       expect(@queue.message_count).to eq(0)
     end
   end

--- a/spec/integration/govuk_index/taxon_spec.rb
+++ b/spec/integration/govuk_index/taxon_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe "taxon publishing" do
 
   it "removes a taxon page" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("taxon" => :all)
-    content_id = "c6d82aef-8f85-43b5-8a15-87719916204c"
-    document = { "link" => "/transport/all", "content_id" => content_id }
+    base_path = "/transport/all"
+    document = { "link" => base_path, "base_path" => base_path }
 
-    commit_document("govuk_test", document, id: content_id, type: "taxon")
-    expect_document_is_in_rummager(document, id: content_id, index: "govuk_test", type: "taxon")
+    commit_document("govuk_test", document, id: base_path, type: "taxon")
+    expect_document_is_in_rummager(document, id: base_path, index: "govuk_test", type: "taxon")
 
-    payload = { "document_type" => "gone", "payload_version" => 15, "content_id" => content_id }
+    payload = { "document_type" => "gone", "payload_version" => 15, "base_path" => base_path }
     @queue.publish(payload.to_json, content_type: "application/json")
 
-    expect_document_missing_in_rummager(id: content_id, index: "govuk_test")
+    expect_document_missing_in_rummager(id: base_path, index: "govuk_test")
   end
 end

--- a/spec/unit/govuk_index/presenters/elasticsearch_delete_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_delete_presenter_spec.rb
@@ -41,14 +41,4 @@ RSpec.describe GovukIndex::ElasticsearchDeletePresenter do
 
     expect { presenter.type }.to raise_error(GovukIndex::NotFoundError)
   end
-
-  it "is invalid if the base_path is missing" do
-    payload = {}
-
-    presenter = described_class.new(payload:)
-
-    expect {
-      presenter.valid!
-    }.to raise_error(GovukIndex::NotIdentifiable)
-  end
 end

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -31,34 +31,6 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     expect(presenter.updated_at).not_to be nil
   end
 
-  context "external content" do
-    it "is valid if it has a URL" do
-      payload = {
-        "document_type" => "external_content",
-        "details" => {
-          "url" => "some URL",
-        },
-      }
-
-      presenter = elasticsearch_presenter(payload)
-
-      presenter.valid!
-    end
-
-    it "is invalid if the URL is missing" do
-      payload = {
-        "document_type" => "external_content",
-        "details" => {},
-      }
-
-      presenter = elasticsearch_presenter(payload)
-
-      expect {
-        presenter.valid!
-      }.to raise_error(described_class::MissingExternalUrl)
-    end
-  end
-
   describe "#image_url" do
     let(:default_news_image_url) { "https://www.test.gov.uk/default_news_image.jpg" }
     let(:expanded_links) do

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -25,16 +25,6 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     }.to raise_error(GovukIndex::UnknownDocumentTypeError)
   end
 
-  it "is invalid if the base_path is missing" do
-    payload = {}
-
-    presenter = elasticsearch_presenter(payload)
-
-    expect {
-      presenter.valid!
-    }.to raise_error(GovukIndex::NotIdentifiable)
-  end
-
   it "sets the updated_at timestamp" do
     payload = generate_random_example(payload: { payload_version: 1 })
     presenter = elasticsearch_presenter(payload, "help_page")

--- a/spec/unit/govuk_index/publishing_event_processor_spec.rb
+++ b/spec/unit/govuk_index/publishing_event_processor_spec.rb
@@ -30,6 +30,57 @@ RSpec.describe GovukIndex::PublishingEventProcessor do
     end
   end
 
+  context "ignoring due to no base_path" do
+    before { allow(GovukIndex::PublishingEventMessageHandler).to receive(:call) }
+
+    it "does not ignore external_content messages with a missing base_path" do
+      message.payload["document_type"] = "external_content"
+      message.payload["base_path"] = nil
+
+      expect(logger).not_to receive(:info).with(
+        /#{content_item['content_id']} ignored due to no base_path/,
+      )
+
+      described_class.new.process(message)
+    end
+
+    it "ignores all other messages with no base_path" do
+      message.payload["base_path"] = nil
+
+      expect(logger).to receive(:info).with(
+        /#{content_item['content_id']} ignored due to no base_path/,
+      )
+
+      described_class.new.process(message)
+    end
+  end
+
+  context "ignoring due to no details.url" do
+    before { allow(GovukIndex::PublishingEventMessageHandler).to receive(:call) }
+
+    it "ignores external_content messages without a details.url" do
+      message.payload["document_type"] = "external_content"
+      message.payload["details"]["url"] = nil
+
+      expect(logger).to receive(:info).with(
+        /#{content_item['content_id']} ignored due to missing details.url/,
+      )
+
+      described_class.new.process(message)
+    end
+
+    it "does not ignore other messages without a details.url" do
+      message.payload["document_type"] = "advice"
+      message.payload["details"]["url"] = nil
+
+      expect(logger).not_to receive(:info).with(
+        /#{content_item['content_id']} ignored due to missing details.url/,
+      )
+
+      described_class.new.process(message)
+    end
+  end
+
   context "when an error is raised" do
     before do
       expect(GovukIndex::PublishingEventMessageHandler)


### PR DESCRIPTION
Currently we raise an error when processing a message from the queue if
the message payload is missing a `base_path` attribute.

However according to the content schema spec[1] this attribute is
optional, so there's no need to raise an error.

[1]: https://github.com/alphagov/publishing-api/blob/7b945cb0a7762b6326708143c7283df6a96daece/content_schemas/formats/contact.jsonnet#L3
