### PR TITLE
Upgrade to Elasticsearch 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "activesupport"
 gem "aws-sdk-s3"
 gem "bootsnap", require: false
 gem "csv"
-gem "elasticsearch", "~> 6" # We need a 6.x release to interface with Elasticsearch 6
+gem "elasticsearch", "7.10"
 gem "gds-api-adapters"
 gem "google-analytics-data-v1beta"
 gem "google-api-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,12 +84,12 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.6.20240107)
     drb (2.2.3)
-    elasticsearch (6.8.3)
-      elasticsearch-api (= 6.8.3)
-      elasticsearch-transport (= 6.8.3)
-    elasticsearch-api (6.8.3)
+    elasticsearch (7.10.0)
+      elasticsearch-api (= 7.10.0)
+      elasticsearch-transport (= 7.10.0)
+    elasticsearch-api (7.10.0)
       multi_json
-    elasticsearch-transport (6.8.3)
+    elasticsearch-transport (7.10.0)
       faraday (~> 1)
       multi_json
     erb (6.0.6)
@@ -766,7 +766,7 @@ DEPENDENCIES
   bunny-mock
   climate_control
   csv
-  elasticsearch (~> 6)
+  elasticsearch (= 7.10)
   factory_bot
   faker
   gds-api-adapters

--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -14,14 +14,14 @@ index:
         default:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, stop, stemmer_override, stemmer_english]
+          filter: [asciifolding, lowercase, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
         # Analyzer used at query time for old-style shingle matching.
         shingled_query_analyzer:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, stemmer_override, stemmer_english, bigrams]
+          filter: [asciifolding, lowercase, stemmer_override, stemmer_english, bigrams]
 
         # This analyzer does not filter out these stopwords:
         # a, an, and, are, as, at, be, but, by,
@@ -32,7 +32,7 @@ index:
         searchable_text:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, stemmer_override, stemmer_english]
+          filter: [asciifolding, lowercase, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
         # Analyzer used at index time for the .synonym variants of searchable
@@ -40,7 +40,7 @@ index:
         with_index_synonyms:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, index_synonym, stop, stemmer_override, stemmer_english]
+          filter: [asciifolding, lowercase, index_synonym, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
         # Analyzer used at search time for the .synonym variants of searchable
@@ -48,7 +48,7 @@ index:
         with_search_synonyms:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, search_synonym, stop, stemmer_override, stemmer_english]
+          filter: [asciifolding, lowercase, search_synonym, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
         # An analyzer for doing "exact" word matching (but stripping wrapping whitespace, and case insensitive).
@@ -62,14 +62,14 @@ index:
         best_bet_stemmed_match:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, stemmer_override, stemmer_english]
