### PR TITLE
Update docs to include a link to the Elasticsearch replication script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Search API is a Sinatra application that interfaces with Elasticsearch.
 
 You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
+To replicate real data into your local development environment, use the [replicate-elasticsearch](https://docs.publishing.service.gov.uk/repos/govuk-docker/how-tos.html#how-to-replicate-data-locally) script provided by GOV.UK Docker.
+
 **Use GOV.UK Docker to run any commands that follow.**
 
 ### Running the test suite


### PR DESCRIPTION
https://gov-uk.atlassian.net/browse/SCH-1620