### PR TITLE
Add rake task to reindex an elasticsearch index from another instance

### DIFF
--- a/lib/index/remote_reindexer.rb
+++ b/lib/index/remote_reindexer.rb
@@ -1,0 +1,103 @@
+module Index
+  class RemoteReindexer
+    class MissingArguments < ArgumentError; end
+    class ReindexFailed < StandardError; end
+
+    def initialize(source_url:, dest_url:, index:, dest_client: nil, poll_interval: 10, out: $stdout)
+      @source_url = source_url
+      @dest_url = dest_url
+      @index = index
+      @dest_client = dest_client || Elasticsearch::Client.new(hosts: [dest_url])
+      @poll_interval = poll_interval
+      @out = out
+
+      validate!
+    end
+
+    def reindex
+      ensure_dest_index_exists!
+
+      @out.puts "Reindexing #{@index} from #{@source_url} to #{@dest_url}"
+
+      task_id = start_reindex
+
+      @out.puts "Reindex started at #{Time.now}."
+      @out.puts "Task_id: #{task_id}"
+
+      poll_until_complete(task_id)
+    end
+
+  private
+
+    def validate!
+      return if @source_url && @dest_url && @index
+
+      raise MissingArguments,
+            "Usage: rake search:remote_reindex[https://source_url:443,https://dest_url:443, index]"
+    end
+
+    def ensure_dest_index_exists!
+      return if @dest_client.indices.exists?(index: @index)
+
+      raise "Destination index '#{@index}' does not exist"
+    end
+
+    def start_reindex
+      response = @dest_client.reindex(
+        body: {
+          source: {
+            remote: { host: @source_url },
+            index: @index,
+          },
+          dest: { index: @index },
+        },
+        wait_for_completion: false,
+      )
+
+      response["task"]
+    end
+
+    def poll_until_complete(task_id)
+      loop do
+        task = @dest_client.tasks.get(task_id: task_id)
+
+        if task["completed"]
+          handle_completion(task)
+          break
+        end
+
+        report_progress(task)
+        sleep @poll_interval
+      end
+    end
+
+    def handle_completion(task)
+      raise ReindexFailed, "Reindex failed: #{task['error'].inspect}" if task["error"]
+
+      result = task["response"]
+
+      @out.puts "Reindex complete!"
+      @out.puts "Created: #{result['created']}"
+      @out.puts "Updated: #{result['updated']}"
+      @out.puts "Failures: #{result['failures'].count}"
+    end
+
+    def report_progress(task)
+      status = task.fetch("task").fetch("status")
+
+      total = status["total"]
+      processed = status["created"] + status["updated"] + status["deleted"]
+      percent = total.zero? ? 0 : (processed.to_f / total * 100).round(1)
+
+      @out.puts sprintf(
+        "[%s] %d/%d documents (%.1f%%) | batches=%d | version_conflicts=%d",
+        Time.now.strftime("%H:%M:%S"),
+        processed,
+        total,
+        percent,
+        status["batches"],
+        status["version_conflicts"],
+      )
+    end
+  end
+end

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -74,6 +74,7 @@ require "indexer/popularity_lookup"
 require "index/client"
 require "index/elasticsearch_processor"
 require "index/response_validator"
+require "index/remote_reindexer"
 
 require "govuk_index"
 require "govuk_index/updater"

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -187,4 +187,13 @@ the existing data, you will need to run the \"migrate_schema\" task instead, whi
       end
     end
   end
+
+  desc "Reindex an Elasticsearch index from a source cluster into a destination cluster."
+  task :remote_reindex, %i[source_url dest_url index] do |_, args|
+    source_url = args[:source_url] || ENV["SOURCE_URI"]
+    dest_url = args[:dest_url] || ENV["DEST_URI"]
+    index = args[:index] || ENV["INDEX"]
+
+    Index::RemoteReindexer.new(source_url:, dest_url:, index:).reindex
+  end
 end

