### PR TITLE
Ensure tests always run in UTC

### DIFF
--- a/lib/sitemap/presenter.rb
+++ b/lib/sitemap/presenter.rb
@@ -1,5 +1,5 @@
 class SitemapPresenter
-  GOVUK_LAUNCH_DATE = Time.new(2012, 10, 17).freeze
+  GOVUK_LAUNCH_DATE = Time.utc(2012, 10, 17).freeze
 
   def initialize(document, property_boost_calculator)
     @document = document

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,10 @@ RSpec.configure do |config|
     Services.cache.clear
   end
 
+  config.around(:each) do |example|
+    ClimateControl.modify(TZ: "UTC") { example.run }
+  end
+
   if config.files_to_run.one?
     config.default_formatter = "doc"
   end

--- a/spec/unit/sitemap/sitemap_presenter_spec.rb
+++ b/spec/unit/sitemap/sitemap_presenter_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SitemapPresenter do
       timestamp: "1995-06-01",
     )
     presented = described_class.new(document, @boost_calculator).to_h
-    expect(presented[:last_updated]).to eq("2012-10-17T00:00:00+00:00")
+    expect(presented[:last_updated]).to eq("2012-10-17T00:00:00Z")
   end
 
   it "last updated is omitted if timestamp is missing" do


### PR DESCRIPTION
Previously, the test suite relied on the host operating system's timezone, which could cause failures when the local timezone was not UTC.

This change explicitly sets ENV['TZ'] to "UTC" before the test environment is loaded, ensuring consistent time-based behaviour across all environments.

part of Jira: https://gov-uk.atlassian.net/browse/SCH-1486