### PR TITLE
Add 'elasticdump' rake task

### DIFF
--- a/lib/elasticdump_runner.rb
+++ b/lib/elasticdump_runner.rb
@@ -1,0 +1,43 @@
+# app/services/elasticdump_runner.rb
+
+class ElasticdumpRunner
+  VERSION = "elasticdump@6.124.1".freeze
+
+  def self.call(parameters)
+    new(parameters).call
+  end
+
+  def initialize(parameters)
+    @input = parameters.fetch(:input)
+    @output = parameters.fetch(:output)
+    @type = parameters.fetch(:type, "data")
+    @indices = parameters.fetch(:indices, SearchConfig.all_index_names)
+    @limit = parameters.fetch(:limit, 1000)
+  end
+
+  def call
+    cache_dir = Dir.mktmpdir
+
+    begin
+      @indices.each do |index|
+        success = system(
+          "npx",
+          "--yes",
+          "--cache",
+          cache_dir,
+          VERSION,
+          "--input", @input,
+          "--output", @output,
+          "--type", @type,
+          "--limit", @limit,
+          "--input-index", index,
+          "--output-index", index
+        )
+
+        abort("elasticdump failed") unless success
+      end
+    ensure
+      FileUtils.remove_entry(cache_dir) if Dir.exist?(cache_dir)
+    end
+  end
+end

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -173,5 +173,6 @@ require "sitemap/generator"
 require "sitemap/presenter"
 require "sitemap/uploader"
 require "retryable_queue_message"
+require "elasticdump_runner"
 
 require "core_extensions/time/to_string"

--- a/lib/tasks/elasticdump.rake
+++ b/lib/tasks/elasticdump.rake
@@ -1,0 +1,11 @@
+desc "Copies data across two clusters"
+task :elasticdump do
+  parameters = JSON.parse(
+    ENV.fetch("ELASTICDUMP_PARAMETERS"),
+    symbolize_names: true,
+  )
+
+  ElasticdumpRunner.call(parameters)
+
+  puts "Done"
+end

--- a/spec/unit/elasticdump_runner_spec.rb
+++ b/spec/unit/elasticdump_runner_spec.rb
@@ -1,0 +1,150 @@
+require "spec_helper"
+
+RSpec.describe ElasticdumpRunner do
+  let(:blue) { "https://blue-cluster.gov.uk" }
+  let(:green) { "https://green-cluster.gov.uk" }
+
+  describe ".call" do
+    it "builds an instance with the given parameters and calls it" do
+      parameters = { input: blue, output: green }
+      runner = instance_double(described_class, call: true)
+
+      allow(described_class).to receive(:new).with(parameters).and_return(runner)
+
+      described_class.call(parameters)
+
+      expect(described_class).to have_received(:new).with(parameters)
+      expect(runner).to have_received(:call)
+    end
+  end
+
+  describe "#call" do
+    subject(:runner) { described_class.new(parameters) }
+
+    before do
+      allow(runner).to receive(:system).and_return(true)
+    end
+
+    context "with only required parameters" do
+      let(:parameters) { { input: blue, output: green } }
+
+      it "raises if :input is missing" do
+        expect { described_class.new(output: green).call }.to raise_error(KeyError)
+      end
+
+      it "raises if :output is missing" do
+        expect { described_class.new(input: blue).call }.to raise_error(KeyError)
+      end
+
+      it "defaults type to 'data' and limit to 1000" do
+        runner.call
+
+        expect(runner).to have_received(:system).with(
+          "npx", "--yes", "--cache", instance_of(String),
+          ElasticdumpRunner::VERSION,
+          "--input", blue,
+          "--output", green,
+          "--type", "data",
+          "--limit", 1000,
+          "--input-index", SearchConfig.all_index_names.first,
+          "--output-index", SearchConfig.all_index_names.first
+        )
+      end
+
+      it "defaults indices to SearchConfig.all_index_names" do
+        runner.call
+
+        SearchConfig.all_index_names.each do |index|
+          expect(runner).to have_received(:system).with(
+            "npx", "--yes", "--cache", instance_of(String),
+            ElasticdumpRunner::VERSION,
+            "--input", blue,
+            "--output", green,
+            "--type", "data",
+            "--limit", 1000,
+            "--input-index", index,
+            "--output-index", index
+          )
+        end
+      end
+    end
+
+    context "with explicit overrides" do
+      let(:parameters) do
+        {
+          input: blue,
+          output: green,
+          type: "mapping",
+          limit: 50,
+          indices: %w[only_index],
+        }
+      end
+
+      it "uses the given type, limit and indices instead of the defaults" do
+        runner.call
+
+        expect(runner).to have_received(:system).once.with(
+          "npx", "--yes", "--cache", instance_of(String),
+          ElasticdumpRunner::VERSION,
+          "--input", blue,
+          "--output", green,
+          "--type", "mapping",
+          "--limit", 50,
+          "--input-index", "only_index",
+          "--output-index", "only_index"
+        )
+      end
+    end
+
+    context "when an elasticdump invocation fails" do
+      let(:parameters) do
+        { input: "http://in", output: "http://out", indices: %w[index_1 index_2] }
+      end
+
+      before do
+        allow(runner).to receive(:system).and_return(true, false)
+      end
+
+      it "aborts the task" do
+        expect { runner.call }.to raise_error(SystemExit)
+      end
+
+      it "stops processing further indices" do
+        expect { runner.call }.to raise_error(SystemExit)
+        expect(runner).to have_received(:system).twice
+      end
+    end
+
+    context "cache directory handling" do
+      let(:parameters) { { input: "http://in", output: "http://out", indices: %w[index_1] } }
+
+      it "creates a temporary directory that exists during the run and is removed after" do
+        captured_dir = nil
+        allow(runner).to receive(:system) do |*args|
+          captured_dir = args[3]
+          expect(Dir.exist?(captured_dir)).to be true
+          true
+        end
+
+        runner.call
+
+        expect(captured_dir).not_to be_nil
+        expect(Dir.exist?(captured_dir)).to be false
+      end
+
+      it "removes the cache directory even when a call fails" do
+        allow(runner).to receive(:system).and_return(false)
+        dirs = []
+        allow(FileUtils).to receive(:remove_entry).and_wrap_original do |original, dir|
+          dirs << dir
+          original.call(dir)
+        end
+
+        expect { runner.call }.to raise_error(SystemExit)
+
+        expect(dirs.size).to eq(1)
+        expect(Dir.exist?(dirs.first)).to be false
+      end
+    end
+  end
+end

