### PR TITLE
[SCH-1679] Pact testing search enum

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -46,21 +46,6 @@ Pact.provider_states_for "GDS API Adapters" do
     WebMock.disable!
   end
 
-  provider_state "there are search results for universal credit" do
-    set_up do
-      document_params = {
-        "title" => "Universal credit",
-        "link" => "/universal-credit",
-      }
-      second_document_params = {
-        "title" => "Universal credit too",
-        "link" => "/universal-credit-too",
-      }
-      commit_document("government_test", document_params)
-      commit_document("government_test", second_document_params)
-    end
-  end
-
   provider_state "there are four search results for universal credit" do
     set_up do
       document_params = {

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -60,4 +60,29 @@ Pact.provider_states_for "GDS API Adapters" do
       commit_document("government_test", second_document_params)
     end
   end
+
+  provider_state "there are four search results for universal credit" do
+    set_up do
+      document_params = {
+        "title" => "Universal credit 1",
+        "link" => "/universal-credit-1",
+      }
+      second_document_params = {
+        "title" => "Universal credit 2",
+        "link" => "/universal-credit-2",
+      }
+      third_document_params = {
+        "title" => "Universal credit 3",
+        "link" => "/universal-credit-3",
+      }
+      fourth_document_params = {
+        "title" => "Universal credit 4",
+        "link" => "/universal-credit-4",
+      }
+      commit_document("government_test", document_params)
+      commit_document("government_test", second_document_params)
+      commit_document("government_test", third_document_params)
+      commit_document("government_test", fourth_document_params)
+    end
+  end
 end


### PR DESCRIPTION
## What
For Search API to [meet the standards required for continuous deployment](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#check-api-contract-tests-pass-ie-adapters-work-with-their-apis), we need contract tests between Search API and its api consumer, gds-api-adaptors. See [Jira ticket SCH-1679](https://gov-uk.atlassian.net/browse/SCH-1679).

This PR builds on #3466, refactoring the existing `provider_state` to be used for `#search_enum` pact tests as well as for `#search`. 

## Details
- The pact tests for `#search_enum` are defined in this [PR](https://github.com/alphagov/gds-api-adapters/pull/1380) and have been published to [our pact broker](https://govuk-pact-broker-6991351eca05.herokuapp.com/).
- You can then verify this pact locally by running `env PACT_CONSUMER_VERSION=branch-search-api-pact-testing-search-enum bundle exec rake pact:verify`.

## Next steps
- Add pact-verify.yml workflow - e.g. [collections/.github/workflows/pact-verify.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/pact-verify.yml)