### PR TITLE
Sch 2066 address sitemap generator spec test failures

### DIFF
--- a/spec/integration/sitemap/generator_spec.rb
+++ b/spec/integration/sitemap/generator_spec.rb
@@ -99,13 +99,13 @@ RSpec.describe Sitemap::Generator do
         {
           "title" => "Cheese in my face",
           "description" => "Hummus weevils",
-          "format" => "cool-format",
+          "format" => "answer",
           "link" => "/an-example-answer",
           "indexable_content" => "I like my badger: he is tasty and delicious",
           "public_timestamp" => "2017-07-01T12:41:34+00:00",
         },
       ],
-      index_name: "government_test",
+      index_name: "govuk_test",
     )
 
     expected_xml = <<~HEREDOC
@@ -141,13 +141,13 @@ RSpec.describe Sitemap::Generator do
         {
           "title" => "Cheese in my face",
           "description" => "Hummus weevils",
-          "format" => "unfiltered-format",
+          "format" => "answer",
           "link" => "/an-example-answer",
           "indexable_content" => "I like my badger: he is tasty and delicious",
           "public_timestamp" => "2017-07-01T12:41:34+00:00",
         },
       ],
-      index_name: "government_test",
+      index_name: "govuk_test",
     )
 
     expected_xml = <<~HEREDOC
@@ -279,7 +279,7 @@ RSpec.describe Sitemap::Generator do
 
 private
 
-  def add_sample_documents(docs, index_name: "government_test")
+  def add_sample_documents(docs, index_name: "govuk_test")
     docs.each do |sample_document|
       insert_document(index_name, sample_document)
     end

--- a/spec/integration/sitemap/generator_spec.rb
+++ b/spec/integration/sitemap/generator_spec.rb
@@ -50,6 +50,49 @@ RSpec.describe Sitemap::Generator do
     generator.run
   end
 
+  it "only includes migrated formats from govuk" do
+    add_sample_documents(
+      [
+        {
+          "title" => "Cheese in my face",
+          "description" => "Hummus weevils",
+          "format" => "answer",
+          "link" => "/an-example-answer",
+          "indexable_content" => "I like my badger: he is tasty and delicious",
+          "public_timestamp" => "2017-07-01T12:41:34+00:00",
+        },
+        {
+          "title" => "Cheese in my face",
+          "description" => "Hummus weevils",
+          "format" => "not-migrated-format",
+          "link" => "/another-example-answer",
+          "indexable_content" => "I like my cat: he is tasty and delicious",
+          "public_timestamp" => "2017-07-01T12:41:34+00:00",
+        },
+      ],
+      index_name: "govuk_test",
+    )
+
+    expected_xml = <<~HEREDOC
+      <?xml version="1.0" encoding="UTF-8"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url>
+          <loc>http://www.dev.gov.uk/</loc>
+          <priority>0.5</priority>
+        </url>
+        <url>
+          <loc>http://www.dev.gov.uk/an-example-answer</loc>
+          <lastmod>2017-07-01T12:41:34+00:00</lastmod>
+          <priority>0.5</priority>
+        </url>
+      </urlset>
+    HEREDOC
+
+    expect(sitemap_uploader).to receive(:upload).with(file_content: expected_xml, file_name: "sitemap_1.xml")
+
+    generator.run
+  end
+
   it "does not include migrated formats from government" do
     add_sample_documents(
       [


### PR DESCRIPTION
Update sitemap tests to use the govuk index in preparation of decommissioning the government index.

There is still one sitemap test remaining that uses the government index. This is testing the filter on returned documents, so should be removed at the same time that the filter is updated, or when we delete the government index.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2066