### PR TITLE
Corrections to document mapping config for some Whitehall document types

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -45,7 +45,6 @@ export_health_certificate: export_health_certificate # Specialist Publisher
 external_content: edition # Search Admin
 farming_grant: farming_grant # Specialist Publisher
 fatality_notice: edition
-field_of_operation: edition # Whitehall Operational Field https://github.com/alphagov/whitehall/blob/main/app/models/operational_field.rb
 finder: edition # Specialist Publisher
 flood_and_coastal_erosion_risk_management_research_report: flood_and_coastal_erosion_risk_management_research_report # Specialist Publisher
 foi_release: edition
@@ -79,13 +78,12 @@ membership: edition
 ministerial_role: edition
 modern_slavery_statement: edition
 national_statistics: edition
-national_statistics_announcement: edition # Whitehall Statistics Announcement https://github.com/alphagov/whitehall/blob/main/app/models/statistics_announcement.rb
 news_story: edition
 notice: edition
 official_statistics: edition
-official_statistics_announcement: edition # Whitehall Statistics Announcement https://github.com/alphagov/whitehall/blob/main/app/models/statistics_announcement.rb
 open_call_for_evidence: edition
 open_consultation: edition
+operational_field: edition # Whitehall Operational Field https://github.com/alphagov/whitehall/blob/main/app/models/operational_field.rb
 oral_statement: edition # Whitehall
 organisation: edition # Whitehall
 our_energy_use: edition
@@ -95,6 +93,7 @@ personal_information_charter: edition
 petitions_and_campaigns: edition
 place: edition
 policy: policy # Policy Publisher
+policy_group: edition # Whitehall policy group https://github.com/alphagov/whitehall/blob/main/app/models/policy_group.rb
 policy_paper: edition
 press_release: edition
 procurement: edition
@@ -124,6 +123,7 @@ staff_update: edition
 standard: edition
 statistical_data_set: edition
 statistics: edition
+statistics_announcement: edition # Whitehall Statistics Announcement https://github.com/alphagov/whitehall/blob/main/app/models/statistics_announcement.rb
 statutory_guidance: edition
 statutory_instrument: statutory_instrument # Specialist Publisher
 step_by_step_nav: edition
@@ -143,7 +143,6 @@ ukhsa_data_access_approval: ukhsa_data_access_approval # Specialist Publisher
 utaac_decision: utaac_decision # Specialist Publisher
 veterans_support_organisation: veterans_support_organisation #Specialist Publisher
 welsh_language_scheme: edition
-working_group: edition # Whitehall policy group https://github.com/alphagov/whitehall/blob/main/app/models/policy_group.rb
 world_news_story: edition
 world_location_news: edition # Whitehall World Location News https://github.com/alphagov/whitehall/blob/main/app/models/world_location_news.rb
 worldwide_organisation: edition


### PR DESCRIPTION
I previously believed that the keys for these configuration values should match the `document_type` attribute in the Publishing API payload, but in fact Search API requires that they should match the format configured in the `migrated_formats.yml` configuration for the `govuk` index.