### PR TITLE
Add a  rake task to safely delete the 'government' index

### DIFF
--- a/lib/tasks/delete_government_index.rake
+++ b/lib/tasks/delete_government_index.rake
@@ -1,5 +1,5 @@
 require "rummager"
-desc "Delete the detailed index"
+desc "Delete the government index"
 task :delete_government_index do
   client = Services.elasticsearch
 
@@ -9,5 +9,5 @@ task :delete_government_index do
 
   client.indices.delete(index: indices)
 rescue Elasticsearch::Transport::Transport::Errors::NotFound
-  puts "No detailed index found"
+  puts "No government index found"
 end

--- a/lib/tasks/delete_government_index.rake
+++ b/lib/tasks/delete_government_index.rake
@@ -1,0 +1,13 @@
+require "rummager"
+desc "Delete the detailed index"
+task :delete_government_index do
+  client = Services.elasticsearch
+
+  indices = client.indices.get_alias(name: "government").keys
+
+  puts "Deleting indices: #{indices.join(', ')}"
+
+  client.indices.delete(index: indices)
+rescue Elasticsearch::Transport::Transport::Errors::NotFound
+  puts "No detailed index found"
+end

--- a/spec/integration/delete_government_index_spec.rb
+++ b/spec/integration/delete_government_index_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+require "rake"
+load "tasks/delete_government_index.rake"
+
+RSpec.describe "delete_government_index rake task", :integration do
+  let(:es_client) do
+    Services.elasticsearch
+  end
+
+  let(:alias_name) { "government" }
+  let(:index_name) { "government-test-1" }
+
+  before do
+    reset_indices!
+
+    es_client.indices.create(index: index_name)
+    es_client.indices.put_alias(index: index_name, name: alias_name)
+  end
+
+  after do
+    reset_indices!
+  end
+
+  def run_task
+    Rake::Task["delete_government_index"].reenable
+    Rake::Task["delete_government_index"].invoke
+  end
+
+  def indices_for_alias
+    es_client.indices.get_alias(name: alias_name).keys
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    []
+  end
+
+  def reset_indices!
+    es_client.indices.delete(index: indices_for_alias) if indices_for_alias.any?
+  end
+
+  it "deletes all indices behind the alias" do
+    expect {
+      run_task
+    }.to change {
+      es_client.indices.exists?(index: index_name)
+    }.from(true).to(false)
+  end
+end


### PR DESCRIPTION
The government index is to be deleted as we are no longer using it to store and search documents.

We add a rake task to automate the removal

https://gov-uk.atlassian.net/browse/SCH-2033