### PR TITLE
[SCH-1638] Configure auto-merging of some dependencies

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,0 +1,7 @@
+api_version: 2
+defaults:
+  update_external_dependencies: true
+  auto_merge: true
+  allowed_semver_bumps:
+    - patch
+    - minor


### PR DESCRIPTION
Now that we've turned on continuous deployment for search-api we can configure dependabot to allow automatic merging of patch and minor dependency update PRs. This is in line with guidance from [RFC-167](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md). It has been confirmed that the repo meets the conditions of this RFC.

See [Jira ticket SCH-1638](https://gov-uk.atlassian.net/browse/SCH-1638).

Other useful links:
- [Guidance for how to configure Dependabot](https://docs.publishing.service.gov.uk/repos/govuk-dependabot-merger.html#content)
- [Search v2 Dependabot configuration for comparison](https://github.com/alphagov/search-api-v2/blob/main/.govuk_dependabot_merger.yml)