### PR TITLE
Clean up from remove content indices

### DIFF
--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -56,11 +56,6 @@ module Search
       end
     end
 
-    def content_index_names
-      # index is a IndexForSearch object, which combines all the content indexes
-      index.index_names
-    end
-
     def process_elasticsearch_errors
       yield
     rescue Elasticsearch::Transport::Transport::Errors::InternalServerError => e

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -201,12 +201,14 @@ RSpec.describe "SearchTest" do
   end
 
   it "only contains fields which are present" do
-    commit_document(index_name, build(:document, "link" => "/early"))
+    commit_document(index_name, build(:document, "link" => "/early", "topical_events" => %w[a_topical_event]))
     commit_document(index_name, build(:document, "link" => "/late"))
 
     get "/search?order=public_timestamp"
 
-    expect(result_links).to eq(["/early", "/late"])
+    results = parsed_response["results"]
+    expect(results[1].keys).not_to include("topical_events")
+    expect(results[0]["topical_events"]).to eq(%w[a_topical_event])
   end
 
   it "validates integer params" do

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -108,12 +108,11 @@ RSpec.describe "SearchTest" do
     end
 
     it "can filter and reject" do
-      get "/search?reject_format=aaib&filter_mainstream_browse_pages[]=browse/page/2"
-      commit_document(index_name, build(:document,
-                                        link: "/three",
-                                        mainstream_browse_pages: "browse/page/3",
-                                        format: "aaib"))
+      get "/search?filter_mainstream_browse_pages[]=browse/page/2"
       expect(result_links.sort).to eq(["/two"])
+
+      get "/search?reject_link=/two&filter_mainstream_browse_pages[]=browse/page/2"
+      expect(result_links).to be_empty
     end
   end
 

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -314,6 +314,19 @@ RSpec.describe "SearchTest" do
     end
   end
 
+  it "can filter times in different time zones" do
+    january_time = "2017-07-01T11:20:00.000-03:00"
+    february_time = "2017-07-02T01:15:00.000+01:00"
+
+    commit_document(index_name, build(:document, link: "/february", opened_date: february_time))
+    commit_document(index_name, build(:document, link: "/january", opened_date: january_time))
+
+    get "/search?filter_opened_date=from:2017-07-01 12:00,to:2017-07-01 23:30:00"
+
+    expect(last_response).to be_ok
+    expect(parsed_response.fetch("results")).to contain_exactly(hash_including("link" => "/january"))
+  end
+
   it "cannot provide date filter key multiple times" do
     get "/search?filter_document_type=cma_case&filter_opened_date[]=from:2014-03-31&filter_opened_date[]=to:2014-04-02"
 

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -33,43 +33,4 @@ module AppHelpers
       end
     end
   end
-
-  RSpec.shared_examples "rejects unknown index" do |path, method: :post|
-    it "returns 404 if the index does not exist" do
-      send(method, path, {}.to_json)
-
-      expect(last_response.status).to eq(404)
-    end
-  end
-
-  RSpec.shared_examples "govuk and detailed index protection" do |path, method: :post|
-    let(:error_message) do
-      "Actions to the govuk or detailed indices are not allowed via this endpoint."
-    end
-
-    context "when index_name is govuk" do
-      it "halts with 403 and the correct message" do
-        send(method, path.gsub(":index", "govuk"), {}.to_json)
-
-        expect(last_response.status).to eq(403)
-        expect(last_response.body).to eq(error_message)
-      end
-    end
-
-    context "when index_name is detailed" do
-      it "halts with 403 and the correct message" do
-        send(method, path.gsub(":index", "detailed"), {}.to_json)
-
-        expect(last_response.status).to eq(403)
-        expect(last_response.body).to eq(error_message)
-      end
-    end
-
-    context "when index_name is not govuk or detailed" do
-      it "allows the request to continue" do
-        send(method, path.gsub(":index", "government_test"), {}.to_json)
-        expect(last_response.status).not_to eq(403)
-      end
-    end
-  end
 end

--- a/spec/support/index_helpers.rb
+++ b/spec/support/index_helpers.rb
@@ -9,7 +9,7 @@ class IndexHelpers
   end
 
   def self.all_index_names
-    SearchConfig.auxiliary_index_names + [SearchConfig.govuk_index_name]
+    SearchConfig.all_index_names
   end
 
   def self.clean_all


### PR DESCRIPTION
Some clean up following on from https://github.com/alphagov/search-api/pull/3624, as well as other tidy up related to removing the government index.