### PR TITLE
[PP-7588] Fix max path length

### DIFF
--- a/lib/analytics/ga4_import/page_view_consolidator.rb
+++ b/lib/analytics/ga4_import/page_view_consolidator.rb
@@ -10,7 +10,7 @@ module Analytics
       def consolidated_page_views
         ga_data
           .reject(&:excluded?)
-          .reject { |page_data| page_data.path.bytesize >= MAX_PATH_LENGTH }
+          .reject { |page_data| page_data.path.bytesize > MAX_PATH_LENGTH }
           .group_by(&:normalised_path)
           .transform_values { |grouped_pages| grouped_pages.sum(&:page_views) }
           .sort_by { |_, views| -views }

--- a/spec/unit/analytics/ga4_import/page_view_consolidator_spec.rb
+++ b/spec/unit/analytics/ga4_import/page_view_consolidator_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Analytics::Ga4Import::PageViewConsolidator do
-  let(:really_long_path) { "/#{'a'.b * (Analytics::Ga4Import::PageViewConsolidator::MAX_PATH_LENGTH - 1)}" }
+  let(:really_long_path) { "/#{'a'.b * Analytics::Ga4Import::PageViewConsolidator::MAX_PATH_LENGTH}" }
 
   let(:ga_data) do
     [


### PR DESCRIPTION
In 5ed2e55, content with a path of 512 bytes or larger was filtered out before being indexed to prevent errors. This requirement comes from Elasticsearch:
https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/mapping-id-field

However, per the Elasticsearch documentation and the introducing commit's message, it should only be paths of greater than 512 bytes that get rejected. This therefore fixes the logic to use greater than rather than greater than or equal to