### PR TITLE
Add tests for rank eval rake task

### DIFF
--- a/docs/relevancy.md
+++ b/docs/relevancy.md
@@ -463,32 +463,6 @@ but something else still gets high traffic ([03c4bfa][], May 2015).
 If we had other signals of content quality we might be able to reduce our
 dependence on the page views.
 
-### Finding underperforming queries
-
-1. Go to the [datastudio report][]
-
-The report does not automatically update, so it will display only the data for the dates displayed.
-
-To get new data, rerun the BigQuery queries.
-
-2. Apply the following filters:
-
-* `click_count >= 100`
-* `median_position >=4`
-
-Underperforming queries are ones with a significant click count and a highish median, i.e. around 4 and above.
-
-![datastudio](images/datastudio-dash.png)
-
-3. Visit the Google Analytics dashboard an underperforming query
-
-Once you have identified an underperforming query, head over to the Google Analytics (GA) dashboard to see the clickthrough rates and positions of the search results for that query.
-
-e.g. [GA dashboard][] for the term "utr".
-
-Use the clickthrough rate of each search result relative to its position to inform your hypotheses.
-
-
 [03c4bfa]: https://github.com/alphagov/search-api/commit/03c4bfa0a1a816a57d38b71ac5cb22c3a107c275
 [0fe6e52]: https://github.com/alphagov/search-api/commit/0fe6e526c78e8b115371855a91d4b39ccb22098a
 [6cbd84f]: https://github.com/alphagov/search-api/commit/6cbd84f36ff70ce1be6a368e807c72ba09c74f23
@@ -521,5 +495,3 @@ Use the clickthrough rate of each search result relative to its position to info
 [synonyms-blog]: https://opensourceconnections.com/blog/2016/12/02/solr-elasticsearch-synonyms-better-patterns-keyphrases/
 [this curve]: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427e5qr62u0si
 [keepwords]: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-keep-words-tokenfilter.html
-[datastudio report]: https://datastudio.google.com/u/0/reporting/1-QjJDH5YkBWhF9qb-WEOuGuGIgNJExds/page/Zaus
-[GA dashboard]: https://analytics.google.com/analytics/web/#/report/conversions-ecommerce-product-list-performance/a26179049w50705554p53872948/_u.date00=20191016&_u.date01=20191023&explorer-table.plotKeys=%5B%5D&explorer-table.rowCount=50&explorer-table.secSegmentId=analytics.customDimension71&explorer-table.advFilter=%5B%5B0,"analytics.productListPosition","RE","%5E%5B0-9%5D%7B1,1%7D$",0%5D,%5B0,"analytics.customDimension71","EQ","utr",0%5D%5D&_r.drilldown=analytics.productListName:Search&explorer-table-dataTable.sortColumnName=analytics.productListCTR&explorer-table-dataTable.sortDescending=true&explorer-segmentExplorer.segmentId=analytics.productListPosition/

--- a/docs/search-quality-metrics.md
+++ b/docs/search-quality-metrics.md
@@ -1,28 +1,8 @@
 # Search Quality Metrics
 
-We assess the quality of Search API search results with two metrics:
-Click Through Rate (an online metric) and Normalised Discounted Cumulative Gain
-([nDCG][]).
-
-## Online metrics
-
-We monitor changes to search relevance over time in a [Search Relevancy Dashboard][].
-We call the metrics displayed there *online metrics*.
-
-Our main online metric is Click Through Rate on the top results
-(top 1, 3, and 5). This isn't a great metric, since users might
-click on something that isn't what they were looking for. But this
-serves our needs in the absence of a more sophisticated way of
-measuring user success following a search.
-
-## Offline metrics
-
-Our main offline metric is nDCG.
-
 We use Elasticsearch's [Ranking Evaluation API](ranking_evaluation_api)
