### PR TITLE
Deprecate post "/commit" endpoint

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -63,12 +63,6 @@ class Rummager < Sinatra::Application
     halt(403, "You do not have permission to access this endpoint") unless u["permissions"].include? permission
   end
 
-  def prevent_access_to_govuk_and_detailed
-    if %w[govuk detailed].include?(index_name)
-      halt(403, "Actions to the govuk or detailed indices are not allowed via this endpoint.")
-    end
-  end
-
   def deprecated_endpoint
     GovukError.notify("Deprecated endpoint accessed", extras: { source_ip: request.ip, path: request.fullpath })
     halt(403, "This endpoint has been deprecated.")
@@ -183,9 +177,7 @@ class Rummager < Sinatra::Application
   end
 
   post "/:index/commit" do
-    require_authentication "manage_search_indices"
-    prevent_access_to_govuk_and_detailed
-    simple_json_result(current_index.commit)
+    deprecated_endpoint
   end
 
   delete "/:index/documents/*" do

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -14,8 +14,6 @@ require "govuk_app_config"
 require "healthcheck/elasticsearch_connectivity_check"
 
 class Rummager < Sinatra::Application
-  class AttemptToUseDefaultMainstreamIndex < StandardError; end
-
   Warden::Strategies.add :bearer_token, Warden::OAuth2::Strategies::Bearer
   Warden::OAuth2.configure { |config| config.token_model = Auth::GdsSso }
   Warden::Strategies.add :mock_bearer_token, Auth::MockStrategy
@@ -120,16 +118,6 @@ class Rummager < Sinatra::Application
 
   error Index::ResponseValidator::NotFound do
     halt(404, env["sinatra.error"].message)
-  end
-
-  error Rummager::AttemptToUseDefaultMainstreamIndex do
-    GovukError.notify(
-      env["sinatra.error"],
-      extra: {
-        params:,
-      },
-    )
-    halt(500, env["sinatra.error"].message)
   end
 
   # Return results for the GOV.UK site search
@@ -254,28 +242,6 @@ class Rummager < Sinatra::Application
     end
   rescue Aws::S3::Errors::NoSuchKey
     halt(404, "No such object")
-  end
-
-  # these endpoints are used to capture any usage of old endpoints which relied on a default index.
-  # They can be removed once we are happy they are not being accessed.
-  delete "/documents" do
-    raise AttemptToUseDefaultMainstreamIndex
-  end
-
-  post "/documents/*" do
-    raise AttemptToUseDefaultMainstreamIndex
-  end
-
-  delete "/documents/*" do
-    raise AttemptToUseDefaultMainstreamIndex
-  end
-
-  post "/commit" do
-    raise AttemptToUseDefaultMainstreamIndex
-  end
-
-  post "/documents" do
-    raise AttemptToUseDefaultMainstreamIndex
   end
 
   post "/unauthenticated/?" do

--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -141,19 +141,6 @@ class Rummager < Sinatra::Application
     end
   end
 
-  get "/content" do
-    deprecated_endpoint
-  end
-
-  delete "/content" do
-    deprecated_endpoint
-  end
-
-  # Insert (or overwrite) a document
-  post "/:index/documents" do
-    deprecated_endpoint
-  end
-
   post "/v2/metasearch/documents" do
     require_authentication "manage_search_indices"
     document = JSON.parse(request.body.read)
@@ -164,14 +151,6 @@ class Rummager < Sinatra::Application
     json_result 200, "Success"
   end
 
-  post "/:index/commit" do
-    deprecated_endpoint
-  end
-
-  delete "/:index/documents/*" do
-    deprecated_endpoint
-  end
-
   delete "/v2/metasearch/documents/*" do
     require_authentication "manage_search_indices"
     id = params["splat"].first
@@ -180,15 +159,6 @@ class Rummager < Sinatra::Application
     deleter.delete
 
     json_result 200, "Success"
-  end
-
-  # Update an existing document
-  post "/:index/documents/*" do
-    deprecated_endpoint
-  end
-
-  delete "/:index/documents" do
-    deprecated_endpoint
   end
 
   get "/_status" do
