### PR TITLE
Handle errors in the Query class at the top level instead

### DIFF
--- a/lib/rummager/app.rb
+++ b/lib/rummager/app.rb
@@ -97,7 +97,11 @@ class Rummager < Sinatra::Application
     halt(503, "Redis queue timed out")
   end
 
-  error Search::Query::Error do
+  error Elasticsearch::Transport::Transport::Errors::BadRequest do
+    halt(400, env["sinatra.error"].message)
+  end
+
+  error Elasticsearch::Transport::Transport::Errors::InternalServerError do
     halt(400, env["sinatra.error"].message)
   end
 

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -1,12 +1,6 @@
 # Performs a search across all indices used for the GOV.UK site search
 module Search
   class Query
-    class Error < StandardError; end
-
-    class NumberOutOfRange < Error; end
-
-    class QueryTooLong < Error; end
-
     attr_reader :index, :registries, :suggestion_blocklist
 
     def initialize(registries:, content_index:, metasearch_index:)
@@ -28,7 +22,7 @@ module Search
       builder = builder_payload[:builder]
       payload = builder_payload[:payload]
 
-      es_response = process_elasticsearch_errors { timed_raw_search(payload) }
+      es_response = timed_raw_search(payload)
 
       process_es_response(search_params, builder, payload, es_response)
     end
@@ -47,28 +41,13 @@ module Search
           include_suggestions:,
         )
 
-        payload = process_elasticsearch_errors { builder.payload }
-
-        { builder:, payload: }
+        { builder:, payload: builder.payload }
       end
     end
 
     def timed_raw_search(payload)
       GovukStatsd.time("elasticsearch.raw_search") do
         index.raw_search(payload)
-      end
-    end
-
-    def process_elasticsearch_errors
-      yield
-    rescue Elasticsearch::Transport::Transport::Errors::InternalServerError => e
-      case e.message
-      when /Numeric value \(([0-9]*)\) out of range of/
-        raise(NumberOutOfRange, "Integer value of #{Regexp.last_match(1)} exceeds maximum allowed")
-      when /maxClauseCount is set to/
-        raise(QueryTooLong, "Query must be less than 1024 words")
-      else
-        raise
       end
     end
 

--- a/spec/integration/app/error_handling_spec.rb
+++ b/spec/integration/app/error_handling_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "ErrorHandlingTest" do
 
   include_examples(
     "a sinatra error handler",
-    exception_class: Search::Query::Error,
+    exception_class: Elasticsearch::Transport::Transport::Errors::BadRequest,
     status: 400,
     body: ->(msg) { msg },
   )


### PR DESCRIPTION
The Query class previously caught InternalServerError (500).  Elasticsearch seems to have changed
its behaviour and throws BadRequest (400) errors now, so this code does not work.

Furthermore, errors involving numbers out of range or query size being too long should be handled in the validation of input parameters

Instead of catching errors in the Query class, we can catch both InternalServerError and  BadRequest errors at the top level in app.rb instead with makes error handler more straightforward
