### PR TITLE
fix Elasticsearch version handling 

### DIFF
--- a/lib/govuk_index/popularity_job.rb
+++ b/lib/govuk_index/popularity_job.rb
@@ -29,9 +29,12 @@ module GovukIndex
     def process_document(document, popularities)
       base_path = document.fetch("_id")
       title = document.dig("_source", "title")
-      identifier = document.slice("_id", "_version")
+      identifier = { _id: document["_id"],
+                     _type: "generic-document",
+                     version: document["_version"],
+                     version_type: "external_gte" }
       OpenStruct.new(
-        identifier: identifier.merge("version_type" => "external_gte", "_type" => "generic-document"),
+        identifier:,
         document: document.fetch("_source").merge(
           "popularity" => popularities.dig(base_path, :popularity_score),
           "popularity_b" => popularities.dig(base_path, :popularity_rank),

--- a/lib/govuk_index/supertype_job.rb
+++ b/lib/govuk_index/supertype_job.rb
@@ -16,7 +16,10 @@ module GovukIndex
           next
         end
         {
-          "identifier" => document.slice("_id", "_type", "_version"),
+          "identifier" => { _id: document["_id"],
+                            _type: document["_type"],
+                            version: document["_version"],
+                            version_type: "external_gte" },
           "document" => document.fetch("_source"),
         }
       end
@@ -36,7 +39,7 @@ module GovukIndex
 
     def process_document(document)
       OpenStruct.new(
-        identifier: document["identifier"].merge("version_type" => "external_gte"),
+        identifier: document["identifier"],
         document: update_document_supertypes(document["document"]),
       )
     end

--- a/spec/integration/govuk_index/popularity_job_spec.rb
+++ b/spec/integration/govuk_index/popularity_job_spec.rb
@@ -2,76 +2,45 @@ require "spec_helper"
 
 RSpec.describe GovukIndex::PopularityJob do
   subject(:job) { described_class.new }
-  let(:index) { instance_double("index") }
+  let(:traffic_index) { SearchConfig.page_traffic_index_name }
+  let(:govuk_index) { SearchConfig.govuk_index_name }
+  let(:document_ids) { ["/test/page1", "/test/page2"] }
 
   before do
-    allow(GovukDocumentTypes).to receive(:supertypes)
-      .with(document_type: "testgroup")
-      .and_return("supertype1" => "type1", "supertype2" => "type2")
-    @processor = instance_double("processor", save: nil, commit: nil)
-    allow(Index::ElasticsearchProcessor).to receive(:new).and_return(@processor)
-    allow(IndexFinder).to receive(:by_name).and_return(index)
+    commit_document(traffic_index,
+                    { path_components: ["/test", "/test/page1"], rank_14: 2, vf_14: 0.1, vc_14: 10 },
+                    id: "/test/page1")
+    commit_document(traffic_index,
+                    { path_components: ["/test", "/test/page2"], rank_14: 1, vf_14: 0.2, vc_14: 20 },
+                    id: "/test/page2")
+    allow(Sidekiq.logger).to receive(:warn)
   end
 
   it "saves the documents with the popularity fields values" do
-    stub_popularity_data(
-      {
-        "document_1" => { popularity_score: 0.7, popularity_rank: 0.5 },
-        "document_2" => { popularity_score: 0.6, popularity_rank: 0.5 },
-      },
-    )
-    documents = [
-      { "_id" => "document_1", "_version" => 1, "_source" => { "title" => "test_doc1" } },
-      { "_id" => "document_2", "_version" => 1, "_source" => { "title" => "test_doc2" } },
-    ]
-    stub_document_lookups(documents)
+    commit_document(govuk_index, build(:document, link: "/test/page1"))
+    commit_document(govuk_index, build(:document, link: "/test/page2"))
 
-    document_ids = documents.map { |document| document["_id"] }
-    job.perform(document_ids, "govuk_test")
+    job.perform(document_ids, govuk_index)
 
-    expect(@processor).to have_received(:save).with(
-      having_attributes(
-        identifier: { "_id" => "document_1", "_version" => 1, "version_type" => "external_gte", "_type" => "generic-document" },
-        document: hash_including({ "popularity" => 0.7, "popularity_b" => 0.5, "title" => "test_doc1" }),
-      ),
-    ).once
-    expect(@processor).to have_received(:save).with(
-      having_attributes(
-        identifier: { "_id" => "document_2", "_version" => 1, "version_type" => "external_gte", "_type" => "generic-document" },
-        document: hash_including({ "popularity" => 0.6, "popularity_b" => 0.5, "title" => "test_doc2" }),
-      ),
-    ).once
-    expect(@processor).to have_received(:commit)
+    expect_document_is_in_rummager({ "link" => "/test/page1",
+                                     "popularity" => (1.0 / 12.0),
+                                     "popularity_b" => 0,
+                                     "view_count" => 10 }, index: govuk_index)
+    expect_document_is_in_rummager({ "link" => "/test/page2",
+                                     "popularity" => (1.0 / 11.0),
+                                     "popularity_b" => 1,
+                                     "view_count" => 20 }, index: govuk_index)
   end
 
   it "writes to the logger and continues to the next document if a document is not found" do
-    stub_popularity_data({ "document_2" => { popularity_score: 0.6, popularity_rank: 0.5 } })
-    document = { "_id" => "document_2", "_source" => { "title" => "test_doc2" } }
-    allow(index).to receive(:get_document_by_id).with("document_1").and_return(nil)
-    allow(index).to receive(:get_document_by_id).with("document_2").and_return(document)
-    logger = double(warn: true)
-    allow(job).to receive(:logger).and_return(logger)
+    commit_document(govuk_index, build(:document, link: "/test/page2"))
 
-    document_ids = %w[document_1 document_2]
-    job.perform(document_ids, "govuk_test")
+    job.perform(document_ids, govuk_index)
 
-    expect(@processor).to have_received(:save).with(
-      having_attributes(
-        identifier: { "_id" => "document_2", "version_type" => "external_gte", "_type" => "generic-document" },
-        document: hash_including({ "popularity" => 0.6, "popularity_b" => 0.5, "title" => "test_doc2" }),
-      ),
-    ).once
-    expect(logger).to have_received(:warn).with("Skipping document_1 as it is not in the index")
-  end
-
-  def stub_popularity_data(data = Hash.new({ popularity_score: 0.5, popularity_rank: 0.5 }))
-    popularity_lookup = instance_double("popularity_lookup", lookup_popularities: data)
-    allow(Indexer::PopularityLookup).to receive(:new).and_return(popularity_lookup)
-  end
-
-  def stub_document_lookups(documents)
-    allow(index).to receive(:get_document_by_id) do |document_id|
-      documents.select { |document| document["_id"] == document_id }.first
-    end
+    expect_document_is_in_rummager({ "link" => "/test/page2",
+                                     "popularity" => (1.0 / 11.0),
+                                     "popularity_b" => 1,
+                                     "view_count" => 20 }, index: govuk_index)
+    expect(Sidekiq.logger).to have_received(:warn).with("Skipping /test/page1 as it is not in the index")
   end
 end


### PR DESCRIPTION
 Use the `version` attribute instead of `_version` for concurrent update handling in Elasticsearch; `_version` is only used in responses.

Replace heavily mocked popularity job tests with integration tests to better verify real behavior rather than implementation details.

see also: 
 https://www.rubydoc.info/gems/elasticsearch-api/Elasticsearch/API/Actions#bulk-instance_method
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-bulk.html#bulk-versioning

Jira: https://gov-uk.atlassian.net/browse/SCH-2164
