### PR TITLE
[SCH-2072] Ruby file to format csv input to gor format

### DIFF
--- a/lib/kibana_log_formatter.rb
+++ b/lib/kibana_log_formatter.rb
@@ -1,0 +1,35 @@
+require "csv"
+require "random/formatter"
+
+# Yup that's the line separator format https://github.com/buger/goreplay/wiki/Saving-and-Replaying-from-file#file-format
+GOR_LINE_SEPARATOR = "\n🐵🙈🙉\n".freeze
+
+kibana_logs_file = ARGV[0]
+gor_traffic_replay_file = "tmp/traffic_replay_#{Time.now.strftime('%Y%m%d%H%M%S')}.gor"
+
+def log_timestamp(row)
+  DateTime.iso8601(row["message"][15, 25], Date::ENGLAND).strftime("%Q")
+end
+
+def save_as_gor(kibana_logs_file, output_file)
+  File.open(output_file, "a") do |f|
+    CSV.foreach(kibana_logs_file, headers: true) do |row|
+      f.print get_gor_entry(row)
+      f.print GOR_LINE_SEPARATOR
+    end
+  end
+end
+
+def get_gor_entry(log_entry)
+  # Protocol header
+  # {Protocol Mode} {24 Random Bytes} {timing} {latency}
+  # "1" means it is Making a request
+  gor_entry = []
+  gor_entry << "1 #{Random.hex(12)} #{log_timestamp(log_entry)}000000 0"
+  gor_entry << "GET #{log_entry['request_uri'].strip} HTTP/1.1\r"
+  gor_entry << "Host: www.gov.uk\r"
+
+  "#{gor_entry.join("\n")}\n\n"
+end
+
+save_as_gor(kibana_logs_file, gor_traffic_replay_file)

--- a/lib/kibana_log_formatter.rb
+++ b/lib/kibana_log_formatter.rb
@@ -1,35 +1,39 @@
 require "csv"
 require "random/formatter"
 
-# Yup that's the line separator format https://github.com/buger/goreplay/wiki/Saving-and-Replaying-from-file#file-format
-GOR_LINE_SEPARATOR = "\n🐵🙈🙉\n".freeze
+class KibanaLogFormatter
+  def initialize(csv_logs_file)
+    @csv_logs_file = csv_logs_file
+    @gor_traffic_replay_file = "tmp/traffic_replay_#{Time.now.strftime('%Y%m%d%H%M%S')}.gor"
+  end
 
-kibana_logs_file = ARGV[0]
-gor_traffic_replay_file = "tmp/traffic_replay_#{Time.now.strftime('%Y%m%d%H%M%S')}.gor"
+  # Yup that's the line separator format https://github.com/buger/goreplay/wiki/Saving-and-Replaying-from-file#file-format
+  GOR_LINE_SEPARATOR = "\n🐵🙈🙉\n".freeze
 
-def log_timestamp(row)
-  DateTime.iso8601(row["message"][15, 25], Date::ENGLAND).strftime("%Q")
-end
-
-def save_as_gor(kibana_logs_file, output_file)
-  File.open(output_file, "a") do |f|
-    CSV.foreach(kibana_logs_file, headers: true) do |row|
-      f.print get_gor_entry(row)
-      f.print GOR_LINE_SEPARATOR
+  def save_as_gor
+    File.open(@gor_traffic_replay_file, "a") do |f|
+      CSV.foreach(@csv_logs_file, headers: true) do |row|
+        f.print get_gor_entry(row)
+        f.print GOR_LINE_SEPARATOR
+      end
     end
   end
+
+private
+
+  def log_timestamp(row)
+    DateTime.iso8601(row["message"][15, 25], Date::ENGLAND).strftime("%Q")
+  end
+
+  def get_gor_entry(log_entry)
+    # Protocol header
+    # {Protocol Mode} {24 Random Bytes} {timing} {latency}
+    # "1" means it is Making a request
+    gor_entry = []
+    gor_entry << "1 #{Random.hex(12)} #{log_timestamp(log_entry)}000000 0"
+    gor_entry << "GET #{log_entry['request_uri'].strip} HTTP/1.1\r"
+    gor_entry << "Host: www.gov.uk\r"
+
+    "#{gor_entry.join("\n")}\n\n"
+  end
 end
