### PR TITLE
[SCH-1679] Setup pact tests with gds-api-adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmp/*
 /data
 /log
 search_check_results.csv
+spec/reports/pacts

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "warden"
 gem "warden-oauth2"
 
 group :development, :test do
+  gem "pact", require: false
+  gem "pact_broker-client"
   gem "pry-byebug"
   gem "rubocop-govuk", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     amq-protocol (2.3.3)
     ast (2.4.3)
+    awesome_print (1.9.2)
     aws-eventstream (1.4.0)
     aws-partitions (1.1195.0)
     aws-sdk-core (3.240.0)
@@ -76,6 +77,7 @@ GEM
     date (3.5.1)
     declarative (0.0.20)
     diff-lcs (1.6.2)
+    dig_rb (1.0.1)
     docile (1.4.0)
     domain_name (0.6.20240107)
     drb (2.2.3)
@@ -89,6 +91,8 @@ GEM
       multi_json
     erb (6.0.1)
     erubi (1.13.1)
+    expgen (0.1.1)
+      parslet
     faraday (1.10.4)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -113,6 +117,7 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.15.5)
+    find_a_port (1.0.1)
     gapic-common (1.2.0)
       faraday (>= 1.9, < 3.a)
       faraday-retry (>= 1.0, < 3.a)
@@ -238,6 +243,8 @@ GEM
     json-schema (6.0.0)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
+    jsonpath (1.1.5)
+      multi_json
     jwt (3.1.2)
       base64
     kgio (2.11.4)
@@ -268,6 +275,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
+    mize (0.6.1)
     mr-sparkle (0.3.0)
       listen (~> 1.0)
       rb-fsevent (>= 0.9)
@@ -473,10 +481,50 @@ GEM
       opentelemetry-api (~> 1.0)
     os (1.1.4)
     ostruct (0.6.3)
+    pact (1.67.3)
+      jsonpath (~> 1.0)
+      pact-mock_service (~> 3.0, >= 3.3.1)
+      pact-support (~> 1.21, >= 1.21.2)
+      rack
+      rack-proxy
+      rack-test (>= 0.6.3, < 3.0.0)
+      rainbow (~> 3.1)
+      rspec (~> 3.0)
+      string_pattern (~> 2.0)
+      thor (>= 0.20, < 2.0)
+      webrick (~> 1.8)
+      zeitwerk (~> 2.3)
+    pact-mock_service (3.12.4)
+      find_a_port (~> 1.0.1)
+      json
+      logger (< 2.0)
+      pact-support (~> 1.16, >= 1.16.4)
+      rack (>= 3.0, < 4.0)
+      rackup (~> 2.0)
+      rspec (>= 2.14)
+      thor (>= 0.19, < 2.0)
+      webrick (~> 1.8)
+    pact-support (1.21.2)
+      awesome_print (~> 1.9)
+      diff-lcs (~> 1.5)
+      expgen (~> 0.1)
+      jsonpath (~> 1.0)
+      rainbow (~> 3.1.1)
+      string_pattern (~> 2.0)
+    pact_broker-client (1.77.0)
+      base64 (~> 0.2)
+      dig_rb (~> 1.0)
+      httparty (>= 0.21.0, < 1.0.0)
+      ostruct
+      rake (~> 13.0)
+      table_print (~> 1.5)
+      term-ansicolor (~> 1.7)
+      thor (>= 0.20, < 2.0)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    parslet (2.0.0)
     plek (5.2.2)
     pp (0.6.3)
       prettyprint
@@ -543,6 +591,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    readline (0.0.4)
+      reline
     redis-client (0.26.2)
       connection_pool
     regexp_parser (2.11.2)
@@ -656,10 +706,21 @@ GEM
       rbtree
       set (~> 1.0)
     statsd-ruby (1.5.0)
+    string_pattern (2.3.0)
+      regexp_parser (~> 2.5, >= 2.5.0)
     stringio (3.2.0)
+    sync (0.5.0)
+    table_print (1.5.7)
+    term-ansicolor (1.11.3)
+      tins (~> 1)
     thor (1.5.0)
     tilt (2.6.1)
     timecop (0.9.10)
+    tins (1.51.0)
+      bigdecimal
+      mize (~> 0.6)
+      readline
+      sync
     trailblazer-option (0.1.2)
     tsort (0.2.0)
     tzinfo (2.0.6)
@@ -713,6 +774,8 @@ DEPENDENCIES
   nokogiri
   oauth2
   oj
+  pact
+  pact_broker-client
   plek
   pry-byebug
   rack

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ To replicate real data into your local development environment, use the [replica
 bundle exec rake
 ```
 
+### Pact tests
+
+Search API has a pact with [GDS API Adapters](https://github.com/alphagov/gds-api-adapters).
+
+See the [guidance on Pact testing](https://docs.publishing.service.gov.uk/manual/pact-testing.html) for how to run and modify the tests.
+
+Note that when you run the tests locally logs are output to `log/production.log` rather than to the console.
+
 ### Additional Docs
 
 - [Search API documentation](docs/using-the-search-api.md)

--- a/Rakefile
+++ b/Rakefile
@@ -12,13 +12,14 @@ Dir[File.join(PROJECT_ROOT, "lib/tasks/**/*.rake")].each { |file| load file }
 
 # rubocop:disable Lint/SuppressedException
 begin
