### PR TITLE
Parts with link

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -144,6 +144,7 @@
     "type": "objects",
     "children": {
       "slug": { "type": "searchable_identifier" },
+      "link": {"type": "searchable_identifier"},
       "title": { "type": "searchable_text" },
       "body": { "type": "searchable_text" }
     }

--- a/lib/govuk_index/payload_preparer.rb
+++ b/lib/govuk_index/payload_preparer.rb
@@ -22,7 +22,18 @@ module GovukIndex
     end
 
     def prepare_parts(payload)
-      return payload unless payload["details"].fetch("parts", []).empty?
+      parts = payload["details"]["parts"]
+
+      if parts && parts.any?
+        updated_parts = parts.map do |part|
+          next part if part["link"]
+
+          link = "#{payload['base_path']}/#{part['slug']}"
+          part.merge("link" => link)
+        end
+
+        return merge_details(payload, "parts", updated_parts)
+      end
 
       details = Indexer::PartsLookup.prepare_parts(
         payload["details"].merge("link" => payload["base_path"]),

--- a/lib/govuk_index/payload_preparer.rb
+++ b/lib/govuk_index/payload_preparer.rb
@@ -33,6 +33,7 @@ module GovukIndex
       presented_parts = details["parts"].map do |part|
         {
           "slug" => part["slug"],
+          "link" => part["link"],
           "title" => part["title"],
           "body" => [{ "content_type" => "text/html", "content" => part["body"] }],
         }

--- a/lib/govuk_index/payload_preparer.rb
+++ b/lib/govuk_index/payload_preparer.rb
@@ -33,8 +33,8 @@ module GovukIndex
       presented_parts = details["parts"].map do |part|
         {
           "slug" => part["slug"],
-          "link" => part["link"],
           "title" => part["title"],
+          "link" => part["link"],
           "body" => [{ "content_type" => "text/html", "content" => part["body"] }],
         }
       end

--- a/lib/govuk_index/presenters/parts_presenter.rb
+++ b/lib/govuk_index/presenters/parts_presenter.rb
@@ -11,6 +11,7 @@ module GovukIndex
         {
           "slug" => part["slug"],
           "title" => part["title"],
+          "link" => part["link"],
           "body" => summarise(part.fetch("body", [{}])),
         }
       end

--- a/lib/indexer/parts_lookup.rb
+++ b/lib/indexer/parts_lookup.rb
@@ -24,6 +24,7 @@ module Indexer
       body = attachment["content"]
       {
         "slug" => attachment["url"].split("/").last,
+        "link" => attachment["url"],
         "title" => attachment["title"],
         "body" => return_raw_body ? body : body.truncate(75, omission: "…", separator: " "),
       }

--- a/lib/indexer/parts_lookup.rb
+++ b/lib/indexer/parts_lookup.rb
@@ -12,7 +12,7 @@ module Indexer
     def prepare_parts(doc_hash, return_raw_body)
       return doc_hash unless doc_hash["parts"].nil?
 
-      attachments = doc_hash.fetch("attachments", []).select { |a| can_be_a_part?(doc_hash, a) }
+      attachments = doc_hash.fetch("attachments", []).select { |a| can_be_a_part?(a) }
       return doc_hash if attachments.empty?
 
       doc_hash.merge("parts" => attachments.map { |a| present_part(a, return_raw_body) })
@@ -30,13 +30,9 @@ module Indexer
       }
     end
 
-    def can_be_a_part?(doc_hash, attachment)
+    def can_be_a_part?(attachment)
       return false unless attachment["url"]
       return false unless attachment["content"]
-
-      # we don't index full part URLs, only slugs, so we need to
-      # ensure the full prefix matches
-      return false unless attachment["url"].start_with? doc_hash["link"]
 
       true
     end

