### PR TITLE
Update Pact tests to use govuk index

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -51,13 +51,15 @@ Pact.provider_states_for "GDS API Adapters" do
       document_params = {
         "title" => "Universal credit",
         "link" => "/universal-credit",
+        "format" => "guide",
       }
       second_document_params = {
         "title" => "Universal credit too",
         "link" => "/universal-credit-too",
+        "format" => "guide",
       }
-      commit_document("government_test", document_params)
-      commit_document("government_test", second_document_params)
+      commit_document("govuk_test", document_params)
+      commit_document("govuk_test", second_document_params)
     end
   end
 end


### PR DESCRIPTION
Prep work for retiring the government index.

In updating the Pact tests to use the govuk index, we need to add a migrated format to the documents, so the documents don't get removed in the post query filter in Search::QueryBuilder.
https://github.com/alphagov/search-api/blob/main/lib/search/query_builder.rb#L22

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1987