### PR TITLE
Retire the detailed index

### DIFF
--- a/bin/stats
+++ b/bin/stats
@@ -29,7 +29,7 @@ def words_without_punctuation(copy)
 end
 
 # The indexes which make up GOV.UK.
-index_names = %w[detailed government govuk]
+index_names = %w[government govuk]
 search_server = SearchConfig.default_instance.search_server
 indices = index_names.map { |name| search_server.index(name) }
 

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -19,7 +19,7 @@ documents are added to the search indexes -->
 	[config/schema/elasticsearch_types](config/schema/elasticsearch_types)
 - **Index**: An [elasticsearch search
 	index](https://www.elastic.co/blog/what-is-an-elasticsearch-index). Search API
-	maintains several separate indices (`detailed`, `government` and `govuk`),
+	maintains separate indices (`government` and `govuk`),
 	but searches return documents from all of them.
 - **Index Group**: An alias in elasticsearch that points to one index at a
 	time. This allows us to rebuild indexes without downtime.
@@ -43,7 +43,7 @@ still requires Sidekiq to be running.
 
 	bundle exec rake message_queue:insert_data_into_govuk
 
-There is also a separate process that listens to only 'links' updates from the publishing API. This is used for updating old indexes that are populated through the '/documents' API (`government`, `detailed`) and can be removed once those indexes no longer exist.
+There is also a separate process that listens to only 'links' updates from the publishing API. This is used for updating old indexes that are populated through the '/documents' API (`government`) and can be removed once those indexes no longer exist.
 
 	bundle exec rake message_queue:listen_to_publishing_queue
 

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,6 +1,6 @@
 production: &default
   base_uri: <%= ENV["ELASTICSEARCH_URI"] || 'http://localhost:9200' %>
-  content_index_names: ["detailed", "government"]
+  content_index_names: ["government"]
   govuk_index_name: "govuk"
   auxiliary_index_names: ["page-traffic", "metasearch"]
   registry_index: "government"

--- a/lib/analytics/export_pages_to_google_analytics.rb
+++ b/lib/analytics/export_pages_to_google_analytics.rb
@@ -4,7 +4,7 @@ require "analytics/load"
 
 module Analytics
   def self.export_pages_to_google_analytics
-    all_content_search_indices = %w[detailed government govuk].freeze
+    all_content_search_indices = %w[government govuk].freeze
     data = Extract.new(all_content_search_indices)
     csv = Transform.to_csv(data)
     Load.upload_csv_to_google_analytics(csv)

--- a/lib/debug/rank_eval.rb
+++ b/lib/debug/rank_eval.rb
@@ -106,15 +106,9 @@ module Debug
     end
 
     def index_for_link(link)
-      return detailed_index_name if link.start_with? "/guidance/"
-
       return government_index_name if link.start_with? "/government/"
 
       govuk_index_name
-    end
-
-    def detailed_index_name
-      @detailed_index_name ||= @search_config.get_index_for_alias("detailed")
     end
 
     def government_index_name

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -11,6 +11,7 @@ module Search
 
     def initialize(registries:, content_index:, metasearch_index:, spelling_index:)
       @index = content_index
+
       @registries = registries
       @metasearch_index = metasearch_index
       @spelling_index = spelling_index

--- a/lib/tasks/delete_detailed_index.rake
+++ b/lib/tasks/delete_detailed_index.rake
@@ -1,0 +1,13 @@
+require "rummager"
+desc "Delete the detailed index"
+task :delete_detailed_index do
+  client = Services.elasticsearch
+
+  indices = client.indices.get_alias(name: "detailed").keys
+
+  puts "Deleting indices: #{indices.join(', ')}"
+
+  client.indices.delete(index: indices)
+rescue Elasticsearch::Transport::Transport::Errors::NotFound
+  puts "No detailed index found"
+end

--- a/spec/integration/delete_detailed_index_spec.rb
+++ b/spec/integration/delete_detailed_index_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+require "rake"
+load "tasks/delete_detailed_index.rake"
+
+RSpec.describe "delete_detailed_index rake task", :integration do
+  let(:es_client) do
+    Services.elasticsearch
+  end
+
+  let(:alias_name) { "detailed" }
+  let(:index_name) { "detailed-test-1" }
+
+  before do
+    reset_indices!
+
+    es_client.indices.create(index: index_name)
+    es_client.indices.put_alias(index: index_name, name: alias_name)
+  end
+
+  after do
+    reset_indices!
+  end
+
+  def run_task
+    Rake::Task["delete_detailed_index"].reenable
+    Rake::Task["delete_detailed_index"].invoke
+  end
+
+  def indices_for_alias
+    es_client.indices.get_alias(name: alias_name).keys
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    []
+  end
+
+  def reset_indices!
+    es_client.indices.delete(index: indices_for_alias) if indices_for_alias.any?
+  end
+
+  it "deletes all indices behind the alias" do
+    expect {
+      run_task
+    }.to change {
+      es_client.indices.exists?(index: index_name)
+    }.from(true).to(false)
+  end
+end

--- a/spec/integration/indexer/amendment_spec.rb
+++ b/spec/integration/indexer/amendment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "ElasticsearchAmendmentTest" do
     stub_tagging_lookup
   end
 
-  it_behaves_like "govuk index protection", "/govuk/documents/%2Fan-example-answer", method: :post
+  it_behaves_like "govuk and detailed index protection", "/:index/documents/%2Fan-example-answer", method: :post
 
   it "amends a document" do
     commit_document(

--- a/spec/integration/indexer/commit_spec.rb
+++ b/spec/integration/indexer/commit_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Commit" do
   describe "post /:index/commit" do
-    it_behaves_like "govuk index protection", "/govuk/commit", method: :post
+    it_behaves_like "govuk and detailed index protection", "/:index/commit", method: :post
     it_behaves_like "rejects unknown index", "/unknown_index/commit", method: :post
   end
 end

--- a/spec/integration/indexer/deletion_spec.rb
+++ b/spec/integration/indexer/deletion_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe "ElasticsearchDeletionTest" do
   describe "delete /:index/documents/*" do
-    it_behaves_like "govuk index protection", "/govuk/documents/%2Fan-example-page", method: :delete
+    it_behaves_like "govuk and detailed index protection", "/:index/documents/%2Fan-example-page", method: :delete
     it_behaves_like "rejects unknown index", "/unknown/documents/%2Fan-example-page", method: :delete
 
     it "removes a document from the index" do
@@ -93,7 +93,7 @@ RSpec.describe "ElasticsearchDeletionTest" do
       expect(last_response.status).to eq(200)
     end
 
-    it_behaves_like "govuk index protection", "/govuk/documents", method: :delete
+    it_behaves_like "govuk and detailed index protection", "/:index/documents", method: :delete
     it_behaves_like "rejects unknown index", "/unknown_index/documents", method: :delete
   end
 end

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "ElasticsearchIndexingTest" do
     with_just_one_cluster
   end
 
-  it_behaves_like "govuk index protection", "/govuk/documents", method: :post
+  it_behaves_like "govuk and detailed index protection", "/:index/documents", method: :post
   it_behaves_like "rejects unknown index", "/unknown_index/documents", method: :post
 
   it "adds a document to the search index" do

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -42,23 +42,32 @@ module AppHelpers
     end
   end
 
-  RSpec.shared_examples "govuk index protection" do |path, method: :post|
+  RSpec.shared_examples "govuk and detailed index protection" do |path, method: :post|
     let(:error_message) do
-      "Actions to govuk index are not allowed via this endpoint, please use the message queue to update this index"
+      "Actions to the govuk or detailed indices are not allowed via this endpoint."
     end
 
     context "when index_name is govuk" do
       it "halts with 403 and the correct message" do
-        send(method, path, {}.to_json)
+        send(method, path.gsub(":index", "govuk"), {}.to_json)
 
         expect(last_response.status).to eq(403)
         expect(last_response.body).to eq(error_message)
       end
     end
 
-    context "when index_name is not govuk" do
+    context "when index_name is detailed" do
+      it "halts with 403 and the correct message" do
+        send(method, path.gsub(":index", "detailed"), {}.to_json)
+
+        expect(last_response.status).to eq(403)
+        expect(last_response.body).to eq(error_message)
+      end
+    end
+
+    context "when index_name is not govuk or detailed" do
       it "allows the request to continue" do
-        send(method, path.gsub("/govuk/", "/government_test/"), {}.to_json)
+        send(method, path.gsub(":index", "government_test"), {}.to_json)
         expect(last_response.status).not_to eq(403)
       end
     end


### PR DESCRIPTION
  The detailed index was previously used to store ‘detailed-guidance’ documents,
  which are now called ‘detailed-guide’. These document types are now handled
  by the govuk index and so the detailed index can be removed

- Remove references to the detailed index
- Add error messaging if the detailed index is being referenced
- Add a rake task to remove the index from Elasticsearch

Jira: https://gov-uk.atlassian.net/browse/SCH-1692