--- a/spec/integration/govuk_index/payload_preparer_spec.rb
+++ b/spec/integration/govuk_index/payload_preparer_spec.rb
@@ -112,9 +112,9 @@ RSpec.describe "Payload preparation" do
           {
             "link" => "/foo",
             "parts" => [
-              { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
-              { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
-              { "slug" => "attachment-3", "title" => "attachment 3", "body" => "body 3" },
+              { "slug" => "attachment-1", "link" => nil, "title" => "attachment 1", "body" => "body 1" },
+              { "slug" => "attachment-2", "link" => nil, "title" => "attachment 2", "body" => "body 2" },
+              { "slug" => "attachment-3", "link" => nil, "title" => "attachment 3", "body" => "body 3" },
             ],
             "attachments" => [
               { "title" => "attachment 1", "content" => "body 1" },
@@ -132,7 +132,7 @@ RSpec.describe "Payload preparation" do
           "/bar" => "document-content-id",
           "/bar/attachment-1" => "attachment-content-id-1",
           "/bar/attachment-2" => "attachment-content-id-2",
-          "/bar/attachment-3" => "attachment-content-id-3",
+          "/baz/attachment-3" => "attachment-content-id-3",
         )
 
         stub_publishing_api_has_expanded_links(
@@ -158,7 +158,7 @@ RSpec.describe "Payload preparation" do
         random_example["details"]["attachments"] = [
           { "url" => "/bar/attachment-1", "title" => "attachment 1", "attachment_type" => "html" },
           { "url" => "/bar/attachment-2", "title" => "attachment 2", "attachment_type" => "html" },
-          { "url" => "/bar/attachment-3", "title" => "attachment 3", "attachment_type" => "html" },
+          { "url" => "/baz/attachment-3", "title" => "attachment 3", "attachment_type" => "html" },
         ]
 
         allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("guide" => :all)
@@ -170,7 +170,7 @@ RSpec.describe "Payload preparation" do
             "parts" => [
               { "slug" => "attachment-1", "link" => "/bar/attachment-1", "title" => "attachment 1", "body" => "body 1" },
               { "slug" => "attachment-2", "link" => "/bar/attachment-2", "title" => "attachment 2", "body" => "body 2" },
-              { "slug" => "attachment-3", "link" => "/bar/attachment-3", "title" => "attachment 3", "body" => "body 3" },
+              { "slug" => "attachment-3", "link" => "/baz/attachment-3", "title" => "attachment 3", "body" => "body 3" },
             ],
             "attachments" => [
               { "title" => "attachment 1", "content" => "body 1" },

--- a/spec/integration/govuk_index/payload_preparer_spec.rb
+++ b/spec/integration/govuk_index/payload_preparer_spec.rb
@@ -168,9 +168,9 @@ RSpec.describe "Payload preparation" do
           {
             "link" => "/bar",
             "parts" => [
-              { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
-              { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
-              { "slug" => "attachment-3", "title" => "attachment 3", "body" => "body 3" },
+              { "slug" => "attachment-1", "link" => "/bar/attachment-1", "title" => "attachment 1", "body" => "body 1" },
+              { "slug" => "attachment-2", "link" => "/bar/attachment-2", "title" => "attachment 2", "body" => "body 2" },
+              { "slug" => "attachment-3", "link" => "/bar/attachment-3", "title" => "attachment 3", "body" => "body 3" },
             ],
             "attachments" => [
               { "title" => "attachment 1", "content" => "body 1" },

--- a/spec/integration/govuk_index/payload_preparer_spec.rb
+++ b/spec/integration/govuk_index/payload_preparer_spec.rb
@@ -95,7 +95,9 @@ RSpec.describe "Payload preparation" do
           },
         )
         random_example["details"]["parts"] = [
-          { "slug" => "foo", "title" => "foo", "body" => [{ "content_type" => "text/html", "content" => "baz" }] },
+          { "slug" => "attachment-1", "title" => "attachment 1", "body" => [{ "content_type" => "text/html", "content" => "body 1" }] },
+          { "slug" => "attachment-2", "title" => "attachment 2", "body" => [{ "content_type" => "text/html", "content" => "body 2" }] },
+          { "slug" => "attachment-3", "title" => "attachment 3", "body" => [{ "content_type" => "text/html", "content" => "body 3" }] },
         ]
         random_example["details"]["attachments"] = [
           { "url" => "/foo/attachment-1", "title" => "attachment 1", "attachment_type" => "html" },
@@ -110,7 +112,9 @@ RSpec.describe "Payload preparation" do
           {
             "link" => "/foo",
             "parts" => [
-              { "slug" => "foo", "title" => "foo", "body" => "baz" },
+              { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
+              { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
+              { "slug" => "attachment-3", "title" => "attachment 3", "body" => "body 3" },
             ],
             "attachments" => [
               { "title" => "attachment 1", "content" => "body 1" },

--- a/spec/integration/govuk_index/payload_preparer_spec.rb
+++ b/spec/integration/govuk_index/payload_preparer_spec.rb
@@ -112,9 +112,9 @@ RSpec.describe "Payload preparation" do
           {
             "link" => "/foo",
             "parts" => [
-              { "slug" => "attachment-1", "link" => nil, "title" => "attachment 1", "body" => "body 1" },
-              { "slug" => "attachment-2", "link" => nil, "title" => "attachment 2", "body" => "body 2" },
-              { "slug" => "attachment-3", "link" => nil, "title" => "attachment 3", "body" => "body 3" },
+              { "slug" => "attachment-1", "link" => "/foo/attachment-1", "title" => "attachment 1", "body" => "body 1" },
+              { "slug" => "attachment-2", "link" => "/foo/attachment-2", "title" => "attachment 2", "body" => "body 2" },
+              { "slug" => "attachment-3", "link" => "/foo/attachment-3", "title" => "attachment 3", "body" => "body 3" },
             ],
             "attachments" => [
               { "title" => "attachment 1", "content" => "body 1" },

--- a/spec/integration/indexer/parts_lookup_spec.rb
+++ b/spec/integration/indexer/parts_lookup_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "PartslookupDuringIndexingTest" do
     )
   end
 
-  it "ignores attachments where the URL doesn't match the parent/slug format" do
+  it "indexes the attachment URL as the link for attachments where the URL doesn't match the parent/slug format" do
     post "/government_test/documents",
          {
            "link" => "/foo",
@@ -178,6 +178,8 @@ RSpec.describe "PartslookupDuringIndexingTest" do
         "link" => "/foo",
         "parts" => [
           { "slug" => "attachment-1", "link" => "/foo/attachment-1", "title" => "attachment 1", "body" => "body 1" },
+          { "slug" => "attachment-4", "link" => "/bar/attachment-4", "title" => "attachment 4", "body" => "body 4" },
+          { "slug" => "attachment-5", "link" => "/baz/attachment-5", "title" => "attachment 5", "body" => "body 5" },
         ],
         "attachments" => [
           { "title" => "attachment 1", "content" => "body 1" },

--- a/spec/integration/indexer/parts_lookup_spec.rb
+++ b/spec/integration/indexer/parts_lookup_spec.rb
@@ -40,7 +40,11 @@ RSpec.describe "PartslookupDuringIndexingTest" do
     post "/government_test/documents",
          {
            "link" => "/foo",
-           "parts" => [{ "slug" => "foo", "title" => "bar", "body" => "baz" }],
+           "parts" => [
+             { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
+             { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
+             { "slug" => "attachment-3", "title" => "attachment 3", "body" => "body 3" },
+           ],
            "attachments" => [
              { "url" => "/foo/attachment-1", "title" => "attachment 1", "attachment_type" => "html" },
              { "url" => "/foo/attachment-2", "title" => "attachment 2", "attachment_type" => "html" },
@@ -51,7 +55,11 @@ RSpec.describe "PartslookupDuringIndexingTest" do
     expect_document_is_in_rummager(
       {
         "link" => "/foo",
-        "parts" => [{ "slug" => "foo", "title" => "bar", "body" => "baz" }],
+        "parts" => [
+          { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
+          { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
+          { "slug" => "attachment-3", "title" => "attachment 3", "body" => "body 3" },
+        ],
         "attachments" => [
           { "title" => "attachment 1", "content" => "body 1" },
           { "title" => "attachment 2", "content" => "body 2" },

--- a/spec/integration/indexer/parts_lookup_spec.rb
+++ b/spec/integration/indexer/parts_lookup_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe "PartslookupDuringIndexingTest" do
          {
            "link" => "/foo",
            "parts" => [
-             { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
-             { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
-             { "slug" => "attachment-3", "title" => "attachment 3", "body" => "body 3" },
+             { "slug" => "attachment-1", "link" => "/foo/attachment-1", "title" => "attachment 1", "body" => "body 1" },
+             { "slug" => "attachment-2", "link" => "/foo/attachment-2", "title" => "attachment 2", "body" => "body 2" },
+             { "slug" => "attachment-3", "link" => "/foo/attachment-3", "title" => "attachment 3", "body" => "body 3" },
            ],
            "attachments" => [
              { "url" => "/foo/attachment-1", "title" => "attachment 1", "attachment_type" => "html" },
@@ -56,9 +56,9 @@ RSpec.describe "PartslookupDuringIndexingTest" do
       {
         "link" => "/foo",
         "parts" => [
-          { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
-          { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
-          { "slug" => "attachment-3", "title" => "attachment 3", "body" => "body 3" },
+          { "slug" => "attachment-1", "link" => "/foo/attachment-1", "title" => "attachment 1", "body" => "body 1" },
+          { "slug" => "attachment-2", "link" => "/foo/attachment-2", "title" => "attachment 2", "body" => "body 2" },
+          { "slug" => "attachment-3", "link" => "/foo/attachment-3", "title" => "attachment 3", "body" => "body 3" },
         ],
         "attachments" => [
           { "title" => "attachment 1", "content" => "body 1" },
@@ -87,9 +87,9 @@ RSpec.describe "PartslookupDuringIndexingTest" do
       {
         "link" => "/foo",
         "parts" => [
-          { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
-          { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
-          { "slug" => "attachment-3", "title" => "attachment 3", "body" => "body 3" },
+          { "slug" => "attachment-1", "link" => "/foo/attachment-1", "title" => "attachment 1", "body" => "body 1" },
+          { "slug" => "attachment-2", "link" => "/foo/attachment-2", "title" => "attachment 2", "body" => "body 2" },
+          { "slug" => "attachment-3", "link" => "/foo/attachment-3", "title" => "attachment 3", "body" => "body 3" },
         ],
         "attachments" => [
           { "title" => "attachment 1", "content" => "body 1" },
@@ -118,8 +118,8 @@ RSpec.describe "PartslookupDuringIndexingTest" do
       {
         "link" => "/foo",
         "parts" => [
-          { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
-          { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
+          { "slug" => "attachment-1", "link" => "/foo/attachment-1", "title" => "attachment 1", "body" => "body 1" },
+          { "slug" => "attachment-2", "link" => "/foo/attachment-2", "title" => "attachment 2", "body" => "body 2" },
         ],
         "attachments" => [
           { "title" => "attachment 1", "content" => "body 1" },
@@ -148,8 +148,8 @@ RSpec.describe "PartslookupDuringIndexingTest" do
       {
         "link" => "/foo",
         "parts" => [
-          { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
-          { "slug" => "attachment-2", "title" => "attachment 2", "body" => "body 2" },
+          { "slug" => "attachment-1", "link" => "/foo/attachment-1", "title" => "attachment 1", "body" => "body 1" },
+          { "slug" => "attachment-2", "link" => "/foo/attachment-2", "title" => "attachment 2", "body" => "body 2" },
         ],
         "attachments" => [
           { "title" => "attachment 1", "content" => "body 1" },
@@ -177,7 +177,7 @@ RSpec.describe "PartslookupDuringIndexingTest" do
       {
         "link" => "/foo",
         "parts" => [
-          { "slug" => "attachment-1", "title" => "attachment 1", "body" => "body 1" },
+          { "slug" => "attachment-1", "link" => "/foo/attachment-1", "title" => "attachment 1", "body" => "body 1" },
         ],
         "attachments" => [
           { "title" => "attachment 1", "content" => "body 1" },

--- a/spec/unit/govuk_index/presenters/parts_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/parts_presenter_spec.rb
@@ -30,11 +30,13 @@ RSpec.describe GovukIndex::PartsPresenter do
         {
           "body" => "hello",
           "slug" => "title-1",
+          "link" => nil,
           "title" => "title 1",
         },
         {
           "body" => "Universal Credit is a payment to help with your living costs. It’s paid…",
           "slug" => "title-2",
+          "link" => nil,
           "title" => "title 2",
         },
       ])
@@ -64,7 +66,7 @@ RSpec.describe GovukIndex::PartsPresenter do
         GovukIndex::MissingTextHtmlContentType.new,
         extra: { content_types: ["text/govspeak"] },
       )
-      expect(presented_parts).to eq([{ "body" => nil, "slug" => "title-1", "title" => "title 1" }])
+      expect(presented_parts).to eq([{ "body" => nil, "slug" => "title-1", "link" => nil, "title" => "title 1" }])
     end
   end
 end

--- a/spec/unit/govuk_index/presenters/parts_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/parts_presenter_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe GovukIndex::PartsPresenter do
         {
           "title" => "title 1",
           "slug" => "title-1",
+          "link" => "/foo/part-1",
           "body" => [
             { "content_type" => "text/govspeak", "content" => "**hello**" },
             { "content_type" => "text/html", "content" => "<strong>hello</strong>" },
@@ -17,6 +18,7 @@ RSpec.describe GovukIndex::PartsPresenter do
         {
           "title" => "title 2",
           "slug" => "title-2",
+          "link" => "/foo/part-2",
           "body" => [
             { "content_type" => "text/govspeak", "content" => "Universal Credit is a payment to help with your living costs. It’s paid monthly - or [twice a month for some people in Scotland](/universal-credit/how-youre-paid). \r\n\r\nYou may be able to get it if you're on a low income or out of work. \r\n\r\n^ This guide is also available in [Welsh (Cymraeg)](/credyd-cynhwysol).\r\n\r\nIf you live in Northern Ireland, go to [Universal Credit in Northern Ireland](https://www.nidirect.gov.uk/universalcredit).\r\n" },
             { "content_type" => "text/html", "content" => "<p>Universal Credit is a payment to help with your living costs. It’s paid monthly - or <a href=\"/universal-credit/how-youre-paid\">twice a month for some people in Scotland</a>.</p>\n\n<p>You may be able to get it if you’re on a low income or out of work.</p>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>This guide is also available in <a href=\"/credyd-cynhwysol\">Welsh (Cymraeg)</a>.</p>\n</div>\n\n<p>If you live in Northern Ireland, go to <a rel=\"external\" href=\"https://www.nidirect.gov.uk/universalcredit\">Universal Credit in Northern Ireland</a>." },
@@ -30,13 +32,13 @@ RSpec.describe GovukIndex::PartsPresenter do
         {
           "body" => "hello",
           "slug" => "title-1",
-          "link" => nil,
+          "link" => "/foo/part-1",
           "title" => "title 1",
         },
         {
           "body" => "Universal Credit is a payment to help with your living costs. It’s paid…",
           "slug" => "title-2",
-          "link" => nil,
+          "link" => "/foo/part-2",
           "title" => "title 2",
         },
       ])


### PR DESCRIPTION
Trello: https://trello.com/c/L3TUHrsG/2564-fix-broken-search-api-links

### What

A SearchAPI document contains an array of `parts` which are built from information stored in the `attachments` key of `details` fetched from Publishing API. Previously, the parts contained only three attributes: `slug`,`title`,`body`. This PR adds an additional field, `link` to parts.

### Why?

[Finder-frontend](https://github.com/alphagov/finder-frontend/blob/a074bb293d2b4ce2c57a147842439a60af415faa/app/presenters/search_result_presenter.rb#L93) uses the value of the `slug` key to build the link to parts returned in search results. It does this by appending the slug to the parent document's URL. In most cases this is fine. However in the case of consultation outcomes' their html_attachments have an additional sub-directory, `/outcome/`, which is not accounted for. 

One known issue this has caused in on the official documents finder, where the part link returns a 404

<img width="933" alt="Screenshot 2025-05-21 at 20 47 33" src="https://github.com/user-attachments/assets/267d5bf1-6b1a-456c-8029-6ea7d5744e98" />

Correct link to the attachment: https://www.gov.uk/government/consultations/uks-future-exhaustion-of-intellectual-property-rights-regime/outcome/government-response-to-the-consultation-on-the-uks-future-exhaustion-of-intellectual-property-rights-regime

Broken link to an attachment from search results: https://www.gov.uk/government/consultations/uks-future-exhaustion-of-intellectual-property-rights-regime/government-response-to-the-consultation-on-the-uks-future-exhaustion-of-intellectual-property-rights-regime

### Todo

- [x] Add a conditional to Finder Frontend - if a part doesn't have a slug then skip
  - PR: https://github.com/alphagov/finder-frontend/pull/3795
- [x] Add link to Search API Document parts array (this PR)
- [x] Run rake task to represent all documents to SearchAPI
  - Can start by checking docs that were updated overnight, or represent a doc or two
  -  Run for all documents with attachments so we can deprecate slug field
    -  https://github.com/alphagov/publishing-api/blob/main/lib/tasks/represent_downstream.rake#L2
- [x] Use SearchAPI to eyeball results
- [x] Update finder-frontend to read the new value of link
- [x] Document the deprecation of the slug field and hand back to the team