+  require "pact/tasks"
   require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:spec)
 rescue LoadError
 end
 # rubocop:enable Lint/SuppressedException
 
-task default: %i[lint spec]
+task default: %i[lint spec pact:verify]
 
 def logger
   Logging.logger.root

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -1,0 +1,63 @@
+ENV["PACT_DO_NOT_TRACK"] = "true"
+ENV["RACK_ENV"] = "test"
+
+require "pact/provider/rspec"
+require "webmock/rspec"
+require "gds_api"
+
+require_relative "../../spec/support/index_helpers"
+require_relative "../../spec/support/integration_test_helper"
+
+Pact.configure do |config|
+  config.reports_dir = "spec/reports/pacts"
+  config.include WebMock::API
+  config.include WebMock::Matchers
+  config.include IntegrationTestHelper
+end
+
+def pact_broker_base_url
+  "https://govuk-pact-broker-6991351eca05.herokuapp.com"
+end
+
+Pact.service_provider "Search API" do
+  include ERB::Util
+
+  honours_pact_with "GDS API Adapters" do
+    if ENV["PACT_URI"]
+      pact_uri(ENV["PACT_URI"])
+    else
+      path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
+      version_modifier = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-main'))}"
+      pact_uri("#{pact_broker_base_url}/#{path}/#{version_modifier}")
+    end
+  end
+end
+
+Pact.provider_states_for "GDS API Adapters" do
+  set_up do
+    WebMock.enable!
+    WebMock.reset!
+    IntegrationTestHelper.allow_elasticsearch_connection_to_test(pact_broker_base_url)
+    IndexHelpers.setup_test_indexes
+  end
+
+  tear_down do
+    IndexHelpers.clean_all
+    WebMock.disable!
+  end
+
+  provider_state "there are search results for universal credit" do
+    set_up do
+      document_params = {
+        "title" => "Universal credit",
+        "link" => "/universal-credit",
+      }
+      second_document_params = {
+        "title" => "Universal credit too",
+        "link" => "/universal-credit-too",
+      }
+      commit_document("government_test", document_params)
+      commit_document("government_test", second_document_params)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,8 @@ require "#{__dir__}/support/fake_s3"
 require "#{__dir__}/support/default_mappings"
 require "#{__dir__}/support/spec_helpers"
 require "#{__dir__}/support/schema_helpers"
-require "#{__dir__}/support/integration_spec_helper"
+require "#{__dir__}/support/integration_test_helper"
+require "#{__dir__}/support/integration_spec_setup_helper"
 require "#{__dir__}/support/index_helpers"
 require "#{__dir__}/support/retryable_queue_examples"
 
@@ -51,7 +52,8 @@ RSpec.configure do |config|
   config.include SpecHelpers
   config.include SchemaHelpers
 
-  config.include IntegrationSpecHelper, tags: :integration
+  config.include IntegrationTestHelper, tags: :integration
+  config.include IntegrationSpecSetupHelper, tags: :integration
   config.include Rack::Test::Methods, tags: :integration
 
   config.expect_with :rspec do |expectations|

--- a/spec/support/integration_spec_setup_helper.rb
+++ b/spec/support/integration_spec_setup_helper.rb
@@ -1,0 +1,43 @@
+require "spec/support/index_helpers"
+require "spec/support/integration_test_helper"
+
+module IntegrationSpecSetupHelper
+  def self.included(base)
+    base.around do |example|
+      IntegrationSpecSetupHelper.allow_connection_during_test do
+        example.run
+        # clean up after test run
+        IndexHelpers.all_index_names.each do |index|
+          clean_index_content(index)
+        end
+      end
+    end
+
+    # we only want to setup the before suite code once, in addition this this we only want to
+    # set it up when we are running integration tests (hence the reason we do it here).
+    @included ||= setup_before_suite
+  end
+
+  def self.setup_before_suite
+    RSpec.configure do |config|
+      config.before(:suite) do
+        IntegrationSpecSetupHelper.allow_connection_during_test do
+          IndexHelpers.setup_test_indexes
+        end
+      end
+
+      config.after(:suite) do
+        IntegrationSpecSetupHelper.allow_connection_during_test do
+          IndexHelpers.clean_all
+        end
+      end
+    end
+  end
+
+  def self.allow_connection_during_test
+    IntegrationTestHelper.allow_elasticsearch_connection_to_test
+    yield
+  ensure
+    IntegrationTestHelper.disable_net_connections
+  end
+end


### PR DESCRIPTION
## What
This PR is the first step in adding contract tests with gds-api-adapters. See [Jira ticket SCH-1679](https://gov-uk.atlassian.net/browse/SCH-1679)

## Details
- The initial new pact is defined in this [PR](https://github.com/alphagov/gds-api-adapters/pull/1375) and has been published to [our pact broker](https://govuk-pact-broker-6991351eca05.herokuapp.com/).
- You can then verify this pact locally by running `env PACT_CONSUMER_VERSION=branch-search-api-pact-testing bundle exec rake pact:verify`.

## Next steps
- Add provider states for other Search API behaviours
- Add pact-verify.yml workflow - e.g. [collections/.github/workflows/pact-verify.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/pact-verify.yml)
