### PR TITLE
Change organisation name type to identifiers

### DIFF
--- a/config/schema/elasticsearch_types/ukhsa_data_access_approval.json
+++ b/config/schema/elasticsearch_types/ukhsa_data_access_approval.json
@@ -2,7 +2,7 @@
   "fields": [
       "ukhsa_approval_status",
       "ukhsa_access_type",
-      "ukhsa_applicant_organisation_name",
+      "ukhsa_organisation_name",
       "ukhsa_applicant_organisation_type",
       "ukhsa_classification_identification_risk",
       "ukhsa_dataset",

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1157,8 +1157,8 @@
   "ukhsa_access_type": {
     "type": "identifiers"
   },
-  "ukhsa_applicant_organisation_name": {
-    "type": "searchable_text"
+  "ukhsa_organisation_name": {
+    "type": "identifiers"
   },
   "ukhsa_applicant_organisation_type": {
     "type": "identifiers"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -209,7 +209,7 @@ module GovukIndex
         types_of_support: specialist.types_of_support,
         ukhsa_approval_status: specialist.ukhsa_approval_status,
         ukhsa_access_type: specialist.ukhsa_access_type,
-        ukhsa_applicant_organisation_name: specialist.ukhsa_applicant_organisation_name,
+        ukhsa_organisation_name: specialist.ukhsa_organisation_name,
         ukhsa_applicant_organisation_type: specialist.ukhsa_applicant_organisation_type,
         ukhsa_classification_identification_risk: specialist.ukhsa_classification_identification_risk,
         ukhsa_dataset: specialist.ukhsa_dataset,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -147,7 +147,7 @@ module GovukIndex
     delegate_to_payload :types_of_support
     delegate_to_payload :ukhsa_approval_status
     delegate_to_payload :ukhsa_access_type
-    delegate_to_payload :ukhsa_applicant_organisation_name
+    delegate_to_payload :ukhsa_organisation_name
     delegate_to_payload :ukhsa_applicant_organisation_type
     delegate_to_payload :ukhsa_classification_identification_risk
     delegate_to_payload :ukhsa_dataset


### PR DESCRIPTION
We're changing the organisation name field type from text to identifiers. This typically requires a reindex; in order to avoid that, we're renaming the field.

[Trello](https://trello.com/c/zubgVL1V/3569-specialist-finder-for-ukhsa-data-releases)