### PR TITLE
Migrate Whitehall finders to Search API [WHIT-1833]

### DIFF
--- a/config/finders/case_studies_finder.yml
+++ b/config/finders/case_studies_finder.yml
@@ -1,0 +1,33 @@
+---
+base_path: "/government/case-studies"
+content_id: 7527cefb-606a-4723-8029-61ee1227f7e0
+description: Real examples of how government programmes are helping businesses and people in the UK.
+document_type: finder
+locale: en
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder
+title: "Case studies: Real-life examples of government activity"
+phase: live
+details:
+  document_noun: case study
+  facets: []
+  filter:
+    format: case_study
+  show_summaries: true
+  default_documents_per_page: 50
+  sort:
+  - name: Relevance
+    key: "-relevance"
+  - name: Updated (newest)
+    key: "-public_timestamp"
+    default: true
+  - name: Updated (oldest)
+    key: public_timestamp
+routes:
+  - type: exact
+    path: "/government/case-studies"
+  - type: exact
+    path: "/government/case-studies.json"
+  - type: exact
+    path: "/government/case-studies.atom"

--- a/config/finders/groups_finder.yml
+++ b/config/finders/groups_finder.yml
@@ -1,0 +1,34 @@
+---
+base_path: "/government/groups"
+content_id: cfe497aa-ebd4-41f0-9250-53a86162f1ee
+description: Find information about a public sector group.
+document_type: finder
+locale: en
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder
+title: Groups
+phase: live
+details:
+  document_noun: group
+  facets: []
+  filter:
+    format: policy_group
+  show_summaries: true
+  sort:
+  - key: title
+    name: A-Z
+    default: true
+  - name: Relevance
+    key: "-relevance"
+  - name: Updated (newest)
+    key: "-public_timestamp"
+  - name: Updated (oldest)
+    key: public_timestamp
+routes:
+  - type: exact
+    path: "/government/groups"
+  - type: exact
+    path: "/government/groups.json"
+  - type: exact
+    path: "/government/groups.atom"

--- a/config/finders/people_finder.yml
+++ b/config/finders/people_finder.yml
@@ -1,0 +1,35 @@
+---
+base_path: "/government/people"
+content_id: 40cd7eba-2c4a-4905-9ed0-9c7e8957ffdf
+description: Find information about a minister or senior official.
+document_type: finder
+locale: en
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder
+title: All ministers and senior officials on GOV.UK
+phase: live
+details:
+  document_noun: person
+  facets: []
+  filter:
+    format: person
+  show_summaries: true
+  default_documents_per_page: 50
+  sort:
+  - key: title
+    name: A-Z
+    default: true
+  - name: Relevance
+    key: "-relevance"
+  - name: Updated (newest)
+    key: "-public_timestamp"
+  - name: Updated (oldest)
+    key: public_timestamp
+routes:
+  - type: exact
+    path: "/government/people"
+  - type: exact
+    path: "/government/people.json"
+  - type: exact
+    path: "/government/people.atom"

--- a/config/finders/statistical_data_sets_finder.yml
+++ b/config/finders/statistical_data_sets_finder.yml
@@ -1,0 +1,45 @@
+---
+base_path: "/government/statistical-data-sets"
+content_id: 2a850366-059a-4be7-8384-a24e27ac650d
+description: List of statistical data sets published by the UK government.
+document_type: finder
+locale: en
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder
+title: Statistical data sets
+phase: live
+details:
+  document_noun: data set
+  filter:
+    format: statistical_data_set
+  show_summaries: true
+  default_documents_per_page: 50
+  sort:
+  - name: Relevance
+    key: "-relevance"
+  - name: Updated (newest)
+    key: "-public_timestamp"
+    default: true
+  - name: Updated (oldest)
+    key: public_timestamp
+  facets:
+  - key: public_timestamp
+    name: Published
+    short_name: Published at
+    display_as_result_metadata: true
+    filterable: true
+    type: date
+  - key: organisations
+    name: Organisation
+    short_name: From
+    display_as_result_metadata: true
+    filterable: true
+    type: text
+routes:
+  - type: exact
+    path: "/government/statistical-data-sets"
+  - type: exact
+    path: "/government/statistical-data-sets.json"
+  - type: exact
+    path: "/government/statistical-data-sets.atom"

--- a/config/finders/worldwide_organisations_finder.yml
+++ b/config/finders/worldwide_organisations_finder.yml
@@ -1,0 +1,34 @@
+---
+base_path: "/world/organisations"
+content_id: 6c3d2ac3-92e0-4ae7-9705-010fa304fd09
+description: A list of British organisations worldwide.
+document_type: finder
+locale: en
+publishing_app: search-api
+rendering_app: finder-frontend
+schema_name: finder
+title: Worldwide organisations
+phase: live
+details:
+  document_noun: organisation
+  facets: []
+  filter:
+    format: worldwide_organisation
+  show_summaries: false
+  sort:
+  - key: title
+    name: A-Z
+    default: true
+  - name: Relevance
+    key: "-relevance"
+  - name: Updated (newest)
+    key: "-public_timestamp"
+  - name: Updated (oldest)
+    key: public_timestamp
+routes:
+  - type: exact
+    path: "/world/organisations"
+  - type: exact
+    path: "/world/organisations.json"
+  - type: exact
+    path: "/world/organisations.atom"

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -25,6 +25,28 @@ namespace :publishing_api do
     end
   end
 
