### PR TITLE
Remove courts and tribunals path segment from organisation slugs [WHIT-1799]

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -48,7 +48,7 @@ module GovukIndex
       when "ministerial_role"
         base_path.gsub(%r{^/government/ministers/}, "")
       when "organisation"
-        base_path.gsub(%r{^/government/organisations/}, "")
+        base_path.gsub(%r{^/government/organisations/}, "").gsub(%r{^/courts-tribunals/}, "")
       when "person"
         base_path.gsub(%r{^/government/people/}, "")
       when "policy"

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -260,6 +260,16 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     expect(presenter.slug).to eq "organisation-slug"
   end
 
+  it "extracts the slug from the base path for a court organisation document" do
+    payload = {
+      "base_path" => "/courts-tribunals/organisation-slug",
+      "document_type" => "organisation",
+    }
+    presenter = common_fields_presenter(payload)
+
+    expect(presenter.slug).to eq "organisation-slug"
+  end
+
   def common_fields_presenter(payload)
     described_class.new(payload)
   end


### PR DESCRIPTION
This is necessary because courts and tribunals on GOV.UK are at a different path to other organisation types.

Without this change, Search API is unable to expand the organisation links, causing Organisations API to experience a server error

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-1799)