### PR TITLE
Add shell script to use elasticdump

### DIFF
--- a/bin/reindex.sh
+++ b/bin/reindex.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CACHE_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$CACHE_DIR"
+}
+
+trap cleanup EXIT
+
+export npm_config_cache="$CACHE_DIR"
+
+npx --yes elasticdump@6.124.1 "$@"


### PR DESCRIPTION
This script installs 'elasticdump' in a temporary directory, runs it and removes it afterwards.

Example Usage:

bin/reindex.sh --input=https://source:443 --output=https://target:443 --index-source=govuk --retryAttempts=3
