### PR TITLE
Add tests for synonyms rake task

### DIFF
--- a/lib/debug/synonyms.rb
+++ b/lib/debug/synonyms.rb
@@ -14,16 +14,18 @@ module Debug
             multi_match: {
               "query" => query,
               "fields" => %w[title.synonym^1000 description.synonym],
+              "analyzer" => "with_search_synonyms",
             },
           },
           highlight: {
             "fields" => { "title.synonym" => {}, "description.synonym" => {} },
+            "type" => "plain",
             "pre_tags" => pre_tags,
             "post_tags" => post_tags,
           },
         }
 
-        client.search(index:, analyzer: "with_search_synonyms", body: search_query)
+        client.search(index:, body: search_query)
       end
 
       def analyze_query(query)

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -25,8 +25,9 @@ namespace :debug do
   end
 
   desc "New synonyms test"
-  task :show_new_synonyms, [:query] do |_, args|
-    model = Debug::Synonyms::Analyzer.new
+  task :show_new_synonyms, [:query, :index_name] do |_, args|
+    index = args.index_name || SearchConfig.govuk_index_name
+    model = Debug::Synonyms::Analyzer.new(index: index)
 
     search_tokens = model.analyze_query(args.query)
     index_tokens = model.analyze_index(args.query)


### PR DESCRIPTION
Adds integration tests for synonyms rake task.

Takes code coverage from 91.57% to 92.07%.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1738