### PR TITLE
Add content_block document types to the disallowed list

### DIFF
--- a/config/govuk_index/allowed_formats.yaml
+++ b/config/govuk_index/allowed_formats.yaml
@@ -394,6 +394,9 @@ disallowed_paths:
 
 disallowed_formats:
 - calculator
+- content_block_contact
+- content_block_pension
+- content_block_tax
 - license_finder
 - special_route:
   - '/homepage'


### PR DESCRIPTION
These document types are not added to the elasticsearch index (as they're not explicitly listed on the allow list) but the deny list helps us to raise a more useful error. See https://github.com/alphagov/search-api/blob/e25d44492394ed27f0dca80ec2b287239de8cdb5/lib/govuk_index/publishing_event_message_handler.rb#L72

jira https://gov-uk.atlassian.net/browse/SCH-2150