### PR TITLE
Add github-actions package-ecosystem to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: ruby
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
We are currently only checking for version updates for `bundler` and `docker`, but we do use some github actions directly (e.g. actions/checkout) and so should also be checking for updates from `github-actions` packages. I've set these checks to be `daily`, to match the frequency for `bundler`.