### PR TITLE
Deprecate parts.slug in favour of parts.link

### DIFF
--- a/lib/govuk_index/payload_preparer.rb
+++ b/lib/govuk_index/payload_preparer.rb
@@ -51,7 +51,7 @@ module GovukIndex
 
       details_with_html_attachments_as_parts["parts"].map do |part|
         {
-          "slug" => part["slug"],
+          "slug" => part["slug"], # Deprecated: superseded by link, to be removed once confident all parts/attachments have a link
           "title" => part["title"],
           "link" => part["link"],
           "body" => [{ "content_type" => "text/html", "content" => part["body"] }],

--- a/lib/govuk_index/presenters/parts_presenter.rb
+++ b/lib/govuk_index/presenters/parts_presenter.rb
@@ -9,7 +9,7 @@ module GovukIndex
 
       parts.map do |part|
         {
-          "slug" => part["slug"],
+          "slug" => part["slug"], # Deprecated: superseded by link, to be removed once confident all parts/attachments have a link
           "title" => part["title"],
           "link" => part["link"],
           "body" => summarise(part.fetch("body", [{}])),


### PR DESCRIPTION
Attachments/parts can live under a different path than their parent document. The new 'link' field replaces the use of 'slug' in order to fix a bug caused by this #3271.

All affected documents have been republished to populate 'link'. We are keeping 'slug' temporarily for backward compatibility until all content with parts or attachments has been republished, after which it can be removed.