### PR TITLE
[SCH-1679] Add pact-verify workflow to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
     name: Lint Ruby
     uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
 
+  pact-tests:
+    name: Run Pact tests
+    uses: ./.github/workflows/pact-verify.yml
+    with:
+      ref: ${{ github.ref }}
+
   test-ruby:
     name: Test Ruby
     uses: ./.github/workflows/rspec.yml

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -1,0 +1,68 @@
+# Pact verify workflow
+#
+# This workflow asserts that Pact contract tests are valid against this
+# codebase. It is trigged when changes are made to this project and it
+# is explicitly called by GDS API Adapters when changes are made there.
+
+name: Run Pact tests
+
+on:
+  workflow_call:
+    inputs:
+      # The commit / tag of this repo to test against
+      ref:
+        required: false
+        type: string
+        default: main
+      # A GitHub Action artifact which contains the pact definition files
+      # Search API calls this action to test new pacts against this
+      # workflow
+      pact_artifact:
+        required: false
+        type: string
+      # When using an artifact this is the file path to the pact that is verified
+      # against
+      pact_artifact_file_to_verify:
+        required: false
+        type: string
+        default: gds_api_adapters-search_api.json
+      # Which version of the pacts to use from the Pact Broker service
+      # This option will be ignored if pact_artifact is set
+      pact_consumer_version:
+        required: false
+        type: string
+        default: branch-main
+
+jobs:
+  pact_verify:
+    name: Verify pact tests
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+    steps:
+      - name: Setup Elasticsearch
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-elasticsearch@main
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: alphagov/search-api
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - if: inputs.pact_artifact == ''
+        run: bundle exec rake pact:verify
+        env:
+          PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+      - if: inputs.pact_artifact != ''
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.pact_artifact }}
+          path: tmp/pacts
+      - if: inputs.pact_artifact != ''
+        run: |
+          # shellcheck disable=SC2102
+          bundle exec rake pact:verify:at[tmp/pacts/${{ inputs.pact_artifact_file_to_verify }}]


### PR DESCRIPTION
Now that we've added the necessary pact tests and tested them locally against the published pacts we can add the pact tests to our CI pipeline. 

There is a [companion PR to add the search-api pact tests to the gds-api-adapters ci workflow](https://github.com/alphagov/gds-api-adapters/pull/1382), but this PR will need to be merged first.