### PR TITLE
Allow indexing of organisations in the govuk index [WHIT-1799]

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -83,6 +83,7 @@ official_statistics: edition
 open_call_for_evidence: edition
 open_consultation: edition
 oral_statement: edition # Whitehall
+organisation: edition # Whitehall
 our_energy_use: edition
 our_governance: edition
 person: person

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -380,7 +380,8 @@ migrated:
 - worldwide_organisation
 - written_statement
 
-indexable: []
+indexable:
+- organisation
 
 non_indexable_path:
 - '/help/cookie-details'
@@ -438,7 +439,6 @@ non_indexable:
 - imported
 - national_statistics_announcement
 - official_statistics_announcement
-- organisation
 - policy_area
 - services_and_information
 - take_part

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -59,6 +59,34 @@ module GovukIndex
       details["attachments"]&.any? { |attachment| attachment["hoc_paper_number"].present? || attachment["unnumbered_hoc_paper"] }
     end
 
+    def acronym
+      details["acronym"]
+    end
+
+    def logo_formatted_title
+      details.dig("logo", "formatted_title")
+    end
+
+    def logo_url
+      details.dig("logo", "image", "url")
+    end
+
+    def organisation_brand
+      details["brand"]
+    end
+
+    def organisation_crest
+      details.dig("logo", "crest")
+    end
+
+    def organisation_state
+      details.dig("organisation_govuk_status", "status")
+    end
+
+    def organisation_type
+      details["organisation_type"]
+    end
+
   private
 
     def service_manual

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -15,6 +15,7 @@ module GovukIndex
 
     def document
       {
+        acronym: details.acronym,
         ai_assurance_technique: specialist.ai_assurance_technique,
         aircraft_category: specialist.aircraft_category,
         aircraft_type: specialist.aircraft_type,
@@ -140,6 +141,8 @@ module GovukIndex
         life_saving_maritime_appliance_manufacturer: specialist.life_saving_maritime_appliance_manufacturer,
         link: common_fields.link,
         location: specialist.location,
+        logo_formatted_title: details.logo_formatted_title,
+        logo_url: details.logo_url,
         mainstream_browse_page_content_ids: expanded_links.mainstream_browse_page_content_ids,
         mainstream_browse_pages: expanded_links.mainstream_browse_pages,
         manual: details.parent_manual,
@@ -149,9 +152,14 @@ module GovukIndex
         market_sector: specialist.market_sector,
         medical_specialism: specialist.medical_specialism,
         opened_date: specialist.opened_date,
+        organisation_brand: details.organisation_brand,
+        organisation_crest: details.organisation_crest,
         organisation_content_ids: expanded_links.organisation_content_ids,
+        organisation_state: details.organisation_state,
+        organisation_type: details.organisation_type,
         organisations: expanded_links.organisations,
         outcome_type: specialist.outcome_type,
+        parent_organisations: expanded_links.parent_organisations,
         part_of_taxonomy_tree: expanded_links.part_of_taxonomy_tree,
         parts: parts.presented_parts,
         people: expanded_links.people,

--- a/lib/govuk_index/presenters/expanded_links_presenter.rb
+++ b/lib/govuk_index/presenters/expanded_links_presenter.rb
@@ -16,6 +16,10 @@ module GovukIndex
       content_ids("organisations")
     end
 
+    def parent_organisations
+      organisation_slugs("ordered_parent_organisations")
+    end
+
     def people
       slugs("people", "/government/people/")
     end

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -256,4 +256,37 @@ RSpec.describe GovukIndex::DetailsPresenter do
       end
     end
   end
+
+  context "organisation" do
+    let(:format) { "organisation" }
+    let(:details) do
+      {
+        "acronym" => "Companies House",
+        "brand" => "department-for-business-trade",
+        "logo" => {
+          "image" => {
+            "url" => "https://assets.publishing.service.gov.uk/media/67f65f2bb7e44efc70acc3db/test_logo.png",
+          },
+          "crest" => "single-identity",
+          "formatted_title" => "Companies House",
+        },
+        "organisation_govuk_status" => {
+          "status" => "live",
+          "updated_at" => nil,
+          "url" => nil,
+        },
+        "organisation_type" => "executive_agency",
+      }
+    end
+
+    it("extracts organisation-specific fields") do
+      expect(presented_details.acronym).to eq(details["acronym"])
+      expect(presented_details.logo_formatted_title).to eq(details["logo"]["formatted_title"])
+      expect(presented_details.logo_url).to eq(details["logo"]["image"]["url"])
+      expect(presented_details.organisation_brand).to eq(details["brand"])
+      expect(presented_details.organisation_crest).to eq(details["logo"]["crest"])
+      expect(presented_details.organisation_state).to eq(details["organisation_govuk_status"]["status"])
+      expect(presented_details.organisation_type).to eq(details["organisation_type"])
+    end
+  end
 end

--- a/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/expanded_links_presenter_spec.rb
@@ -64,6 +64,25 @@ RSpec.describe GovukIndex::ExpandedLinksPresenter do
     expect(presenter.primary_publishing_organisation).to eq(expected_primary_publishing_organisation)
   end
 
+  it "parent_organisations" do
+    expanded_links = {
+      "ordered_parent_organisations" => [
+        {
+          "base_path" => "/government/organisations/uk-visas-and-immigration",
+          "content_id" => "04148522-b0c1-4137-b687-5f3c3bdd561a",
+          "locale" => "en",
+          "title" => "UK Visas and Immigration",
+        },
+      ],
+    }
+
+    presenter = expanded_links_presenter(expanded_links)
+
+    expected_parent_organisations = %w[uk-visas-and-immigration]
+
+    expect(presenter.parent_organisations).to eq(expected_parent_organisations)
+  end
+
   it "topical_events" do
     expanded_links = {
       "topical_events" => [


### PR DESCRIPTION
This requires adding a number of organisation-specific fields to handle logo, status, branding etc.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-1799)