### PR TITLE
SCH-1987 Refactor integration tests to use `govuk_test` index in examples

### DIFF
--- a/spec/integration/govuk_index/supertype_updater_spec.rb
+++ b/spec/integration/govuk_index/supertype_updater_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe GovukIndex::SupertypeUpdater do
-  let(:index) { "government_test" }
+  let(:index) { "govuk_test" }
 
   before do
     allow(GovukDocumentTypes).to receive(:supertypes)

--- a/spec/integration/indexer/closing_spec.rb
+++ b/spec/integration/indexer/closing_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "ElasticsearchClosingTest" do
   end
 
   it "will not allow insertion into closed index" do
-    index = search_server.index_group("government_test").current
+    index = search_server.index_group("govuk_test").current
     index.close
 
     expect {
@@ -15,6 +15,6 @@ RSpec.describe "ElasticsearchClosingTest" do
 
     # Re-opening the index again, as they are not recreated on each test run
     # anymore.
-    client.indices.open(index: "government_test")
+    client.indices.open(index: "govuk_test")
   end
 end

--- a/spec/integration/indexer/index_group_spec.rb
+++ b/spec/integration/indexer/index_group_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe "ElasticsearchIndexGroupTest" do
   before do
     allow(Clusters).to receive(:active).and_return([Clusters.default_cluster])
-    @group_name = "government_test"
+    @group_name = "govuk_test"
     IndexHelpers.clean_index_group(@group_name)
 
     @index_group = search_server.index_group(@group_name)
@@ -24,7 +24,7 @@ RSpec.describe "ElasticsearchIndexGroupTest" do
     expect(@index_group.index_names.count).to eq(1)
     expect(index.index_name).to eq(@index_group.index_names[0])
     expect(
-      SearchConfig.default_instance.search_server.schema.elasticsearch_mappings("government"),
+      SearchConfig.default_instance.search_server.schema.elasticsearch_mappings("govuk"),
     ).to eq(index.mappings)
   end
 

--- a/spec/integration/indexer/locking_spec.rb
+++ b/spec/integration/indexer/locking_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "ElasticsearchLockingTest" do
   end
 
   it "will not allow inserts while locked" do
-    index = search_server.index_group("government_test").current
+    index = search_server.index_group("govuk_test").current
     with_lock(index) do
       expect {
         index.add([sample_document])
@@ -15,7 +15,7 @@ RSpec.describe "ElasticsearchLockingTest" do
   end
 
   it "will not allow updates while locked" do
-    index = search_server.index_group("government_test").current
+    index = search_server.index_group("govuk_test").current
     index.add([sample_document])
 
     with_lock(index) do
@@ -26,7 +26,7 @@ RSpec.describe "ElasticsearchLockingTest" do
   end
 
   it "will not allow deletes while locked" do
-    index = search_server.index_group("government_test").current
+    index = search_server.index_group("govuk_test").current
     index.add([sample_document])
 
     with_lock(index) do
@@ -37,7 +37,7 @@ RSpec.describe "ElasticsearchLockingTest" do
   end
 
   it "will unlock once the block is completed and allow inserts as per normal" do
-    index = search_server.index_group("government_test").current
+    index = search_server.index_group("govuk_test").current
     with_lock(index) do
       # Nothing to do here
     end

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "MissingMetadataTest" do
       results = runner.retrieve_records_with_missing_value
 
       expect(results).to be_empty
+      expect(io.string).to include("Skipping edition/https://www.nhs.uk")
     end
 
     it "ignores already set content_id" do

--- a/spec/integration/missing_metadata_spec.rb
+++ b/spec/integration/missing_metadata_spec.rb
@@ -4,23 +4,25 @@ RSpec.describe "MissingMetadataTest" do
   describe "#retrieve_records_with_missing_value" do
     it "finds missing content_id" do
       commit_document(
-        "government_test",
+        "govuk_test",
         {
           "link" => "/path/to_page",
+          "format" => "guide",
         },
       )
 
       runner = MissingMetadata::Runner.new("content_id", search_config: SearchConfig.default_instance, logger: io)
       results = runner.retrieve_records_with_missing_value
 
-      expect([{ _id: "/path/to_page", index: "government_test" }]).to eq results
+      expect([{ _id: "/path/to_page", index: "govuk_test" }]).to eq results
     end
 
     it "ignores external links" do
       commit_document(
-        "government_test",
+        "govuk_test",
         {
           "link" => "https://www.nhs.uk",
+          "format" => "guide",
         },
       )
 
@@ -33,10 +35,11 @@ RSpec.describe "MissingMetadataTest" do
 
     it "ignores already set content_id" do
       commit_document(
-        "government_test",
+        "govuk_test",
         {
           "link" => "/path/to_page",
           "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
+          "format" => "guide",
         },
       )
 
@@ -48,26 +51,28 @@ RSpec.describe "MissingMetadataTest" do
 
     it "finds missing document_type" do
       commit_document(
-        "government_test",
+        "govuk_test",
         {
           "link" => "/path/to_page",
           "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
+          "format" => "guide",
         },
       )
 
       runner = MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io)
       results = runner.retrieve_records_with_missing_value
 
-      expect([{ _id: "/path/to_page", index: "government_test", content_id: "8aea1742-9cc6-4dfb-a63b-12c3e66a601f" }]).to eq results
+      expect([{ _id: "/path/to_page", index: "govuk_test", content_id: "8aea1742-9cc6-4dfb-a63b-12c3e66a601f" }]).to eq results
     end
 
     it "ignores already set document_type" do
       commit_document(
-        "government_test",
+        "govuk_test",
         {
           "link" => "/path/to_page",
           "content_id" => "8aea1742-9cc6-4dfb-a63b-12c3e66a601f",
           "content_store_document_type" => "guide",
+          "format" => "guide",
         },
       )
 
@@ -82,9 +87,10 @@ RSpec.describe "MissingMetadataTest" do
     context "when add metadata returns an error" do
       it "logs a message and skips the result" do
         commit_document(
-          "government_test",
+          "govuk_test",
           {
             "link" => "/path/to_page",
+            "format" => "guide",
           },
         )
         allow_any_instance_of(MissingMetadata::Fetcher).to receive(:add_metadata).and_raise(StandardError)
@@ -120,10 +126,11 @@ RSpec.describe "MissingMetadataTest" do
       context "when content_id is available" do
         it "gets content from publishing api and updates document" do
           commit_document(
-            "government_test",
+            "govuk_test",
             {
               "link" => @base_path,
               "content_id" => @content_id,
+              "format" => "guide",
             },
           )
           stub_publishing_api_has_item(@publishing_content_item)
@@ -131,17 +138,18 @@ RSpec.describe "MissingMetadataTest" do
           MissingMetadata::Runner.new("content_store_document_type", search_config: SearchConfig.default_instance, logger: io).update
 
           expect(a_request(:get, @get_content_url)).to have_been_made.once
-          expect_document_is_in_rummager(@updated_content_item, index: "government_test", id: @base_path)
+          expect_document_is_in_rummager(@updated_content_item, index: "govuk_test", id: @base_path)
         end
       end
 
       context "when fetch content times out" do
         it "sleeps for 1 second and retries, until content is returned" do
           commit_document(
-            "government_test",
+            "govuk_test",
             {
               "link" => @base_path,
               "content_id" => @content_id,
+              "format" => "guide",
             },
           )
           allow(Kernel).to receive(:sleep).and_return(true)
@@ -155,16 +163,17 @@ RSpec.describe "MissingMetadataTest" do
           expect(a_request(:get, @get_content_url)).to have_been_made.twice
           expect(Kernel).to have_received(:sleep).with(1).exactly(1).times
           expect(io.string).to include("Publishing API timed out getting content... retrying")
-          expect_document_is_in_rummager(@updated_content_item, index: "government_test", id: @base_path)
+          expect_document_is_in_rummager(@updated_content_item, index: "govuk_test", id: @base_path)
         end
       end
 
       context "when content_id is not available" do
         it "gets content id and content from publishing api and updates document" do
           commit_document(
-            "government_test",
+            "govuk_test",
             {
               "link" => @base_path,
+              "format" => "guide",
             },
           )
           stub_publishing_api_has_lookups(@base_path => @content_id)
@@ -174,16 +183,17 @@ RSpec.describe "MissingMetadataTest" do
 
           expect(a_request(:post, @get_content_id_url)).to have_been_made.once
           expect(a_request(:get, @get_content_url)).to have_been_made.once
-          expect_document_is_in_rummager(@updated_content_item, index: "government_test", id: @base_path)
+          expect_document_is_in_rummager(@updated_content_item, index: "govuk_test", id: @base_path)
         end
       end
 
       context "when fetch content_id times out" do
         it "sleeps for 1 second and retries, until content_id is returned" do
           commit_document(
-            "government_test",
+            "govuk_test",
             {
               "link" => @base_path,
+              "format" => "guide",
             },
           )
           allow(Kernel).to receive(:sleep).and_return(true)
@@ -200,7 +210,7 @@ RSpec.describe "MissingMetadataTest" do
           expect(a_request(:get, @get_content_url)).to have_been_made.once
           expect(Kernel).to have_received(:sleep).with(1).exactly(1).times
           expect(io.string).to include("Publishing API timed out getting content_id... retrying")
-          expect_document_is_in_rummager(@updated_content_item, index: "government_test", id: @base_path)
+          expect_document_is_in_rummager(@updated_content_item, index: "govuk_test", id: @base_path)
         end
       end
     end

--- a/spec/integration/schema/stemming_spec.rb
+++ b/spec/integration/schema/stemming_spec.rb
@@ -61,7 +61,7 @@ private
 
   def fetch_tokens_for_analyzer(query, analyzer)
     result = client.indices.analyze(
-      index: "government_test",
+      index: "govuk_test",
       body: {
         analyzer: analyzer.to_s,
         text: query,

--- a/spec/integration/search/duplicate_finder_spec.rb
+++ b/spec/integration/search/duplicate_finder_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Search::DuplicateFinder do
-  let(:index) { "government_test" }
+  let(:index) { "govuk_test" }
   describe "there are no documents in Elasticsearch" do
     it "returns an empty array" do
       expect(Search::DuplicateFinder.new(index:).find_duplicates).to eq([])

--- a/spec/integration/search/quoted_and_unquoted_searches_spec.rb
+++ b/spec/integration/search/quoted_and_unquoted_searches_spec.rb
@@ -54,69 +54,76 @@ private
 
   def commit_london_transport_docs
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "This is about London and its environs",
         "indexable_content" => "London is a world-class city with a modern transport infrastucture",
         "link" => "/london-and-environs",
+        "format" => "guide",
       },
     )
 
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "This is about the transport in Britain",
         "indexable_content" => "Britain has a developed transport infrastructure, especially in London",
         "link" => "/transport-in-britain",
+        "format" => "guide",
       },
     )
 
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Transport for London formerly known as London Transport",
         "indexable_content" => "Transport for London used to be known as London Transport",
         "link" => "/transport-for-london",
