### PR TITLE
Remove separate Elasticsearch suggestion query

### DIFF
--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -38,11 +38,14 @@ module Search
     attr_reader :metasearch_index
 
     def timed_build_query(search_params)
+      include_suggestions = search_params.suggest_spelling? && suggestion_blocklist.should_correct?(search_params.query)
+
       GovukStatsd.time("build_query") do
         builder = QueryBuilder.new(
           search_params:,
           content_index_names:,
           metasearch_index:,
+          include_suggestions:,
         )
 
         payload = process_elasticsearch_errors { builder.payload }
@@ -77,10 +80,6 @@ module Search
 
     def process_es_response(search_params, builder, payload, es_response)
       # Augment the response with the suggest result from a separate query.
-      if search_params.suggest_spelling?
-        es_response["suggest"] = run_spell_checks(search_params)
-      end
-
       if search_params.suggest_autocomplete?
         es_response["autocomplete"] = run_autocomplete_query(search_params)
       end
@@ -116,35 +115,6 @@ module Search
       AggregateResultPresenter.merge_examples(presented_aggregates, examples)
 
       presented_aggregates
-    end
-
-    # Elasticsearch tries to find spelling suggestions for words that don't occur in
-    # our content, as they are probably mispelled. However, currently it is
-    # returning suggestions for words that do not occur in *every* index. Because
-    # some indexes contain very few words, Elasticsearch returns too many spelling
-    # suggestions for common terms. For example, using the suggester on all indices
-    # will yield a suggestion for "PAYE", because it's mentioned only in the
-    # `govuk` index, and not in other indexes.
-    #
-    # This issue is mentioned in
-    # https://github.com/elastic/elasticsearch/issues/7472.
-    #
-    # Our solution is to run a separate query to fetch the suggestions, only using
-    # the indices we want.
-    def run_spell_checks(search_params)
-      return unless suggestion_blocklist.should_correct?(search_params.query)
-
-      GovukStatsd.increment "suggest.spelling"
-      GovukStatsd.time("suggest.spelling") do
-        query = {
-          size: 0,
-          suggest: QueryComponents::Suggest.new(search_params).payload,
-        }
-
-        response = index.raw_search(query)
-
-        response["suggest"]
-      end
     end
 
     def run_autocomplete_query(search_params)

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -38,10 +38,13 @@ module Search
     attr_reader :metasearch_index
 
     def timed_build_query(search_params)
+      include_suggestions = search_params.suggest_spelling? && suggestion_blocklist.should_correct?(search_params.query)
+
       GovukStatsd.time("build_query") do
         builder = QueryBuilder.new(
           search_params:,
           metasearch_index:,
+          include_suggestions:,
         )
 
         payload = process_elasticsearch_errors { builder.payload }
@@ -71,10 +74,6 @@ module Search
 
     def process_es_response(search_params, builder, payload, es_response)
       # Augment the response with the suggest result from a separate query.
-      if search_params.suggest_spelling?
-        es_response["suggest"] = run_spell_checks(search_params)
-      end
-
       if search_params.suggest_autocomplete?
         es_response["autocomplete"] = run_autocomplete_query(search_params)
       end
@@ -110,35 +109,6 @@ module Search
       AggregateResultPresenter.merge_examples(presented_aggregates, examples)
 
       presented_aggregates
-    end
-
-    # Elasticsearch tries to find spelling suggestions for words that don't occur in
-    # our content, as they are probably mispelled. However, currently it is
-    # returning suggestions for words that do not occur in *every* index. Because
-    # some indexes contain very few words, Elasticsearch returns too many spelling
-    # suggestions for common terms. For example, using the suggester on all indices
-    # will yield a suggestion for "PAYE", because it's mentioned only in the
-    # `govuk` index, and not in other indexes.
-    #
-    # This issue is mentioned in
-    # https://github.com/elastic/elasticsearch/issues/7472.
-    #
-    # Our solution is to run a separate query to fetch the suggestions, only using
-    # the indices we want.
-    def run_spell_checks(search_params)
-      return unless suggestion_blocklist.should_correct?(search_params.query)
-
-      GovukStatsd.increment "suggest.spelling"
-      GovukStatsd.time("suggest.spelling") do
-        query = {
-          size: 0,
-          suggest: QueryComponents::Suggest.new(search_params).payload,
-        }
-
-        response = index.raw_search(query)
-
-        response["suggest"]
-      end
     end
 
     def run_autocomplete_query(search_params)

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -5,10 +5,11 @@ module Search
 
     attr_reader :search_params
 
-    def initialize(search_params:, content_index_names:, metasearch_index:)
+    def initialize(search_params:, content_index_names:, metasearch_index:, include_suggestions: false)
       @search_params = search_params
       @content_index_names = content_index_names
       @metasearch_index = metasearch_index
+      @include_suggestions = include_suggestions
     end
 
     def payload
@@ -24,6 +25,7 @@ module Search
         aggs: aggregates,
         highlight:,
         explain: search_params.debug[:explain],
+        suggest:,
       )
     end
 
@@ -71,7 +73,13 @@ module Search
 
   private
 
-    attr_reader :content_index_names, :metasearch_index
+    attr_reader :content_index_names, :metasearch_index, :include_suggestions
+
+    def suggest
+      return {} unless include_suggestions
+
+      QueryComponents::Suggest.new(search_params).payload
+    end
 
     def best_bets
       QueryComponents::BestBets.new(metasearch_index:, search_params:)

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -5,9 +5,10 @@ module Search
 
     attr_reader :search_params
 
-    def initialize(search_params:, metasearch_index:)
+    def initialize(search_params:, metasearch_index:, include_suggestions: false)
       @search_params = search_params
       @metasearch_index = metasearch_index
+      @include_suggestions = include_suggestions
     end
 
     def payload
@@ -23,6 +24,7 @@ module Search
         aggs: aggregates,
         highlight:,
         explain: search_params.debug[:explain],
+        suggest:,
       )
     end
 
@@ -67,7 +69,13 @@ module Search
 
   private
 
-    attr_reader :metasearch_index
+    attr_reader :metasearch_index, :include_suggestions
+
+    def suggest
+      return {} unless include_suggestions
+
+      QueryComponents::Suggest.new(search_params).payload
+    end
 
     def best_bets
       QueryComponents::BestBets.new(metasearch_index:, search_params:)


### PR DESCRIPTION
The separate suggestion query was originally introduced to work around Elasticsearch returning spelling suggestions for terms missing from some indices but present in others.

Now that search uses a single index, this workaround is no longer necessary. Suggestions can be fetched as part of the main query, removing the extra Elasticsearch request.

According to the comment:

    Elasticsearch tries to find spelling suggestions for words that don't occur in
    our content, as they are probably mispelled. However, currently it is
    returning suggestions for words that do not occur in *every* index. Because
    ome indexes contain very few words, Elasticsearch returns too many spelling
    suggestions for common terms. For example, using the suggester on all indices
    will yield a suggestion for "PAYE", because it's mentioned only in the
    `govuk` index, and not in other indexes.

    This issue is mentioned in
    https://github.com/elastic/elasticsearch/issues/7472.

    Our solution is to run a separate query to fetch the suggestions, only using
    the indices we want.

https://gov-uk.atlassian.net/browse/SCH-2059