-
-def get_gor_entry(log_entry)
-  # Protocol header
-  # {Protocol Mode} {24 Random Bytes} {timing} {latency}
-  # "1" means it is Making a request
-  gor_entry = []
-  gor_entry << "1 #{Random.hex(12)} #{log_timestamp(log_entry)}000000 0"
-  gor_entry << "GET #{log_entry['request_uri'].strip} HTTP/1.1\r"
-  gor_entry << "Host: www.gov.uk\r"
-
-  "#{gor_entry.join("\n")}\n\n"
-end
-
-save_as_gor(kibana_logs_file, gor_traffic_replay_file)

--- a/lib/kibana_log_formatter.rb
+++ b/lib/kibana_log_formatter.rb
@@ -1,35 +1,39 @@
 require "csv"
 require "random/formatter"
 
-# Yup that's the line separator format https://github.com/buger/goreplay/wiki/Saving-and-Replaying-from-file#file-format
-GOR_LINE_SEPARATOR = "\n🐵🙈🙉\n".freeze
+class KibanaLogFormatter
+  def initialize(csv_logs_file, gor_traffic_replay_file = "tmp/traffic_replay_#{Time.now.strftime('%Y%m%d%H%M%S')}.gor")
+    @csv_logs_file = csv_logs_file
+    @gor_traffic_replay_file = gor_traffic_replay_file
+  end
 
-kibana_logs_file = ARGV[0]
-gor_traffic_replay_file = "tmp/traffic_replay_#{Time.now.strftime('%Y%m%d%H%M%S')}.gor"
+  # Yup that's the line separator format https://github.com/buger/goreplay/wiki/Saving-and-Replaying-from-file#file-format
+  GOR_LINE_SEPARATOR = "\n🐵🙈🙉\n".freeze
 
-def log_timestamp(row)
-  DateTime.iso8601(row["message"][15, 25], Date::ENGLAND).strftime("%Q")
-end
-
-def save_as_gor(kibana_logs_file, output_file)
-  File.open(output_file, "a") do |f|
-    CSV.foreach(kibana_logs_file, headers: true) do |row|
-      f.print get_gor_entry(row)
-      f.print GOR_LINE_SEPARATOR
+  def save_as_gor
+    File.open(@gor_traffic_replay_file, "a") do |f|
+      CSV.foreach(@csv_logs_file, headers: true) do |row|
+        f.print get_gor_entry(row)
+        f.print GOR_LINE_SEPARATOR
+      end
     end
   end
+
+private
+
+  def log_timestamp(row)
+    DateTime.iso8601(row["message"][15, 25], Date::ENGLAND).strftime("%Q")
+  end
+
+  def get_gor_entry(log_entry)
+    # Protocol header
+    # {Protocol Mode} {24 Random Bytes} {timing} {latency}
+    # "1" means it is Making a request
+    gor_entry = []
+    gor_entry << "1 #{Random.hex(12)} #{log_timestamp(log_entry)}000000 0"
+    gor_entry << "GET #{log_entry['request_uri'].strip} HTTP/1.1\r"
+    gor_entry << "Host: www.gov.uk\r"
+
+    "#{gor_entry.join("\n")}\n\n"
+  end
 end
-
-def get_gor_entry(log_entry)
-  # Protocol header
-  # {Protocol Mode} {24 Random Bytes} {timing} {latency}
-  # "1" means it is Making a request
-  gor_entry = []
-  gor_entry << "1 #{Random.hex(12)} #{log_timestamp(log_entry)}000000 0"
-  gor_entry << "GET #{log_entry['request_uri'].strip} HTTP/1.1\r"
-  gor_entry << "Host: www.gov.uk\r"
-
-  "#{gor_entry.join("\n")}\n\n"
-end
-
-save_as_gor(kibana_logs_file, gor_traffic_replay_file)

