### PR TITLE
Add test logging for rake tasks

### DIFF
--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -77,7 +77,9 @@ data using sidekiq jobs.
 This does not update the schema.
 "
   task :update_popularity do
+    logger.info "Updating popularity data..."
     GovukIndex::Updater.update(SearchConfig.govuk_index_name, GovukIndex::PopularityJob)
+    logger.info "Popularity data updated"
   end
 
   desc "Update supertypes from govuk_document_types gem.

--- a/lib/tasks/page_traffic.rake
+++ b/lib/tasks/page_traffic.rake
@@ -16,5 +16,6 @@ namespace :page_traffic do
       logger.info "Performing page traffic load for cluster #{cluster.key}..."
       GovukIndex::PageTrafficLoader.new(cluster:).load_from(report)
     end
+    logging.info "Finished performing page traffic load"
   end
 end


### PR DESCRIPTION
I'm not clear whether the existing logging we have for rake tasks isn't appearing in the argo logs because the logs are too long and they're disappearing off the top, or isn't appearing in the argo logs because we've not set up logging correctly for rake tasks. Adding logging messages at the end of our regularly-scheduled rake tasks to see if they appear in the logs.

Edit: deploying this branch to integration for the weekend to see if it works. Marking as draft for now.

Progress 08/06/2026
- Tests over the weekend revealed that logging statements that included in rake tasks are not being output to the logs in Argo.