### PR TITLE
Add tests to cover rummager/app.rb

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -75,10 +75,6 @@ class Rummager < Sinatra::Application
     @index_name ||= params["index"]
   end
 
-  def text_error(content)
-    halt 403, { "Content-Type" => "text/plain" }, content
-  end
-
   def json_only
     unless [nil, "json"].include? params[:request_format]
       expires 86_400, :public

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -318,7 +318,7 @@ class Rummager < Sinatra::Application
   end
 
   def serve_from_s3(key)
-    o = Aws::S3::Object.new(bucket_name: ENV["AWS_S3_SITEMAPS_BUCKET_NAME"], key:)
+    o = Services.s3_client.get_object(bucket: ENV["AWS_S3_SITEMAPS_BUCKET_NAME"], key:)
 
     headers "Content-Type" => "application/xml",
             "Cache-Control" => "public",
@@ -326,9 +326,9 @@ class Rummager < Sinatra::Application
             "Last-Modified" => o.last_modified.httpdate
 
     stream do |out|
-      o.get.body.each { |chunk| out << chunk }
+      o.body.each { |chunk| out << chunk }
     end
-  rescue Aws::S3::Errors::NotFound
+  rescue Aws::S3::Errors::NoSuchKey
     halt(404, "No such object")
   end
 

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -16,6 +16,10 @@ module Services
     )
   end
 
+  def self.s3_client
+    Aws::S3::Client.new
+  end
+
   # Build a client to connect to one or more elasticsearch nodes.
   # hosts should be a comma separated string. Valid formats
   # are documented at http://www.rubydoc.info/gems/elasticsearch-transport#Setting_Hosts

--- a/spec/integration/app/error_handling_spec.rb
+++ b/spec/integration/app/error_handling_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+
+RSpec.describe "ErrorHandlingTest" do
+  RSpec.shared_examples "a sinatra error handler" do |exception_class:, status:, body:|
+    it "returns #{status} for #{exception_class}" do
+      allow(SearchConfig).to receive(:run_search)
+                               .and_raise(exception_class.new("error"))
+
+      get "/search"
+
+      expect(last_response.status).to eq(status)
+
+      if body.respond_to?(:call)
+        expect(last_response.body).to eq(body.call("error"))
+      else
+        expect(last_response.body).to eq(body)
+      end
+    end
+  end
+
+  RSpec.shared_examples "blocks default mainstream index usage" do |http_method:, path:|
+    it "#{http_method.upcase} #{path} raises AttemptToUseDefaultMainstreamIndex" do
+      expect(GovukError).to receive(:notify)
+                              .with(
+                                instance_of(Rummager::AttemptToUseDefaultMainstreamIndex),
+                                extra: hash_including(:params),
+                              )
+
+      send(http_method, path)
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to be_present
+    end
+  end
+
+  include_examples(
+    "a sinatra error handler",
+    exception_class: Index::ResponseValidator::NotFound,
+    status: 404,
+    body: ->(msg) { msg },
+  )
+
+  include_examples(
+    "a sinatra error handler",
+    exception_class: Elasticsearch::Transport::Transport::Errors::RequestTimeout,
+    status: 503,
+    body: "Elasticsearch timed out",
+  )
+
+  include_examples(
+    "a sinatra error handler",
+    exception_class: Elasticsearch::Transport::Transport::SnifferTimeoutError,
+    status: 503,
+    body: "Elasticsearch timed out",
+  )
+
+  include_examples(
+    "a sinatra error handler",
+    exception_class: RedisClient::TimeoutError,
+    status: 503,
+    body: "Redis queue timed out",
+  )
+
+  include_examples(
+    "a sinatra error handler",
+    exception_class: Indexer::BulkIndexFailure,
+    status: 500,
+    body: ->(msg) { msg },
+  )
+
+  include_examples(
+    "a sinatra error handler",
+    exception_class: Search::Query::Error,
+    status: 400,
+    body: ->(msg) { msg },
+  )
+
+  [
+    [:delete, "/documents"],
+    [:post,   "/documents/123"],
+    [:delete, "/documents/123"],
+    [:post,   "/commit"],
+    [:post,   "/documents"],
+  ].each do |http_method, path|
+    include_examples(
+      "blocks default mainstream index usage",
+      http_method:,
+      path:,
+    )
+  end
+
+  it "notifies GovukError with the exception and params" do
+    error = Index::ResponseValidator::ElasticsearchError.new("error")
+
+    expect(GovukError).to receive(:notify).with(
+      error,
+      extra: hash_including(:params),
+    )
+
+    allow(SearchConfig).to receive(:run_search).and_raise(error)
+
+    get "/search", foo: "bar"
+
+    expect(last_response.status).to eq(500)
+  end
+end

