### PR TITLE
Add unit tests for publishing event message handler

### DIFF
--- a/lib/govuk_index.rb
+++ b/lib/govuk_index.rb
@@ -4,6 +4,4 @@ module GovukIndex
   class NotFoundError < StandardError; end
 
   class UnknownDocumentTypeError < StandardError; end
-
-  class NotIdentifiable < StandardError; end
 end

--- a/lib/govuk_index/publishing_event_message_handler.rb
+++ b/lib/govuk_index/publishing_event_message_handler.rb
@@ -79,11 +79,6 @@ module GovukIndex
         logger.info("#{routing_key} -> UNKNOWN #{identifier}")
       end
 
-    # Rescuing as we don't want to retry this class of error
-    rescue NotIdentifiable => e
-      return if DOCUMENT_TYPES_WITHOUT_BASE_PATH.include?(payload["document_type"])
-
-      GovukError.notify(e, extra: { message_body: payload })
       # Unpublishing messages for something that does not exist may have been
       # processed out of order so we don't want to notify errbit but just allow
       # the process to continue

--- a/lib/govuk_index/publishing_event_message_handler.rb
+++ b/lib/govuk_index/publishing_event_message_handler.rb
@@ -79,9 +79,9 @@ module GovukIndex
         logger.info("#{routing_key} -> UNKNOWN #{identifier}")
       end
 
-      # Unpublishing messages for something that does not exist may have been
-      # processed out of order so we don't want to notify errbit but just allow
-      # the process to continue
+    # Unpublishing messages for something that does not exist may have been
+    # processed out of order so we don't want to notify errbit but just allow
+    # the process to continue
     rescue NotFoundError
       logger.info("#{payload['base_path']} could not be found.")
       Services.statsd_client.increment("govuk_index.not-found-error")


### PR DESCRIPTION
Increases coverage of `GovukIndex::PublishingEventMessageHandler` to 100%.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1598