### PR TITLE
Add operational field indexable content mapping

### DIFF
--- a/lib/govuk_index/presenters/indexable_content_presenter.rb
+++ b/lib/govuk_index/presenters/indexable_content_presenter.rb
@@ -6,6 +6,7 @@ module GovukIndex
       "document_collection" => %w[collection_groups],
       "licence" => %w[licence_short_description licence_overview],
       "local_transaction" => %w[introduction more_information need_to_know],
+      "operational_field" => %w[description],
       "transaction" => %w[introductory_paragraph more_information],
       "travel_advice" => %w[summary],
       "flood_and_coastal_erosion_risk_management_research_report" => %w[metadata.project_code],

--- a/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/indexable_content_presenter_spec.rb
@@ -155,4 +155,17 @@ RSpec.describe GovukIndex::IndexableContentPresenter do
       expect(subject.indexable_content).to eq("hidden 1\n\n\nhidden 2")
     end
   end
+
+  context "operational_field format" do
+    let(:format) { "operational_field" }
+    let(:details) do
+      {
+        "description" => "<div class=\"govspeak\"><p>Test content.</p></div>",
+      }
+    end
+
+    it "description is indexed" do
+      expect(subject.indexable_content).to eq("Test content.")
+    end
+  end
 end


### PR DESCRIPTION
In the government index, operational field documents have an `indexable_content` field which contains the description which is sent directly to Search API from Whitehall. Once we migrate operational fields to the govuk index, we need to make sure this value can be populated from the Publishing API payload description.