### PR TITLE
Add tests for missing metadata

### DIFF
--- a/lib/missing_metadata/fetcher.rb
+++ b/lib/missing_metadata/fetcher.rb
@@ -4,8 +4,9 @@ module MissingMetadata
     class MissingDocumentError < StandardError
     end
 
-    def initialize(publishing_api)
+    def initialize(publishing_api, logger = $stdout)
       @publishing_api = publishing_api
+      @logger = logger
     end
 
     def add_metadata(result)
@@ -26,7 +27,7 @@ module MissingMetadata
 
       content_id || raise(MissingDocumentError, "Failed to look up base path")
     rescue GdsApi::TimedOutException
-      puts "Publishing API timed out getting content_id... retrying"
+      logger.puts "Publishing API timed out getting content_id... retrying"
       sleep(1)
       retry
     end
@@ -43,13 +44,13 @@ module MissingMetadata
         content_id:,
       )
     rescue GdsApi::TimedOutException
-      puts "Publishing API timed out getting content... retrying"
+      logger.puts "Publishing API timed out getting content... retrying"
       sleep(1)
       retry
     end
 
   private
 
-    attr_reader :publishing_api
+    attr_reader :publishing_api, :logger
   end
 end

--- a/lib/missing_metadata/fetcher.rb
+++ b/lib/missing_metadata/fetcher.rb
@@ -35,13 +35,17 @@ module MissingMetadata
     def update_metadata(content_id, index_name, document_id)
       response = publishing_api.get_content(content_id)
 
+      updates = {
+        "content_store_document_type" => response["document_type"],
+        "publishing_app" => response["publishing_app"],
+        "rendering_app" => response["rendering_app"],
+        "content_id" => content_id,
+      }
+
       Indexer::AmendJob.perform_async(
         index_name,
         document_id,
-        content_store_document_type: response["document_type"],
-        publishing_app: response["publishing_app"],
-        rendering_app: response["rendering_app"],
-        content_id:,
+        updates,
       )
     rescue GdsApi::TimedOutException
       logger.puts "Publishing API timed out getting content... retrying"

--- a/lib/missing_metadata/fetcher.rb
+++ b/lib/missing_metadata/fetcher.rb
@@ -28,7 +28,7 @@ module MissingMetadata
       content_id || raise(MissingDocumentError, "Failed to look up base path")
     rescue GdsApi::TimedOutException
       logger.puts "Publishing API timed out getting content_id... retrying"
-      sleep(1)
+      Kernel.sleep(1)
       retry
     end
 
@@ -45,7 +45,7 @@ module MissingMetadata
       )
     rescue GdsApi::TimedOutException
       logger.puts "Publishing API timed out getting content... retrying"
-      sleep(1)
+      Kernel.sleep(1)
       retry
     end
 

--- a/lib/missing_metadata/runner.rb
+++ b/lib/missing_metadata/runner.rb
@@ -7,8 +7,8 @@ module MissingMetadata
       @missing_field_name = missing_field_name
       @search_config = search_config
       publishing_api = Services.publishing_api
-      @fetcher = MissingMetadata::Fetcher.new(publishing_api)
       @logger = logger
+      @fetcher = MissingMetadata::Fetcher.new(publishing_api, logger)
     end
 
     def update
@@ -22,7 +22,7 @@ module MissingMetadata
         begin
           @fetcher.add_metadata(result)
         rescue StandardError
-          puts "Skipped result #{result[:elasticsearch_type]}/#{result[:_id]}: #{$ERROR_INFO}"
+          logger.puts "Skipped result #{result[:elasticsearch_type]}/#{result[:_id]}: #{$ERROR_INFO}"
         end
       end
     end

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe "MissingMetadataTest" do
       expect([{ _id: "/path/to_page", index: "government_test" }]).to eq results
     end
 
