### PR TITLE
Ensure rake tasks are included in the coverage report

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,13 @@ ENV["RACK_ENV"] = "test"
 require "pry"
 
 require "simplecov"
-SimpleCov.start { add_filter "/spec/" }
+SimpleCov.start do
+  add_filter "/spec/"
+  add_filter "/config/"
+  add_filter "/env.rb"
+  track_files "{lib}/**/*.rb"
+  track_files "{lib}/**/*.rake"
+end
 
 $LOAD_PATH << File.expand_path("..", __dir__)
 $LOAD_PATH << File.expand_path("../lib", __dir__)
@@ -42,6 +48,8 @@ require "#{__dir__}/support/index_helpers"
 require "#{__dir__}/support/retryable_queue_examples"
 
 require "gds_api/test_helpers/publishing_api"
+
+Dir.glob(File.join(__dir__, "../lib/tasks/**/*.rake")).each { |file| load file }
 
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/spec/integration/}) do |metadata|

--- a/spec/unit/tasks/duplicates_spec.rb
+++ b/spec/unit/tasks/duplicates_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
 require "rake"
-load "tasks/duplicates.rake"
 
 RSpec.describe "duplicates", "RakeTest" do
   let(:fake_duplicates) do

--- a/spec/unit/tasks/indices_spec.rb
+++ b/spec/unit/tasks/indices_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
 require "rake"
-load "tasks/indices.rake"
 
 RSpec.describe "indices" do
   let(:elasticsearch_client) { double("Elasticsearch::Client") }

--- a/spec/unit/tasks/message_queue_spec.rb
+++ b/spec/unit/tasks/message_queue_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
 require "rake"
-load "tasks/message_queue.rake"
 
 RSpec.describe Indexer::MessageProcessor, "RakeTest" do
   describe "message_queue:listen_to_publishing_queue" do


### PR DESCRIPTION
  Ensure all relevant files are included in the coverage report

  - track all ruby and rake files
  - load all rake tasks before the test suite startsa
  - remove 'load' commands from rake spec files to avoid double loading

There are 15 rake files and 160 ruby files.
```
find ./lib -type f -name "*.rake" | wc -l   => 14
find ./lib -type f -name "*.rb" | wc -l    => 156
```

The coverage report now correctly shows 170 files: 


<img width="641" height="125" alt="image" src="https://github.com/user-attachments/assets/859bc83f-a1ab-4e5f-b5cc-60ec36dad082" />

