### PR TITLE
[SCH-2073] Pin SHAs for third-party actions

### DIFF
--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -50,7 +50,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.310.0
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
       - if: inputs.pact_artifact == ''

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -38,7 +38,7 @@ jobs:
           path: vendor/publishing-api
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.310.0
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
Pin non-alphagov/non-github actions

-As per policy: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha

JIRA Card: https://gov-uk.atlassian.net/browse/SCH-2073