@@ -256,5 +226,36 @@ class Rummager < Sinatra::Application
     headers = { "WWW-Authenticate" => %(Bearer error=#{bearer_error}) }
     body = { message: }.to_json
     halt(401, headers, body)
+  end
+
+  # Deprecated routes (since April 2026).
+  # Accessing these routes raises an error so we can detect any remaining usage.
+  # They can be removed once we’re confident they are no longer in use.
+  get "/content" do
+    deprecated_endpoint
+  end
+
+  delete "/content" do
+    deprecated_endpoint
+  end
+
+  post "/:index/documents" do
+    deprecated_endpoint
+  end
+
+  post "/:index/documents/*" do
+    deprecated_endpoint
+  end
+
+  delete "/:index/documents" do
+    deprecated_endpoint
+  end
+
+  post "/:index/commit" do
+    deprecated_endpoint
+  end
+
+  delete "/:index/documents/*" do
+    deprecated_endpoint
   end
 end

--- a/spec/integration/app/authorization_spec.rb
+++ b/spec/integration/app/authorization_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "AuthorizationTests" do
     end
 
     it "prevents access to a route that requires authentication when no authentication is provided" do
-      response = post "/government_test/commit", {}.to_json
+      response = post "/v2/metasearch/documents", {}.to_json
 
       expect(response.status).to eq(401)
     end

--- a/spec/integration/app/deprecated_endpoints_spec.rb
+++ b/spec/integration/app/deprecated_endpoints_spec.rb
@@ -20,4 +20,5 @@ RSpec.describe "Deprecate content endpoints" do
   include_examples "forbidden request", :get, "/content"
   include_examples "forbidden request", :delete, "/content"
   include_examples "forbidden request", :delete, "/govuk_test/documents"
+  include_examples "forbidden request", :post, "/:index/commit"
 end

--- a/spec/integration/app/error_handling_spec.rb
+++ b/spec/integration/app/error_handling_spec.rb
@@ -18,20 +18,6 @@ RSpec.describe "ErrorHandlingTest" do
     end
   end
 
-  RSpec.shared_examples "blocks default mainstream index usage" do |http_method:, path:|
-    it "#{http_method.upcase} #{path} raises AttemptToUseDefaultMainstreamIndex" do
-      expect(GovukError).to receive(:notify)
-                              .with(
-                                instance_of(Rummager::AttemptToUseDefaultMainstreamIndex),
-                                extra: hash_including(:params),
-                              )
-
-      send(http_method, path)
-      expect(last_response.status).to eq(500)
-      expect(last_response.body).to be_present
-    end
-  end
-
   include_examples(
     "a sinatra error handler",
     exception_class: Index::ResponseValidator::NotFound,
@@ -66,20 +52,6 @@ RSpec.describe "ErrorHandlingTest" do
     status: 400,
     body: ->(msg) { msg },
   )
-
-  [
-    [:delete, "/documents"],
-    [:post,   "/documents/123"],
-    [:delete, "/documents/123"],
-    [:post,   "/commit"],
-    [:post,   "/documents"],
-  ].each do |http_method, path|
-    include_examples(
-      "blocks default mainstream index usage",
-      http_method:,
-      path:,
-    )
-  end
 
   it "notifies GovukError with the exception and params" do
     error = Index::ResponseValidator::ElasticsearchError.new("error")

--- a/spec/integration/indexer/commit_spec.rb
+++ b/spec/integration/indexer/commit_spec.rb
@@ -1,8 +1,0 @@
-require "spec_helper"
-
-RSpec.describe "Commit" do
-  describe "post /:index/commit" do
-    it_behaves_like "govuk and detailed index protection", "/:index/commit", method: :post
-    it_behaves_like "rejects unknown index", "/unknown_index/commit", method: :post
-  end
-end


### PR DESCRIPTION
This route is no longer in use

Remove some previously deprecated endpoints and reorder some routes 

jira: https://gov-uk.atlassian.net/browse/SCH-1989