### PR TITLE
[SCH-1598] Add tests for sitemap Uploader class

### DIFF
--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -190,6 +190,7 @@ require "services"
 require "sitemap/property_boost_calculator"
 require "sitemap/generator"
 require "sitemap/presenter"
+require "sitemap/uploader"
 require "retryable_queue_message"
 
 require "core_extensions/time/to_string"

--- a/spec/unit/sitemap/uploader_spec.rb
+++ b/spec/unit/sitemap/uploader_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+RSpec.describe Sitemap::Uploader do
+  let(:bucket_name) { "test-bucket" }
+  let(:file_name) { "sitemap.xml" }
+  let(:file_content) { "<sitemap>...</sitemap>" }
+  let(:s3_object_double) { instance_double(Aws::S3::Object) }
+  let(:logger) { Logging.logger[described_class] }
+
+  subject(:uploader) { described_class.new(bucket_name) }
+
+  before do
+    allow(Aws::S3::Object)
+      .to receive(:new)
+      .with(bucket_name:, key: file_name)
+      .and_return(s3_object_double)
+  end
+
+  context "when the file uploads successfully" do
+    let(:put_object_output) { instance_double(Aws::S3::Types::PutObjectOutput) }
+
+    before do
+      allow(s3_object_double)
+        .to receive(:put)
+        .with(body: file_content)
+        .and_return(put_object_output)
+    end
+
+    it "uploads a sitemap to an AWS S3 bucket" do
+      expect(logger)
+        .to receive(:info)
+        .with("Uploading #{file_name} ...")
+
+      expect(Aws::S3::Object)
+        .to receive(:new)
+        .with(bucket_name:, key: file_name)
+
+      expect(s3_object_double)
+        .to receive(:put)
+        .with(body: file_content)
+
+      uploader.upload(file_content:, file_name:)
+    end
+  end
+
+  context "when then file fails to upload" do
+    before do
+      allow(s3_object_double)
+        .to receive(:put)
+        .with(body: file_content)
+        .and_return(nil)
+    end
+
+    it "raises an error" do
+      expected_error = "Failed to create sitemap file '#{file_name}'"
+
+      expect { uploader.upload(file_content:, file_name:).to raise_error(expected_error) }
+    end
+  end
+end


### PR DESCRIPTION
# What?
Add tests for Sitemap::Uploader

# Why?
Increases the test coverage for Sitemap::Uploader from 44% to 100%.

# Coverage report

## Before
<img width="755" height="45" alt="Screenshot 2025-11-17 at 11 43 25" src="https://github.com/user-attachments/assets/0bc4f74c-6264-4365-ac71-2a0023510a35" />

## After
<img width="755" height="45" alt="Screenshot 2025-11-17 at 11 44 42" src="https://github.com/user-attachments/assets/c96addab-8058-4e13-8b82-612ab3cc8833" />
