### PR TITLE
Sch 1987 refactor unit tests to use govuk test index

### DIFF
--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -253,6 +253,7 @@ RSpec.describe SearchIndices::Index do
     it "shows the index has not recovered" do
       recovery = { index_name => { "shards" => [{ "stage" => "DONE" }, { "stage" => "INDEX" }] } }
       allow(indices_client).to receive(:recovery).with(index: index_name).and_return(recovery)
+      expect(index.index_recovered?).to be false
     end
   end
 

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe SearchIndices::Index do
   include Fixtures::DefaultMappings
 
   before do
-    @index = build_government_index
+    @index = build_govuk_index
   end
 
   it "has returns the name of the index as real_name" do
-    stub_request(:get, "http://example.com:9200/government_test/_alias")
+    stub_request(:get, "http://example.com:9200/govuk_test/_alias")
       .to_return(
-        body: { "real-name" => { "aliases" => { "government_test" => {} } } }.to_json,
+        body: { "real-name" => { "aliases" => { "govuk_test" => {} } } }.to_json,
         headers: { "Content-Type" => "application/json" },
       )
 
@@ -18,7 +18,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "returns nil for real_name when elasticsearch returns a 404 response" do
-    stub_request(:get, "http://example.com:9200/government_test/_alias")
+    stub_request(:get, "http://example.com:9200/govuk_test/_alias")
       .to_return(
         status: 404,
         body: '{"error":"IndexMissingException[[text-index] missing]","status":404}',
@@ -31,7 +31,7 @@ RSpec.describe SearchIndices::Index do
   it "returns nil for real_name when elasticsearch reports the index as missing" do
     # elasticsearch is weird: even though /index/_status 404s if the index
     # doesn't exist, /index/_alias returns a 200.
-    stub_request(:get, "http://example.com:9200/government_test/_alias")
+    stub_request(:get, "http://example.com:9200/govuk_test/_alias")
       .to_return(
         body: "{}",
         headers: { "Content-Type" => "application/json" },
@@ -41,9 +41,9 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "exists" do
-    stub_request(:get, "http://example.com:9200/government_test/_alias")
+    stub_request(:get, "http://example.com:9200/govuk_test/_alias")
       .to_return(
-        body: { "real-name" => { "aliases" => { "government_test" => {} } } }.to_json,
+        body: { "real-name" => { "aliases" => { "govuk_test" => {} } } }.to_json,
         headers: { "Content-Type" => "application/json" },
       )
 
@@ -66,11 +66,11 @@ RSpec.describe SearchIndices::Index do
 
     response = <<~RESPONSE
       {"took":0,"items":[
-        { "index": { "_index":"government_test", "_type":"generic-document", "_id":"/foo/bar", "ok":true } },
-        { "index": { "_index":"government_test", "_type":"generic-document", "_id":"/foo/baz", "error":"stuff" } }
+        { "index": { "_index":"govuk_test", "_type":"generic-document", "_id":"/foo/bar", "ok":true } },
+        { "index": { "_index":"govuk_test", "_type":"generic-document", "_id":"/foo/baz", "error":"stuff" } }
       ]}
     RESPONSE
-    stub_request(:post, "http://example.com:9200/government_test/_bulk").to_return(
+    stub_request(:post, "http://example.com:9200/govuk_test/_bulk").to_return(
       body: response,
       headers: { "Content-Type" => "application/json" },
     )
@@ -84,7 +84,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can be searched" do
-    stub_get = stub_request(:get, "http://example.com:9200/government_test/generic-document/_search").with(
+    stub_get = stub_request(:get, "http://example.com:9200/govuk_test/generic-document/_search").with(
       body: %r{"query":"keyword search"},
     ).to_return(
       body: '{"hits":{"hits":[]}}',
@@ -97,7 +97,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can manually commit changes" do
-    refresh_url = "http://example.com:9200/government_test/_refresh"
+    refresh_url = "http://example.com:9200/govuk_test/_refresh"
     stub_request(:post, refresh_url).to_return(
       body: '{"ok":true,"_shards":{"total":1,"successful":1,"failed":0}}',
       headers: { "Content-Type" => "application/json" },
@@ -109,7 +109,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can fetch documents by format" do
-    search_pattern = "http://example.com:9200/government_test/_search?scroll=1m&search_type=query_then_fetch&size=500&version=true"
+    search_pattern = "http://example.com:9200/govuk_test/_search?scroll=1m&search_type=query_then_fetch&size=500&version=true"
     stub_request(:get, search_pattern).with(
       body: { query: { term: { format: "organisation" } }, _source: { includes: %w[title link] }, sort: %w[_doc] },
     ).to_return(
@@ -133,7 +133,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can fetch documents by format with certain fields" do
-    search_pattern = "http://example.com:9200/government_test/_search?scroll=1m&search_type=query_then_fetch&size=500&version=true"
+    search_pattern = "http://example.com:9200/govuk_test/_search?scroll=1m&search_type=query_then_fetch&size=500&version=true"
 
     stub_request(:get, search_pattern).with(
       body: "{\"query\":{\"term\":{\"format\":\"organisation\"}},\"_source\":{\"includes\":[\"title\",\"link\"]},\"sort\":[\"_doc\"]}",
@@ -159,7 +159,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can count the documents without retrieving them all" do
-    search_pattern = "http://example.com:9200/government_test/_search?scroll=1m&search_type=query_then_fetch&size=50&version=true"
+    search_pattern = "http://example.com:9200/govuk_test/_search?scroll=1m&search_type=query_then_fetch&size=50&version=true"
     stub_request(:get, search_pattern).with(
       body: { query: expected_all_documents_query, sort: %w[_doc] }.to_json,
     ).to_return(
@@ -170,7 +170,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can retrieve all documents" do
-    search_uri = "http://example.com:9200/government_test/_search?scroll=1m&search_type=query_then_fetch&size=50&version=true"
+    search_uri = "http://example.com:9200/govuk_test/_search?scroll=1m&search_type=query_then_fetch&size=50&version=true"
 
     stub_request(:get, search_uri).with(
       body: { query: expected_all_documents_query, sort: %w[_doc] }.to_json,
@@ -198,7 +198,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can scroll through the documents" do
-    search_uri = "http://example.com:9200/government_test/_search?scroll=1m&search_type=query_then_fetch&size=2&version=true"
+    search_uri = "http://example.com:9200/govuk_test/_search?scroll=1m&search_type=query_then_fetch&size=2&version=true"
 
     allow(described_class).to receive(:scroll_batch_size).and_return(2)
 
@@ -239,7 +239,7 @@ RSpec.describe SearchIndices::Index do
   describe "#index_recovered" do
     let(:elasticsearch_client) { double("Elasticsearch::Client") }
     let(:indices_client) { double("Elasticsearch::API::Indices::IndicesClient") }
-    let(:index) { build_government_index }
+    let(:index) { build_govuk_index }
     let(:index_name) { index.index_name }
     before do
       allow(Services).to receive(:elasticsearch).and_return(elasticsearch_client)
@@ -270,10 +270,10 @@ private
     }.to_json
   end
 
-  def build_government_index
+  def build_govuk_index
     base_uri = "http://example.com:9200"
     search_config = SearchConfig.default_instance
-    described_class.new(base_uri, "government_test", "government_test", default_mappings, search_config)
+    described_class.new(base_uri, "govuk_test", "govuk_test", default_mappings, search_config)
   end
 
   def stub_popularity_index_requests(paths, popularity, total_pages = 10, total_requested = total_pages, paths_to_return = paths)

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -16,26 +16,26 @@ RSpec.describe SearchIndices::IndexGroup do
     @server = SearchIndices::SearchServer.new(
       base_uri,
       @schema,
-      %w[government custom],
+      %w[foo custom],
       "govuk",
-      %w[government],
+      %w[foo],
       SearchConfig.default_instance,
     )
   end
 
   it "create index" do
     expected_body = {
-      "settings" => @schema.elasticsearch_settings("government"),
-      "mappings" => @schema.elasticsearch_mappings("government"),
+      "settings" => @schema.elasticsearch_settings("govuk"),
+      "mappings" => @schema.elasticsearch_mappings("govuk"),
     }.to_json
-    stub = stub_request(:put, %r{#{base_uri}/government-.*})
+    stub = stub_request(:put, %r{#{base_uri}/govuk-.*})
       .with(body: expected_body)
       .to_return(elasticsearch_ok)
-    index = @server.index_group("government").create_index
+    index = @server.index_group("govuk").create_index
 
     assert_requested(stub)
     expect(index).to be_a SearchIndices::Index
-    expect(index.index_name).to match(/^government-/)
+    expect(index.index_name).to match(/^govuk-/)
   end
 
   it "switch index with no existing alias" do

--- a/spec/unit/query_components/booster_spec.rb
+++ b/spec/unit/query_components/booster_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe QueryComponents::Booster do
     end
   end
 
-  it "not boost government index results" do
+  it "not boost Whitehall formats" do
     builder = described_class.new(search_query_params)
     result = builder.wrap({ some: "query" })
 

--- a/spec/unit/tasks/duplicates_spec.rb
+++ b/spec/unit/tasks/duplicates_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "duplicates", "RakeTest" do
       },
     ]
   end
-  let(:index) { "government" }
+  let(:index) { "govuk" }
 
   before do
     Rake::Task[task_name].reenable


### PR DESCRIPTION
Update unit tests to refer to the govuk index, since the government index is being retired.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1987