### PR TITLE
Update field definitions for patent decision schema to use identifiers

### DIFF
--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1234,6 +1234,6 @@
     "type": "searchable_multivalued_text"
   },
   "patent_decision_type_of_hearing": {
-    "type": "searchable_multivalued_text"
+    "type": "identifiers"
   }
 }


### PR DESCRIPTION
This PR updates the filter schema for the patent decision finder added in https://github.com/alphagov/search-api/pull/3552

Following [field_types.json](https://github.com/alphagov/search-api/blob/main/config/schema/field_types.json),`identifiers` is the correct type for fields with a small, fixed set of values used only for exact-match filtering and aggregation.

In this case, `patent_decision_type_of_hearing` only has two fixed, controlled values (inter-partes-only, ex-parte-only) and is used exclusively for filtering. See [patent_decision.json](https://github.com/alphagov/specialist-publisher/blob/56d83d495cfeabaf4d6278aac32a1b179f0422e8/lib/documents/schemas/patent_decisions.json#L8-L31)

