### PR TITLE
[SCH-1975] Add rake task to get docs from one index and check against another

### DIFF
--- a/lib/search/document_finder.rb
+++ b/lib/search/document_finder.rb
@@ -1,0 +1,26 @@
+module Search
+  class DocumentFinder
+    TIMEOUT = 60
+
+    def get_all_document_ids(index)
+      response = Services.elasticsearch(timeout: TIMEOUT).search(
+        index: index,
+        size: 0, # temp figure - to be replaced
+        body: {
+          _source: %w[content_id],
+          query: {
+            match_all: {},
+          },
+        },
+      )
+
+      document_ids = []
+
+      documents = response.dig("hits", "hits")
+
+      documents.each do |document|
+        document_ids << document["_source"]["content_id"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding a rake task to retrieve `content_id`s for all docs in one index, and then to check another index to ensure they exist there. Intended to be used to check that all docs from `government` index were copied over to `govuk` index.

WIP: 
- added initial attempt at search query to get all docs
- Need to set a batch size then re-request until all docs are retrieved
- Haven't checked yet whether digging gives correct output.