### PR TITLE
Add security-analysis job to ci.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
     name: Lint Ruby
     uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
 
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
   test-ruby:
     name: Test Ruby
     uses: ./.github/workflows/rspec.yml

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "warden"
 gem "warden-oauth2"
 
 group :development, :test do
+  gem "brakeman", require: false
   gem "pry-byebug"
   gem "rubocop-govuk", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
     bigdecimal (3.3.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
+    brakeman (7.1.1)
+      racc
     builder (3.3.0)
     bunny (2.24.0)
       amq-protocol (~> 2.3)
@@ -692,6 +694,7 @@ DEPENDENCIES
   activesupport
   aws-sdk-s3
   bootsnap
+  brakeman
   bunny-mock
   climate_control
   elasticsearch (~> 6)

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+require "rubygems"
+require "bundler/setup"
+
+ARGV.unshift("--ensure-latest")
+
+load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
The security-analysis job is present in the ci.yml workflows for search-api-v2 and for search-api-v2-beta-features. Adding it to the ci.yml workflow for this repo too for parity.