### PR TITLE
Limit GA4 path length before indexing into Elasticsearch

### DIFF
--- a/lib/analytics/ga4_import/page_view_consolidator.rb
+++ b/lib/analytics/ga4_import/page_view_consolidator.rb
@@ -1,6 +1,8 @@
 module Analytics
   module Ga4Import
     class PageViewConsolidator
+      MAX_PATH_LENGTH = 512
+
       def initialize(ga_data)
         @ga_data = ga_data
       end
@@ -8,6 +10,7 @@ module Analytics
       def consolidated_page_views
         ga_data
           .reject(&:excluded?)
+          .reject { |page_data| page_data.path.bytesize >= MAX_PATH_LENGTH }
           .group_by(&:normalised_path)
           .transform_values { |grouped_pages| grouped_pages.sum(&:page_views) }
           .sort_by { |_, views| -views }

--- a/spec/unit/analytics/ga4_import/page_view_consolidator_spec.rb
+++ b/spec/unit/analytics/ga4_import/page_view_consolidator_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 RSpec.describe Analytics::Ga4Import::PageViewConsolidator do
+  let(:really_long_path) { "/#{'a'.b * (Analytics::Ga4Import::PageViewConsolidator::MAX_PATH_LENGTH - 1)}" }
+
   let(:ga_data) do
     [
       Analytics::Ga4Import::PageData.new("/example1", "Title", 10),
@@ -13,6 +15,7 @@ RSpec.describe Analytics::Ga4Import::PageViewConsolidator do
       Analytics::Ga4Import::PageData.new("/example3/y/blah", "Smart Answer", 1000),
       Analytics::Ga4Import::PageData.new("http://example.com/example99", "Title", 10),
       Analytics::Ga4Import::PageData.new("/not-real-path", "Page not found - GOV.UK", 99),
+      Analytics::Ga4Import::PageData.new(really_long_path, "Path is too long", 10),
     ]
   end
 
@@ -41,6 +44,10 @@ RSpec.describe Analytics::Ga4Import::PageViewConsolidator do
 
     it "combines page views for page data that normalises to the same path" do
       expect(consolidator.consolidated_page_views).to include(["/example4/blah", 100])
+    end
+
+    it "removes paths longer than MAX_PATH_LENGTH bytes" do
+      expect(consolidator.consolidated_page_views).not_to include([really_long_path, 10])
     end
   end
 end


### PR DESCRIPTION
We have been seeing a large number of errors from Sidekiq::GovukIndex::PageTrafficJob. The root cause is malformed data retrieved from GA4, which the job attempts to index into Elasticsearch.

Elasticsearch rejects these documents because the base_path field exceeds its 512-byte limit.

GOV.UK paths should never be this long, so values exceeding 512 bytes can be safely treated as invalid. This change filters out those paths before indexing.

https://gov-uk.atlassian.net/browse/SCH-1663