### PR TITLE
(CM-934) Make Content Blocks available to Search API

### DIFF
--- a/config/govuk_index/mapped_document_types.yaml
+++ b/config/govuk_index/mapped_document_types.yaml
@@ -25,6 +25,10 @@ complaints_procedure: edition
 consultation: edition
 consultation_outcome: edition
 contact: contact
+content_block_contact: edition
+content_block_pension: edition
+content_block_tax: edition
+content_block_time_period: edition
 coronavirus_landing_page: edition
 corporate_report: edition
 correspondence: edition

--- a/config/govuk_index/migrated_formats.yaml
+++ b/config/govuk_index/migrated_formats.yaml
@@ -4,6 +4,11 @@ migrated:
 - mainstream_browse_page
 # Contacts
 - contact
+# Content Block Manager
+- content_block_contact
+- content_block_pension
+- content_block_tax
+- content_block_time_period
 # Publisher
 - answer
 - guide


### PR DESCRIPTION
This adds the various content blocks as supported document types in Search API