### PR TITLE
Sch 1738 search api rake tasks delete unused and add tests for debug.rake

### DIFF
--- a/spec/integration/helpers/best_bet_helpers.rb
+++ b/spec/integration/helpers/best_bet_helpers.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+module BestBetIntegrationTestHelpers
+  def get_links(path)
+    get(path)
+    parsed_response["results"].map { |result| result["link"] }
+  end
+
+  def add_best_bet(args)
+    payload = build_sample_bet_hash(
+      query: args[:query],
+      type: args[:type],
+      best_bets: [args.slice(:link, :position)],
+      worst_bets: [],
+    )
+
+    post "/metasearch_test/documents", payload.to_json
+    commit_index("metasearch_test")
+  end
+
+  def add_worst_bet(args)
+    payload = build_sample_bet_hash(
+      query: args[:query],
+      type: args[:type],
+      best_bets: [],
+      worst_bets: [args.slice(:link, :position)],
+    )
+
+    post "/metasearch_test/documents", payload.to_json
+    commit_index("metasearch_test")
+  end
+
+  def build_sample_bet_hash(query:, type:, best_bets:, worst_bets:)
+    {
+      "#{type}_query" => query,
+      details: JSON.generate(
+        {
+          best_bets:,
+          worst_bets:,
+        },
+      ),
+      _type: "best_bet",
+      _id: "#{query}-#{type}",
+    }
+  end
+end

--- a/spec/integration/search/best_bets_spec.rb
+++ b/spec/integration/search/best_bets_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
+require_relative "../helpers/best_bet_helpers"
 
 RSpec.describe "best/worst bet functionality" do
+  include BestBetIntegrationTestHelpers
+
   it "boosts exact best bets" do
     commit_document(
       "govuk_test",
@@ -149,50 +152,5 @@ RSpec.describe "best/worst bet functionality" do
     links = get_links "/search?q=bet+best"
 
     expect(links).not_to include("/only-shown-for-exact-matches")
-  end
-
-private
-
-  def get_links(path)
-    get(path)
-    parsed_response["results"].map { |result| result["link"] }
-  end
-
-  def add_best_bet(args)
-    payload = build_sample_bet_hash(
-      query: args[:query],
-      type: args[:type],
-      best_bets: [args.slice(:link, :position)],
-      worst_bets: [],
-    )
-
-    post "/metasearch_test/documents", payload.to_json
-    commit_index("metasearch_test")
-  end
-
-  def add_worst_bet(args)
-    payload = build_sample_bet_hash(
-      query: args[:query],
-      type: args[:type],
-      best_bets: [],
-      worst_bets: [args.slice(:link, :position)],
-    )
-
-    post "/metasearch_test/documents", payload.to_json
-    commit_index("metasearch_test")
-  end
-
-  def build_sample_bet_hash(query:, type:, best_bets:, worst_bets:)
-    {
-      "#{type}_query" => query,
-      details: JSON.generate(
-        {
-          best_bets:,
-          worst_bets:,
-        },
-      ),
-      _type: "best_bet",
-      _id: "#{query}-#{type}",
-    }
   end
 end

--- a/spec/integration/tasks/debug_spec.rb
+++ b/spec/integration/tasks/debug_spec.rb
@@ -2,6 +2,7 @@ require "rake"
 
 RSpec.describe "debug" do
   before { Rake::Task[task_name].reenable }
+
   describe "debug:show_old_index_link" do
     let(:task_name) { "debug:show_old_index_link" }
     let(:link) { "/path/to_page" }
@@ -20,6 +21,40 @@ RSpec.describe "debug" do
         # check document includes expected key/value pairs
         expect(output).to include('"link"=>"/path/to_page"')
         expect(output).to include('"real_index_name"=>"government_test"')
+        expect(output).to include('"_id"=>"/path/to_page"')
+
+        # check output is multi-line (pretty-printed)
+        expect(output).to include("\n")
+        expect(output.lines.count).to be > 1
+      end
+    end
+
+    context "the document does not exist in the index" do
+      it "prints nothing" do
+        output = capture_stdout { Rake::Task[task_name].invoke(link) }
+        expect(output).to eq("nil\n")
+      end
+    end
+  end
+
+  describe "debug:show_govuk_link" do
+    let(:task_name) { "debug:show_govuk_link" }
+    let(:link) { "/path/to_page" }
+
+    context "the document exists in the index" do
+      it "pretty prints a document from the new content index" do
+        commit_document(
+          "govuk_test",
+          {
+            "link" => link,
+          },
+        )
+
+        output = capture_stdout { Rake::Task[task_name].invoke(link) }
+
+        # check document includes expected key/value pairs
+        expect(output).to include('"link"=>"/path/to_page"')
+        expect(output).to include('"real_index_name"=>"govuk_test"')
         expect(output).to include('"_id"=>"/path/to_page"')
 
         # check output is multi-line (pretty-printed)

--- a/spec/integration/tasks/debug_spec.rb
+++ b/spec/integration/tasks/debug_spec.rb
@@ -1,0 +1,38 @@
+require "rake"
+
+RSpec.describe "debug" do
+  before { Rake::Task[task_name].reenable }
+  describe "debug:show_old_index_link" do
+    let(:task_name) { "debug:show_old_index_link" }
+    let(:link) { "/path/to_page" }
+
+    context "the document exists in the index" do
+      it "pretty prints a document from the old indexes" do
+        commit_document(
+          "government_test",
+          {
+            "link" => link,
+          },
+        )
+
+        output = capture_stdout { Rake::Task[task_name].invoke(link) }
+
+        # check document includes expected key/value pairs
+        expect(output).to include('"link"=>"/path/to_page"')
+        expect(output).to include('"real_index_name"=>"government_test"')
+        expect(output).to include('"_id"=>"/path/to_page"')
+
+        # check output is multi-line (pretty-printed)
+        expect(output).to include("\n")
+        expect(output.lines.count).to be > 1
+      end
+    end
+
+    context "the document does not exist in the index" do
+      it "prints nothing" do
+        output = capture_stdout { Rake::Task[task_name].invoke(link) }
+        expect(output).to eq("nil\n")
+      end
+    end
+  end
+end

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -59,4 +59,13 @@ module SpecHelpers
     end
     raise RandomExampleError, "Could not generate example"
   end
+
+  def capture_stdout
+    old = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = old
+  end
 end

--- a/spec/unit/tasks/duplicates_spec.rb
+++ b/spec/unit/tasks/duplicates_spec.rb
@@ -68,13 +68,4 @@ RSpec.describe "duplicates", "RakeTest" do
       end
     end
   end
-
-  def capture_stdout
-    old = $stdout
-    $stdout = StringIO.new
-    yield
-    $stdout.string
-  ensure
-    $stdout = old
-  end
 end


### PR DESCRIPTION
First half of work to add test coverage for the debug rake tasks. This PR covers:

- show_old_index_link
- show_govuk_link
- fetch_best_bets

It takes code coverage from 91.33% to 91.59%.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1738