### PR TITLE
Add csv gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "activesupport"
 gem "aws-sdk-s3"
 gem "bootsnap", require: false
+gem "csv"
 gem "elasticsearch", "~> 6" # We need a 6.x release to interface with Elasticsearch 6
 gem "gds-api-adapters"
 gem "google-analytics-data-v1beta"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -771,6 +771,7 @@ DEPENDENCIES
   bootsnap
   bunny-mock
   climate_control
+  csv
   elasticsearch (~> 6)
   factory_bot
   faker


### PR DESCRIPTION
To silence warning on app start-up:
/app/lib/rummager.rb:10: warning: csv was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0. You can add csv to your Gemfile or gemspec to silence this warning.