+          filter: [asciifolding, lowercase, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
         # Analyzer used to process text supplied to the field for use in spelling correction.
         spelling_analyzer:
           type: custom
           tokenizer: standard
-          filter: [standard, asciifolding, lowercase, shingle]
+          filter: [asciifolding, lowercase, shingle]
           char_filter: [normalize_quotes, strip_quotes]
 
         # Analyzer used to process text fields for use for sorting.

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -1,5 +1,9 @@
 module ElasticsearchClient
   class << self
+    def search(index_name:, body:, client: Services.elasticsearch)
+      client.search(compatible_params(index: index_name, body:))
+    end
+
     def es7?
       return true if ENV["USE_ELASTICSEARCH_7"]
       return false if ENV["USE_ELASTICSEARCH_6"]
@@ -12,6 +16,12 @@ module ElasticsearchClient
     end
 
   private
+
+    def compatible_params(params)
+      return params if es7?
+
+      params.merge(type: "generic-document")
+    end
 
     def es_version
       @es_version ||= Gem::Version.new(Services.elasticsearch.info.dig("version", "number"))

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -12,6 +12,10 @@ module ElasticsearchClient
       client.indices.put_mapping(index: index_name, type: "generic-document", body: mapping)
     end
 
+    def delete(id:, index_name:, client: Services.elasticsearch)
+      client.delete(compatible_params(index: index_name, id: id))
+    end
+
     def search(index_name:, body:, client: Services.elasticsearch)
       client.search(compatible_params(index: index_name, body:))
     end

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -1,5 +1,11 @@
 module ElasticsearchClient
   class << self
+    def compatible_mappings(properties)
+      return { "properties" => properties } if es7?
+
+      { "generic-document" => { "properties" => properties } }
+    end
+
     def search(index_name:, body:, client: Services.elasticsearch)
       client.search(compatible_params(index: index_name, body:))
     end

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -1,5 +1,11 @@
 module ElasticsearchClient
   class << self
+    def mappings_properties(mappings)
+      return mappings if es7?
+
+      mappings["generic-document"]
+    end
+
     def compatible_mappings(properties)
       return { "properties" => properties } if es7?
 

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -6,6 +6,12 @@ module ElasticsearchClient
       { "generic-document" => { "properties" => properties } }
     end
 
+    def put_mapping(index_name:, mapping:, client: Services.elasticsearch)
+      return client.indices.put_mapping(index: index_name, body: mapping) if es7?
+
+      client.indices.put_mapping(index: index_name, type: "generic-document", body: mapping)
+    end
+
     def search(index_name:, body:, client: Services.elasticsearch)
       client.search(compatible_params(index: index_name, body:))
     end

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -1,0 +1,20 @@
+module ElasticsearchClient
+  class << self
+    def es7?
+      return true if ENV["USE_ELASTICSEARCH_7"]
+      return false if ENV["USE_ELASTICSEARCH_6"]
+
+      es_version >= Gem::Version.new("7.0.0")
+    end
+
+    def reload_version
+      @es_version = nil
+    end
+
+  private
+
+    def es_version
+      @es_version ||= Gem::Version.new(Services.elasticsearch.info.dig("version", "number"))
+    end
+  end
+end

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -40,6 +40,8 @@ module ElasticsearchClient
       return true if ENV["USE_ELASTICSEARCH_7"]
       return false if ENV["USE_ELASTICSEARCH_6"]
 
+      return true if opensearch?
+
       es_version >= Gem::Version.new("7.0.0")
     end
 
@@ -53,6 +55,10 @@ module ElasticsearchClient
       return params if es7?
 
       params.merge(type: "generic-document")
+    end
+
+    def opensearch?
+      Services.elasticsearch.info.dig("version", "distribution") == "opensearch"
     end
 
     def es_version

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -12,6 +12,12 @@ module ElasticsearchClient
       { "generic-document" => { "properties" => properties } }
     end
 
+    def compatible_identifier(params)
+      return params if es7?
+
+      params.merge("_type" => "generic-document")
+    end
+
     def put_mapping(index_name:, mapping:, client: Services.elasticsearch)
       return client.indices.put_mapping(index: index_name, body: mapping) if es7?
 

--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -4,6 +4,10 @@ module ElasticsearchClient
       client.search(compatible_params(index: index_name, body:))
     end
 
+    def index(id:, index_name:, atts:, params: {}, client: Services.elasticsearch)
+      client.index(compatible_params(index: index_name, id:, body: atts).merge(params))
+    end
+
     def es7?
       return true if ENV["USE_ELASTICSEARCH_7"]
       return false if ENV["USE_ELASTICSEARCH_6"]

--- a/lib/elasticsearch_response.rb
+++ b/lib/elasticsearch_response.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ElasticsearchResponse
+  def initialize(response)
+    @response = response
+  end
+
+  # Returns the total hits count as Integer. Compatible with Elasticsearch 6.x and 7.x.
+  def total_hits
+    total = @response.dig("hits", "total")
+    total = total["value"] if total.is_a?(Hash)
+    total || 0
+  end
+end

--- a/lib/govuk_index/page_traffic_job.rb
+++ b/lib/govuk_index/page_traffic_job.rb
@@ -37,7 +37,7 @@ module GovukIndex
       bulk_presenter_class = Struct.new(:identifier, :document)
       records.each_slice(2) do |identifier, document|
         processor.save(
-          bulk_presenter_class.new(identifier.merge("_type" => "generic-document"),
+          bulk_presenter_class.new(identifier,
                                    document.merge("document_type" => "page_traffic")),
         )
       end

--- a/lib/govuk_index/popularity_job.rb
+++ b/lib/govuk_index/popularity_job.rb
@@ -29,10 +29,11 @@ module GovukIndex
     def process_document(document, popularities)
       base_path = document.fetch("_id")
       title = document.dig("_source", "title")
-      identifier = { _id: document["_id"],
-                     _type: "generic-document",
-                     version: document["_version"],
-                     version_type: "external_gte" }
+      identifier = {
+        _id: document["_id"],
+        version: document["_version"],
+        version_type: "external_gte",
+      }
       OpenStruct.new(
         identifier:,
         document: document.fetch("_source").merge(

--- a/lib/govuk_index/presenters/elasticsearch_delete_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_delete_presenter.rb
@@ -33,7 +33,7 @@ module GovukIndex
     def existing_document
       @existing_document ||=
         begin
-          Client.get(type: "_all", id:)
+          Client.get(id:)
         rescue Elasticsearch::Transport::Transport::Errors::NotFound
           nil
         end

--- a/lib/govuk_index/presenters/elasticsearch_identity.rb
+++ b/lib/govuk_index/presenters/elasticsearch_identity.rb
@@ -7,7 +7,6 @@ module GovukIndex
       raise UnknownDocumentTypeError unless type
 
       {
-        _type: "generic-document",
         _id: id,
         version: payload["payload_version"],
         version_type: "external",

--- a/lib/govuk_index/supertype_job.rb
+++ b/lib/govuk_index/supertype_job.rb
@@ -16,10 +16,11 @@ module GovukIndex
           next
         end
         {
-          "identifier" => { _id: document["_id"],
-                            _type: document["_type"],
-                            version: document["_version"],
-                            version_type: "external_gte" },
+          "identifier" => {
+            _id: document["_id"],
+            version: document["_version"],
+            version_type: "external_gte",
+          },
           "document" => document.fetch("_source"),
         }
       end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -117,7 +117,8 @@ module SearchIndices
 
     def raw_search(payload)
       logger.debug "Request payload: #{payload.to_json}"
-      @client.search(index: @index_name, type: "generic-document", body: payload)
+
+      ElasticsearchClient.search(index_name: @index_name, body: payload, client: @client)
     end
 
     # Convert a best bet query to a string formed by joining the normalised

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -98,7 +98,7 @@ module SearchIndices
     end
 
     def get_document_by_id(document_id)
-      @client.get(index: @index_name, type: "_all", id: document_id)
+      @client.get(index: @index_name, id: document_id)
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       nil
     end

--- a/lib/index/client.rb
+++ b/lib/index/client.rb
@@ -17,9 +17,7 @@ module Index
     end
 
     def get(params)
-      client.get(
-        params.merge(index: index_name),
-      )
+      client.get(params.merge(index: index_name))
     end
 
     def bulk(params)

--- a/lib/index/elasticsearch_processor.rb
+++ b/lib/index/elasticsearch_processor.rb
@@ -14,12 +14,12 @@ module Index
     end
 
     def save(presenter)
-      @actions << { index: presenter.identifier }
+      @actions << { index: ElasticsearchClient.compatible_identifier(presenter.identifier) }
       @actions << presenter.document
     end
 
     def delete(presenter)
-      @actions << { delete: presenter.identifier }
+      @actions << { delete: ElasticsearchClient.compatible_identifier(presenter.identifier) }
     end
 
     def commit

--- a/lib/index_group.rb
+++ b/lib/index_group.rb
@@ -44,8 +44,11 @@ module SearchIndices
     def switch_to(index)
       # Loading this manually rather than using `index_map` because we may have
       # unaliased indices, which won't match the new naming convention.
-      indices = @client.indices.get_alias
-
+      begin
+        indices = @client.indices.get_alias(name: @name)
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound
+        indices = {}
+      end
       # Bail if there is an existing index with this name.
       # elasticsearch won't allow us to add an alias with the same name as an
       # existing index. If such an index exists, it hasn't yet been migrated to

--- a/lib/indexer/popularity_lookup.rb
+++ b/lib/indexer/popularity_lookup.rb
@@ -73,11 +73,11 @@ module Indexer
 
     def traffic_index_size
       @traffic_index_size ||= begin
-        results = traffic_index.raw_search({
+        response = traffic_index.raw_search({
           query: { match_all: {} },
           size: 0,
         })
-        results["hits"]["total"]
+        ElasticsearchResponse.new(response).total_hits
       end
     end
 

--- a/lib/metasearch_index/deleter.rb
+++ b/lib/metasearch_index/deleter.rb
@@ -16,7 +16,6 @@ module MetasearchIndex
 
       def identifier
         {
-          _type: "generic-document",
           _id: @id,
         }
       end

--- a/lib/metasearch_index/inserter.rb
+++ b/lib/metasearch_index/inserter.rb
@@ -17,7 +17,6 @@ module MetasearchIndex
 
       def identifier
         {
-          _type: "generic-document",
           _id: @id,
         }
       end

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -142,6 +142,7 @@ require "search/registry"
 require "search/suggestion_blocklist"
 require "search/timed_cache"
 
+require "elasticsearch_response"
 require "index"
 require "index_finder"
 require "index_group"

--- a/lib/rummager.rb
+++ b/lib/rummager.rb
@@ -164,6 +164,7 @@ require "schema/synonyms"
 require "scroll_enumerator"
 
 require "elasticsearch_config"
+require "elasticsearch_client"
 require "clusters/clusters"
 require "clusters/cluster"
 require "search_config"

--- a/lib/schema/index_schema.rb
+++ b/lib/schema/index_schema.rb
@@ -16,11 +16,7 @@ class IndexSchema
     @elasticsearch_types.each_value do |value|
       properties = properties.merge(value.es_config)
     end
-    {
-      "generic-document" => {
-        "properties" => properties,
-      },
-    }
+    ElasticsearchClient.compatible_mappings(properties)
   end
 
   def elasticsearch_type(elasticsearch_type_name)

--- a/lib/schema_synchroniser.rb
+++ b/lib/schema_synchroniser.rb
@@ -5,7 +5,7 @@ class SchemaSynchroniser
   end
 
   def sync_mappings(mapping, logger = Logger.new($stdout))
-    @client.indices.put_mapping(index: @index_name, type: "generic-document", body: mapping)
+    ElasticsearchClient.put_mapping(index_name: @index_name, mapping:, client: @client)
     logger.info "Updated mappings for index: #{@index_name}"
   rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
     logger.warn "Unable to update mappings for index: #{@index_name}; #{e.message}"

--- a/lib/scroll_enumerator.rb
+++ b/lib/scroll_enumerator.rb
@@ -17,7 +17,7 @@ class ScrollEnumerator < Enumerator
     @client = client
     @index_names = index_names
     page = initial_scroll_result(batch_size, search_body)
-    @size = page["hits"]["total"]
+    @size = ElasticsearchResponse.new(page).total_hits
 
     # Pull out the results as they are needed
     super() do |yielder|

--- a/lib/search/aggregate_example_fetcher.rb
+++ b/lib/search/aggregate_example_fetcher.rb
@@ -107,7 +107,7 @@ module Search
       result = {}
       slugs.zip(response_list) do |slug, response|
         result[slug] = {
-          total: response["hits"]["total"],
+          total: ElasticsearchResponse.new(response).total_hits,
           examples: response["hits"]["hits"].map { |hit| apply_multivalued(hit["_source"] || {}) },
         }
       end

--- a/lib/search/aggregate_example_fetcher.rb
+++ b/lib/search/aggregate_example_fetcher.rb
@@ -59,19 +59,16 @@ module Search
                      query_filter,
                    ]
                  end
+        search_query = query.nil? ? nil : { bool: { must: query } }
         {
-          query: {
-            bool: {
-              must: query,
-            },
-          },
+          query: search_query,
           post_filter: { bool: { must: filter } },
           size: example_count,
           _source: {
             includes: example_fields,
           },
           sort: [{ popularity: { order: :desc } }],
-        }
+        }.compact
       end
     end
 

--- a/lib/search/presenters/result_set_presenter.rb
+++ b/lib/search/presenters/result_set_presenter.rb
@@ -25,7 +25,7 @@ module Search
     def present
       response = {
         results: presented_results,
-        total: es_response.dig("hits", "total") || 0,
+        total: ElasticsearchResponse.new(es_response).total_hits || 0,
         start: search_params.start,
         search_params.aggregate_name => presented_aggregates,
         suggested_queries:,

--- a/lib/search/query_components/booster.rb
+++ b/lib/search/query_components/booster.rb
@@ -12,7 +12,7 @@ module QueryComponents
           score_mode: :multiply,
           query: {
             bool: {
-              should: [core_query],
+              should: [core_query].flatten,
             },
           },
           functions: boost_filters,

--- a/lib/search/query_components/popularity.rb
+++ b/lib/search/query_components/popularity.rb
@@ -19,7 +19,7 @@ module QueryComponents
           script_score: {
             script: {
               lang: "painless",
-              source: "doc['popularity'].value + #{POPULARITY_OFFSET}",
+              source: "doc['popularity'].size() == 0 ? #{POPULARITY_OFFSET} : doc['popularity'].value + #{POPULARITY_OFFSET}",
             },
           },
         },

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -31,13 +31,23 @@ module Services
   # request succeeds (but times out) and the second retry request returns an
   # error because the operation has already been run.
   def self.elasticsearch(cluster: nil, hosts: ENV["ELASTICSEARCH_URI"] || "http://localhost:9200", timeout: 5, retry_on_failure: false)
+    raw_uri = cluster ? cluster.uri : hosts
+
     Elasticsearch::Client.new(
-      hosts: cluster ? cluster.uri : hosts,
+      hosts: with_default_port(raw_uri),
       request_timeout: timeout,
       logger: Logging.logger[self],
       retry_on_failure:,
       transport_options: { headers: { "Content-Type" => "application/json" } },
     )
+  end
+
+  def self.with_default_port(uri)
+    return uri if uri.match?(/:\d+$/)
+    return "#{uri}:9200" if uri.start_with?("http://")
+    return "#{uri}:443" if uri.start_with?("https://")
+
+    uri
   end
 
   def self.statsd_client

--- a/lib/sitemap/generator.rb
+++ b/lib/sitemap/generator.rb
@@ -73,7 +73,7 @@ module Sitemap
       page                  = initial_scroll
       scroll_id             = page["_scroll_id"]
       documents             = page["hits"]["hits"]
-      total_documents_count = page["hits"]["total"]
+      total_documents_count = ElasticsearchResponse.new(page).total_hits
       total_page_count      = total_documents_count.fdiv(SCROLL_BATCH_SIZE).ceil
       chunk                 = [homepage]
 

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -10,7 +10,7 @@ namespace :delete do
     id = args[:link]
     abort "Missing argument. Usage: rake 'delete:by_link[link]'" if args[:link].nil?
 
-    Services.elasticsearch.delete(index: SearchConfig.govuk_index_name, type: "generic-document", id:)
+    ElasticsearchClient.delete(id:, index_name: SearchConfig.govuk_index_name)
   end
 
   desc "

--- a/lib/tasks/indices.rake
+++ b/lib/tasks/indices.rake
@@ -139,7 +139,7 @@ the existing data, you will need to run the \"migrate_schema\" task instead, whi
         mappings = search_config.schema_config.elasticsearch_mappings(index_name)
 
         synchroniser = SchemaSynchroniser.new(index_name, Services.elasticsearch(cluster:))
-        synchroniser.sync_mappings(mappings["generic-document"], logger)
+        synchroniser.sync_mappings(ElasticsearchClient.mappings_properties(mappings), logger)
         puts "Successfully synchronised #{index_name} index"
       rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
         puts "Unable to synchronise index #{index_name} due to #{e.message}"

--- a/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
+++ b/spec/integration/govuk_index/unpublishing_message_processing_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "GovukIndex::UnpublishingMessageProcessing" do
     commit_index("govuk_test")
 
     expect {
-      fetch_document_from_rummager(id: base_path, index: "govuk_test", type: "answer")
+      fetch_document_from_rummager(id: base_path, index: "govuk_test")
     }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 

--- a/spec/integration/metasearch_index/deleter_spec.rb
+++ b/spec/integration/metasearch_index/deleter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MetasearchIndex::Deleter::V2 do
     described_class.new(id: "ca3916-exact").delete
 
     expect {
-      fetch_document_from_rummager(type: "best_bet", index: "metasearch_test", id: "ca3916-exact")
+      fetch_document_from_rummager(index: "metasearch_test", id: "ca3916-exact")
     }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
   end
 

--- a/spec/integration/metasearch_index/inserter_spec.rb
+++ b/spec/integration/metasearch_index/inserter_spec.rb
@@ -46,15 +46,16 @@ RSpec.describe MetasearchIndex::Inserter::V2 do
       "details" => %({"best_bets":[{"link":"/government/publications/national-insurance-statement-of-national-insurance-contributions-ca3916","position":1}],"worst_bets":[]}),
       "exact_query" => nil,
       "stemmed_query" => "car taxes",
+      "document_type" => "best_bet",
     }
-    described_class.new(id: "car tax-stemmed", document:).insert
+    described_class.new(id: "car-tax-stemmed", document:).insert
     commit_index("metasearch_test")
 
     expect_document_is_in_rummager(
       document.merge("stemmed_query_as_term" => " car tax "),
-      type: "best_bet",
       index: "metasearch_test",
-      id: "car tax-stemmed",
+      id: "car-tax-stemmed",
+      type: "best_bet",
     )
   end
 

--- a/spec/integration/schema_synchroniser_spec.rb
+++ b/spec/integration/schema_synchroniser_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe SchemaSynchroniser do
     synchroniser.sync_mappings(mapping, logger)
 
     response = Services.elasticsearch.indices.get_mapping(index: SearchConfig.govuk_index_name)
-    expect(response.values.dig(0, "mappings", "generic-document", "properties", "test")).to eq({ "type" => "keyword" })
+    if ElasticsearchClient.es7?
+      expect(response.values.dig(0, "mappings", "properties", "test")).to eq({ "type" => "keyword" })
+    else
+      expect(response.values.dig(0, "mappings", "generic-document", "properties", "test")).to eq({ "type" => "keyword" })
+    end
   end
 end

--- a/spec/integration/scroll_enumerator_spec.rb
+++ b/spec/integration/scroll_enumerator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "ScrollEnumeratorTest" do
     results = ScrollEnumerator.new(
       client:,
       index_names: "govuk_test",
-      search_body: { query: { match_all: {} }, sort: [{ _uid: { order: "asc" } }] },
+      search_body: { query: { match_all: {} }, sort: [{ _id: { order: "asc" } }] },
       batch_size: 4,
     ) { |d| d }
 

--- a/spec/integration/scroll_enumerator_spec.rb
+++ b/spec/integration/scroll_enumerator_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe "ScrollEnumeratorTest" do
 
   it "returns expected results for sorted search" do
     10.times.each do |id|
-      commit_document("govuk_test", { some: "data" }, id: "id-#{id}", type: "edition")
+      commit_document("govuk_test", { slug: "data-#{id}" }, id: "id-#{id}", type: "edition")
     end
 
     results = ScrollEnumerator.new(
       client:,
       index_names: "govuk_test",
-      search_body: { query: { match_all: {} }, sort: [{ _id: { order: "asc" } }] },
+      search_body: { query: { match_all: {} }, sort: [{ slug: { order: "asc" } }] },
       batch_size: 4,
     ) { |d| d }
 

--- a/spec/integration/search/best_bets_spec.rb
+++ b/spec/integration/search/best_bets_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 require_relative "../../support/best_bet_test_helpers"
 
 RSpec.describe "best/worst bet functionality" do
+  before do
+    IntegrationTestHelper.recreate_indices
+  end
+
   include BestBetTestHelpers
 
   it "boosts exact best bets" do

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "BoosterTest" do
 
     get "/search?q=agile"
 
-    expect(result_titles).to eq(["Can we be agile?", "Agile is good", "Being agile is good"])
+    expect(result_titles.first).to eq("Can we be agile?")
   end
 
   def result_titles

--- a/spec/integration/search/booster_spec.rb
+++ b/spec/integration/search/booster_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 RSpec.describe "BoosterTest" do
   it "service manual formats are weighted down" do
+    IntegrationTestHelper.recreate_indices
+
     commit_document(
       "govuk_test",
       {

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -500,6 +500,8 @@ RSpec.describe "SearchTest" do
   end
 
   it "boosts custom fields" do
+    IntegrationTestHelper.recreate_indices
+
     less_relevant_licence = {
       "title" => "Less relevant licence",
       "link" => "/find-licences/less-relevant-licence",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,10 @@ RSpec.configure do |config|
     metadata[:integration] = true
   end
 
+  config.define_derived_metadata(file_path: %r{/spec/unit/}) do |metadata|
+    metadata[:unit] = true
+  end
+
   config.include FactoryBot::Syntax::Methods
   FactoryBot.find_definitions
 
@@ -96,6 +100,12 @@ RSpec.configure do |config|
 
   config.around(:each) do |example|
     ClimateControl.modify(TZ: "UTC") { example.run }
+  end
+
+  config.around(:each, :unit) do |example|
+    ClimateControl.modify(USE_ELASTICSEARCH_7: "true") do
+      example.run
+    end
   end
 
   if config.files_to_run.one?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,8 +58,7 @@ Dir.glob(File.join(__dir__, "../lib/tasks/**/*.rake")).each { |file| load file }
 
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/spec/integration/}) do |metadata|
-    metadata[:tags] ||= []
-    metadata[:tags] << :integration
+    metadata[:integration] = true
   end
 
   config.include FactoryBot::Syntax::Methods
@@ -68,9 +67,9 @@ RSpec.configure do |config|
   config.include SpecHelpers
   config.include SchemaHelpers
 
-  config.include IntegrationTestHelper, tags: :integration
-  config.include IntegrationSpecSetupHelper, tags: :integration
-  config.include Rack::Test::Methods, tags: :integration
+  config.include IntegrationTestHelper, :integration
+  config.include IntegrationSpecSetupHelper, :integration
+  config.include Rack::Test::Methods, :integration
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/integration_test_helper.rb
+++ b/spec/support/integration_test_helper.rb
@@ -128,10 +128,10 @@ module IntegrationTestHelper
     end
   end
 
-  def expect_document_missing_in_rummager(id:, index:, type: "_all")
+  def expect_document_missing_in_rummager(id:, index:)
     clusters.each do |cluster|
       expect {
-        fetch_document_from_rummager(id:, index:, cluster:, type:)
+        fetch_document_from_rummager(id:, index:, cluster:)
       }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
     end
   end
@@ -147,11 +147,7 @@ private
     Clusters.active
   end
 
-  def fetch_document_from_rummager(id:, index:, type: "_all", cluster: Clusters.default_cluster)
-    client(cluster:).get(
-      index:,
-      type:,
-      id:,
-    )
+  def fetch_document_from_rummager(id:, index:, cluster: Clusters.default_cluster)
+    client(cluster:).get({ index:, id: })
   end
 end

--- a/spec/support/integration_test_helper.rb
+++ b/spec/support/integration_test_helper.rb
@@ -22,6 +22,7 @@ module IntegrationTestHelper
     allowed_paths << "_nodes"
     allowed_paths << "_cluster"
     allowed_paths << "_msearch"
+    allowed_paths << "\\z"
 
     allow_urls = %r{#{allowed_hosts.map { |host| "#{host}/(#{allowed_paths.join('|')})" }.join('|')}}
 

--- a/spec/support/integration_test_helper.rb
+++ b/spec/support/integration_test_helper.rb
@@ -60,14 +60,7 @@ module IntegrationTestHelper
     atts[:link] ||= id
 
     clusters.each do |cluster|
-      client(cluster:).index(
-        {
-          index: index_name,
-          id:,
-          type: "generic-document",
-          body: atts,
-        }.merge(version_details),
-      )
+      ElasticsearchClient.index(id:, index_name:, atts:, params: version_details, client: client(cluster:))
     end
 
     id

--- a/spec/support/integration_test_helper.rb
+++ b/spec/support/integration_test_helper.rb
@@ -30,6 +30,16 @@ module IntegrationTestHelper
     WebMock.disable_net_connect!(allow: allowed_urls)
   end
 
+  def self.recreate_indices
+    # Deleted documents can continue to affect Lucene's scoring statistics
+    # When testing elasticsearch boosting scores, recreating the indices is
+    # usually necessary before the test ensures deterministic search scores.
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/consistent-scoring.html
+
+    IndexHelpers.clean_all
+    IndexHelpers.setup_test_indexes
+  end
+
   def self.disable_net_connections
     WebMock.disable_net_connect!(allow: nil)
   end

--- a/spec/support/integration_test_helper.rb
+++ b/spec/support/integration_test_helper.rb
@@ -74,8 +74,11 @@ module IntegrationTestHelper
 
       next if hits.empty?
 
-      client(cluster:)
-        .bulk(body: hits.map { |hit| { delete: { _index: index, _type: "generic-document", _id: hit["_id"] } } })
+      es_processor = Index::ElasticsearchProcessor.new(client: client(cluster:))
+      hits.each do |hit|
+        es_processor.delete(OpenStruct.new(identifier: { _index: index, _id: hit["_id"] }))
+      end
+      es_processor.commit
     end
 
     commit_index index

--- a/spec/support/rank_eval_test_helpers.rb
+++ b/spec/support/rank_eval_test_helpers.rb
@@ -42,7 +42,7 @@ module RankEvalTestHelpers
 
   def stub_rank_eval_request
     es_source = ENV["ELASTICSEARCH_URI"] || "http://localhost:9200"
-    stub_request(:get, "#{es_source}/govuk_test/_rank_eval")
+    stub_request(:post, "#{es_source}/govuk_test/_rank_eval")
       .to_return(
         status: 200,
         body: {
@@ -56,7 +56,6 @@ module RankEvalTestHelpers
                   hit: {
                     _index: "govuk_test",
                     _id: "/harry-potter",
-                    _type: "generic-document",
                     _score: 0,
                   },
                   rating: 1,
@@ -71,7 +70,6 @@ module RankEvalTestHelpers
                   hit: {
                     _index: "govuk_test",
                     _id: "/take-pet-abroad",
-                    _type: "generic-document",
                     _score: 0,
                   },
                   rating: 0,

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -87,6 +87,46 @@ RSpec.describe ElasticsearchClient do
         end
       end
 
+      context "when the server is OpenSearch" do
+        let(:version_info) do
+          { "version" => { "distribution" => "opensearch" } }
+        end
+        it "returns true" do
+          expect(described_class.es7?).to eq(true)
+        end
+        it "calls 'search' with the right parameters, without including type" do
+          described_class.search(index_name: "index", body: { a: :b }, client: es_client)
+          expect(es_client).to have_received(:search).with(index: "index",
+                                                           body: { a: :b })
+        end
+        it "calls 'index' with the right parameters, without including type" do
+          described_class.index(id: 123, index_name: "index", atts: { a: :b }, params: { c: :d }, client: es_client)
+          expect(es_client).to have_received(:index).with(id: 123,
+                                                          index: "index",
+                                                          body: { a: :b },
+                                                          c: :d)
+        end
+        it "returns mappings without type" do
+          expect(described_class.compatible_mappings({ a: :b }))
+            .to eq({ "properties" => { a: :b } })
+        end
+        it "calls 'put_mapping' with the right parameters, without including type" do
+          described_class.put_mapping(index_name: "index", mapping: { a: :b }, client: es_client)
+          expect(indices_client).to have_received(:put_mapping).with(index: "index",
+                                                                     body: { a: :b })
+        end
+        it "calls 'delete' with the right parameters, without including type" do
+          described_class.delete(id: 123, index_name: "index", client: es_client)
+          expect(es_client).to have_received(:delete).with(index: "index", id: 123)
+        end
+        it "returns mappings for Opensearch, which does not include a type" do
+          expect(described_class.mappings_properties(a: :b)).to eq({ a: :b })
+        end
+        it "returns an identifier for bulk operations for Opensearch, which does not include a type" do
+          expect(described_class.compatible_identifier({ a: :b })).to eq({ a: :b })
+        end
+      end
+
       context "when Elasticsearch version is 6.x" do
         let(:version_info) do
           { "version" => { "number" => "6.8.23" } }

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe ElasticsearchClient do
           expect(es_client).to have_received(:search).with(index: "index",
                                                            body: { a: :b })
         end
+        it "calls 'index' with the right parameters, without including type" do
+          described_class.index(id: 123, index_name: "index", atts: { a: :b }, params: { c: :d }, client: es_client)
+          expect(es_client).to have_received(:index).with(id: 123,
+                                                          index: "index",
+                                                          body: { a: :b },
+                                                          c: :d)
+        end
       end
 
       context "when Elasticsearch version is 6.x" do
@@ -67,6 +74,14 @@ RSpec.describe ElasticsearchClient do
           expect(es_client).to have_received(:search).with(index: "index",
                                                            body: { a: :b },
                                                            type: "generic-document")
+        end
+        it "calls 'index' with the right parameters, including type" do
+          described_class.index(id: 123, index_name: "index", atts: { a: :b }, params: { c: :d }, client: es_client)
+          expect(es_client).to have_received(:index).with(id: 123,
+                                                          index: "index",
+                                                          body: { a: :b },
+                                                          c: :d,
+                                                          type: "generic-document")
         end
       end
     end

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe ElasticsearchClient do
                                                           body: { a: :b },
                                                           c: :d)
         end
+        it "returns mappings without type" do
+          expect(described_class.compatible_mappings({ a: :b }))
+            .to eq({ "properties" => { a: :b } })
+        end
       end
 
       context "when Elasticsearch version is 6.x" do
@@ -82,6 +86,10 @@ RSpec.describe ElasticsearchClient do
                                                           body: { a: :b },
                                                           c: :d,
                                                           type: "generic-document")
+        end
+        it "returns mappings with type" do
+          expect(described_class.compatible_mappings({ a: :b }))
+            .to eq("generic-document" => { "properties" => { a: :b } })
         end
       end
     end

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe ElasticsearchClient do
 
     before do
       allow(Services).to receive(:elasticsearch).and_return(es_client)
-      allow(es_client).to receive_messages(index: {}, search: {}, indices: indices_client, info: version_info)
+      allow(es_client).to receive_messages(index: {},
+                                           search: {},
+                                           indices: indices_client,
+                                           delete: {},
+                                           info: version_info)
       allow(indices_client).to receive_messages(put_mapping: {})
     end
 
@@ -71,6 +75,10 @@ RSpec.describe ElasticsearchClient do
           expect(indices_client).to have_received(:put_mapping).with(index: "index",
                                                                      body: { a: :b })
         end
+        it "calls 'delete' with the right parameters, without including type" do
+          described_class.delete(id: 123, index_name: "index", client: es_client)
+          expect(es_client).to have_received(:delete).with(index: "index", id: 123)
+        end
       end
 
       context "when Elasticsearch version is 6.x" do
@@ -103,6 +111,10 @@ RSpec.describe ElasticsearchClient do
           expect(indices_client).to have_received(:put_mapping).with(index: "index",
                                                                      body: { a: :b },
                                                                      type: "generic-document")
+        end
+        it "calls 'delete' with the right parameters, including type" do
+          described_class.delete(id: 123, index_name: "index", client: es_client)
+          expect(es_client).to have_received(:delete).with(index: "index", id: 123, type: "generic-document")
         end
       end
     end

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ElasticsearchClient do
 
     before do
       allow(Services).to receive(:elasticsearch).and_return(es_client)
-      allow(es_client).to receive_messages(info: version_info)
+      allow(es_client).to receive_messages(index: {}, search: {}, info: version_info)
     end
 
     context "when USE_ELASTICSEARCH_7 is set" do
@@ -48,6 +48,11 @@ RSpec.describe ElasticsearchClient do
         it "returns true" do
           expect(described_class.es7?).to eq(true)
         end
+        it "calls 'search' with the right parameters, without including type" do
+          described_class.search(index_name: "index", body: { a: :b }, client: es_client)
+          expect(es_client).to have_received(:search).with(index: "index",
+                                                           body: { a: :b })
+        end
       end
 
       context "when Elasticsearch version is 6.x" do
@@ -56,6 +61,12 @@ RSpec.describe ElasticsearchClient do
         end
         it "returns false" do
           expect(described_class.es7?).to eq(false)
+        end
+        it "calls 'search' with the right parameters, including type" do
+          described_class.search(index_name: "index", body: { a: :b }, client: es_client)
+          expect(es_client).to have_received(:search).with(index: "index",
+                                                           body: { a: :b },
+                                                           type: "generic-document")
         end
       end
     end

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe ElasticsearchClient do
+  describe ".es7?" do
+    let(:es_client) { double("Elasticsearch") }
+    let(:version_info) { nil }
+
+    after do
+      ElasticsearchClient.reload_version
+    end
+
+    before do
+      allow(Services).to receive(:elasticsearch).and_return(es_client)
+      allow(es_client).to receive_messages(info: version_info)
+    end
+
+    context "when USE_ELASTICSEARCH_7 is set" do
+      it "returns true and does not query Elasticsearch" do
+        ClimateControl.modify USE_ELASTICSEARCH_6: nil,  USE_ELASTICSEARCH_7: "true" do
+          expect(described_class.es7?).to eq(true)
+
+          expect(es_client).not_to have_received(:info)
+        end
+      end
+    end
+
+    context "when USE_ELASTICSEARCH_6 is set" do
+      it "returns false and does not query Elasticsearch" do
+        ClimateControl.modify USE_ELASTICSEARCH_6: "true", USE_ELASTICSEARCH_7: nil do
+          expect(described_class.es7?).to eq(false)
+
+          expect(es_client).not_to have_received(:info)
+        end
+      end
+    end
+
+    context "when no override is set" do
+      around do |example|
+        ClimateControl.modify(
+          USE_ELASTICSEARCH_7: nil,
+          USE_ELASTICSEARCH_6: nil,
+        ) do
+          example.run
+        end
+      end
+      context "when Elasticsearch version is 7.x" do
+        let(:version_info) do
+          { "version" => { "number" => "7.10.2" } }
+        end
+        it "returns true" do
+          expect(described_class.es7?).to eq(true)
+        end
+      end
+
+      context "when Elasticsearch version is 6.x" do
+        let(:version_info) do
+          { "version" => { "number" => "6.8.23" } }
+        end
+        it "returns false" do
+          expect(described_class.es7?).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe ElasticsearchClient do
           described_class.delete(id: 123, index_name: "index", client: es_client)
           expect(es_client).to have_received(:delete).with(index: "index", id: 123)
         end
+        it "returns mappings for Elasticsearch version 7, which does not include a type" do
+          expect(described_class.mappings_properties(a: :b)).to eq({ a: :b })
+        end
       end
 
       context "when Elasticsearch version is 6.x" do
@@ -115,6 +118,9 @@ RSpec.describe ElasticsearchClient do
         it "calls 'delete' with the right parameters, including type" do
           described_class.delete(id: 123, index_name: "index", client: es_client)
           expect(es_client).to have_received(:delete).with(index: "index", id: 123, type: "generic-document")
+        end
+        it "returns mappings for Elasticsearch version 6, which includes a type" do
+          expect(described_class.mappings_properties("generic-document" => { a: :b })).to eq({ a: :b })
         end
       end
     end

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe ElasticsearchClient do
   describe ".es7?" do
     let(:es_client) { double("Elasticsearch") }
+    let(:indices_client) { double("IndicesClient") }
     let(:version_info) { nil }
 
     after do
@@ -9,7 +10,8 @@ RSpec.describe ElasticsearchClient do
 
     before do
       allow(Services).to receive(:elasticsearch).and_return(es_client)
-      allow(es_client).to receive_messages(index: {}, search: {}, info: version_info)
+      allow(es_client).to receive_messages(index: {}, search: {}, indices: indices_client, info: version_info)
+      allow(indices_client).to receive_messages(put_mapping: {})
     end
 
     context "when USE_ELASTICSEARCH_7 is set" do
@@ -64,6 +66,11 @@ RSpec.describe ElasticsearchClient do
           expect(described_class.compatible_mappings({ a: :b }))
             .to eq({ "properties" => { a: :b } })
         end
+        it "calls 'put_mapping' with the right parameters, without including type" do
+          described_class.put_mapping(index_name: "index", mapping: { a: :b }, client: es_client)
+          expect(indices_client).to have_received(:put_mapping).with(index: "index",
+                                                                     body: { a: :b })
+        end
       end
 
       context "when Elasticsearch version is 6.x" do
@@ -90,6 +97,12 @@ RSpec.describe ElasticsearchClient do
         it "returns mappings with type" do
           expect(described_class.compatible_mappings({ a: :b }))
             .to eq("generic-document" => { "properties" => { a: :b } })
+        end
+        it "calls 'put_mapping' with the right parameters, including type" do
+          described_class.put_mapping(index_name: "index", mapping: { a: :b }, client: es_client)
+          expect(indices_client).to have_received(:put_mapping).with(index: "index",
+                                                                     body: { a: :b },
+                                                                     type: "generic-document")
         end
       end
     end

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -82,6 +82,9 @@ RSpec.describe ElasticsearchClient do
         it "returns mappings for Elasticsearch version 7, which does not include a type" do
           expect(described_class.mappings_properties(a: :b)).to eq({ a: :b })
         end
+        it "returns an identifier for bulk operations for Elasticsearch version 7, which does not include a type" do
+          expect(described_class.compatible_identifier({ a: :b })).to eq({ a: :b })
+        end
       end
 
       context "when Elasticsearch version is 6.x" do
@@ -121,6 +124,9 @@ RSpec.describe ElasticsearchClient do
         end
         it "returns mappings for Elasticsearch version 6, which includes a type" do
           expect(described_class.mappings_properties("generic-document" => { a: :b })).to eq({ a: :b })
+        end
+        it "returns an identifier for bulk operations for Elasticsearch version 6, which includes a type" do
+          expect(described_class.compatible_identifier({ a: :b })).to eq({ "_type" => "generic-document", a: :b })
         end
       end
     end

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can be searched" do
-    stub_get = stub_request(:post, "http://example.com:9200/govuk_test/generic-document/_search").with(
+    stub_get = stub_request(:post, "http://example.com:9200/#{SearchConfig.govuk_index_name}/_search").with(
       body: %r{"query":"keyword search"},
     ).to_return(
       body: '{"hits":{"hits":[]}}',

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can be searched" do
-    stub_get = stub_request(:get, "http://example.com:9200/govuk_test/generic-document/_search").with(
+    stub_get = stub_request(:post, "http://example.com:9200/govuk_test/generic-document/_search").with(
       body: %r{"query":"keyword search"},
     ).to_return(
       body: '{"hits":{"hits":[]}}',
@@ -77,7 +77,7 @@ RSpec.describe SearchIndices::Index do
 
   it "can fetch documents by format" do
     search_pattern = "http://example.com:9200/govuk_test/_search?scroll=1m&search_type=query_then_fetch&size=500&version=true"
-    stub_request(:get, search_pattern).with(
+    stub_request(:post, search_pattern).with(
       body: { query: { term: { format: "organisation" } }, _source: { includes: %w[title link] }, sort: %w[_doc] },
     ).to_return(
       body: { _scroll_id: "abcdefgh", hits: { total: 10, hits: [] } }.to_json,
@@ -102,7 +102,7 @@ RSpec.describe SearchIndices::Index do
   it "can fetch documents by format with certain fields" do
     search_pattern = "http://example.com:9200/govuk_test/_search?scroll=1m&search_type=query_then_fetch&size=500&version=true"
 
-    stub_request(:get, search_pattern).with(
+    stub_request(:post, search_pattern).with(
       body: "{\"query\":{\"term\":{\"format\":\"organisation\"}},\"_source\":{\"includes\":[\"title\",\"link\"]},\"sort\":[\"_doc\"]}",
     ).to_return(
       body: { _scroll_id: "abcdefgh", hits: { total: 10, hits: [] } }.to_json,
@@ -146,7 +146,7 @@ private
 
   def stub_popularity_index_requests(paths, popularity, total_pages = 10, total_requested = total_pages, paths_to_return = paths)
     # stub the request for total results
-    stub_request(:get, "http://example.com:9200/page-traffic_test/generic-document/_search")
+    stub_request(:post, "http://example.com:9200/page-traffic_test/generic-document/_search")
       .with(body: { "query" => { "match_all" => {} }, "size" => 0 }.to_json)
       .to_return(
         body: { "hits" => { "total" => total_pages } }.to_json,
@@ -181,7 +181,7 @@ private
       },
     }
 
-    stub_request(:get, "http://example.com:9200/page-traffic_test/generic-document/_search")
+    stub_request(:post, "http://example.com:9200/page-traffic_test/generic-document/_search")
       .with(body: expected_query.to_json)
       .to_return(
         body: response.to_json,

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe SearchIndices::Index do
 private
 
   def scroll_uri(scroll_id)
-    "http://example.com:9200/_search/scroll?scroll=1m&scroll_id=#{scroll_id}"
+    "http://example.com:9200/_search/scroll/#{scroll_id}?scroll=1m"
   end
 
   def scroll_response_body(scroll_id, total_results, results)

--- a/spec/unit/govuk_index/presenters/elasticsearch_delete_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_delete_presenter_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe GovukIndex::ElasticsearchDeletePresenter do
     allow_any_instance_of(described_class).to receive(:existing_document).and_return(existing_document)
 
     expected_identifier = {
-      _type: "generic-document",
       _id: "/cheese",
       version: 15,
       version_type: "external",

--- a/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
+++ b/spec/unit/govuk_index/presenters/elasticsearch_presenter_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe GovukIndex::ElasticsearchPresenter do
     payload = generate_random_example(payload: { payload_version: 1 })
 
     expected_identifier = {
-      _type: "generic-document",
       _id: payload["base_path"],
       version: 1,
       version_type: "external",

--- a/spec/unit/index/elasticsearch_processor_spec.rb
+++ b/spec/unit/index/elasticsearch_processor_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Index::ElasticsearchProcessor do
   it "saves valid document" do
     presenter = double(:presenter)
     allow(presenter).to receive(:identifier).and_return(
-      _type: "help_page",
       _id: "/cheese",
     )
     allow(presenter).to receive(:document).and_return(
@@ -32,7 +31,6 @@ RSpec.describe Index::ElasticsearchProcessor do
   it "deletes valid document" do
     presenter = double(:presenter)
     allow(presenter).to receive(:identifier).and_return(
-      _type: "help_page",
       _id: "/cheese",
     )
     allow(presenter).to receive(:document).and_return(

--- a/spec/unit/index_group_spec.rb
+++ b/spec/unit/index_group_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "switch index with no existing alias" do
     new_index = double("New index", index_name: "test-new")
-    get_stub = stub_request(:get, "#{base_uri}/_alias")
+    get_stub = stub_request(:get, "#{base_uri}/_alias/test")
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },
@@ -65,7 +65,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "switch index with existing alias" do
     new_index = double("New index", index_name: "test-new")
-    get_stub = stub_request(:get, "#{base_uri}/_alias")
+    get_stub = stub_request(:get, "#{base_uri}/_alias/test")
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },
@@ -94,7 +94,7 @@ RSpec.describe SearchIndices::IndexGroup do
   it "switch index with multiple existing aliases" do
     # Not expecting the system to get into this state, but it should cope
     new_index = double("New index", index_name: "test-new")
-    get_stub = stub_request(:get, "#{base_uri}/_alias")
+    get_stub = stub_request(:get, "#{base_uri}/_alias/test")
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },
@@ -124,7 +124,7 @@ RSpec.describe SearchIndices::IndexGroup do
 
   it "switch index with existing real index" do
     new_index = double("New index", index_name: "test-new")
-    stub_request(:get, "#{base_uri}/_alias")
+    stub_request(:get, "#{base_uri}/_alias/test")
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },

--- a/spec/unit/schema/index_schema_parser_spec.rb
+++ b/spec/unit/schema/index_schema_parser_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe IndexSchemaParser do
 
     it "include configuration for the `manual section` type in the `govuk` index" do
       es_mappings = @index_schemas["govuk"].es_mappings
-      expect(es_mappings.keys).to include("generic-document")
-      expect(es_mappings["generic-document"]["properties"]).to match(
+      expect(es_mappings["properties"]).to match(
         hash_including({
           "manual" => @identifier_es_config,
           "link" => @identifier_es_config,

--- a/spec/unit/search/aggregate_example_fetcher_spec.rb
+++ b/spec/unit/search/aggregate_example_fetcher_spec.rb
@@ -3,11 +3,6 @@ require "spec_helper"
 RSpec.describe Search::AggregateExampleFetcher do
   def query_for_example_global(field, value, return_fields)
     {
-      query: {
-        bool: {
-          must: nil,
-        },
-      },
       post_filter: { bool: { must: { term: { field => value } } } },
       size: 2,
       _source: {

--- a/spec/unit/services_spec.rb
+++ b/spec/unit/services_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe Services do
+  describe ".elasticsearch" do
+    before do
+      allow(Elasticsearch::Client).to receive(:new)
+    end
+
+    [
+      ["http://localhost", "http://localhost:9200"],
+      ["http://localhost:9200", "http://localhost:9200"],
+      ["https://example.com", "https://example.com:443"],
+      ["https://example.com:443", "https://example.com:443"],
+    ].each do |input, expected|
+      it "Ensures the URL has the correct port when it is #{input}" do
+        described_class.elasticsearch(hosts: input)
+
+        expect(Elasticsearch::Client).to have_received(:new)
+                                           .with(hash_including(hosts: expected))
+      end
+    end
+  end
+end

--- a/spec/unit/tasks/indices_spec.rb
+++ b/spec/unit/tasks/indices_spec.rb
@@ -236,15 +236,16 @@ RSpec.describe "indices" do
       expect(output).to include("Updating schema on cluster A")
 
       index_names.each do |index_name|
-        expect(indices_client).to have_received(:put_mapping).with(index: index_name, type: "generic-document", body: kind_of(Hash))
+        expect(indices_client).to have_received(:put_mapping).with(index: index_name, body: kind_of(Hash))
+
         expect(output).to include("Successfully synchronised #{index_name} index")
       end
     end
     it "reports failures" do
       failed_index_name = index_names.first
       allow(indices_client).to receive(:put_mapping)
-        .with(index: failed_index_name, type: "generic-document", body: kind_of(Hash))
-        .and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest.new("test error"))
+       .with(index: failed_index_name, body: kind_of(Hash))
+       .and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest.new("test error"))
 
       output = capture_stdout { Rake::Task[task_name].invoke }
       expect(output).to include("Unable to synchronise index #{failed_index_name} due to test error")

--- a/spec/unit/time_based_index_cleanup_spec.rb
+++ b/spec/unit/time_based_index_cleanup_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe SearchIndices::IndexGroup do
       },
     }
 
-    stub_request(:get, %r{#{base_uri}/test(.*?)/_search})
+    stub_request(:post, %r{#{base_uri}/test(.*?)/_search})
       .with(
         body: expected_timed_delete_body,
       ).to_return(


### PR DESCRIPTION
This PR ensures Search API can use the legacy Elasticseach 6.8 cluster as well as a newer Elasticsearch 7.10 cluster.

It uses the ElasticsearchClient class to query the cluster to determine the Elasticsearch version and then provides some simple abstractions to ensure compatibility.

Once we fully migrated to Elasticsearch 7.10, the ElasticsearchClient class can be removed.

This PR builds on https://github.com/alphagov/search-api/pull/3548, which upgrades the client gem

Jira: https://gov-uk.atlassian.net/browse/SCH-2026