### PR TITLE
Sitemap request validation

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -317,6 +317,12 @@ class Rummager < Sinatra::Application
     serve_from_s3(sitemap)
   end
 
+  post "/sitemaps/*" do
+    headers = { "Allow" => "GET" }
+    body = { message: "Method Not Allowed: Use GET to access the sitemap." }.to_json
+    halt(405, headers, body)
+  end
+
   def serve_from_s3(key)
     o = Services.s3_client.get_object(bucket: ENV["AWS_S3_SITEMAPS_BUCKET_NAME"], key:)
 

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -210,6 +210,10 @@ class Rummager < Sinatra::Application
     serve_from_s3("#{sitemap}.xml")
   end
 
+  post %r{/sitemap} do
+    halt 404
+  end
+
   def serve_from_s3(key)
     o = Services.s3_client.get_object(bucket: ENV["AWS_S3_SITEMAPS_BUCKET_NAME"], key:)
 

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -78,7 +78,7 @@ class Rummager < Sinatra::Application
   end
 
   def xml_only(request_format)
-    halt 404 if request_format != "xml"
+    halt 404 unless ["xml", nil].include? request_format
   end
 
   helpers do
@@ -199,12 +199,13 @@ class Rummager < Sinatra::Application
     ).call
   end
 
-  get %r{/sitemap\.(\w+)} do |request_format|
+  get %r{/sitemap(?:\.(\w+))?} do |request_format|
     xml_only(request_format)
     serve_from_s3("sitemap.xml")
   end
 
-  get %r{/sitemaps/(\w+)\.(\w+)} do |sitemap, request_format|
+  # matches /sitemaps/sitemap_1.xml and /sitemaps/sitemap_1
+  get %r{/sitemaps/(\w+)(?:\.(\w+))?} do |sitemap, request_format|
     xml_only(request_format)
     serve_from_s3("#{sitemap}.xml")
   end

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -77,6 +77,10 @@ class Rummager < Sinatra::Application
     end
   end
 
+  def xml_only(request_format)
+    halt 404 if request_format != "xml"
+  end
+
   helpers do
     include Helpers
   end
@@ -195,12 +199,14 @@ class Rummager < Sinatra::Application
     ).call
   end
 
-  get "/sitemap.xml" do
+  get %r{/sitemap\.(\w+)} do |request_format|
+    xml_only(request_format)
     serve_from_s3("sitemap.xml")
   end
 
-  get "/sitemaps/:sitemap" do |sitemap|
-    serve_from_s3(sitemap)
+  get %r{/sitemaps/(\w+)\.(\w+)} do |sitemap, request_format|
+    xml_only(request_format)
+    serve_from_s3("#{sitemap}.xml")
   end
 
   def serve_from_s3(key)

--- a/spec/integration/app/sitemap_spec.rb
+++ b/spec/integration/app/sitemap_spec.rb
@@ -55,4 +55,13 @@ RSpec.describe "SitemapTest" do
       end
     end
   end
+
+  describe "post /sitemaps/*" do
+    it "returns a 405 error message" do
+      post "/sitemaps/server/anything/stuff.php"
+      expect(last_response.status).to eq(405)
+      expect(last_response.headers["Allow"]).to eq("GET")
+      expect(last_response.body).to eq({ message: "Method Not Allowed: Use GET to access the sitemap." }.to_json)
+    end
+  end
 end

--- a/spec/integration/app/sitemap_spec.rb
+++ b/spec/integration/app/sitemap_spec.rb
@@ -1,5 +1,12 @@
 require "spec_helper"
 
+RSpec.shared_examples "will respond with a 404 unless the request is for an xml format" do |path|
+  it "get requests are halted" do
+    get path
+    expect(last_response.status).to eq(404)
+  end
+end
+
 RSpec.describe "SitemapTest" do
   let(:bucket) { "test-bucket" }
   let(:body_content) do
@@ -11,6 +18,9 @@ RSpec.describe "SitemapTest" do
     XML
   end
   describe "get /sitemap.xml" do
+    it_behaves_like "will respond with a 404 unless the request is for an xml format", "/sitemap.php"
+    it_behaves_like "will respond with a 404 unless the request is for an xml format", "/sitemap"
+
     it "streams the sitemap XML from S3" do
       ClimateControl.modify AWS_S3_SITEMAPS_BUCKET_NAME: bucket do
         allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
@@ -27,13 +37,17 @@ RSpec.describe "SitemapTest" do
       end
     end
   end
-  describe "get /sitemaps/:sitemap" do
+  describe "get /sitemaps/:sitemap.xml" do
+    it_behaves_like "will respond with a 404 unless the request is for an xml format", "/sitemaps/something.php"
+    it_behaves_like "will respond with a 404 unless the request is for an xml format", "/sitemaps/something"
+
     it "streams the sitemap XML from S3" do
       ClimateControl.modify AWS_S3_SITEMAPS_BUCKET_NAME: bucket do
         allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
         Services.s3_client.put_object(key: "something.xml",
                                       bucket:,
                                       body: body_content)
