### PR TITLE
Move and fix search:check_recovery rake task

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -161,7 +161,7 @@ module SearchIndices
       # Check if an index has recovered all its shards.
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html
       # If something goes wrong, a shard can get stuck and not reach the DONE state.
-      index_info = @client.indices.recovery(index: index_name)[index_name]
+      index_info = @client.indices.recovery(index: index_name)[real_name]
       index_info["shards"].all? { |shard_info| shard_info["stage"] == "DONE" }
     end
 

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -103,4 +103,15 @@ namespace :debug do
       end
     end
   end
+
+  desc "Check whether a restored index has recovered"
+  task :check_recovery, [:index_name, :clusters] do |_, args|
+    raise "An 'index_name' must be supplied" unless args.index_name
+
+    clusters_from_args(args).each do |cluster|
+      index = search_server(cluster:).index_group(args.index_name).current
+      puts "Recovery status of #{args.index_name} on cluster #{cluster.key} (#{cluster.uri}):"
+      puts index.index_recovered?
+    end
+  end
 end

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -188,15 +188,4 @@ the existing data, you will need to run the \"migrate_schema\" task instead, whi
       end
     end
   end
-
-  desc "Check whether a restored index has recovered"
-  task :check_recovery, [:index_name, :clusters] do |_, args|
-    raise "An 'index_name' must be supplied" unless args.index_name
-
-    clusters_from_args(args).each do |cluster|
-      index = search_server(cluster:).index_group(args.index_name).current
-      puts "Recovery status of #{args.index_name} on cluster #{cluster.key} (#{cluster.uri}):"
-      puts index.index_recovered?
-    end
-  end
 end

--- a/spec/integration/tasks/debug_spec.rb
+++ b/spec/integration/tasks/debug_spec.rb
@@ -170,4 +170,16 @@ RSpec.describe "debug" do
       end
     end
   end
+
+  describe "debug:check_recovery" do
+    let(:task_name) { "debug:check_recovery" }
+    it "returns the recovery status, which on the test database should be 'ok'" do
+      output = capture_stdout { Rake::Task[task_name].invoke(SearchConfig.govuk_index_name) }
+      expect(output).to match(/Recovery status of/)
+      expect(output).to match(/true/)
+    end
+    it "needs an argument" do
+      expect { Rake::Task[task_name].invoke }.to raise_error(StandardError, /An 'index_name' must be supplied/)
+    end
+  end
 end

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -125,27 +125,6 @@ RSpec.describe SearchIndices::Index do
     expect((1..10).map { |i| "/organisation-#{i}" }).to eq(result.map { |r| r["link"] })
   end
 
-  describe "#index_recovered" do
-    let(:elasticsearch_client) { double("Elasticsearch::Client") }
-    let(:indices_client) { double("Elasticsearch::API::Indices::IndicesClient") }
-    let(:index) { build_govuk_index }
-    let(:index_name) { index.index_name }
-    before do
-      allow(Services).to receive(:elasticsearch).and_return(elasticsearch_client)
-      allow(elasticsearch_client).to receive(:indices).and_return(indices_client)
-    end
-    it "shows the index is recovered" do
-      recovery = { index_name => { "shards" => [{ "stage" => "DONE" }, { "stage" => "DONE" }] } }
-      allow(indices_client).to receive(:recovery).with(index: index_name).and_return(recovery)
-      expect(index.index_recovered?).to be true
-    end
-    it "shows the index has not recovered" do
-      recovery = { index_name => { "shards" => [{ "stage" => "DONE" }, { "stage" => "INDEX" }] } }
-      allow(indices_client).to receive(:recovery).with(index: index_name).and_return(recovery)
-      expect(index.index_recovered?).to be false
-    end
-  end
-
 private
 
   def scroll_uri(scroll_id)

--- a/spec/unit/tasks/indices_spec.rb
+++ b/spec/unit/tasks/indices_spec.rb
@@ -335,24 +335,6 @@ RSpec.describe "indices" do
     end
   end
 
-  describe "check_recovery" do
-    let(:task_name) { "search:check_recovery" }
-    before do
-      recovery = { index_name => { "shards" => [{ "stage" => "DONE" }, { "stage" => "DONE" }] } }
-      allow(indices_client).to receive(:recovery).with(index: index_name).and_return(recovery)
-    end
-    it "checks recovery for all indices" do
-      output = capture_stdout { Rake::Task[task_name].invoke(index_name) }
-      expect(indices_client).to have_received(:recovery).with(index: index_name)
-
-      expect(output).to include("Recovery status of #{index_name} on cluster A")
-      expect(output).to include("true")
-    end
-    it "needs an argument" do
-      expect { Rake::Task[task_name].invoke }.to raise_error(StandardError, /An 'index_name' must be supplied/)
-    end
-  end
-
   def capture_stdout
     old = $stdout
     $stdout = StringIO.new


### PR DESCRIPTION
Move search:check_recovery rake task to the debug namespace

This rake task checks whether a restored index has recovered and therefore fits better under debug
 
The fix involves using the 'real' name and not the alias to find the recovery status in the hash returned by @client.indices.recovery

Add an integration test to verify correct behaviour: https://gov-uk.atlassian.net/browse/SCH-2101