--- a/lib/tasks/traffic_replay.rake
+++ b/lib/tasks/traffic_replay.rake
@@ -1,0 +1,15 @@
+require "csv"
+require "kibana_log_formatter"
+
+namespace :traffic_replay do
+  desc "Reformat csv search traffic logs to gor format"
+  task :format_logs, [:log_file] do |_, args|
+    abort "Missing argument. Usage: rake traffic_replay:format_logs[log_file]" if args.log_file.nil?
+
+    logger.info "Starting reformatting of search traffic logs"
+
+    KibanaLogFormatter.new(args[:log_file]).save_as_gor
+
+    logger.info "Finished reformatting of search traffic logs"
+  end
+end

--- a/spec/unit/kibana_log_formatter_spec.rb
+++ b/spec/unit/kibana_log_formatter_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+require "tempfile"
+
+RSpec.describe KibanaLogFormatter do
+  let(:file) { Tempfile.create(%w[logs .csv]) }
+  let(:output_gor_file) { Tempfile.create(%w[traffic_replay_ .gor]) }
+  let(:input_csv_file) do
+    CSV.generate do |csv|
+      csv << %w[request_uri timestamp message]
+      csv << %w[/api/search.json 2026-06-17T10:00:01+00:00 {"@timestamp":"2026-06-17T10:00:01+00:00","body_bytes_sent":26134}]
+      csv << %w[/search/news-and-communications 2026-06-17T10:03:03+00:00 {"@timestamp":"2026-06-17T10:03:03+00:00","body_bytes_sent":439144}]
+      csv << %w[/search/all?keywords= 2026-06-17T09:58:20+00:00 {"@timestamp":"2026-06-17T09:58:20+00:00","body_bytes_sent":111202}]
+    end
+  end
+  let(:gor_formatted_first_request) { "1781690401000000000 0\nGET /api/search.json HTTP/1.1\r\nHost: www.gov.uk\r\n\n\n🐵🙈🙉\n" }
+
+  subject(:formatter) { described_class.new(file, output_gor_file) }
+
+  before do
+    file.write(input_csv_file)
+    file.close
+  end
+
+  after do
+    File.unlink(output_gor_file.path)
+  end
+
+  describe "#save_as_gor" do
+    it "formats the output correctly" do
+      formatter.save_as_gor
+      expect(File.open(output_gor_file.path).read).to include(gor_formatted_first_request)
+    end
+  end
+end

--- a/spec/unit/tasks/traffic_replay_spec.rb
+++ b/spec/unit/tasks/traffic_replay_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+require "rake"
+
+RSpec.describe "traffic_replay" do
+  let(:kibana_log_formatter) { double("KibanaLogFormatter") }
+  let(:file_name) { "log_file.csv" }
+
+  before do
+    Rake::Task[task_name].reenable
+    allow(KibanaLogFormatter).to receive(:new).with(file_name).and_return(kibana_log_formatter)
+    allow(kibana_log_formatter).to receive(:save_as_gor)
+  end
+
+  describe "format_logs" do
+    let(:task_name) { "traffic_replay:format_logs" }
+
+    context "when no log file is provided" do
+      it "prints a helpful message and exits" do
+        expect {
+          Rake::Task[task_name].invoke(nil)
+        }.to output("Missing argument. Usage: rake traffic_replay:format_logs[log_file]\n").to_stderr
+                                                                                  .and raise_error(SystemExit)
+      end
+    end
+
+    context "when a log file is provided" do
+      it "calls save_as_gor" do
+        Rake::Task[task_name].invoke(file_name)
+
+        expect(kibana_log_formatter).to have_received(:save_as_gor)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a rake task to reformat a csv file of kibana logs into gor format. These transactions can then be replayed to using GoReplay.

The rake task is currently written to be run locally from search-api folder on a kibana logs template file saved to `/tmp` using `bundle exec rake traffic_replay:format_logs\[tmp/search_router_traffic_20260618_9am-10am.csv\]`

This is one step in the search traffic replay for elasticsearch upgrade. See [Jira ticket SCH-2072](https://gov-uk.atlassian.net/browse/SCH-2072) for the full process.