### PR TITLE
Refactor connectivity integration tests

### DIFF
--- a/spec/support/connectivity_test_helpers.rb
+++ b/spec/support/connectivity_test_helpers.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+module ConnectivityTestHelpers
+  def stub_connectivity_check
+    es_source = ENV["ELASTICSEARCH_URI"] || "http://localhost:9200"
+    stub_request(:get, "#{es_source}/_cluster/health")
+      .to_return(
+        status: 200,
+        body: {
+          "cluster_name": "A",
+          "status": "green",
+          "timed_out": false,
+          "number_of_nodes": 1,
+          "number_of_data_nodes": 1,
+          "active_primary_shards": 1,
+          "active_shards": 1,
+          "relocating_shards": 0,
+          "initializing_shards": 0,
+          "unassigned_shards": 1,
+          "delayed_unassigned_shards": 0,
+          "number_of_pending_tasks": 0,
+          "number_of_in_flight_fetch": 0,
+          "task_max_waiting_in_queue_millis": 0,
+          "active_shards_percent_as_number": 50.0,
+        }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+  end
+
+  def stub_connectivity_fail_check
+    es_source = ENV["ELASTICSEARCH_URI"] || "http://localhost:9200"
+    stub_request(:get, "#{es_source}/_cluster/health")
+      .to_return(
+        status: 200,
+        body: "",
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+  end
+end


### PR DESCRIPTION
Increases test coverage for lib/healthcheck/elasticsearch_connectivity_check.rb to 96.88% - leaves one line of untested code.
<img width="924" height="113" alt="Screenshot 2025-12-03 at 16 05 54" src="https://github.com/user-attachments/assets/d02ebefd-25be-4f52-9a78-8184cee26a0c" />

Stub the requests to `_cluster/health` in a similar way to the stubbing used for diskspace check.

Previously although the tests were raising a Faraday Error it was raising with a message about incorrect number of arguments rather than not being able to connect to clusters.
