### PR TITLE
Remove shingles implementation

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -23,12 +23,6 @@ index:
           tokenizer: standard
           filter: [standard, asciifolding, lowercase, stemmer_override, stemmer_english, bigrams]
 
-        with_shingles:
-          type: custom
-          tokenizer: standard
-          filter: [standard, asciifolding, lowercase, stemmer_override, stemmer_english, bigrams]
-          char_filter: [normalize_quotes, strip_quotes]
-
         # This analyzer does not filter out these stopwords:
         # a, an, and, are, as, at, be, but, by,
         # for, if, in, into, is, it,

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -53,11 +53,6 @@
           "index": true,
           "analyzer": "searchable_text"
         },
-        "shingles": {
-          "type": "text",
-          "index": true,
-          "analyzer": "with_shingles"
-        },
         "synonym": {
           "type": "text",
           "index": true,
@@ -79,11 +74,6 @@
           "type": "text",
           "index": true,
           "analyzer": "searchable_text"
-        },
-        "shingles": {
-          "type": "text",
-          "index": true,
-          "analyzer": "with_shingles"
         },
         "synonym": {
           "type": "text",
@@ -124,11 +114,6 @@
           "index": true,
           "analyzer": "string_for_sorting",
           "fielddata": true
-        },
-        "shingles": {
-          "type": "text",
-          "index": true,
-          "analyzer": "with_shingles"
         },
         "no_stop": {
           "type": "text",

--- a/lib/search/query_components/core_query.rb
+++ b/lib/search/query_components/core_query.rb
@@ -91,7 +91,6 @@ module QueryComponents
         [
           match_all_terms(priority_fields.keys, query, MATCH_ALL_MULTI_BOOST),
           match_any_terms(priority_fields.keys, query, MATCH_ANY_MULTI_BOOST),
-          match_bigrams(priority_fields.keys, query, MATCH_ANY_MULTI_BOOST),
           minimum_should_match("all_searchable_text", query, MATCH_MINIMUM_BOOST),
         ],
       )
@@ -184,22 +183,6 @@ module QueryComponents
           operator: "or",
           fields:,
           analyzer: query_analyzer,
-        },
-      }
-    end
-
-    def match_bigrams(fields, query, boost = 1.0)
-      return {} unless search_params.use_shingles?
-
-      fields = fields.map { |f| "#{f}.shingles" }
-
-      {
-        multi_match: {
-          boost:,
-          query: escape(query),
-          operator: "or",
-          fields:,
-          analyzer: "shingled_query_analyzer",
         },
       }
     end

--- a/lib/search/query_parameters.rb
+++ b/lib/search/query_parameters.rb
@@ -75,10 +75,6 @@ module Search
       query && (suggest.include?("spelling") || suggest.include?("spelling_with_highlighting"))
     end
 
-    def use_shingles?
-      ab_tests[:shingles] == "B"
-    end
-
     def model_variant
       return unless model_variants.include? ab_tests[:mv]
 

--- a/spec/unit/query_components/core_query_spec.rb
+++ b/spec/unit/query_components/core_query_spec.rb
@@ -48,16 +48,4 @@ RSpec.describe QueryComponents::CoreQuery do
       expect(query.to_s).not_to match(/all_searchable_text\.synonym/)
     end
   end
-
-  context "the B variant of shingles" do
-    it "makes unquoted search queries match bigrams" do
-      builder = described_class.new(
-        search_query_params(ab_tests: { shingles: "B" }),
-      )
-
-      query = builder.unquoted_phrase_query("income tax")
-
-      expect(query.to_s).to include("shingled_query_analyzer")
-    end
-  end
 end


### PR DESCRIPTION
This was used as part of an AB test and never implemented.

We are unlikely to need this in future as most text-based queries are handled by search v2.

This was removed before and reinstated

See also:
https://github.com/alphagov/search-api/commit/b9402aa6be280632496636c213dde57bbcd458f1 https://github.com/alphagov/search-api/commit/3d9f46ec0850882a5c9c26c6c340209b5f1d179b

https://gov-uk.atlassian.net/browse/SCH-2156