--- a/spec/integration/app/healthcheck_spec.rb
+++ b/spec/integration/app/healthcheck_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe "HealthcheckTest" do
     stub_diskspace_check
   end
 
+  describe "live check" do
+    it "returns an OK status" do
+      get "/healthcheck/live"
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers["Content-Type"]).to eq("text/plain")
+      expect(last_response.body).to eq("OK")
+    end
+  end
+
   describe "#redis_connectivity check" do
     # We only check for cannot connect because govuk_app_config has tests for this
     context "when Sidekiq CANNOT connect to Redis" do

--- a/spec/integration/app/sitemap_spec.rb
+++ b/spec/integration/app/sitemap_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+require "spec/support/diskspace_test_helpers"
+require "spec/support/connectivity_test_helpers"
+
+RSpec.describe "SitemapTest" do
+  let(:bucket) { "test-bucket" }
+  let(:body_content) do
+    <<~XML
+      <urlset>
+        <url><loc>https://example.com/</loc></url>
+        <url><loc>https://example.com/about</loc></url>
+      </urlset>
+    XML
+  end
+  describe "get /sitemap.xml" do
+    it "streams the sitemap XML from S3" do
+      ClimateControl.modify AWS_S3_SITEMAPS_BUCKET_NAME: bucket do
+        allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
+        Services.s3_client.put_object(key: "sitemap.xml",
+                                      bucket:,
+                                      body: body_content)
+        get "/sitemap.xml"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.headers["Content-Type"]).to eq("application/xml")
+        expect(last_response.headers["Cache-Control"]).to eq("public")
+        expect(last_response.headers["Last-Modified"]).to eq(FakeS3::LAST_MODIFIED.httpdate)
+        expect(last_response.body).to eq(body_content)
+      end
+    end
+  end
+  describe "get /sitemaps/:sitemap" do
+    it "streams the sitemap XML from S3" do
+      ClimateControl.modify AWS_S3_SITEMAPS_BUCKET_NAME: bucket do
+        allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
+        Services.s3_client.put_object(key: "something.xml",
+                                      bucket:,
+                                      body: body_content)
+        get "/sitemaps/something.xml"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.headers["Content-Type"]).to eq("application/xml")
+        expect(last_response.headers["Cache-Control"]).to eq("public")
+        expect(last_response.headers["Last-Modified"]).to eq(FakeS3::LAST_MODIFIED.httpdate)
+        expect(last_response.body).to eq(body_content)
+      end
+    end
+    it "cannot find the sitemap" do
+      ClimateControl.modify AWS_S3_SITEMAPS_BUCKET_NAME: bucket do
+        allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
+        get "/sitemaps/something.xml"
+
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to eq("No such object")
+      end
+    end
+  end
+end

--- a/spec/integration/indexer/amendment_spec.rb
+++ b/spec/integration/indexer/amendment_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "ElasticsearchAmendmentTest" do
     stub_tagging_lookup
   end
 