-to assess the quality of results retrieved from Elasticsearch prior
-to re-ranking.
-The API enables us to score how well search-api ranks results for a given query.
+to assess the quality of results retrieved from Elasticsearch prior to re-ranking. 
+The API enables us to score how well search-api ranks results by relevancy for a given query.
 
 ### What is rank evaluation?
 
@@ -71,8 +51,7 @@ returning better results than the query for `harry potter`.
 Moreover, if the score for `harry potter` was `0.2392687105963024` before
 we made a change, then that means we've made a good change for that query.
 
-This can be measured over time, and it is! See the section on 'What do we do
-with the query scores?' below.
+This could be measured over time, though we don't do this systematically at the moment.
 
 ## How do we compute a score for a query?
 
@@ -124,36 +103,14 @@ in time.
 
 ## What do we do with the query scores?
 
-We use them for checking changes locally, as a quick check before we run an AB
-test.
-
-```
-bundle exec rake relevance:ndcg
-```
-
-We also report the rank evaluation scores to graphite.
-This enables us to plot how relevancy changes over time (overall
-  and for a given query).
-
-This runs every 3 hours in all environments:
-```
-SEND_TO_GRAPHITE=true bundle exec rake relevance:ndcg
-```
-
-See the Search Relevancy grafana dashboard.
+We can run the rake task `debug:rank_evaluation` and look at the query scores before
+and after making a change, so we can see the effect of the change on search ranking.
 
 ## How do we collect relevancy judgements?
 
-We use a combination of implicit and explicit relevance judgements.
+We use explicit judgements based on expert opinion. The relevance judgements are uploaded 
+manually in CSV format to an S3 bucket, which then gets pulled by search-api when the rake
+task runs.
 
-The implicit relevance judgements are derived from user click data.
-
-The explicit judgements are provided by experts across government via
-the search relevance tool: https://github.com/alphagov/govuk-search-relevance-tool.
-
-Relevance judgements are uploaded in CSV format to an S3 bucket,
-which then gets pulled by search-api when the scheduled job runs.
-
-[ranking_evaluation_api]: https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-rank-eval.html#search-rank-eval
+[ranking_evaluation_api]: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-rank-eval.html#search-rank-eval
 [nDCG]: https://en.wikipedia.org/wiki/Discounted_cumulative_gain
