### PR TITLE
Update ranking evaluation rake task to work with BigQuery clickstream dataset 

### DIFF
--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -4,9 +4,9 @@ require "json"
 
 module Evaluation
   class RankEval
-    def initialize(datafile, ab_tests)
+    def initialize(datafile)
       @data = load_from_csv(datafile)
-      @search_params = ab_tests.nil? ? {} : { "ab_tests" => [ab_tests] }
+      @search_params = {}
       @search_config = SearchConfig.parse_parameters(@search_params).search_config
     end
 

--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -4,10 +4,6 @@ require "json"
 
 module Evaluation
   class RankEval
-    def initialize(datafile)
-      @data = load_from_csv(datafile)
-    end
-
     def load_from_csv(datafile)
       data = {}
       last_query = ""
@@ -29,8 +25,8 @@ module Evaluation
       ignore_extra_judgements(data)
     end
 
-    def evaluate
-      requests = queries.each_with_object([]) do |(query, data), acc|
+    def evaluate(csv_data)
+      requests = queries(csv_data).each_with_object([]) do |(query, data), acc|
         acc << {
           id: query,
           request: {
@@ -57,8 +53,8 @@ module Evaluation
       }
     end
 
-    def queries
-      @queries ||= @data.each_with_object({}) do |(query, judgements), queries|
+    def queries(csv_data)
+      @queries ||= csv_data.each_with_object({}) do |(query, judgements), queries|
         queries[query] = {
           es_query: SearchConfig.generate_query({ "q" => [query] }),
           judgements:,

--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -2,7 +2,7 @@ require "csv"
 require "httparty"
 require "json"
 
-module Debug
+module Evaluation
   class RankEval
     def initialize(datafile, ab_tests)
       @data = load_from_csv(datafile)

--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -6,7 +6,6 @@ module Evaluation
   class RankEval
     def initialize(datafile)
       @data = load_from_csv(datafile)
-      @search_config = SearchConfig.parse_parameters({}).search_config
     end
 
     def load_from_csv(datafile)
@@ -85,7 +84,7 @@ module Evaluation
       #   metric: { dcg: { k: 10, normalize: true } },
       # )
 
-      uri = @search_config.base_uri
+      uri = instance.base_uri
       options = {
         body: { requests:, metric: { dcg: { k: 10, normalize: true } } }.to_json,
         headers: { "Content-Type" => "application/json" },
@@ -111,7 +110,11 @@ module Evaluation
     end
 
     def govuk_index_name
-      @govuk_index_name ||= @search_config.get_index_for_alias(SearchConfig.govuk_index_name)
+      @govuk_index_name ||= instance.get_index_for_alias(SearchConfig.govuk_index_name)
+    end
+
+    def instance
+      @instance ||= SearchConfig.default_instance
     end
   end
 end

--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -16,8 +16,10 @@ module Evaluation
         raise "missing score for row '#{row}'" if score.nil?
         raise "missing content id for row '#{row}'" if content_id.nil?
 
+        link = convert_to_link(content_id)
+
         data[query] = data.fetch(query, [])
-        data[query] << ({ score: score.to_i, link: content_id})
+        data[query] << ({ score: score.to_i, link: })
 
         last_query = query
       end
@@ -63,6 +65,15 @@ module Evaluation
     end
 
   private
+
+    def convert_to_link(data)
+      return data if data.include?("/")
+
+      Services
+        .publishing_api
+        .get_content(data)
+        .to_h["base_path"]
+    end
 
     def rank_eval(requests)
       # This workaround was put in because the elasticsearch ruby client used to

--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -6,8 +6,7 @@ module Evaluation
   class RankEval
     def initialize(datafile)
       @data = load_from_csv(datafile)
-      @search_params = {}
-      @search_config = SearchConfig.parse_parameters(@search_params).search_config
+      @search_config = SearchConfig.parse_parameters({}).search_config
     end
 
     def load_from_csv(datafile)
@@ -62,7 +61,7 @@ module Evaluation
     def queries
       @queries ||= @data.each_with_object({}) do |(query, judgements), queries|
         queries[query] = {
-          es_query: SearchConfig.generate_query(@search_params.merge("q" => [query])),
+          es_query: SearchConfig.generate_query({ "q" => [query] }),
           judgements:,
         }
       end

--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -16,7 +16,7 @@ module Evaluation
         score = row["score"]
         link = row["link"]
 
-        raise "missing query for row '#{row}'" if query.nil?
+        raise "missing query for row '#{row}'" if query.empty?
         raise "missing score for row '#{row}'" if score.nil?
         raise "missing link for row '#{row}" if link.nil?
 

--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -8,16 +8,16 @@ module Evaluation
       data = {}
       last_query = ""
       CSV.foreach(datafile, headers: true) do |row|
-        query = (row["query"] || last_query).strip
-        score = row["score"]
-        link = row["link"]
+        query = (row["queryEntry.query"] || last_query).strip
+        score = row["queryEntry.targets.score"]
+        content_id = row["queryEntry.targets.uri"]
 
         raise "missing query for row '#{row}'" if query.empty?
         raise "missing score for row '#{row}'" if score.nil?
-        raise "missing link for row '#{row}" if link.nil?
+        raise "missing content id for row '#{row}'" if content_id.nil?
 
         data[query] = data.fetch(query, [])
-        data[query] << ({ score: score.to_i, link: })
+        data[query] << ({ score: score.to_i, link: content_id})
 
         last_query = query
       end

--- a/lib/evaluation/rank_eval.rb
+++ b/lib/evaluation/rank_eval.rb
@@ -16,7 +16,7 @@ module Evaluation
         raise "missing score for row '#{row}'" if score.nil?
         raise "missing content id for row '#{row}'" if content_id.nil?
 
-        link = convert_to_link(content_id)
+        link = convert_to_link(content_id) || content_id
 
         data[query] = data.fetch(query, [])
         data[query] << ({ score: score.to_i, link: })

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -2,7 +2,6 @@ require "aws-sdk-s3"
 require "csv"
 require "rummager"
 require "rainbow"
-require "debug/rank_eval"
 require "debug/synonyms"
 require "tempfile"
 
@@ -56,36 +55,6 @@ namespace :debug do
         puts title
         puts description if description
         puts ""
-      end
-    end
-  end
-
-  desc "Check how well the search query performs for a set of relevancy judgements"
-  task :ranking_evaluation, [:datafile, :ab_tests] do |_, args|
-    csv = args.datafile || begin
-      bucket = ENV["AWS_S3_RELEVANCY_BUCKET_NAME"]
-      raise "Missing required AWS_S3_RELEVANCY_BUCKET_NAME envvar" if bucket.nil?
-
-      csv = Tempfile.open(["judgements", ".csv"])
-      Services.s3_client.get_object(bucket:, key: "judgements.csv", response_target: csv.path)
-      csv.path
-    end
-
-    begin
-      evaluator = Debug::RankEval.new(csv, args.ab_tests)
-      results = evaluator.evaluate
-
-      maxlen = results[:query_scores].map { |query, _| query.length }.max
-      results[:query_scores].each do |query, score|
-        justified_query = "#{query}:".ljust(maxlen + 1)
-        puts "#{justified_query} #{score}"
-      end
-      puts "---"
-      puts "overall score: #{results[:score]}"
-    ensure
-      if csv.is_a?(Tempfile)
-        csv.close
-        csv.unlink
       end
     end
   end

--- a/lib/tasks/ranking_evaluation.rake
+++ b/lib/tasks/ranking_evaluation.rake
@@ -1,0 +1,31 @@
+require "evaluation/rank_eval"
+
+desc "Check how well the search query performs for a set of relevancy judgements"
+task :ranking_evaluation, [:datafile, :ab_tests] do |_, args|
+  csv = args.datafile || begin
+    bucket = ENV["AWS_S3_RELEVANCY_BUCKET_NAME"]
+    raise "Missing required AWS_S3_RELEVANCY_BUCKET_NAME envvar" if bucket.nil?
+
+    csv = Tempfile.open(["judgements", ".csv"])
+    Services.s3_client.get_object(bucket:, key: "judgements.csv", response_target: csv.path)
+    csv.path
+  end
+
+  begin
+    evaluator = Evaluation::RankEval.new(csv, args.ab_tests)
+    results = evaluator.evaluate
+
+    maxlen = results[:query_scores].map { |query, _| query.length }.max
+    results[:query_scores].each do |query, score|
+      justified_query = "#{query}:".ljust(maxlen + 1)
+      puts "#{justified_query} #{score}"
+    end
+    puts "---"
+    puts "overall score: #{results[:score]}"
+  ensure
+    if csv.is_a?(Tempfile)
+      csv.close
+      csv.unlink
+    end
+  end
+end

--- a/lib/tasks/ranking_evaluation.rake
+++ b/lib/tasks/ranking_evaluation.rake
@@ -1,7 +1,7 @@
 require "evaluation/rank_eval"
 
 desc "Check how well the search query performs for a set of relevancy judgements"
-task :ranking_evaluation, [:datafile, :ab_tests] do |_, args|
+task :ranking_evaluation, [:datafile] do |_, args|
   csv = args.datafile || begin
     bucket = ENV["AWS_S3_RELEVANCY_BUCKET_NAME"]
     raise "Missing required AWS_S3_RELEVANCY_BUCKET_NAME envvar" if bucket.nil?
@@ -12,7 +12,7 @@ task :ranking_evaluation, [:datafile, :ab_tests] do |_, args|
   end
 
   begin
-    evaluator = Evaluation::RankEval.new(csv, args.ab_tests)
+    evaluator = Evaluation::RankEval.new(csv)
     results = evaluator.evaluate
 
     maxlen = results[:query_scores].map { |query, _| query.length }.max

--- a/lib/tasks/ranking_evaluation.rake
+++ b/lib/tasks/ranking_evaluation.rake
@@ -12,8 +12,9 @@ task :ranking_evaluation, [:datafile] do |_, args|
   end
 
   begin
-    evaluator = Evaluation::RankEval.new(csv)
-    results = evaluator.evaluate
+    evaluator = Evaluation::RankEval.new
+    csv_data = evaluator.load_from_csv(csv)
+    results = evaluator.evaluate(csv_data)
 
     maxlen = results[:query_scores].map { |query, _| query.length }.max
     results[:query_scores].each do |query, score|

--- a/spec/integration/tasks/debug_spec.rb
+++ b/spec/integration/tasks/debug_spec.rb
@@ -1,10 +1,8 @@
 require "rake"
 require_relative "../../support/best_bet_test_helpers"
-require_relative "../../support/rank_eval_test_helpers"
 
 RSpec.describe "debug" do
   include BestBetTestHelpers
-  include RankEvalTestHelpers
 
   before { Rake::Task[task_name].reenable }
 
@@ -96,39 +94,6 @@ RSpec.describe "debug" do
 
         expect(output).to include("Sample matches (basic query with synonyms):")
         expect(output).to include("No results found")
-      end
-    end
-  end
-
-  describe "debug:ranking_evaluation" do
-    let(:task_name) { "debug:ranking_evaluation" }
-
-    context "the bucket is provided and contains a judgement csv" do
-      let(:bucket) { "test-bucket" }
-      let(:filename) { "judgements.csv" }
-
-      before do
-        allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
-        Services.s3_client.put_object(key: filename,
-                                      bucket:,
-                                      body: mock_judgement_csv)
-
-        stub_rank_eval_request
-      end
-
-      it "calculates how well search performs" do
-        ClimateControl.modify AWS_S3_RELEVANCY_BUCKET_NAME: bucket do
-          output = capture_stdout { Rake::Task[task_name].invoke }
-          expect(output).to include("Ignoring 1 judgements for /government/renew-a-passport queried with query 'passport'")
-          expect(output.squeeze(" ")).to include(rank_eval_expected_output)
-        end
-      end
-    end
-
-    context "no bucket or datafile is provided" do
-      it "raises an error" do
-        expect { Rake::Task[task_name].invoke }
-          .to raise_error("Missing required AWS_S3_RELEVANCY_BUCKET_NAME envvar")
       end
     end
   end

--- a/spec/integration/tasks/ranking_evaluation_spec.rb
+++ b/spec/integration/tasks/ranking_evaluation_spec.rb
@@ -20,12 +20,14 @@ RSpec.describe "ranking_evaluation" do
                                       body: mock_clickstream_csv)
 
         stub_rank_eval_request
+        stub_publishing_api_has_item({ content_id: "harry-potter-content-id", base_path: "/harry-potter" })
+        stub_publishing_api_has_item({ content_id: "passport-content-id", base_path: "/passport" })
       end
 
       it "calculates how well search performs" do
         ClimateControl.modify AWS_S3_RELEVANCY_BUCKET_NAME: bucket do
           output = capture_stdout { Rake::Task[task_name].invoke }
-          expect(output).to include("Ignoring 1 judgements for passport-content-id queried with query 'passport'")
+          expect(output).to include("Ignoring 1 judgements for /passport queried with query 'passport'")
           expect(output.squeeze(" ")).to include(rank_eval_expected_output)
         end
       end

--- a/spec/integration/tasks/ranking_evaluation_spec.rb
+++ b/spec/integration/tasks/ranking_evaluation_spec.rb
@@ -1,0 +1,41 @@
+require "rake"
+require_relative "../../support/rank_eval_test_helpers"
+
+RSpec.describe "ranking_evaluation" do
+  include RankEvalTestHelpers
+
+  before { Rake::Task[task_name].reenable }
+
+  describe "ranking_evaluation" do
+    let(:task_name) { "ranking_evaluation" }
+
+    context "the bucket is provided and contains a judgement csv" do
+      let(:bucket) { "test-bucket" }
+      let(:filename) { "judgements.csv" }
+
+      before do
+        allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
+        Services.s3_client.put_object(key: filename,
+                                      bucket:,
+                                      body: mock_judgement_csv)
+
+        stub_rank_eval_request
+      end
+
+      it "calculates how well search performs" do
+        ClimateControl.modify AWS_S3_RELEVANCY_BUCKET_NAME: bucket do
+          output = capture_stdout { Rake::Task[task_name].invoke }
+          expect(output).to include("Ignoring 1 judgements for /government/renew-a-passport queried with query 'passport'")
+          expect(output.squeeze(" ")).to include(rank_eval_expected_output)
+        end
+      end
+    end
+
+    context "no bucket or datafile is provided" do
+      it "raises an error" do
+        expect { Rake::Task[task_name].invoke }
+          .to raise_error("Missing required AWS_S3_RELEVANCY_BUCKET_NAME envvar")
+      end
+    end
+  end
+end

--- a/spec/integration/tasks/ranking_evaluation_spec.rb
+++ b/spec/integration/tasks/ranking_evaluation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "ranking_evaluation" do
         allow(Services).to receive(:s3_client).and_return(FakeS3.fake_s3_client)
         Services.s3_client.put_object(key: filename,
                                       bucket:,
-                                      body: mock_judgement_csv)
+                                      body: mock_clickstream_csv)
 
         stub_rank_eval_request
       end
@@ -25,7 +25,7 @@ RSpec.describe "ranking_evaluation" do
       it "calculates how well search performs" do
         ClimateControl.modify AWS_S3_RELEVANCY_BUCKET_NAME: bucket do
           output = capture_stdout { Rake::Task[task_name].invoke }
-          expect(output).to include("Ignoring 1 judgements for /government/renew-a-passport queried with query 'passport'")
+          expect(output).to include("Ignoring 1 judgements for passport-content-id queried with query 'passport'")
           expect(output.squeeze(" ")).to include(rank_eval_expected_output)
         end
       end

--- a/spec/support/rank_eval_test_helpers.rb
+++ b/spec/support/rank_eval_test_helpers.rb
@@ -16,18 +16,18 @@ module RankEvalTestHelpers
 
   def create_malformed_csv(row)
     CSV.generate do |csv|
-      csv << %w[query link score]
+      csv << ["queryEntry.query", "queryEntry.targets.uri", "queryEntry.targets.score"]
       csv << row
     end
   end
 
-  def mock_judgement_csv
+  def mock_clickstream_csv
     CSV.generate do |csv|
-      csv << %w[query rating link score]
-      csv << ["harry potter", "relevant", "/harry-potter", 3]
-      csv << ["passport", "relevant", "/government/renew-a-passport", 3]
+      csv << %w[queryEntry.query queryEntry.targets.uri queryEntry.targets.score]
+      csv << ["harry potter", "harry-potter-content-id", 3]
+      csv << ["passport", "passport-content-id", 3]
       # add repeated row to test ignore_extra_judgements
-      csv << ["passport", "near", "/government/renew-a-passport", 2]
+      csv << ["passport", "passport-content-id", 2]
     end
   end
 

--- a/spec/support/rank_eval_test_helpers.rb
+++ b/spec/support/rank_eval_test_helpers.rb
@@ -14,7 +14,7 @@ module RankEvalTestHelpers
     datafile.unlink
   end
 
-  def create_malformed_csv(row)
+  def create_csv(row)
     CSV.generate do |csv|
       csv << ["queryEntry.query", "queryEntry.targets.uri", "queryEntry.targets.score"]
       csv << row

--- a/spec/support/rank_eval_test_helpers.rb
+++ b/spec/support/rank_eval_test_helpers.rb
@@ -2,6 +2,25 @@ require "csv"
 require "spec_helper"
 
 module RankEvalTestHelpers
+  def build_datafile(name, data)
+    datafile = Tempfile.new([name.to_s, ".csv"])
+    datafile.write(data)
+    datafile.rewind
+    datafile
+  end
+
+  def delete_datafile(datafile)
+    datafile.close
+    datafile.unlink
+  end
+
+  def create_malformed_csv(row)
+    CSV.generate do |csv|
+      csv << %w[query link score]
+      csv << row
+    end
+  end
+
   def mock_judgement_csv
     CSV.generate do |csv|
       csv << %w[query rating link score]

--- a/spec/unit/lib/evaluation/rank_eval_spec.rb
+++ b/spec/unit/lib/evaluation/rank_eval_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Evaluation::RankEval do
 
   RSpec.shared_examples "a malformed CSV row validation" do |expected_error, bad_row|
     around do |example|
-      csv_data = create_malformed_csv(bad_row)
+      csv_data = create_csv(bad_row)
       datafile = build_datafile("malformed_csv", csv_data)
       @datafile = datafile
 
@@ -52,8 +52,8 @@ RSpec.describe Evaluation::RankEval do
 
     context "when publishing api has the content" do
       before do
-        stub_publishing_api_has_item({ content_id: "harry-potter-content-id", base_path: "/harry-potter" })
-        stub_publishing_api_has_item({ content_id: "passport-content-id", base_path: "/passport" })
+        stub_publishing_api_has_item({ content_id: "harry-potter-content-id", base_path: "/harry-potter", document_type: "guide" })
+        stub_publishing_api_has_item({ content_id: "passport-content-id", base_path: "/passport", document_type: "guide" })
       end
 
       let(:expected_output) do
@@ -81,6 +81,26 @@ RSpec.describe Evaluation::RankEval do
         delete_datafile(@datafile)
 
         expect(hash).to eq(expected_output)
+      end
+
+      context "when the csv contains external content links" do
+        before do
+          stub_publishing_api_has_item({ content_id: "external-content-content-id", document_type: "external_content" })
+        end
+
+        let(:csv_data) { create_csv(%w[contact external-content-content-id 3]) }
+        let(:datafile) { build_datafile("external_content_csv", csv_data) }
+        let(:expected_output) { { "contact" => [{ score: 3, link: "external-content-content-id" }] } }
+
+        it "it uses content id as the link" do
+          @datafile = datafile
+          hash = evaluator.load_from_csv(@datafile)
+          delete_datafile(@datafile)
+
+          assert_publishing_api(:get, "#{Plek.find('publishing-api')}/v2/content/external-content-content-id")
+
+          expect(hash).to eq(expected_output)
+        end
       end
     end
 

--- a/spec/unit/lib/evaluation/rank_eval_spec.rb
+++ b/spec/unit/lib/evaluation/rank_eval_spec.rb
@@ -6,7 +6,7 @@ require_relative "../../../../lib/evaluation/rank_eval"
 RSpec.describe Evaluation::RankEval do
   include RankEvalTestHelpers
 
-  let(:evaluator) { described_class }
+  let(:evaluator) { described_class.new }
 
   RSpec.shared_examples "a malformed CSV row validation" do |expected_error, bad_row|
     around do |example|
@@ -20,7 +20,7 @@ RSpec.describe Evaluation::RankEval do
     end
 
     it "raises the expected validation error" do
-      expect { evaluator.new(@datafile) }.to raise_error(expected_error)
+      expect { evaluator.load_from_csv(@datafile) }.to raise_error(expected_error)
     end
   end
 
@@ -35,6 +35,26 @@ RSpec.describe Evaluation::RankEval do
 
     context "link is missing" do
       it_behaves_like "a malformed CSV row validation", "missing link for row 'harry potter,,3\n", ["harry potter", nil, 3]
+    end
+
+    context "when a valid csv is provided" do
+      before do
+        csv_data = mock_judgement_csv
+        datafile = build_datafile("mock_judgement_csv", csv_data)
+        @datafile = datafile
+      end
+
+      let(:expected_output) do
+        {
+          "harry potter" => [{ score: 3, link: "/harry-potter" }],
+          "passport" => [{ score: 3, link: "/government/renew-a-passport" }],
+        }
+      end
+
+      it "creates a hash of csv data" do
+        hash = evaluator.load_from_csv(@datafile)
+        expect(hash).to eq(expected_output)
+      end
     end
   end
 end

--- a/spec/unit/lib/evaluation/rank_eval_spec.rb
+++ b/spec/unit/lib/evaluation/rank_eval_spec.rb
@@ -26,28 +26,28 @@ RSpec.describe Evaluation::RankEval do
 
   describe "#load_from_csv" do
     context "when query is missing" do
-      it_behaves_like "a malformed CSV row validation", "missing query for row ',/harry-potter,3\n'", [nil, "/harry-potter", 3]
+      it_behaves_like "a malformed CSV row validation", "missing query for row ',harry-potter-content-id,3\n'", [nil, "harry-potter-content-id", 3]
     end
 
     context "when score is missing" do
-      it_behaves_like "a malformed CSV row validation", "missing score for row 'harry potter,/harry-potter,\n'", ["harry potter", "/harry-potter", nil]
+      it_behaves_like "a malformed CSV row validation", "missing score for row 'harry potter,harry-potter-content-id,\n'", ["harry potter", "harry-potter-content-id", nil]
     end
 
-    context "link is missing" do
-      it_behaves_like "a malformed CSV row validation", "missing link for row 'harry potter,,3\n", ["harry potter", nil, 3]
+    context "content id is missing" do
+      it_behaves_like "a malformed CSV row validation", "missing content id for row 'harry potter,,3\n'", ["harry potter", nil, 3]
     end
 
     context "when a valid csv is provided" do
       before do
-        csv_data = mock_judgement_csv
-        datafile = build_datafile("mock_judgement_csv", csv_data)
+        csv_data = mock_clickstream_csv
+        datafile = build_datafile("mock_clickstream_csv", csv_data)
         @datafile = datafile
       end
 
       let(:expected_output) do
         {
-          "harry potter" => [{ score: 3, link: "/harry-potter" }],
-          "passport" => [{ score: 3, link: "/government/renew-a-passport" }],
+          "harry potter" => [{ score: 3, link: "harry-potter-content-id" }],
+          "passport" => [{ score: 3, link: "passport-content-id" }],
         }
       end
 

--- a/spec/unit/lib/evaluation/rank_eval_spec.rb
+++ b/spec/unit/lib/evaluation/rank_eval_spec.rb
@@ -24,6 +24,19 @@ RSpec.describe Evaluation::RankEval do
     end
   end
 
+  RSpec.shared_examples "Raises the Publishing API error" do |error_class|
+    before do
+      publishing_api_stub
+      csv_data = mock_clickstream_csv
+      datafile = build_datafile("mock_clickstream_csv", csv_data)
+      @datafile = datafile
+    end
+
+    it "raises the error" do
+      expect { evaluator.load_from_csv(@datafile) }.to raise_error(error_class)
+    end
+  end
+
   describe "#load_from_csv" do
     context "when query is missing" do
       it_behaves_like "a malformed CSV row validation", "missing query for row ',harry-potter-content-id,3\n'", [nil, "harry-potter-content-id", 3]
@@ -37,24 +50,56 @@ RSpec.describe Evaluation::RankEval do
       it_behaves_like "a malformed CSV row validation", "missing content id for row 'harry potter,,3\n'", ["harry potter", nil, 3]
     end
 
-    context "when a valid csv is provided" do
+    context "when publishing api has the content" do
       before do
-        csv_data = mock_clickstream_csv
-        datafile = build_datafile("mock_clickstream_csv", csv_data)
-        @datafile = datafile
+        stub_publishing_api_has_item({ content_id: "harry-potter-content-id", base_path: "/harry-potter" })
+        stub_publishing_api_has_item({ content_id: "passport-content-id", base_path: "/passport" })
       end
 
       let(:expected_output) do
         {
-          "harry potter" => [{ score: 3, link: "harry-potter-content-id" }],
-          "passport" => [{ score: 3, link: "passport-content-id" }],
+          "harry potter" => [{ score: 3, link: "/harry-potter" }],
+          "passport" => [{ score: 3, link: "/passport" }],
         }
       end
 
+      let(:datafile) { build_datafile("mock_clickstream_csv", mock_clickstream_csv) }
+
+      it "sends content id to publishing api to fetch the relevant document" do
+        @datafile = datafile
+        evaluator.load_from_csv(@datafile)
+        delete_datafile(@datafile)
+
+        # https://github.com/alphagov/gds-api-adapters/blob/017768c7a4637334321855a51c47b8a36385ae42/lib/gds_api/test_helpers/publishing_api.rb#L310
+        assert_publishing_api(:get, "#{Plek.find('publishing-api')}/v2/content/harry-potter-content-id")
+        assert_publishing_api(:get, "#{Plek.find('publishing-api')}/v2/content/passport-content-id", nil, 2)
+      end
+
       it "creates a hash of csv data" do
+        @datafile = datafile
         hash = evaluator.load_from_csv(@datafile)
+        delete_datafile(@datafile)
+
         expect(hash).to eq(expected_output)
       end
+    end
+
+    context "when the publishing api is unavailable" do
+      let(:publishing_api_stub) { stub_publishing_api_isnt_available }
+
+      it_behaves_like "Raises the Publishing API error", GdsApi::HTTPUnavailable
+    end
+
+    context "when the content item is not found" do
+      let(:publishing_api_stub) { stub_any_publishing_api_call_to_return_not_found }
+
+      it_behaves_like "Raises the Publishing API error", GdsApi::HTTPNotFound
+    end
+
+    context "when publishing API timesout" do
+      let(:publishing_api_stub) { stub_any_publishing_api_call_to_return_timeout }
+
+      it_behaves_like "Raises the Publishing API error", GdsApi::TimedOutException
     end
   end
 end

--- a/spec/unit/lib/evaluation/rank_eval_spec.rb
+++ b/spec/unit/lib/evaluation/rank_eval_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "tempfile"
+require_relative "../../../support/rank_eval_test_helpers"
+require_relative "../../../../lib/evaluation/rank_eval"
+
+RSpec.describe Evaluation::RankEval do
+  include RankEvalTestHelpers
+
+  let(:evaluator) { described_class }
+
+  RSpec.shared_examples "a malformed CSV row validation" do |expected_error, bad_row|
+    around do |example|
+      csv_data = create_malformed_csv(bad_row)
+      datafile = build_datafile("malformed_csv", csv_data)
+      @datafile = datafile
+
+      example.run
+
+      delete_datafile(datafile)
+    end
+
+    it "raises the expected validation error" do
+      expect { evaluator.new(@datafile) }.to raise_error(expected_error)
+    end
+  end
+
+  describe "#load_from_csv" do
+    context "when query is missing" do
+      it_behaves_like "a malformed CSV row validation", "missing query for row ',/harry-potter,3\n'", [nil, "/harry-potter", 3]
+    end
+
+    context "when score is missing" do
+      it_behaves_like "a malformed CSV row validation", "missing score for row 'harry potter,/harry-potter,\n'", ["harry potter", "/harry-potter", nil]
+    end
+
+    context "link is missing" do
+      it_behaves_like "a malformed CSV row validation", "missing link for row 'harry potter,,3\n", ["harry potter", nil, 3]
+    end
+  end
+end


### PR DESCRIPTION
## What

Update the existing rank_evaluation rake task so that it can consume a clickstream judgement list. 

```
kubectl -n apps exec -it deploy/search-api -- bash
rake ranking_evaluation
```

| Old csv format | New csv format |
|-|-|
|<img width="450" height="254" alt="Screenshot 2026-06-16 at 13 59 20" src="https://github.com/user-attachments/assets/bd6a17ba-274e-493b-be4f-b4a6d87ef5df" /> | <img width="623" height="260" alt="Screenshot 2026-06-16 at 14 00 06" src="https://github.com/user-attachments/assets/2e4cba8f-55d3-4674-a37b-eb81cecff430" />| 

## Why

To support the upgrade of elasticsearch from 6.8 to 7.10 we would like to be able to obtain an nDCG score for our search results, so that we can compare relevance pre and post upgrade. The clickstream judgement list is taken from BigQuery, and is the list used to evaluate site search results (powered by search-api-v2/google Agent Search). 

JIRA ticket: https://gov-uk.atlassian.net/browse/SCH-1976