--- a/spec/unit/index/remote_reindexer_spec.rb
+++ b/spec/unit/index/remote_reindexer_spec.rb
@@ -1,0 +1,178 @@
+require "spec_helper"
+require "stringio"
+
+RSpec.describe Index::RemoteReindexer do
+  let(:source_url) { "https://source:443" }
+  let(:dest_url)   { "https://dest:443" }
+  let(:index)      { "my_index" }
+  let(:out)        { StringIO.new }
+
+  let(:indices_client) { instance_double("Elasticsearch::API::Indices::IndicesClient") }
+  let(:tasks_client)   { instance_double("Elasticsearch::API::Tasks::TasksClient") }
+  let(:dest_client) do
+    instance_double("ElasticsearchClient", indices: indices_client, tasks: tasks_client)
+  end
+
+  subject(:reindexer) do
+    described_class.new(
+      source_url: source_url,
+      dest_url: dest_url,
+      index: index,
+      dest_client: dest_client,
+      poll_interval: 0,
+      out: out,
+    )
+  end
+
+  describe "#initialize" do
+    it "does not raise when all required args are present" do
+      expect { reindexer }.not_to raise_error
+    end
+
+    it "raises MissingArguments when source_url is missing" do
+      expect {
+        described_class.new(source_url: nil, dest_url: dest_url, index: index, dest_client: dest_client)
+      }.to raise_error(described_class::MissingArguments, /Usage: rake/)
+    end
+
+    it "raises MissingArguments when dest_url is missing" do
+      expect {
+        described_class.new(source_url: source_url, dest_url: nil, index: index, dest_client: dest_client)
+      }.to raise_error(described_class::MissingArguments)
+    end
+
+    it "raises MissingArguments when index is missing" do
+      expect {
+        described_class.new(source_url: source_url, dest_url: dest_url, index: nil, dest_client: dest_client)
+      }.to raise_error(described_class::MissingArguments)
+    end
+  end
+
+  describe "#reindex" do
+    context "when the destination index does not exist" do
+      before { allow(indices_client).to receive(:exists?).with(index: index).and_return(false) }
+
+      it "raises without attempting to reindex" do
+        expect(dest_client).not_to receive(:reindex)
+        expect { reindexer.reindex }.to raise_error("Destination index 'my_index' does not exist")
+      end
+    end
+
+    context "when the remote index exists" do
+      before do
+        allow(indices_client).to receive(:exists?).with(index: index).and_return(true)
+        allow(dest_client).to receive(:reindex).and_return({ "task" => "task123" })
+      end
+
+      it "kicks off the reindex with the expected request body" do
+        allow(tasks_client).to receive(:get).with(task_id: "task123").and_return(
+          "completed" => true,
+          "response" => { "created" => 1, "updated" => 0, "failures" => [] },
+        )
+
+        reindexer.reindex
+
+        expect(dest_client).to have_received(:reindex).with(
+          body: {
+            source: { remote: { host: source_url }, index: index },
+            dest: { index: index },
+          },
+          wait_for_completion: false,
+        )
+      end
+
+      context "when the task completes successfully" do
+        before do
+          allow(tasks_client).to receive(:get).with(task_id: "task123").and_return(
+            "completed" => true,
+            "response" => { "created" => 10, "updated" => 5, "failures" => [] },
+          )
+        end
+
+        it "does not raise and prints a summary" do
+          expect { reindexer.reindex }.not_to raise_error
+
+          expect(out.string).to include("Reindex complete!")
+          expect(out.string).to include("Created: 10")
+          expect(out.string).to include("Updated: 5")
+          expect(out.string).to include("Failures: 0")
+        end
+      end
+
+      context "when the task completes with an error" do
+        before do
+          allow(tasks_client).to receive(:get).with(task_id: "task123").and_return(
+            "completed" => true,
+            "error" => { "type" => "some_error" },
+          )
+        end
+
+        it "raises ReindexFailed" do
+          expect { reindexer.reindex }.to raise_error(described_class::ReindexFailed, /some_error/)
+        end
+      end
+
+      context "when the task is still in progress" do
+        let(:in_progress_task) do
+          {
+            "completed" => false,
+            "task" => {
+              "status" => {
+                "total" => 100,
+                "created" => 20,
+                "updated" => 10,
+                "deleted" => 0,
+                "batches" => 3,
+                "version_conflicts" => 1,
+              },
+            },
+          }
+        end
+        let(:completed_task) do
+          { "completed" => true, "response" => { "created" => 80, "updated" => 20, "failures" => [] } }
+        end
+
+        it "polls until completion, sleeping between checks and logging progress" do
+          allow(tasks_client).to receive(:get).with(task_id: "task123")
+                                              .and_return(in_progress_task, completed_task)
+          allow(reindexer).to receive(:sleep)
+
+          reindexer.reindex
+
+          expect(tasks_client).to have_received(:get).twice
+          expect(reindexer).to have_received(:sleep).once.with(0)
+          expect(out.string).to include("30/100 documents (30.0%)")
+          expect(out.string).to include("batches=3")
+          expect(out.string).to include("version_conflicts=1")
+        end
+
+        context "and the total is zero" do
+          let(:zero_total_task) do
+            {
+              "completed" => false,
+              "task" => {
+                "status" => {
+                  "total" => 0,
+                  "created" => 0,
+                  "updated" => 0,
+                  "deleted" => 0,
+                  "batches" => 0,
+                  "version_conflicts" => 0,
+                },
+              },
+            }
+          end
+
+          it "reports 0% instead of dividing by zero" do
+            allow(tasks_client).to receive(:get).with(task_id: "task123")
+                                                .and_return(zero_total_task, completed_task)
+            allow(reindexer).to receive(:sleep)
+
+            expect { reindexer.reindex }.not_to raise_error
+            expect(out.string).to include("0/0 documents (0.0%)")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/tasks/indices_spec.rb
+++ b/spec/unit/tasks/indices_spec.rb
@@ -331,6 +331,56 @@ RSpec.describe "indices" do
     end
   end
 
