### PR TITLE
Remove auxiliary index names

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,7 +1,6 @@
 production: &default
   base_uri: <%= ENV["ELASTICSEARCH_URI"] || 'http://localhost:9200' %>
   govuk_index_name: "govuk"
-  auxiliary_index_names: ["page-traffic", "metasearch"]
   metasearch_index_name: "metasearch"
   page_traffic_index_name: "page-traffic"
   popularity_rank_offset: 10
@@ -17,7 +16,6 @@ development:
 test:
   base_uri: <%= ENV.fetch('ELASTICSEARCH_URI', 'http://localhost:9200') %>
   govuk_index_name: "govuk_test"
-  auxiliary_index_names: ["page-traffic_test", "metasearch_test"]
   metasearch_index_name: "metasearch_test"
   page_traffic_index_name: "page-traffic_test"
   popularity_rank_offset: 10

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -25,7 +25,7 @@ module SearchIndices
       @mappings = mappings
       @search_config = search_config
       @elasticsearch_types = @search_config.schema_config.elasticsearch_types(base_index_name)
-      @is_content_index = !(SearchConfig.auxiliary_index_names.include? base_index_name)
+      @is_content_index = SearchConfig.govuk_index_name == base_index_name
     end
 
     def schema

--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -86,19 +86,9 @@ module Indexer
         return nil
       end
 
-      traffic_index_name = SearchConfig.auxiliary_index_names.find do |index|
-        index.start_with?("page-traffic")
-      end
+      result = @search_config.search_server.index(SearchConfig.page_traffic_index_name)
 
-      if traffic_index_name
-        result = @search_config.search_server.index(traffic_index_name)
-
-        if result.exists?
-          return result
-        end
-      end
-
-      nil
+      result if result.exists?
     end
   end
 end

--- a/lib/search_config.rb
+++ b/lib/search_config.rb
@@ -5,7 +5,6 @@ class SearchConfig
     %w[
       metasearch_index_name
       popularity_rank_offset
-      auxiliary_index_names
       govuk_index_name
       page_traffic_index_name
     ].each do |config_method|
@@ -33,7 +32,7 @@ class SearchConfig
     end
 
     def all_index_names
-      auxiliary_index_names + [govuk_index_name]
+      [govuk_index_name, page_traffic_index_name, metasearch_index_name]
     end
 
     def run_search(raw_parameters)
@@ -84,8 +83,6 @@ class SearchConfig
     @search_server ||= SearchIndices::SearchServer.new(
       cluster.uri,
       schema_config,
-      SearchConfig.auxiliary_index_names,
-      SearchConfig.govuk_index_name,
       self,
     )
   end

--- a/lib/search_server.rb
+++ b/lib/search_server.rb
@@ -4,12 +4,9 @@ module SearchIndices
   class SearchServer
     attr_reader :schema
 
-    def initialize(base_uri, schema, auxiliary_index_names, govuk_index_name,
-                   search_config)
+    def initialize(base_uri, schema, search_config)
       @base_uri = base_uri
       @schema = schema
-      @auxiliary_index_names = auxiliary_index_names
-      @govuk_index_name = govuk_index_name
       @search_config = search_config
     end
 
@@ -38,7 +35,7 @@ module SearchIndices
 
     def index_name_valid?(index_name)
       index_name.split(",").all? do |name|
-        @auxiliary_index_names.include?(name) || @govuk_index_name == name
+        SearchConfig.all_index_names.include?(name)
       end
     end
   end

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe SearchIndices::IndexGroup do
     @server = SearchIndices::SearchServer.new(
       base_uri,
       @schema,
-      %w[foo custom],
-      "govuk",
       SearchConfig.default_instance,
     )
   end

--- a/spec/unit/search_server_spec.rb
+++ b/spec/unit/search_server_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 RSpec.describe SearchIndices::SearchServer do
-  let(:auxiliary_index_names) { SearchConfig.auxiliary_index_names }
   let(:govuk_index_name) { SearchConfig.govuk_index_name }
   def schema_config
     schema = double("schema config")
@@ -11,21 +10,21 @@ RSpec.describe SearchIndices::SearchServer do
   end
 
   it "returns an index" do
-    search_server = described_class.new("http://l", schema_config, auxiliary_index_names, govuk_index_name, SearchConfig.default_instance)
-    index = search_server.index(auxiliary_index_names.first)
+    search_server = described_class.new("http://l", schema_config, SearchConfig.default_instance)
+    index = search_server.index(SearchConfig.page_traffic_index_name)
     expect(index).to be_a(SearchIndices::Index)
-    expect(index.index_name).to eq(auxiliary_index_names.first)
+    expect(index.index_name).to eq(SearchConfig.page_traffic_index_name)
   end
 
   it "returns an index for govuk index" do
-    search_server = described_class.new("http://l", schema_config, auxiliary_index_names, govuk_index_name, SearchConfig.default_instance)
+    search_server = described_class.new("http://l", schema_config, SearchConfig.default_instance)
     index = search_server.index(govuk_index_name)
     expect(index).to be_a(SearchIndices::Index)
     expect(index.index_name).to eq(govuk_index_name)
   end
 
   it "raises an error for unknown index" do
-    search_server = described_class.new("http://l", schema_config, auxiliary_index_names, govuk_index_name, SearchConfig.default_instance)
+    search_server = described_class.new("http://l", schema_config, SearchConfig.default_instance)
     expect {
       search_server.index("unknown")
     }.to raise_error(SearchIndices::NoSuchIndex)

--- a/spec/unit/time_based_index_cleanup_spec.rb
+++ b/spec/unit/time_based_index_cleanup_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe SearchIndices::IndexGroup do
     @server = SearchIndices::SearchServer.new(
       base_uri,
       @schema,
-      %w[government custom],
-      "govuk",
       SearchConfig.default_instance,
     )
   end


### PR DESCRIPTION
Auxiliary index names are no longer needed now that search uses a single content index, page traffic index, and metasearch index.

Simplify the code by removing support for auxiliary index names and refactor SearchServer to read index names from SearchConfig instead of accepting govuk_index_name and auxiliary_index_names as arguments.