+    it "ignores external links" do
+      commit_document(
+        "government_test",
+        {
+          "link" => "https://www.nhs.uk",
+        },
+      )
+
+      runner = MissingMetadata::Runner.new("content_id", search_config: SearchConfig.default_instance, logger: io)
+      results = runner.retrieve_records_with_missing_value
+
+      expect(results).to be_empty
+    end
+
     it "ignores already set content_id" do
       commit_document(
         "government_test",
@@ -60,6 +74,134 @@ RSpec.describe "MissingMetadataTest" do
       results = runner.retrieve_records_with_missing_value
 
       expect(results).to be_empty
+    end
+  end
+
+  describe "#update" do
+    context "when add metadata returns an error" do
+      it "logs a message and skips the result" do
+        commit_document(
+          "government_test",
+          {
+            "link" => "/path/to_page",
+          },
+        )
+        allow_any_instance_of(MissingMetadata::Fetcher).to receive(:add_metadata).and_raise(StandardError)
+
+        MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io).update
+
+        expect(io.string).to include("Skipped result //path/to_page: StandardError")
+      end
+    end
+
+    context "when fetcher adds meta data" do
+      before do
+        @base_path = "/path/to_page"
+        @content_id = "8aea1742-9cc6-4dfb-a63b-12c3e66a601f"
+        @publishing_content_item = {
+          content_id: @content_id,
+          document_type: "edition",
+          publishing_app: "publisher",
+          rendering_app: "frontend",
+        }
+        @updated_content_item = {
+          "content_id" => @content_id,
+          "content_store_document_type" => "edition",
+          "publishing_app" => "publisher",
+          "rendering_app" => "frontend",
+        }
+        @get_content_id_url = "#{::GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_ENDPOINT}/lookup-by-base-path"
+        @get_content_url = "#{::GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}/content/#{@content_id}"
+
+        stub_publishing_api_has_expanded_links({ content_id: @content_id }, with_drafts: false)
+      end
+
+      context "when content_id is available" do
+        it "gets content from publishing api and updates document" do
+          commit_document(
+            "government_test",
+            {
+              "link" => @base_path,
+              "content_id" => @content_id,
+            },
+          )
+          stub_publishing_api_has_item(@publishing_content_item)
+
+          MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io).update
+
+          expect(a_request(:get, @get_content_url)).to have_been_made.once
+          expect_document_is_in_rummager(@updated_content_item, index: "government_test", id: @base_path)
+        end
+      end
+
+      context "when fetch content times out" do
+        it "sleeps for 1 second and retries, until content is returned" do
+          commit_document(
+            "government_test",
+            {
+              "link" => @base_path,
+              "content_id" => @content_id,
+            },
+          )
+          allow(Kernel).to receive(:sleep).and_return(true)
+          stub_request(:get, @get_content_url).with(query: hash_including({}))
+            .to_timeout
+            .then
+            .to_return(status: 200, body: @publishing_content_item.to_json, headers: {})
+
+          MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io).update
+
+          expect(a_request(:get, @get_content_url)).to have_been_made.twice
+          expect(Kernel).to have_received(:sleep).with(1).exactly(1).times
+          expect(io.string).to include("Publishing API timed out getting content... retrying")
+          expect_document_is_in_rummager(@updated_content_item, index: "government_test", id: @base_path)
+        end
+      end
+
+      context "when content_id is not available" do
+        it "gets content id and content from publishing api and updates document" do
+          commit_document(
+            "government_test",
+            {
+              "link" => @base_path,
+            },
+          )
+          stub_publishing_api_has_lookups(@base_path => @content_id)
+          stub_publishing_api_has_item(@publishing_content_item)
+
+          MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io).update
+
+          expect(a_request(:post, @get_content_id_url)).to have_been_made.once
+          expect(a_request(:get, @get_content_url)).to have_been_made.once
+          expect_document_is_in_rummager(@updated_content_item, index: "government_test", id: @base_path)
+        end
+      end
+
+      context "when fetch content_id times out" do
+        it "sleeps for 1 second and retries, until content_id is returned" do
+          commit_document(
+            "government_test",
+            {
+              "link" => @base_path,
+            },
+          )
+          allow(Kernel).to receive(:sleep).and_return(true)
+          lookup_hash = { @base_path => @content_id }
+          stub_request(:post, @get_content_id_url)
+                .to_timeout
+                .then
+                .to_return(body: lookup_hash.to_json)
+          stub_publishing_api_has_item(@publishing_content_item)
+
+          MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io).update
+
+          expect(a_request(:post, @get_content_id_url)).to have_been_made.twice
+          expect(a_request(:get, @get_content_url)).to have_been_made.once
+          expect(Kernel).to have_received(:sleep).with(1).exactly(1).times
+          expect(io.string).to include("Publishing API timed out getting content_id... retrying")
+          expect_document_is_in_rummager(@updated_content_item, index: "government_test", id: @base_path)
+        end
+      end
     end
   end
 

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -1,64 +1,66 @@
 require "spec_helper"
 
 RSpec.describe "MissingMetadataTest" do