--- a/spec/unit/tasks/elasticdump_spec.rb
+++ b/spec/unit/tasks/elasticdump_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+require "rake"
+
+RSpec.describe "elasticdump rake task" do
+  let(:task_name) { "elasticdump" }
+  let(:task) { Rake::Task[task_name] }
+  let(:blue) { "https://blue-cluster.gov.uk" }
+  let(:green) { "https://green-cluster.gov.uk" }
+
+  before do
+    task.reenable
+  end
+
+  subject(:invoke_task) { task.invoke }
+
+  let(:parameters) do
+    { input: blue, output: green, indices: %w[index_1] }
+  end
+
+  before do
+    allow(ElasticdumpRunner).to receive(:call)
+    allow(Kernel).to receive(:puts)
+  end
+
+  it "parses ELASTICDUMP_PARAMETERS from the environment with symbolized keys" do
+    ClimateControl.modify(ELASTICDUMP_PARAMETERS: parameters.to_json) do
+      invoke_task
+    end
+
+    expect(ElasticdumpRunner).to have_received(:call).with(parameters)
+  end
+
+  it "raises if ELASTICDUMP_PARAMETERS is not set" do
+    ClimateControl.modify(ELASTICDUMP_PARAMETERS: nil) do
+      expect { invoke_task }.to raise_error(KeyError)
+    end
+  end
+
+  it "raises if ELASTICDUMP_PARAMETERS is not valid JSON" do
+    ClimateControl.modify(ELASTICDUMP_PARAMETERS: "not json") do
+      expect { invoke_task }.to raise_error(JSON::ParserError)
+    end
+  end
+
+  it "prints 'Done' after the runner completes" do
+    output = capture_stdout do
+      ClimateControl.modify(ELASTICDUMP_PARAMETERS: parameters.to_json) do
+        invoke_task
+      end
+    end
+
+    expect(output).to include("Done")
+  end
+
+  it "does not print 'Done' if the runner raises" do
+    allow(ElasticdumpRunner).to receive(:call).and_raise(StandardError, "boom")
+
+    output = capture_stdout do
+      ClimateControl.modify(ELASTICDUMP_PARAMETERS: parameters.to_json) do
+        expect { invoke_task }.to raise_error(StandardError, "boom")
+      end
+    end
+
+    expect(output).to_not include("Done")
+  end
+end


### PR DESCRIPTION
Add rake task to call 'elasticdump' (https://github.com/elasticsearch-dump/elasticsearch-dump) to transfer data from one Elasticsearch cluster to another. It expects an environment variable called ELASTICDUMP_PARAMETERS which should contain a JSON representation of a Hash containing parameters that get passed to elasticdump.

https://gov-uk.atlassian.net/browse/SCH-2234