### PR TITLE
Add HMRC manuals finder

### DIFF
--- a/config/finders/hmrc_manuals_finder.yml
+++ b/config/finders/hmrc_manuals_finder.yml
@@ -1,0 +1,75 @@
+---
+base_path: "/find-hmrc-manuals"
+content_id: f11819b7-1c54-4b54-a8e8-56e0004b2dbf
+description: Find and search HMRC technical guidance for HMRC staff and tax professionals.
+details:
+  beta_message: Help us improve this page - email your feedback to <a class="govuk-link" href="mailto:hmrcmanualsteam@hmrc.gov.uk">hmrcmanualsteam@hmrc.gov.uk</a>
+  summary:
+    - content: |-
+        These manuals contain technical guidance for HMRC staff and tax professionals and are also published in
+        accordance with the [HMRC Publication scheme](https://www.gov.uk/government/organisations/hm-revenue-customs/about/publication-scheme).
+
+        The guidance is not comprehensive and does not provide a definitive answer in every case. It is based on the law
+        as it stood when they were published. HMRC publishes amended or supplementary guidance if there's a change in
+        the law or in the department's interpretation of it.
+
+        Find out [how HMRC advice and information can help you](https://www.gov.uk/guidance/when-you-can-rely-on-information-or-advice-provided-by-hm-revenue-and-customs).
+      content_type: text/govspeak
+  filter:
+    content_store_document_type:
+      - hmrc_manual
+      - hmrc_manual_section
+  facets:
+    - allowed_values:
+        - label: HMRC manual
+          value: hmrc_manual
+        - label: HMRC manual page
+          value: hmrc_manual_section
+      display_as_result_metadata: false
+      filterable: true
+      key: content_store_document_type
+      name: Page type
+      preposition: of type
+      type: text
+    - name: Last updated
+      key: public_timestamp
+      type: date
+      display_as_result_metadata: true
+      filterable: true
+      short_name: Updated
+      preposition: Updated
+  sort:
+    - key: title
+      name: A-Z
+      default: true
+    - key: -popularity
+      name: Most viewed
+    - key: -relevance
+      name: Relevance
+    - key: -public_timestamp
+      name: Updated (newest)
+    - key: public_timestamp
+      name: Updated (oldest)
+  document_noun: result
+  show_summaries: false
+  show_metadata_block: true
+  show_table_of_contents: true
+  default_documents_per_page: 50
+document_type: finder
+locale: en
+organisations:
+- 6667cce2-e809-4e21-ae09-cb0bdc1ddda3 # HMRC
+taxons:
+- 5d0b158c-7c31-41f8-84ae-8e4e950c1f0c # /money/tax-agent-guidance
+phase: beta
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder
+title: Find HMRC manuals
+routes:
+  - type: exact
+    path: /find-hmrc-manuals
+  - type: exact
+    path: /find-hmrc-manuals.json
+  - type: exact
+    path: /find-hmrc-manuals.atom

--- a/lib/content_item_publisher/finder_presenter.rb
+++ b/lib/content_item_publisher/finder_presenter.rb
@@ -18,6 +18,14 @@ module ContentItemPublisher
       Array(content_item["ordered_related_items"])
     end
 
+    def organisations
+      Array(content_item["organisations"])
+    end
+
+    def taxons
+      Array(content_item["taxons"])
+    end
+
     def facet_group
       facet_group = content_item.dig("links", "facet_group")
       facet_group ? { "facet_group" => facet_group } : {}
@@ -28,6 +36,8 @@ module ContentItemPublisher
         "email_alert_signup" => email_alert_signup,
         "parent" => content_item_parent,
         "ordered_related_items" => ordered_related_items,
+        "organisations" => organisations,
+        "taxons" => taxons,
       }.merge(facet_group)
 
       { content_id:, links: }

--- a/spec/unit/content_item_publisher/finder_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_presenter_spec.rb
@@ -30,9 +30,13 @@ RSpec.describe ContentItemPublisher::FinderPresenter do
         email_signup_links = [finder["signup_content_id"]].compact
         parent_links = [finder["parent"]].compact
         ordered_related_items_links = [finder["ordered_related_items"]].compact
+        organisations_links = Array(finder["organisations"])
+        taxon_links = Array(finder["taxons"])
         expect(instance.present_links[:links]).to eq({ "email_alert_signup" => email_signup_links,
                                                        "parent" => parent_links,
-                                                       "ordered_related_items" => ordered_related_items_links })
+                                                       "ordered_related_items" => ordered_related_items_links,
+                                                       "taxons" => taxon_links,
+                                                       "organisations" => organisations_links })
       end
 
       it "includes facet_group in the links hash if present" do
@@ -42,11 +46,19 @@ RSpec.describe ContentItemPublisher::FinderPresenter do
       end
 
       it "uses empty arrays to remove links" do
-        finder_with_no_links = finder.except("parent").except("signup_content_id").except("ordered_related_items")
+        finder_with_no_links = finder.except(
+          "parent",
+          "signup_content_id",
+          "ordered_related_items",
+          "organisations",
+          "taxons",
+        )
         presenter_with_empty_links = described_class.new(finder_with_no_links, timestamp)
 
         expect(presenter_with_empty_links.present_links[:links]).to eq({ "email_alert_signup" => [],
                                                                          "parent" => [],
+                                                                         "organisations" => [],
+                                                                         "taxons" => [],
                                                                          "ordered_related_items" => [] })
       end
     end


### PR DESCRIPTION
This is a new finder that lets users search through all HMRC manuals / manual sections.

I've been working behind the scenes with HMRC to agree the content and settings for this, which is now done. We're planning on deploying it to production as a trial, and HMRC are going to get feedback on its effectiveness from external the users of their manuals.

As this is only configuration, and I haven't had to change any code or reindex anything in search, I don't think this will add to our maintenance burden significantly. I've also done everything I can to manage down HMRC's expectations of ongoing support - they understand that there's no promise of ongoing feature improvements to this finder, and they're still keen to have it over the current situation (where it's difficult to search across HMRC manuals).

[You can currently see the finder deployed to integration here](https://www.integration.publishing.service.gov.uk/find-hmrc-manuals)

Published using `FINDER_CONFIG=hmrc_manuals_finder.yml rake publishing_api:publish_finder`