+
         get "/sitemaps/something.xml"
 
         expect(last_response.status).to eq(200)

--- a/spec/integration/app/sitemap_spec.rb
+++ b/spec/integration/app/sitemap_spec.rb
@@ -69,4 +69,13 @@ RSpec.describe "SitemapTest" do
       end
     end
   end
+
+  describe "posting to a sitemap" do
+    it "returns a 404" do
+      ["/sitemap.xml", "/sitemaps/some/things", "/sitemap/foo.php"].each do |path|
+        post path
+        expect(last_response.status).to eq(404)
+      end
+    end
+  end
 end

--- a/spec/integration/app/sitemap_spec.rb
+++ b/spec/integration/app/sitemap_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.shared_examples "will respond with a 404 unless the request is for an xml format" do |path|
+RSpec.shared_examples "will respond with a 404 if formats other than xml are requested" do |path|
   it "get requests are halted" do
     get path
     expect(last_response.status).to eq(404)
@@ -17,9 +17,8 @@ RSpec.describe "SitemapTest" do
       </urlset>
     XML
   end
-  describe "get /sitemap.xml" do
-    it_behaves_like "will respond with a 404 unless the request is for an xml format", "/sitemap.php"
-    it_behaves_like "will respond with a 404 unless the request is for an xml format", "/sitemap"
+  describe "get /sitemap" do
+    it_behaves_like "will respond with a 404 if formats other than xml are requested", "/sitemap.php"
 
     it "streams the sitemap XML from S3" do
       ClimateControl.modify AWS_S3_SITEMAPS_BUCKET_NAME: bucket do
@@ -27,19 +26,20 @@ RSpec.describe "SitemapTest" do
         Services.s3_client.put_object(key: "sitemap.xml",
                                       bucket:,
                                       body: body_content)
-        get "/sitemap.xml"
-
-        expect(last_response.status).to eq(200)
-        expect(last_response.headers["Content-Type"]).to eq("application/xml")
-        expect(last_response.headers["Cache-Control"]).to eq("public")
-        expect(last_response.headers["Last-Modified"]).to eq(FakeS3::LAST_MODIFIED.httpdate)
-        expect(last_response.body).to eq(body_content)
+        ["/sitemap.xml", "/sitemap"].each do |path|
+          get path
+          expect(last_response.status).to eq(200)
+          expect(last_response.headers["Content-Type"]).to eq("application/xml")
+          expect(last_response.headers["Cache-Control"]).to eq("public")
+          expect(last_response.headers["Last-Modified"]).to eq(FakeS3::LAST_MODIFIED.httpdate)
+          expect(last_response.body).to eq(body_content)
+        end
       end
     end
   end
-  describe "get /sitemaps/:sitemap.xml" do
-    it_behaves_like "will respond with a 404 unless the request is for an xml format", "/sitemaps/something.php"
-    it_behaves_like "will respond with a 404 unless the request is for an xml format", "/sitemaps/something"
+
+  describe "get /sitemaps/:sitemap" do
+    it_behaves_like "will respond with a 404 if formats other than xml are requested", "/sitemaps/something.php"
 
     it "streams the sitemap XML from S3" do
       ClimateControl.modify AWS_S3_SITEMAPS_BUCKET_NAME: bucket do
@@ -48,15 +48,17 @@ RSpec.describe "SitemapTest" do
                                       bucket:,
                                       body: body_content)
 
-        get "/sitemaps/something.xml"
-
-        expect(last_response.status).to eq(200)
-        expect(last_response.headers["Content-Type"]).to eq("application/xml")
-        expect(last_response.headers["Cache-Control"]).to eq("public")
-        expect(last_response.headers["Last-Modified"]).to eq(FakeS3::LAST_MODIFIED.httpdate)
-        expect(last_response.body).to eq(body_content)
+        ["/sitemaps/something.xml", "/sitemaps/something"].each do |path|
+          get path
+          expect(last_response.status).to eq(200)
+          expect(last_response.headers["Content-Type"]).to eq("application/xml")
+          expect(last_response.headers["Cache-Control"]).to eq("public")
+          expect(last_response.headers["Last-Modified"]).to eq(FakeS3::LAST_MODIFIED.httpdate)
+          expect(last_response.body).to eq(body_content)
+        end
       end
     end
+
     it "cannot find the sitemap" do
       ClimateControl.modify AWS_S3_SITEMAPS_BUCKET_NAME: bucket do
         allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)


### PR DESCRIPTION
We get relatively frequent vulnerability scans to the sitemaps endpoint which is causing [sentry](https://govuk.sentry.io/issues/?environment=production&project=1461905&query=is%3Aunresolved%20sitemap&referrer=issue-list&sort=freq&statsPeriod=90d) noise.

🚧 WIP 

These are the errors:

:x: Sinatra::BadRequest 
:x: Aws::S3::Errors::BadRequest
:x: NoMethodError
:x: ArgumentError
:x: Aws::S3::Errors::NotFound



