### PR TITLE
Populate slugs in document_collections

### DIFF
--- a/lib/govuk_index/presenters/common_fields_presenter.rb
+++ b/lib/govuk_index/presenters/common_fields_presenter.rb
@@ -47,6 +47,8 @@ module GovukIndex
 
     def slug
       case format
+      when "document_collection"
+        base_path.gsub(%r{^/government/collections/}, "")
       when "mainstream_browse_page"
         base_path.gsub(%r{^/browse/}, "")
       when "ministerial_role"

--- a/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/common_fields_presenter_spec.rb
@@ -300,6 +300,16 @@ RSpec.describe GovukIndex::CommonFieldsPresenter do
     expect(presenter.slug).to eq "announcement-slug"
   end
 
+  it "extracts the slug from the base path for a document collection" do
+    payload = {
+      "base_path" => "/government/collections/collection-slug",
+      "document_type" => "document_collection",
+    }
+    presenter = common_fields_presenter(payload)
+
+    expect(presenter.slug).to eq "collection-slug"
+  end
+
   def common_fields_presenter(payload)
     described_class.new(payload)
   end


### PR DESCRIPTION
Documents that have the format document_collection are no longer populating the slug field in elasticsearch. This prevents the document_collections field being expanded correctly via the registries look up [1]. This change populates the slug field using the base path, so that the document_collections field can be expanded correctly.

[1] https://github.com/alphagov/search-api/blob/main/lib/search/registries.rb#L19

Jira link: https://gov-uk.atlassian.net/browse/SCH-1990

Have tested this on integration, republished document_collection documents and now all document_collections in the govuk index have slugs 🎉 