-  it "finds missing content_id" do
-    commit_document(
-      "government_test",
-      {
-        "link" => "/path/to_page",
-      },
-    )
+  describe "#retrieve_records_with_missing_value" do
+    it "finds missing content_id" do
+      commit_document(
+        "government_test",
+        {
+          "link" => "/path/to_page",
+        },
+      )
 
-    runner = MissingMetadata::Runner.new("content_id", search_config: SearchConfig.default_instance, logger: io)
-    results = runner.retrieve_records_with_missing_value
+      runner = MissingMetadata::Runner.new("content_id", search_config: SearchConfig.default_instance, logger: io)
+      results = runner.retrieve_records_with_missing_value
 
-    expect([{ _id: "/path/to_page", index: "government_test" }]).to eq results
-  end
+      expect([{ _id: "/path/to_page", index: "government_test" }]).to eq results
+    end
 
-  it "ignores already set content_id" do
-    commit_document(
-      "government_test",
-      {
-        "link" => "/path/to_page",
-        "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
-      },
-    )
+    it "ignores already set content_id" do
+      commit_document(
+        "government_test",
+        {
+          "link" => "/path/to_page",
+          "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
+        },
+      )
 
-    runner = MissingMetadata::Runner.new("content_id", search_config: SearchConfig.default_instance, logger: io)
-    results = runner.retrieve_records_with_missing_value
+      runner = MissingMetadata::Runner.new("content_id", search_config: SearchConfig.default_instance, logger: io)
+      results = runner.retrieve_records_with_missing_value
 
-    expect(results).to be_empty
-  end
+      expect(results).to be_empty
+    end
 
-  it "finds missing document_type" do
-    commit_document(
-      "government_test",
-      {
-        "link" => "/path/to_page",
-        "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
-      },
-    )
+    it "finds missing document_type" do
+      commit_document(
+        "government_test",
+        {
+          "link" => "/path/to_page",
+          "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
+        },
+      )
 
-    runner = MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io)
-    results = runner.retrieve_records_with_missing_value
+      runner = MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io)
+      results = runner.retrieve_records_with_missing_value
 
-    expect([{ _id: "/path/to_page", index: "government_test", content_id: "8aea1742-9cc6-4dfb-a63b-12c3e66a601f" }]).to eq results
-  end
+      expect([{ _id: "/path/to_page", index: "government_test", content_id: "8aea1742-9cc6-4dfb-a63b-12c3e66a601f" }]).to eq results
+    end
 
-  it "ignores already set document_type" do
-    commit_document(
-      "government_test",
-      {
-        "link" => "/path/to_page",
-        "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
-        "content_store_document_type" => "guide",
-      },
-    )
+    it "ignores already set document_type" do
+      commit_document(
+        "government_test",
+        {
+          "link" => "/path/to_page",
+          "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
+          "content_store_document_type" => "guide",
+        },
+      )
 
-    runner = MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io)
-    results = runner.retrieve_records_with_missing_value
+      runner = MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io)
+      results = runner.retrieve_records_with_missing_value
 
-    expect(results).to be_empty
+      expect(results).to be_empty
+    end
   end
 
   def io


### PR DESCRIPTION
Adds testing for:

- lib/missing_metadata/fetcher.rb: 37.04 % -> 100%
- lib/missing_metadata/runner.rb: 75.00 % -> 100%

Increases overall test coverage to 96.09% 🥳 

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1598

I've added some context on the existing tests so they're easier to follow, but it does mean there are lots of formatting changes in this PR. I've split up the commits so that the first one is formatting/context changes and the rest are functional changes, so I'd recommend reviewing this PR by looking at individual commits separately.