### PR TITLE
Map Whitehall document types to Search API format

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -3,8 +3,12 @@ module GovukIndex
     CUSTOM_FORMAT_MAP = {
       "esi_fund" => "european_structural_investment_fund",
       "external_content" => "recommended-link",
+      "field_of_operation" => "operational_field",
+      "national_statistics_announcement" => "statistics_announcement",
+      "official_statistics_announcement" => "statistics_announcement",
       "service_manual_homepage" => "service_manual_guide",
       "service_manual_service_standard" => "service_manual_guide",
+      "working_group" => "policy_group",
     }.freeze
 
     extend MethodBuilder


### PR DESCRIPTION
The `document_type` value in the Publishing API payload differs from the Search API format. Mapping the two via the common fields presenter enables indexing of these types in the GOVUK index.

_This isn't currently covered by a unit test and I haven't added one because the format method only does a trivial hash lookup, but happy to add one if desired._ - edit: there is a test, I missed it