### PR TITLE
Make Elasticdump rake task more robust

### DIFF
--- a/lib/elasticdump_runner.rb
+++ b/lib/elasticdump_runner.rb
@@ -12,7 +12,7 @@ class ElasticdumpRunner
     @output = parameters.fetch(:output)
     @type = parameters.fetch(:type, "data")
     @indices = parameters.fetch(:indices, SearchConfig.all_index_names)
-    @limit = parameters.fetch(:limit, 1000)
+    @limit = parameters.fetch(:limit, 1000).to_s
   end
 
   def call

--- a/spec/unit/elasticdump_runner_spec.rb
+++ b/spec/unit/elasticdump_runner_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ElasticdumpRunner do
           "--input", blue,
           "--output", green,
           "--type", "data",
-          "--limit", 1000,
+          "--limit", "1000",
           "--input-index", SearchConfig.all_index_names.first,
           "--output-index", SearchConfig.all_index_names.first
         )
@@ -61,7 +61,7 @@ RSpec.describe ElasticdumpRunner do
             "--input", blue,
             "--output", green,
             "--type", "data",
-            "--limit", 1000,
+            "--limit", "1000",
             "--input-index", index,
             "--output-index", index
           )
@@ -89,7 +89,7 @@ RSpec.describe ElasticdumpRunner do
           "--input", blue,
           "--output", green,
           "--type", "mapping",
-          "--limit", 50,
+          "--limit", "50",
           "--input-index", "only_index",
           "--output-index", "only_index"
         )

--- a/spec/unit/tasks/elasticdump_spec.rb
+++ b/spec/unit/tasks/elasticdump_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "elasticdump rake task" do
 
   before do
     allow(ElasticdumpRunner).to receive(:call)
-    allow(Kernel).to receive(:puts)
   end
 
   it "parses ELASTICDUMP_PARAMETERS from the environment with symbolized keys" do


### PR DESCRIPTION
The 'limit' parameter can now accept an integer or string. Previously this could only be a string.