### PR TITLE
[SCH-2036] Use govuk index to serve spelling suggestions.

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -7,9 +7,6 @@ production: &default
   metasearch_index_name: "metasearch"
   page_traffic_index_name: "page-traffic"
   popularity_rank_offset: 10
-  # When doing spell checking, which indices to use?
-  spelling_index_names:
-    - government
   clusters:
     - uri_key: base_uri
       key: A
@@ -28,8 +25,6 @@ test:
   metasearch_index_name: "metasearch_test"
   page_traffic_index_name: "page-traffic_test"
   popularity_rank_offset: 10
-  spelling_index_names:
-    - government_test
   clusters:
     - uri_key: base_uri
       key: A

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -7,14 +7,12 @@ module Search
 
     class QueryTooLong < Error; end
 
-    attr_reader :index, :registries, :spelling_index, :suggestion_blocklist
+    attr_reader :index, :registries, :suggestion_blocklist
 
-    def initialize(registries:, content_index:, metasearch_index:, spelling_index:)
+    def initialize(registries:, content_index:, metasearch_index:)
       @index = content_index
-
       @registries = registries
       @metasearch_index = metasearch_index
-      @spelling_index = spelling_index
       @suggestion_blocklist = SuggestionBlocklist.new(registries)
     end
 

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -130,7 +130,7 @@ module Search
     # some indexes contain very few words, Elasticsearch returns too many spelling
     # suggestions for common terms. For example, using the suggester on all indices
     # will yield a suggestion for "PAYE", because it's mentioned only in the
-    # `government` index, and not in other indexes.
+    # `govuk` index, and not in other indexes.
     #
     # This issue is mentioned in
     # https://github.com/elastic/elasticsearch/issues/7472.
@@ -147,7 +147,7 @@ module Search
           suggest: QueryComponents::Suggest.new(search_params).payload,
         }
 
-        response = spelling_index.raw_search(query)
+        response = index.raw_search(query)
 
         response["suggest"]
       end

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -64,10 +64,6 @@ module Search
       index.index_names
     end
 
-    def fetch_spell_checks(search_params)
-      SpellCheckFetcher.new(search_params, registries).es_response
-    end
-
     def process_elasticsearch_errors
       yield
     rescue Elasticsearch::Transport::Transport::Errors::InternalServerError => e

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -8,7 +8,6 @@ class SearchConfig
       popularity_rank_offset
       auxiliary_index_names
       content_index_names
-      spelling_index_names
       govuk_index_name
       page_traffic_index_name
     ].each do |config_method|
@@ -117,10 +116,6 @@ class SearchConfig
 
   def metasearch_index
     @metasearch_index ||= search_server.index(SearchConfig.metasearch_index_name)
-  end
-
-  def spelling_index
-    @spelling_index ||= search_server.index_for_search(SearchConfig.spelling_index_names)
   end
 
   def content_index

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -159,7 +159,6 @@ private
       content_index:,
       registries:,
       metasearch_index:,
-      spelling_index:,
     )
   end
 

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "SearchTest" do
 
   it "spell checking with blocklisted typo" do
     commit_document(
-      "government_test",
+      "govuk_test",
       {
         "title" => "Brexitt",
         "description" => "Brexitt",


### PR DESCRIPTION
Previously we used the government index to serve spelling suggestions. This was a necessary workaround when we had multiple content indices. Now all content is read from a single index, we can serve spelling suggestions from govuk index instead.

See Jira ticket [SCH-2036](https://gov-uk.atlassian.net/browse/SCH-2036)

Deployed to integration & checked that spelling suggestions still worked ✅ 

[SCH-2036]: https://gov-uk.atlassian.net/browse/SCH-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