### PR TITLE
Fix flaky test by working around Elasticsearch test isolation

### DIFF
--- a/spec/integration/govuk_index/taxon_spec.rb
+++ b/spec/integration/govuk_index/taxon_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 RSpec.describe "taxon publishing" do
+  # Using a unique base path to work around an atomicity issue with Elasticsearch
+  # that is causing intermittent test failures.
+  let(:base_path) { "/transport/#{SecureRandom.uuid}" }
+
   before do
     bunny_mock = BunnyMock.new
     @channel = bunny_mock.start.channel
@@ -20,7 +24,7 @@ RSpec.describe "taxon publishing" do
       schema: "taxon",
       payload: {
         document_type: "taxon",
-        base_path: "/transport/all",
+        base_path:,
       },
     )
 
@@ -33,7 +37,6 @@ RSpec.describe "taxon publishing" do
 
   it "removes a taxon page" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("taxon" => :all)
-    base_path = "/transport/all"
     document = { "link" => base_path, "base_path" => base_path }
 
     commit_document("govuk_test", document, id: base_path, type: "taxon")


### PR DESCRIPTION
For a number of months we have been experiencing test failures related to the "indexes a taxon page" test. As per below:

```
  1) taxon publishing indexes a taxon page
     Failure/Error:
       client(cluster:).get(
         index:,
         type:,
         id:,
       )

     Elasticsearch::Transport::Transport::Errors::NotFound:
       [404] {"_index":"govuk_test-2025-05-29t09-02-59z-015c5151-3623-4ce0-a358-f708dac57940","_type":"_all","_id":"/transport/all","found":false}
```

I have spent some time trying to understand the source of these issues and see how they could be resolved. Ultimately I was unsuccessful in establishing a definitive source, however I believe it is an aspect of asynchronous behaviour in Elasticsearch, and ultimately have resolved it by changing the ids used in these test with Elasticsearch to not conflict.

---

My understanding of the issue is that if two independent tests involve writing an record to Elasticsearch there is a risk of a conflict issue. In debugging the failing tests I found that although the index had been emptied by [1] there was still ability for a write to fail:

```
[{"took"=>1, "errors"=>true, "items"=>[{"index"=>{"_index"=>"govuk_test-2025-05-29t13-49-54z-a11737f6-40e8-48a8-b458-5bb88439995a", "_type"=>"generic-document", "_id"=>"/transport/all", "status"=>409, "error"=>{"type"=>"version_conflict_engine_exception", "reason"=>"[generic-document][/transport/all]: version conflict, current version [8] is higher or equal to the one provided [3]", "index_uuid"=>"rOQkQ9L_T4CUFdC8pWvQYw", "shard"=>"1", "index"=>"govuk_test-2025-05-29t13-49-54z-a11737f6-40e8-48a8-b458-5bb88439995a"}}}]}]
```

This would be despite querying for the item yielding no results:

```
(byebug) Services.elasticsearch(cluster: Clusters.active.first, timeout: 10).get(index: "govuk_test", id: "/transport/all")
*** Elasticsearch::Transport::Transport::Errors::NotFound Exception: [404] {"_index":"govuk_test-2025-05-29t13-49-54z-a11737f6-40e8-48a8-b458-5bb88439995a","_type":"_all","_id":"/transport/all","found":false}

nil
```

This left me with 3 potential ideas of how to resolve this:

1. Work out how to make Elasticsearch be up-to-date with all previous actions and know the item is deleted
2. Try to avoid the conflict with a different id values
3. Try to avoid the conflict with incrementing the current version number

Option 1 seemed the best option for the system and the one I wanted to take, however I couldn't establish actions that achieved this. Even running a refresh on the index didn't fix it (and indeed that is already done as part of the deletion task [2]). Potentially this could be resolved by us using refresh on write as part of the queries, but this seems quite an overhaul for this large codebase.

I decided that option 2 was preferable to option 3 as option 3 would need to consider state in tests that had run before and ideally we want tests isolated from each other. Hence a random id was used.

I didn't manage to establish why this test had become flaky when it didn't used to be - nor why we don't seem to see similar failures elsewhere in the app.

[1]: https://github.com/alphagov/search-api/blob/831d5ae0a708d078373851479f9a8b119b729968/spec/support/integration_spec_helper.rb#L17-L19
[2]: https://github.com/alphagov/search-api/blob/831d5ae0a708d078373851479f9a8b119b729968/spec/support/integration_spec_helper.rb#L115