### PR TITLE
Delete schema for detailed index

### DIFF
--- a/config/schema/indexes/detailed.json
+++ b/config/schema/indexes/detailed.json
@@ -1,5 +1,0 @@
-{
-  "elasticsearch_types": [
-    "edition"
-  ]
-}


### PR DESCRIPTION
The detailed index has been decommissioned so this is no longer required.

See https://github.com/alphagov/search-api/pull/3471