### PR TITLE
Add UKHSA chemical hazards finder (WHIT-1467)

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -131,6 +131,7 @@ transaction: edition
 transparency: edition
 travel_advice: edition # Travel advice publisher
 travel_advice_index: edition # Travel advice publisher
+ukhsa_chemical_hazard: ukhsa_chemical_hazard # Specialist Publisher
 ukhsa_data_access_approval: ukhsa_data_access_approval # Specialist Publisher
 utaac_decision: utaac_decision # Specialist Publisher
 veterans_support_organisation: veterans_support_organisation #Specialist Publisher

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -53,6 +53,7 @@ migrated:
 - tax_tribunal_decision
 - trademark_decision
 - traffic_commissioner_regulatory_decision
+- ukhsa_chemical_hazard
 - ukhsa_data_access_approval
 - utaac_decision
 - veterans_support_organisation

--- a/config/schema/elasticsearch_types/ukhsa_chemical_hazard.json
+++ b/config/schema/elasticsearch_types/ukhsa_chemical_hazard.json
@@ -1,0 +1,6 @@
+{
+  "fields": [
+    "ukhsa_chemical_name",
+    "ukhsa_product_category"
+  ]
+}

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1165,6 +1165,13 @@
     "type": "date"
   },
 
+  "ukhsa_chemical_name": {
+    "type": "identifiers"
+  },
+  "ukhsa_product_category": {
+    "type": "identifiers"
+  },
+
   "design_decision_british_library_number": {
     "type": "searchable_text"
   },

--- a/config/schema/indexes/govuk.json
+++ b/config/schema/indexes/govuk.json
@@ -47,6 +47,7 @@
     "tax_tribunal_decision",
     "trademark_decision",
     "traffic_commissioner_regulatory_decision",
+    "ukhsa_chemical_hazard",
     "ukhsa_data_access_approval",
     "utaac_decision",
     "veterans_support_organisation"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -217,6 +217,8 @@ module GovukIndex
         ukhsa_classification_identification_risk: specialist.ukhsa_classification_identification_risk,
         ukhsa_dataset: specialist.ukhsa_dataset,
         ukhsa_approval_date: specialist.ukhsa_approval_date,
+        ukhsa_chemical_name: specialist.ukhsa_chemical_name,
+        ukhsa_product_category: specialist.ukhsa_product_category,
         updated_at: common_fields.updated_at,
         use_case: specialist.use_case,
         user_journey_document_supertype: common_fields.user_journey_document_supertype,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -155,6 +155,8 @@ module GovukIndex
     delegate_to_payload :ukhsa_classification_identification_risk
     delegate_to_payload :ukhsa_dataset
     delegate_to_payload :ukhsa_approval_date
+    delegate_to_payload :ukhsa_chemical_name
+    delegate_to_payload :ukhsa_product_category
     delegate_to_payload :use_case, convert_to_array: true
     delegate_to_payload :value_of_funding
     delegate_to_payload :vessel_type


### PR DESCRIPTION
UKSHA have identified the need for a new finder. This PR adds the schema, document format and custom fields to search API. 

More detail can be [found here](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?assignee=61eecab7e218f0006ad495ba&assignee=5caf4d888c2c1a75f3e46ef6&selectedIssue=WHIT-1467)