+  describe "remote_reindex" do
+    let(:task_name) { "search:remote_reindex" }
+    let(:source_url) { "http://source:9200" }
+    let(:dest_url)   { "http://dest:9200" }
+    let(:index)      { "users" }
+
+    let(:reindexer) { instance_double("RemoteReindexer", reindex: true) }
+
+    before do
+      allow(Index::RemoteReindexer)
+        .to receive(:new)
+              .and_return(reindexer)
+    end
+    it "creates a RemoteReindexer with the supplied task arguments" do
+      Rake::Task[task_name].invoke(source_url, dest_url, index)
+
+      expect(Index::RemoteReindexer).to have_received(:new).with(
+        source_url: source_url,
+        dest_url: dest_url,
+        index: index,
+      )
+
+      expect(reindexer).to have_received(:reindex)
+    end
+
+    context "when task arguments are omitted" do
+      around do |example|
+        ClimateControl.modify(
+          SOURCE_URI: source_url,
+          DEST_URI: dest_url,
+          INDEX: index,
+        ) do
+          example.run
+        end
+      end
+
+      it "uses environment variables" do
+        Rake::Task[task_name].invoke
+
+        expect(Index::RemoteReindexer).to have_received(:new).with(
+          source_url: source_url,
+          dest_url: dest_url,
+          index: index,
+        )
+
+        expect(reindexer).to have_received(:reindex)
+      end
+    end
+  end
+
   def capture_stdout
     old = $stdout
     $stdout = StringIO.new


### PR DESCRIPTION
We are about to upgrade our Elasticsearch cluster from version 6.8 to 7.10. As part of the upgrade we need to reindex the data from the old to the new cluster. This is a rather complex ‘curl’ command and so a rake task is better so we have fewer chances to make a mistake

This PR adds a rake task that reindexes an index from one Elasticsearch cluster to another. 

https://gov-uk.atlassian.net/browse/SCH-2234