### PR TITLE
Mark organisation document type as migrated to the govuk index [WHIT-1799]

### DIFF
--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -354,6 +354,7 @@ migrated:
 - open_call_for_evidence
 - open_consultation
 - oral_statement
+- organisation
 - our_energy_use
 - our_governance
 - personal_information_charter
@@ -381,8 +382,7 @@ migrated:
 - worldwide_organisation
 - written_statement
 
-indexable:
-- organisation
+indexable: []
 
 non_indexable_path:
 - '/help/cookie-details'

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -27,7 +27,7 @@ module Search
 
     def organisations
       BaseRegistry.new(
-        index,
+        govuk_index,
         field_definitions,
         "organisation",
         %w[

--- a/spec/integration/search/batch_search_spec.rb
+++ b/spec/integration/search/batch_search_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe "BatchSearchTest" do
 
   it "expands organisations" do
     commit_treatment_of_dragons_document({ "organisations" => ["/ministry-of-magic"] })
-    commit_ministry_of_magic_document({ "format" => "organisation" })
+    commit_ministry_of_magic_document({ "format" => "organisation", "index" => "govuk_test" })
     get build_get_url([{ q: "dragons" }, { q: "ministry of magic" }])
     results = parsed_response["results"]
     expect(results[0]["results"][0]["organisations"]).to eq(
@@ -312,7 +312,7 @@ RSpec.describe "BatchSearchTest" do
 
   it "expands organisations via content_id" do
     commit_treatment_of_dragons_document({ "organisation_content_ids" => %w[organisation-content-id] })
-    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation" })
+    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation", "index" => "govuk_test" })
 
     get build_get_url([{ q: "dragons" }, { q: "ministry of magic" }])
     results = parsed_response["results"]
@@ -331,7 +331,7 @@ RSpec.describe "BatchSearchTest" do
 
   it "search for expanded organisations works" do
     commit_treatment_of_dragons_document({ "organisation_content_ids" => %w[organisation-content-id] })
-    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation" })
+    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation", "index" => "govuk_test" })
 
     get build_get_url([{ q: "dragons", fields: %w[expanded_organisations] }, { q: "ministry of magic" }])
     results = parsed_response["results"]
@@ -342,7 +342,7 @@ RSpec.describe "BatchSearchTest" do
 
   it "filter by organisation content_ids works" do
     commit_treatment_of_dragons_document({ "organisation_content_ids" => %w[organisation-content-id] })
-    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation" })
+    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation", "index" => "govuk_test" })
 
     get build_get_url([{ filter_organisation_content_ids: "organisation-content-id" }, { q: "ministry of magic" }])
     results = parsed_response["results"]

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe "SearchTest" do
 
   it "expands organisations" do
     commit_treatment_of_dragons_document({ "organisations" => ["/ministry-of-magic"] })
-    commit_ministry_of_magic_document({ "format" => "organisation" })
+    commit_ministry_of_magic_document({ "format" => "organisation", "index" => "govuk_test" })
 
     get "/search.json?q=dragons"
 
@@ -414,7 +414,7 @@ RSpec.describe "SearchTest" do
 
   it "also works with the /api prefix" do
     commit_treatment_of_dragons_document({ "organisations" => ["/ministry-of-magic"] })
-    commit_ministry_of_magic_document({ "format" => "organisation" })
+    commit_ministry_of_magic_document({ "format" => "organisation", "index" => "govuk_test" })
 
     get "/api/search.json?q=dragons"
 
@@ -427,7 +427,7 @@ RSpec.describe "SearchTest" do
 
   it "expands organisations via content_id" do
     commit_treatment_of_dragons_document({ "organisation_content_ids" => %w[organisation-content-id] })
-    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation" })
+    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation", "index" => "govuk_test" })
 
     get "/search.json?q=dragons"
 
@@ -444,7 +444,7 @@ RSpec.describe "SearchTest" do
 
   it "search for expanded organisations works" do
     commit_treatment_of_dragons_document({ "organisation_content_ids" => %w[organisation-content-id] })
-    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation" })
+    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation", "index" => "govuk_test" })
 
     get "/search.json?q=dragons&fields[]=expanded_organisations"
 
@@ -453,7 +453,7 @@ RSpec.describe "SearchTest" do
 
   it "filter by organisation content_ids works" do
     commit_treatment_of_dragons_document({ "organisation_content_ids" => %w[organisation-content-id] })
-    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation" })
+    commit_ministry_of_magic_document({ "content_id" => "organisation-content-id", "format" => "organisation", "index" => "govuk_test" })
 
     get "/search.json?filter_organisation_content_ids[]=organisation-content-id"
 


### PR DESCRIPTION
The data for all organisations has been successfully indexed within the `govuk` index, so it's time to switch over Search API to return it's results for organisations from there.

This also requires us to use the `govuk` index for entity expansion when presenting results. This change required making sure that the test organisation document for the search spec is present in the govuk index. However, doing this across the test suite caused a number of unrelated tests to fail, so we have overriding the test setup on a case-by-case basis.

JIRA: https://gov-uk.atlassian.net/browse/WHIT-1799