### PR TITLE
Add topical event fields

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -53,6 +53,8 @@ module GovukIndex
         base_path.gsub(%r{^/government/people/}, "")
       when "policy"
         base_path.gsub(%r{^/government/policies/}, "")
+      when "topical_event"
+        base_path.gsub(%r{^/government/topical-events/}, "")
       end
     end
 

--- a/lib/govuk_index/presenters/details_presenter.rb
+++ b/lib/govuk_index/presenters/details_presenter.rb
@@ -51,11 +51,11 @@ module GovukIndex
     end
 
     def start_date
-      details["opening_date"]
+      details["start_date"] or details["opening_date"]
     end
 
     def end_date
-      details["closing_date"]
+      details["end_date"] or details["closing_date"]
     end
 
     def has_official_document?

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -270,6 +270,16 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     expect(presenter.slug).to eq "organisation-slug"
   end
 
+  it "extracts the slug from the base path for a topical event document" do
+    payload = {
+      "base_path" => "/government/topical-events/event-slug",
+      "document_type" => "topical_event",
+    }
+    presenter = common_fields_presenter(payload)
+
+    expect(presenter.slug).to eq "event-slug"
+  end
+
   def common_fields_presenter(payload)
     described_class.new(payload)
   end

--- a/spec/unit/govuk_index/presenters/details_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/details_presenter_spec.rb
@@ -310,4 +310,37 @@ RSpec.describe GovukIndex::DetailsPresenter do
       expect(presented_details.closed_at).to eq("2024-06-01T00:00:00.000+01:00")
     end
   end
+
+  context "any format" do
+    let(:format) { "any" }
+    context "it has a start and an end date" do
+      let(:details) do
+        {
+          "start_date" => "2024-06-01T00:00:00.000+01:00",
+          "end_date" => "2024-06-02T00:00:00.000+01:00",
+          "opening_date" => "2024-06-03T00:00:00.000+01:00",
+          "closing_date" => "2024-06-04T00:00:00.000+01:00",
+        }
+      end
+
+      it("presents the start and end date values") do
+        expect(presented_details.start_date).to eq("2024-06-01T00:00:00.000+01:00")
+        expect(presented_details.end_date).to eq("2024-06-02T00:00:00.000+01:00")
+      end
+    end
+
+    context "it has an opening and a closing date" do
+      let(:details) do
+        {
+          "opening_date" => "2024-06-01T00:00:00.000+01:00",
+          "closing_date" => "2024-06-02T00:00:00.000+01:00",
+        }
+      end
+
+      it("presents the start and end date values") do
+        expect(presented_details.start_date).to eq("2024-06-01T00:00:00.000+01:00")
+        expect(presented_details.end_date).to eq("2024-06-02T00:00:00.000+01:00")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Enable the govuk indexing process to extract the slug, start and end date fields from the Publishing API payload for topical events. We reuse the existing Elasticsearch field definitions instead of declaring new fields specifically for topical events.