### PR TITLE
Pin pact to version 1.X

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "warden"
 gem "warden-oauth2"
 
 group :development, :test do
-  gem "pact", require: false
+  gem "pact", "~> 1.67", require: false
   gem "pact_broker-client"
   gem "pry-byebug"
   gem "rubocop-govuk", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -778,7 +778,7 @@ DEPENDENCIES
   nokogiri
   oauth2
   oj
-  pact
+  pact (~> 1.67)
   pact_broker-client
   plek
   pry-byebug


### PR DESCRIPTION
Pact 2.0.0 introduces major changes to the way tests are written and arranged.

It is not simple to migrate, as all the pact tests will need rewriting.

Pinning to version 1.x until we are able to rewrite the pact tests to be compatible with 2.0.