+        "format" => "guide",
       },
     )
   end
 
   def commit_synonym_documents
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Driving abroad",
         "indexable_content" => "Driving abroad can be tricky.  For a start, they drive on the wrong side of the road",
         "link" => "/driving-abroad",
+        "format" => "guide",
       },
     )
 
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Driving overseas",
         "indexable_content" => "Driving overseas can be tricky.  For a start, they drive on the wrong side of the road",
         "link" => "/driving-overseas",
+        "format" => "guide",
       },
     )
   end
 
   def commit_stemming_documents
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Dog ownership",
         "indexable_content" => "Owning a dog is a lifelong commitment",
         "link" => "/dog-ownership",
+        "format" => "guide",
       },
     )
 
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Problem Dogs",
         "indexable_content" => "Dogs which attack people can be put down and the owner prosecuted",
         "link" => "/problem_dogs",
+        "format" => "guide",
       },
     )
   end

--- a/spec/integration/search/results_with_highlighting_spec.rb
+++ b/spec/integration/search/results_with_highlighting_spec.rb
@@ -3,10 +3,11 @@ require "spec_helper"
 RSpec.describe "ResultsWithHighlightingTest" do
   it "doesn't break without keywords" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "I am the result",
         "link" => "/some-nice-link",
+        "format" => "guide",
       },
     )
 
