### PR TITLE
Handle empty filter parameters

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -287,12 +287,12 @@ private
     # operation is :reject or :filter
     # multivalue_query is :all or :any
     def initialize(field_name, values, operation, multivalue_query)
+      @errors = values.empty? ? [%(no value for parameter "#{field_name}")] : []
       @field_name = field_name
       @include_missing = values.include? BaseParameterParser::MISSING_FIELD_SPECIAL_VALUE
       @values = Array(values).reject { |value| value == BaseParameterParser::MISSING_FIELD_SPECIAL_VALUE }
       @operation = operation
       @multivalue_query = multivalue_query
-      @errors = []
     end
 
     def type

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -248,6 +248,14 @@ RSpec.describe "SearchTest" do
     expect(parsed_response).to eq({ "error" => "Invalid value \"a\" for parameter \"start\" (expected positive integer)" })
   end
 
+  it "ensures each filter parameter contains a value" do
+    get "/search.json?filter_public_timestamp"
+
+    expect(last_response.status).to eq(422)
+    error_message = JSON.parse(last_response.body).fetch("error")
+    expect(error_message).to include(%(no value for parameter "public_timestamp"))
+  end
+
   it "allows integer params leading zeros" do
     get "/search?start=09"
 


### PR DESCRIPTION
Requests with empty filter parameters, such as '/search.json?filter_public_timestamp' should return an HTTP code 422 (Unprocessable Entity) and not raise an exception

Jira:  https://gov-uk.atlassian.net/browse/SCH-1579