+  it_behaves_like "govuk index protection", "/govuk/documents/%2Fan-example-answer", method: :post
+
   it "amends a document" do
     commit_document(
       "government_test",

--- a/spec/integration/indexer/commit_spec.rb
+++ b/spec/integration/indexer/commit_spec.rb
@@ -1,0 +1,7 @@
+require "spec_helper"
+
+RSpec.describe "Commit" do
+  describe "post /:index/commit" do
+    it_behaves_like "govuk index protection", "/govuk/commit", method: :post
+  end
+end

--- a/spec/integration/indexer/commit_spec.rb
+++ b/spec/integration/indexer/commit_spec.rb
@@ -3,5 +3,6 @@ require "spec_helper"
 RSpec.describe "Commit" do
   describe "post /:index/commit" do
     it_behaves_like "govuk index protection", "/govuk/commit", method: :post
+    it_behaves_like "rejects unknown index", "/unknown_index/commit", method: :post
   end
 end

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -1,63 +1,70 @@
 require "spec_helper"
 
 RSpec.describe "ElasticsearchDeletionTest" do
-  it "removes a document from the index" do
-    commit_document(
-      "government_test",
-      {
-        "link" => "/an-example-page",
-      },
-    )
+  describe "delete /:index/documents/*" do
+    it_behaves_like "govuk index protection", "/govuk/documents/%2Fan-example-page", method: :delete
 
-    delete "/government_test/documents/%2Fan-example-page"
-
-    expect_document_missing_in_rummager(id: "/an-example-page", index: "government_test")
-  end
-
-  it "removes a document from the index queued" do
-    commit_document(
-      "government_test",
-      {
-        "link" => "/an-example-page",
-      },
-    )
-
-    delete "/government_test/documents/%2Fan-example-page"
-
-    expect(last_response.status).to eq(202)
-  end
-
-  it "removes document with url" do
-    commit_document(
-      "government_test",
-      {
-        "link" => "http://example.com/",
-      },
-    )
-
-    delete "/government_test/documents/edition/http:%2F%2Fexample.com%2F"
-
-    expect_document_missing_in_rummager(id: "http://example.com/", index: "government_test")
-  end
-
-  it "deletes a best bet by type and id" do
-    post "/metasearch_test/documents",
-         {
-           "_id" => "jobs_exact",
-           "_type" => "best_bet",
-           "link" => "/something",
-         }.to_json
-
-    commit_index("government_test")
-
-    delete "/metasearch_test/documents/best_bet/jobs_exact"
-
-    expect {
-      client.get(
-        index: "metasearch_test",
-        type: "best_bet",
-        id: "jobs_exact",
+    it "removes a document from the index" do
+      commit_document(
+        "government_test",
+        {
+          "link" => "/an-example-page",
+        },
       )
-    }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+
+      delete "/government_test/documents/%2Fan-example-page"
+
+      expect_document_missing_in_rummager(id: "/an-example-page", index: "government_test")
+    end
+
+    it "removes a document from the index queued" do
+      commit_document(
+        "government_test",
+        {
+          "link" => "/an-example-page",
+        },
+      )
+
+      delete "/government_test/documents/%2Fan-example-page"
+
+      expect(last_response.status).to eq(202)
+    end
+
+    it "removes document with url" do
+      commit_document(
+        "government_test",
+        {
+          "link" => "http://example.com/",
+        },
+      )
+
+      delete "/government_test/documents/edition/http:%2F%2Fexample.com%2F"
+
+      expect_document_missing_in_rummager(id: "http://example.com/", index: "government_test")
+    end
+
+    it "deletes a best bet by type and id" do
+      post "/metasearch_test/documents",
+           {
+             "_id" => "jobs_exact",
+             "_type" => "best_bet",
+             "link" => "/something",
+           }.to_json
+
+      commit_index("government_test")
+
+      delete "/metasearch_test/documents/best_bet/jobs_exact"
+
+      expect {
+        client.get(
+          index: "metasearch_test",
+          type: "best_bet",
+          id: "jobs_exact",
+        )
+      }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
+  end
+  describe "delete /:index/documents" do
+    it_behaves_like "govuk index protection", "/govuk/documents", method: :delete
   end
 end

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "ElasticsearchDeletionTest" do
              "link" => "/something",
            }.to_json
 
-      commit_index("government_test")
+      commit_index("metasearch_test")
 
       delete "/metasearch_test/documents/best_bet/jobs_exact"
 

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 RSpec.describe "ElasticsearchDeletionTest" do
   describe "delete /:index/documents/*" do
     it_behaves_like "govuk index protection", "/govuk/documents/%2Fan-example-page", method: :delete
+    it_behaves_like "rejects unknown index", "/unknown/documents/%2Fan-example-page", method: :delete
 
     it "removes a document from the index" do
       commit_document(
@@ -66,5 +67,6 @@ RSpec.describe "ElasticsearchDeletionTest" do
   end
   describe "delete /:index/documents" do
     it_behaves_like "govuk index protection", "/govuk/documents", method: :delete
+    it_behaves_like "rejects unknown index", "/unknown_index/documents", method: :delete
   end
 end

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe "ElasticsearchDeletionTest" do
       expect_document_missing_in_rummager(id: "/an-example-page", index: "government_test")
     end
 
+    it "removes a document from the index, explicitly giving the type" do
+      commit_document(
+        "government_test",
+        { "link" => "/an-example-page" },
+        type: "generic-document",
+      )
+
+      delete "/government_test/documents/%2Fan-example-page",
+             { document_type: "generic-document" }.to_json,
+             { "CONTENT_TYPE" => "application/json" }
+
+      expect_document_missing_in_rummager(id: "/an-example-page", index: "government_test", type: "generic-document")
+    end
+
     it "removes a document from the index queued" do
       commit_document(
         "government_test",

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -66,6 +66,19 @@ RSpec.describe "ElasticsearchDeletionTest" do
     end
   end
   describe "delete /:index/documents" do
+    it "no longer supports the 'delete_all' option" do
+      delete "/government_test/documents", delete_all: true
+      expect(last_response.status).to eq(400)
+    end
+    it "removes a document from the index" do
+      commit_document("government_test", { "link" => "/an-example-page" })
+
+      delete "/government_test/documents", link: "/an-example-page"
+
+      expect_document_missing_in_rummager(id: "/an-example-page", index: "government_test")
+      expect(last_response.status).to eq(200)
+    end
+
     it_behaves_like "govuk index protection", "/govuk/documents", method: :delete
     it_behaves_like "rejects unknown index", "/unknown_index/documents", method: :delete
   end

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "ElasticsearchIndexingTest" do
     with_just_one_cluster
   end
 
+  it_behaves_like "govuk index protection", "/govuk/documents", method: :post
+
   it "adds a document to the search index" do
     stub_publishing_api_has_expanded_links(
       {

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "ElasticsearchIndexingTest" do
   end
 
   it_behaves_like "govuk index protection", "/govuk/documents", method: :post
+  it_behaves_like "rejects unknown index", "/unknown_index/documents", method: :post
 
   it "adds a document to the search index" do
     stub_publishing_api_has_expanded_links(

--- a/spec/integration/metasearch_index/v2_inserter_spec.rb
+++ b/spec/integration/metasearch_index/v2_inserter_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe "V2MetasearchTest" do
+  let(:id) { "ca3916" }
+  let(:document) do
+    {
+      "details" => %({"best_bets":[{"link":"/government/publications/national-insurance-statement-of-national-insurance-contributions-ca3916","position":1}],"worst_bets":[]}),
+      "exact_query" => "ca3916",
+      "stemmed_query" => nil,
+    }
+  end
+  describe "post /v2/metasearch/documents" do
+    it "inserts a new best bet" do
+      post "/v2/metasearch/documents", document.merge("_id" => id).to_json, { "CONTENT_TYPE" => "application/json" }
+      expect_document_is_in_rummager(document, type: "best_bet", index: SearchConfig.metasearch_index_name, id:)
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq({ result: "Success" }.to_json)
+    end
+  end
+
+  describe "delete /v2/metasearch/documents/:id" do
+    it "deletes a best bet" do
+      commit_document(SearchConfig.metasearch_index_name,
+                      document,
+                      type: "best_bet",
+                      id:)
+      delete "/v2/metasearch/documents/#{id}"
+      expect_document_missing_in_rummager(id: id, index: SearchConfig.metasearch_index_name)
+    end
+  end
+end

--- a/spec/integration/search/batch_search_spec.rb
+++ b/spec/integration/search/batch_search_spec.rb
@@ -6,6 +6,9 @@ RSpec.configure do |c|
 end
 
 RSpec.describe "BatchSearchTest" do
+  it_behaves_like "json-only endpoint", "/batch_search", "?search%5B%5D%5B0%5D%5Bq%5D=ministry+of+magic"
+  it_behaves_like "json-only endpoint", "/api/batch_search", "?search%5B%5D%5B0%5D%5Bq%5D=ministry+of+magic"
+
   it "can return multiple distinct results" do
     commit_ministry_of_magic_document
     commit_treatment_of_dragons_document

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -6,6 +6,9 @@ RSpec.configure do |c|
 end
 
 RSpec.describe "SearchTest" do
+  it_behaves_like "json-only endpoint", "/search", "?q=important"
+  it_behaves_like "json-only endpoint", "/api/search", "?q=important"
+
   it "returns success" do
     get "/search?q=important"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ Sidekiq.logger.level = Logger::WARN
 require "webmock/rspec"
 
 require "#{__dir__}/support/app_helpers"
+require "#{__dir__}/support/fake_s3"
 require "#{__dir__}/support/default_mappings"
 require "#{__dir__}/support/spec_helpers"
 require "#{__dir__}/support/schema_helpers"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ Sidekiq.logger.level = Logger::WARN
 
 require "webmock/rspec"
 
+require "#{__dir__}/support/app_helpers"
 require "#{__dir__}/support/default_mappings"
 require "#{__dir__}/support/spec_helpers"
 require "#{__dir__}/support/schema_helpers"

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+module AppHelpers
+  RSpec.shared_examples "govuk index protection" do |path, method: :post|
+    let(:error_message) do
+      "Actions to govuk index are not allowed via this endpoint, please use the message queue to update this index"
+    end
+
+    context "when index_name is govuk" do
+      it "halts with 403 and the correct message" do
+        send(method, path, {}.to_json)
+
+        expect(last_response.status).to eq(403)
+        expect(last_response.body).to eq(error_message)
+      end
+    end
+
+    context "when index_name is not govuk" do
+      it "allows the request to continue" do
+        send(method, path.gsub("/govuk/", "/government_test/"), {}.to_json)
+        expect(last_response.status).not_to eq(403)
+      end
+    end
+  end
+end

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 module AppHelpers
+  RSpec.shared_examples "rejects unknown index" do |path, method: :post|
+    it "returns 404 if the index does not exist" do
+      send(method, path, {}.to_json)
+
+      expect(last_response.status).to eq(404)
+    end
+  end
+
   RSpec.shared_examples "govuk index protection" do |path, method: :post|
     let(:error_message) do
       "Actions to govuk index are not allowed via this endpoint, please use the message queue to update this index"

--- a/spec/support/fake_s3.rb
+++ b/spec/support/fake_s3.rb
@@ -1,0 +1,31 @@
+module FakeS3
+  LAST_MODIFIED = Time.utc(2025, 12, 13, 17, 30, 0).freeze
+
+  def self.fake_s3_client
+    fake_s3 = {}
+    Aws::S3::Client.new(stub_responses: true).tap do |client|
+      client.stub_responses(
+        :put_object, lambda { |context|
+                       bucket = context.params[:bucket]
+                       key = context.params[:key]
+                       body = context.params[:body]
+                       fake_s3[bucket] ||= {}
+                       fake_s3[bucket][key] = {
+                         body: body,
+                         last_modified: LAST_MODIFIED,
+                       }
+                       {}
+                     }
+      )
+      client.stub_responses(
+        :get_object, lambda { |context|
+                       bucket = context.params[:bucket]
+                       key = context.params[:key]
+                       object = fake_s3.dig(bucket, key)
+
+                       object.nil? ? "NoSuchKey" : object
+                     }
+      )
+    end
+  end
+end

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -175,10 +175,10 @@ module IntegrationSpecHelper
     end
   end
 
-  def expect_document_missing_in_rummager(id:, index:)
+  def expect_document_missing_in_rummager(id:, index:, type: "_all")
     clusters.each do |cluster|
       expect {
-        fetch_document_from_rummager(id:, index:, cluster:)
+        fetch_document_from_rummager(id:, index:, cluster:, type:)
       }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
     end
   end


### PR DESCRIPTION
This PR is split into small commits, each covering a specific piece of previously untested functionality.

Additional changes include:
•	A small refactor to the S3 file–fetching logic to make it easier to test
•	Introduction of a fake S3 module to simplify S3-related tests

<img width="797" height="87" alt="image" src="https://github.com/user-attachments/assets/cefd1dde-c786-4915-a7e9-2ca40629705d" />


Jira: https://gov-uk.atlassian.net/browse/SCH-1598