### PR TITLE
Add integration test for page_traffic rake task and small refactors

### DIFF
--- a/lib/analytics/ga4_import/elastic_search_relevancy_serialiser.rb
+++ b/lib/analytics/ga4_import/elastic_search_relevancy_serialiser.rb
@@ -8,7 +8,7 @@ module Analytics
       def relevance
         consolidated_data.flat_map.with_index(1) do |(base_path, page_views), index|
           [
-            elastic_search_index(base_path).to_json,
+            elastic_search_identifier(base_path).to_json,
             elastic_search_rank(base_path, index, page_views).to_json,
           ]
         end
@@ -18,13 +18,8 @@ module Analytics
 
       attr_reader :consolidated_data
 
-      def elastic_search_index(base_path)
-        {
-          index: {
-            _type: "page-traffic",
-            _id: base_path,
-          },
-        }
+      def elastic_search_identifier(base_path)
+        { _id: base_path }
       end
 
       def elastic_search_rank(base_path, index, page_views)

--- a/lib/govuk_index/page_traffic_job.rb
+++ b/lib/govuk_index/page_traffic_job.rb
@@ -32,15 +32,17 @@ module GovukIndex
     def perform(data, destination_index, cluster_key)
       records = Sidekiq.load_json(Zlib::Inflate.inflate(Base64.decode64(data)))
       cluster = Clusters.get_cluster(cluster_key)
-      actions = Index::ElasticsearchProcessor.new(client: GovukIndex::Client.new(timeout: BULK_INDEX_TIMEOUT, index_name: destination_index, clusters: [cluster]))
+      processor = Index::ElasticsearchProcessor.new(client: GovukIndex::Client.new(timeout: BULK_INDEX_TIMEOUT, index_name: destination_index, clusters: [cluster]))
 
+      bulk_presenter_class = Struct.new(:identifier, :document)
       records.each_slice(2) do |identifier, document|
-        identifier["index"] = identifier["index"].merge("_type" => "generic-document")
-        document["document_type"] = "page_traffic"
-        actions.raw(identifier, document)
+        processor.save(
+          bulk_presenter_class.new(identifier.merge("_type" => "generic-document"),
+                                   document.merge("document_type" => "page_traffic")),
+        )
       end
 
-      actions.commit
+      processor.commit
     end
   end
 end

--- a/lib/index/elasticsearch_processor.rb
+++ b/lib/index/elasticsearch_processor.rb
@@ -13,11 +13,6 @@ module Index
       @actions = []
     end
 
-    def raw(identifier, document)
-      @actions << identifier
-      @actions << document
-    end
-
     def save(presenter)
       @actions << { index: presenter.identifier }
       @actions << presenter.document

--- a/spec/integration/govuk_index/page_traffic_loader_spec.rb
+++ b/spec/integration/govuk_index/page_traffic_loader_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Loading page traffic data" do
   it "adds data to the page traffic index" do
     id = "/test/page/#{SecureRandom.uuid}"
     data = [
-      { index: { _id: id, _type: "page_traffic" } }.to_json,
+      { _id: id }.to_json,
       { rank_14: 100, vf_14: 0.345, vc_14: 12 }.to_json,
     ].join("\n")
 

--- a/spec/integration/tasks/page_traffic_spec.rb
+++ b/spec/integration/tasks/page_traffic_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+require "rake"
+
+RSpec.describe "page_traffic" do
+  before do
+    task.reenable
+    allow(::Google::Analytics::Data::V1beta::AnalyticsData::Client).to receive(:new).and_return(ga_client)
+  end
+
+  describe "page_traffic:load", type: :task do
+    let(:task_name) { "page_traffic:load" }
+    let(:task) { Rake::Task[task_name] }
+    let(:index) { SearchConfig.page_traffic_index_name }
+    let(:ga_client) { double(::Google::Analytics::Data::V1beta::AnalyticsData::Client) }
+    let(:report) do
+      { rows:
+        [{ dimension_values: [{ value: "/doc1" }, { value: "doc 1" }],
+           metric_values: [{ value: "100" }] },
+         { dimension_values: [{ value: "/doc2" }, { value: "doc 2" }],
+           metric_values: [{ value: "200" }] }] }
+    end
+    before do
+      allow(ga_client).to receive(:run_report).and_return(report, {})
+    end
+    it "Adds entries to the traffic index" do
+      task.invoke
+
+      document1 = fetch_document_from_rummager(id: "/doc1", index:)
+      document2 = fetch_document_from_rummager(id: "/doc2", index:)
+
+      expect(document1["_source"]).to include("rank_14" => 2, "vc_14" => 100, "vf_14" => 100.0 / 300.0)
+      expect(document2["_source"]).to include("rank_14" => 1, "vc_14" => 200, "vf_14" => 200.0 / 300.0)
+    end
+  end
+end

--- a/spec/unit/analytics/ga4_import/elastic_search_relevancy_serialiser_spec.rb
+++ b/spec/unit/analytics/ga4_import/elastic_search_relevancy_serialiser_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Analytics::Ga4Import::ElasticSearchRelevancySerialiser do
       index_data = JSON.parse(relevancy_data.first)
       page_data = JSON.parse(relevancy_data.second)
 
-      expect(index_data).to match("index" => hash_including("_type" => "page-traffic", "_id" => /^\/example/))
+      expect(index_data).to match("_id" => /^\/example/)
       expect(page_data).to match(hash_including("path_components", "rank_14", "vc_14", "vf_14"))
     end
 


### PR DESCRIPTION
* Add integration spec for page_traffic task
* Remove ElasticseachProcessor#raw and small refactors of page_traffic_job.rb

Add an integration test for the page_traffic task that runs the code all at once and checks if the relevant documents are created in the page traffic index.

The ElasticseachProcessor#raw method is only used by the PageTrafficJob, and the '#save' method is a better fit. The ElasticseachProcessor#raw is removed and a few small refactors are implemented

https://gov-uk.atlassian.net/browse/SCH-2173