@@ -18,10 +19,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "returns highlighted title" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "I am the result",
         "link" => "/some-nice-link",
+        "format" => "guide",
       },
     )
 
@@ -33,11 +35,12 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "returns highlighted title fallback" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Thing without",
         "description" => "I am the result",
         "link" => "/some-nice-link",
+        "format" => "guide",
       },
     )
 
@@ -49,10 +52,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "returns highlighted description" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "link" => "/some-nice-link",
         "description" => "This is a test search result of many results.",
+        "format" => "guide",
       },
     )
 
@@ -66,10 +70,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "highlights mixed quoted/unquoted queries" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "link" => "/some-nice-link",
         "description" => "This is a test search result of many results.",
+        "format" => "guide",
       },
     )
 
@@ -83,10 +88,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "highlights quoted queries in their entirety (other than stopwords)" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "link" => "/some-nice-link",
         "description" => "The ministry of magic is a magic ministry.",
+        "format" => "guide",
       },
     )
 
@@ -100,10 +106,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "highlights synonyms" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "link" => "/some-nice-link",
         "description" => "This is one (1) page.",
+        "format" => "guide",
       },
     )
 
@@ -117,10 +124,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "doesn't highlight synonyms if they're disabled" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "link" => "/some-nice-link",
         "description" => "This is one (1) page.",
+        "format" => "guide",
       },
     )
 
@@ -134,11 +142,12 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "returns documents html escaped" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Escape & highlight my title",
         "link" => "/some-nice-link",
         "description" => "Escape & highlight the description as well.",
+        "format" => "guide",
       },
     )
 
@@ -154,10 +163,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "returns truncated correctly where result at start of description" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "link" => "/some-nice-link",
         "description" => "word #{'something ' * 200}",
+        "format" => "guide",
       },
     )
 
@@ -170,10 +180,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "returns truncated correctly where result at end of description" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "link" => "/some-nice-link",
         "description" => "#{'something ' * 200} word",
+        "format" => "guide",
       },
     )
 
@@ -186,10 +197,11 @@ RSpec.describe "ResultsWithHighlightingTest" do
 
   it "returns truncated correctly where result in middle of description" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "link" => "/some-nice-link",
         "description" => "#{'something ' * 200} word #{'something ' * 200}",
+        "format" => "guide",
       },
     )
 


### PR DESCRIPTION
Update integration tests to refer to the govuk index, since the government index is being retired.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1987