### PR TITLE
Sch 1990 remove registry index

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -3,7 +3,6 @@ production: &default
   content_index_names: ["government"]
   govuk_index_name: "govuk"
   auxiliary_index_names: ["page-traffic", "metasearch"]
-  registry_index: "government"
   metasearch_index_name: "metasearch"
   page_traffic_index_name: "page-traffic"
   popularity_rank_offset: 10
@@ -21,7 +20,6 @@ test:
   content_index_names: ["government_test"]
   govuk_index_name: "govuk_test"
   auxiliary_index_names: ["page-traffic_test", "metasearch_test"]
-  registry_index: "government_test"
   metasearch_index_name: "metasearch_test"
   page_traffic_index_name: "page-traffic_test"
   popularity_rank_offset: 10

--- a/lib/search/presenters/entity_expander.rb
+++ b/lib/search/presenters/entity_expander.rb
@@ -33,7 +33,6 @@ module Search
     MAPPINGS = [
       Mapping.new(:document_collections),
       Mapping.new(:organisations),
-      Mapping.new(:policy_areas),
       Mapping.new(:world_locations),
       Mapping.new(:people),
       Mapping.new(:roles),

--- a/lib/search/presenters/entity_expander.rb
+++ b/lib/search/presenters/entity_expander.rb
@@ -31,7 +31,6 @@ module Search
     end
 
     MAPPINGS = [
-      Mapping.new(:document_series),
       Mapping.new(:document_collections),
       Mapping.new(:organisations),
       Mapping.new(:policy_areas),

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -9,7 +9,7 @@ module Search
         organisations:,
         organisation_content_ids: organisations,
         document_collections: govuk_registry_for_document_format("document_collection"),
-        world_locations: registry_for_document_format("world_location"),
+        world_locations: govuk_registry_for_document_format("world_location"),
         people: govuk_registry_for_document_format("person"),
         roles: govuk_registry_for_document_format("ministerial_role"),
       }

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -15,7 +15,6 @@ module Search
         # than "topic", we will expand `policy_areas` with data from documents
         # with format `topic`.
         policy_areas: registry_for_document_format("topic"),
-        document_series: registry_for_document_format("document_series"),
         document_collections: registry_for_document_format("document_collection"),
         world_locations: registry_for_document_format("world_location"),
         people: govuk_registry_for_document_format("person"),

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -8,13 +8,6 @@ module Search
       @as_hash ||= {
         organisations:,
         organisation_content_ids: organisations,
-
-        # Whitehall has a thing called `topic`, which is being renamed to "policy
-        # area", because there already are seven things called "topic". Until
-        # Whitehall publishes the policy areas with format "policy_area" rather
-        # than "topic", we will expand `policy_areas` with data from documents
-        # with format `topic`.
-        policy_areas: registry_for_document_format("topic"),
         document_collections: govuk_registry_for_document_format("document_collection"),
         world_locations: registry_for_document_format("world_location"),
         people: govuk_registry_for_document_format("person"),

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -15,7 +15,7 @@ module Search
         # than "topic", we will expand `policy_areas` with data from documents
         # with format `topic`.
         policy_areas: registry_for_document_format("topic"),
-        document_collections: registry_for_document_format("document_collection"),
+        document_collections: govuk_registry_for_document_format("document_collection"),
         world_locations: registry_for_document_format("world_location"),
         people: govuk_registry_for_document_format("person"),
         roles: govuk_registry_for_document_format("ministerial_role"),

--- a/lib/search/registries.rb
+++ b/lib/search/registries.rb
@@ -54,14 +54,6 @@ module Search
       search_server.index_for_search([SearchConfig.govuk_index_name])
     end
 
-    def registry_for_document_format(format)
-      BaseRegistry.new(index, field_definitions, format)
-    end
-
-    def index
-      search_server.index_for_search([SearchConfig.registry_index])
-    end
-
     def field_definitions
       @field_definitions ||= search_server.schema.field_definitions
     end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -3,7 +3,6 @@ class SearchConfig
     attr_writer :instance
 
     %w[
-      registry_index
       metasearch_index_name
       popularity_rank_offset
       auxiliary_index_names

--- a/lib/tasks/report_inconsistent_aggregate_values.rake
+++ b/lib/tasks/report_inconsistent_aggregate_values.rake
@@ -11,7 +11,6 @@ task :report_inconsistent_aggregate_values do
   aggregates = %w[
     document_collections
     organisations
-    policy_areas
     world_locations
     people
   ]

--- a/lib/tasks/report_inconsistent_aggregate_values.rake
+++ b/lib/tasks/report_inconsistent_aggregate_values.rake
@@ -9,7 +9,6 @@ task :report_inconsistent_aggregate_values do
   # Same as in `lib/search/presenters/entity_expander.rb` minus
   # the content_id mappings which are not valid aggregate fields.
   aggregates = %w[
-    document_series
     document_collections
     organisations
     policy_areas

--- a/spec/unit/result_set_presenter_spec.rb
+++ b/spec/unit/result_set_presenter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Search::ResultSetPresenter do
        "_source" => {
          "title" => "Dairy farming and schemes",
          "link" => "/dairy-farming-and-schemes",
-         "policy_areas" => %w[farming],
+         "document_collections" => %w[farming],
        },
      }]
   end
@@ -157,9 +157,9 @@ RSpec.describe Search::ResultSetPresenter do
 
   context "results with a registry" do
     before do
-      policy_area_registry = {
+      document_collections_registry = {
         "farming" => {
-          "link" => "/government/topics/farming",
+          "link" => "/government/collections/farming",
           "title" => "Farming",
         },
       }
@@ -167,11 +167,11 @@ RSpec.describe Search::ResultSetPresenter do
       @output = described_class.new(
         search_params: Search::QueryParameters.new(
           start: 0,
-          return_fields: %w[policy_areas],
+          return_fields: %w[document_collections],
           aggregate_name: :aggregates,
         ),
         es_response: sample_es_response,
-        registries: { policy_areas: policy_area_registry },
+        registries: { document_collections: document_collections_registry },
       ).present
     end
 
@@ -208,10 +208,10 @@ RSpec.describe Search::ResultSetPresenter do
     it "have the expanded topic" do
       result = @output[:results][2]
       expect([{
-        "link" => "/government/topics/farming",
+        "link" => "/government/collections/farming",
         "title" => "Farming",
         "slug" => "farming",
-      }]).to eq result["policy_areas"]
+      }]).to eq result["document_collections"]
     end
   end
 end


### PR DESCRIPTION
In elasticsearch.yml there is a mapping of a "registry_index" to the government index. This reference is used in code that looks up linked documents to supported expanded links for four fields that could exist on an elasticsearch document:

- policy areas
- document_series
- document_collections
- world_locations

The `policy_areas` and `document_series` fields have been deprecated, meaning we no longer need the link expansion and so it's being removed. For the other two, we're switching to look up additional information from the govuk index instead of the government index. We're then deleting the reference to the registry_index, in preparation of deprecating the government index.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1990

This PR can be merged now that https://github.com/alphagov/search-api/pull/3613 is merged and documents with the format "document_collection" have been republished to populate the slug field in elasticsearch. This ensures the registry look up will stay functional, once we switch to using the govuk index. This has been tested on integration.