### PR TITLE
Set show_summaries to true for hmrc manuals finder.

### DIFF
--- a/config/finders/hmrc_manuals_finder.yml
+++ b/config/finders/hmrc_manuals_finder.yml
@@ -51,7 +51,7 @@ details:
     - key: public_timestamp
       name: Updated (oldest)
   document_noun: result
-  show_summaries: false
+  show_summaries: true
   show_metadata_block: true
   show_table_of_contents: true
   default_documents_per_page: 50


### PR DESCRIPTION
This displays the description of a document under each result in the hmrc_manuals_finder.

**Before**: 
<img width="986" height="797" alt="image" src="https://github.com/user-attachments/assets/fa00b43c-3d9e-4a41-9451-2cc139a8b8f0" />

**After**:
<img width="989" height="849" alt="image" src="https://github.com/user-attachments/assets/1f526b0d-1cba-4737-95f2-e518f1d7fa67" />

Jira: https://gov-uk.atlassian.net/browse/SCH-1705