+  # TEMPORARY TASK - we'll run this to enable migration of Whitehall's finders.
+  # It will then be deleted.
+  # Jira: https://gov-uk.atlassian.net/browse/WHIT-1833
+  desc "Take over ownership of a route (used for migrating finder from Whitehall)"
+  task :claim_route do
+    route_to_claim = ENV["FINDER_BASE_PATH"]
+
+    unless route_to_claim
+      raise "Please supply a valid base path to claim, e.g. FINDER_BASE_PATH=/government/case-studies"
+    end
+
+    puts "Claiming route #{route_to_claim}..."
+    Services.publishing_api.put_path(
+      route_to_claim,
+      {
+        publishing_app: "search-api",
+        override_existing: true,
+      },
+    )
+    puts "Route claimed."
+  end
+
   desc "
     Publish finder and email signup content items
 


### PR DESCRIPTION
## What

This PR migrates the last remaining finders out of Whitehall, and into Search API, fulfilling an architectural commitment made [some time ago](https://github.com/alphagov/whitehall/blob/75f4d532fa29443bd316fd395afb471a3d00c2e7/docs/finders.md#how-to-publish-a-finder-in-whitehall):

We've translated the JSON configs to their YAML equivalents as best as possible. There is no email signup page for any of these finders. The only rendering difference should be in the new "Sort by" dropdown, which is a UX improvement.

## Why

Non-specialist finders have historically been spread across both Whitehall and Search API. A decision was made a while ago for these finders to live in Search API only, but the migration never happened. We're now migrating these finders and will delete their configurations from Whitehall.

Jira: [WHIT-1833](https://gov-uk.atlassian.net/browse/WHIT-1833)

## Deployment

We've successfully tested this on integration.

```
# claim the route
k exec -it deploy/search-api -- rake FINDER_BASE_PATH=/government/case-studies publishing_api:claim_route
# publish the finder
k exec -it deploy/search-api -- rake FINDER_CONFIG=case_studies_finder.yml publishing_api:publish_finder

k exec -it deploy/search-api -- rake FINDER_BASE_PATH=/government/groups publishing_api:claim_route
k exec -it deploy/search-api -- rake FINDER_CONFIG=groups_finder.yml publishing_api:publish_finder

k exec -it deploy/search-api -- rake FINDER_BASE_PATH=/government/people publishing_api:claim_route
k exec -it deploy/search-api -- rake FINDER_CONFIG=people_finder.yml publishing_api:publish_finder

k exec -it deploy/search-api -- rake FINDER_BASE_PATH=/world/organisations publishing_api:claim_route
k exec -it deploy/search-api -- rake FINDER_CONFIG=worldwide_organisations_finder.yml publishing_api:publish_finder

k exec -it deploy/search-api -- rake FINDER_BASE_PATH=/government/statistical-data-sets publishing_api:claim_route
k exec -it deploy/search-api -- rake FINDER_CONFIG=statistical_data_sets_finder.yml publishing_api:publish_finder
```

## Screenshots

<https://www.gov.uk/government/case-studies>

<details>
<summary>Case studies finder</summary>

| Before | After |
|--------|------|
| <img src="https://github.com/user-attachments/assets/dd3598c9-56a8-4607-9293-b17509fab0aa" /> | <img src="https://github.com/user-attachments/assets/ff8060f3-cd5a-4582-a454-827c112fc0d8" /> |
</details>

<https://www.gov.uk/government/groups>

<details>
<summary>Groups finder</summary>

| Before | After |
|--------|------|
| <img src="https://github.com/user-attachments/assets/52caac1b-ddf0-4a26-833f-9602324bdc6b" /> | <img src="https://github.com/user-attachments/assets/c2413308-ae54-4954-9ce9-620e01c9bfcb" /> |
</details>

<https://www.gov.uk/government/people>

<details>
<summary>People finder</summary>

| Before | After |
|--------|------|
| <img src="https://github.com/user-attachments/assets/a86b857b-d36f-457a-a365-6eb2d52af972" /> | <img src="https://github.com/user-attachments/assets/adad2f68-56fc-4e78-9950-c10bd2bfca54" /> |
</details>

<https://www.gov.uk/government/statistical-data-sets>

<details>
<summary>Statistical data sets finder</summary>

| Before | After |
|--------|------|
| <img  src="https://github.com/user-attachments/assets/c920fb45-000c-4fd6-a891-890393fd0dca" /> | <img src="https://github.com/user-attachments/assets/be0f7dc7-514e-444a-b5c1-b765d30a4fe7" /> |
</details>

<https://www.gov.uk/world/organisations>

<details>
<summary>Worldwide organisations finder</summary>

| Before | After |
|--------|------|
| <img src="https://github.com/user-attachments/assets/352e4d74-a7dd-4936-8711-55707f6e9e68" /> | <img src="https://github.com/user-attachments/assets/78a66101-c328-4701-84d4-5811b7291593" /> |
</details>

[WHIT-1833]: https://gov-uk.atlassian.net/browse/WHIT-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