-[search relevancy dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/search_relevancy.json?orgId=1

--- a/lib/debug/rank_eval.rb
+++ b/lib/debug/rank_eval.rb
@@ -71,11 +71,16 @@ module Debug
   private
 
     def rank_eval(requests)
-      # https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html
-      # AWS doesn't permit us to speak to all indexes with the rank eval api,
-      # and the elasticsearch client has a bug that prevents us calling individual
-      # indexes (https://github.com/elastic/elasticsearch-ruby/pull/698).
-      # This is a fix for that situation.
+      # This workaround was put in because the elasticsearch ruby client used to
+      # have a bug that prevented us calling rank_eval with an index argument.
+      # https://github.com/elastic/elasticsearch-ruby/pull/724
+      # This bug has since been fixed, but removing this workaround means
+      # that instead of using the httparty/net http timeout default,
+      # we'd be using the elasticsearch timeout we have set, which is
+      # not long enough for the rank_eval call. Because the timeout is a global
+      # setting on the elasticsearch client, changing the timeout to only affect
+      # the rank evaluation workflow would require a refactor.
+
       # @search_config.rank_eval(
       #   requests: requests,
       #   metric: { dcg: { k: 10, normalize: true } },

--- a/lib/debug/rank_eval.rb
+++ b/lib/debug/rank_eval.rb
@@ -112,11 +112,11 @@ module Debug
     end
 
     def government_index_name
-      @government_index_name ||= @search_config.get_index_for_alias("government")
+      @government_index_name ||= @search_config.get_index_for_alias(SearchConfig.content_index_names)
     end
 
     def govuk_index_name
-      @govuk_index_name ||= @search_config.get_index_for_alias("govuk")
+      @govuk_index_name ||= @search_config.get_index_for_alias(SearchConfig.govuk_index_name)
     end
   end
 end

--- a/lib/debug/rank_eval.rb
+++ b/lib/debug/rank_eval.rb
@@ -75,7 +75,7 @@ module Debug
       # have a bug that prevented us calling rank_eval with an index argument.
       # https://github.com/elastic/elasticsearch-ruby/pull/724
       # This bug has since been fixed, but removing this workaround means
-      # that instead of using the httparty/net http timeout default,
+      # that instead of using timeout specified here,
       # we'd be using the elasticsearch timeout we have set, which is
       # not long enough for the rank_eval call. Because the timeout is a global
       # setting on the elasticsearch client, changing the timeout to only affect
@@ -90,6 +90,7 @@ module Debug
       options = {
         body: { requests:, metric: { dcg: { k: 10, normalize: true } } }.to_json,
         headers: { "Content-Type" => "application/json" },
+        timeout: 120,
       }
       indices = "*"
       url = "#{uri}/#{indices}/_rank_eval"

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -60,12 +60,11 @@ namespace :debug do
   desc "Check how well the search query performs for a set of relevancy judgements"
   task :ranking_evaluation, [:datafile, :ab_tests] do |_, args|
     csv = args.datafile || begin
-      bucket_name = ENV["AWS_S3_RELEVANCY_BUCKET_NAME"]
-      raise "Missing required AWS_S3_RELEVANCY_BUCKET_NAME envvar" if bucket_name.nil?
+      bucket = ENV["AWS_S3_RELEVANCY_BUCKET_NAME"]
+      raise "Missing required AWS_S3_RELEVANCY_BUCKET_NAME envvar" if bucket.nil?
 
       csv = Tempfile.open(["judgements", ".csv"])
-      o = Aws::S3::Object.new(bucket_name:, key: "judgements.csv")
-      o.get(response_target: csv.path)
+      Services.s3_client.get_object(bucket:, key: "judgements.csv", response_target: csv.path)
       csv.path
     end
 

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -80,13 +80,6 @@ namespace :debug do
       end
       puts "---"
       puts "overall score: #{results[:score]}"
-
-      if ENV["SEND_TO_GRAPHITE"]
-        Services.statsd_client.gauge(
-          "relevancy.query.overall_score.rank_eval",
-          results[:score],
-        )
-      end
     ensure
       if csv.is_a?(Tempfile)
         csv.close

--- a/spec/integration/search/best_bets_spec.rb
+++ b/spec/integration/search/best_bets_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
-require_relative "../helpers/best_bet_helpers"
+require_relative "../../support/best_bet_test_helpers"
 
 RSpec.describe "best/worst bet functionality" do
-  include BestBetIntegrationTestHelpers
+  include BestBetTestHelpers
 
   it "boosts exact best bets" do
     commit_document(

--- a/spec/integration/tasks/debug_spec.rb
+++ b/spec/integration/tasks/debug_spec.rb
@@ -1,8 +1,10 @@
 require "rake"
 require_relative "../helpers/best_bet_helpers"
+require_relative "../../support/rank_eval_test_helpers"
 
 RSpec.describe "debug" do
   include BestBetIntegrationTestHelpers
+  include RankEvalTestHelpers
 
   before { Rake::Task[task_name].reenable }
 
@@ -118,6 +120,39 @@ RSpec.describe "debug" do
 
         expect(output).to include("Sample matches (basic query with synonyms):")
         expect(output).to include("No results found")
+      end
+    end
+  end
+
+  describe "debug:ranking_evaluation" do
+    let(:task_name) { "debug:ranking_evaluation" }
+
+    context "the bucket is provided and contains a judgement csv" do
+      let(:bucket) { "test-bucket" }
+      let(:filename) { "judgements.csv" }
+
+      before do
+        allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
+        Services.s3_client.put_object(key: filename,
+                                      bucket:,
+                                      body: mock_judgement_csv)
+
+        stub_rank_eval_request
+      end
+
+      it "calculates how well search performs" do
+        ClimateControl.modify AWS_S3_RELEVANCY_BUCKET_NAME: bucket do
+          output = capture_stdout { Rake::Task[task_name].invoke }
+          expect(output).to include("Ignoring 1 judgements for /government/renew-a-passport queried with query 'passport'")
+          expect(output.squeeze(" ")).to include(rank_eval_expected_output)
+        end
+      end
+    end
+
+    context "no bucket or datafile is provided" do
+      it "raises an error" do
+        expect { Rake::Task[task_name].invoke }
+          .to raise_error("Missing required AWS_S3_RELEVANCY_BUCKET_NAME envvar")
       end
     end
   end

--- a/spec/integration/tasks/debug_spec.rb
+++ b/spec/integration/tasks/debug_spec.rb
@@ -1,9 +1,9 @@
 require "rake"
-require_relative "../helpers/best_bet_helpers"
+require_relative "../../support/best_bet_test_helpers"
 require_relative "../../support/rank_eval_test_helpers"
 
 RSpec.describe "debug" do
-  include BestBetIntegrationTestHelpers
+  include BestBetTestHelpers
   include RankEvalTestHelpers
 
   before { Rake::Task[task_name].reenable }

--- a/spec/support/best_bet_test_helpers.rb
+++ b/spec/support/best_bet_test_helpers.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-module BestBetIntegrationTestHelpers
+module BestBetTestHelpers
   def get_links(path)
     get(path)
     parsed_response["results"].map { |result| result["link"] }

--- a/spec/support/rank_eval_test_helpers.rb
+++ b/spec/support/rank_eval_test_helpers.rb
@@ -1,0 +1,70 @@
+require "csv"
+require "spec_helper"
+
+module RankEvalTestHelpers
+  def mock_judgement_csv
+    CSV.generate do |csv|
+      csv << %w[query rating link score]
+      csv << ["harry potter", "relevant", "/harry-potter", 3]
+      # use /government to test fetching alias for government index
+      csv << ["passport", "relevant", "/government/renew-a-passport", 3]
+      # add repeated row to test ignore_extra_judgements
+      csv << ["passport", "near", "/government/renew-a-passport", 2]
+    end
+  end
+
+  def rank_eval_expected_output
+    <<~OUTPUT
+      harry potter: 1
+      passport: 0
+      ---
+      overall score: 0.5
+    OUTPUT
+  end
+
+  def stub_rank_eval_request
+    es_source = ENV["ELASTICSEARCH_URI"] || "http://localhost:9200"
+    stub_request(:post, "#{es_source}/*/_rank_eval")
+      .to_return(
+        status: 200,
+        body: {
+          metric_score: 0.5,
+          details: {
+            "harry potter": {
+              metric_score: 1,
+              unrated_docs: [{ _index: "govuk_test", _id: "/who-is-harry-potter" }],
+              hits: [
+                {
+                  hit: {
+                    _index: "govuk_test",
+                    _id: "/harry-potter",
+                    _type: "generic-document",
+                    _score: 0,
+                  },
+                  rating: 1,
+                },
+              ],
+            },
+            passport: {
+              metric_score: 0,
+              unrated_docs: [{ _index: "govuk_test", _id: "/universal_credit" }],
+              hits: [
+                {
+                  hit: {
+                    _index: "govuk_test",
+                    _id: "/take-pet-abroad",
+                    _type: "generic-document",
+                    _score: 0,
+                  },
+                  rating: 0,
+                },
+              ],
+            },
+          },
+        }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+  end
+end


### PR DESCRIPTION
Tidy up and add tests for rank evaluation rake task. There's a few things going on in here. I'd recommend reviewing the commits in order.

Takes test coverage from 92.07% to 93.28% 🎉 

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1738

I've tested the rake task locally, by running it with a judgements csv file in the repo's temp folder. I've also tested the branch on integration, connecting to the AWS bucket to get the judgement csv from there.