### PR TITLE
Enable branch coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "pry"
 
 require "simplecov"
 SimpleCov.start do
+  enable_coverage :branch
   add_filter "/spec/"
   add_filter "/config/"
   add_filter "/env.rb"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,11 @@ require "pry"
 require "simplecov"
 SimpleCov.start do
   enable_coverage :branch
-  add_filter "/spec/"
-  add_filter "/config/"
-  add_filter "/env.rb"
-  track_files "{lib}/**/*.rb"
-  track_files "{lib}/**/*.rake"
+  skip "/spec/"
+  skip "/config/"
+  skip "/env.rb"
+  cover "{lib}/**/*.rb"
+  cover "{lib}/**/*.rake"
 end
 
 $LOAD_PATH << File.expand_path("..", __dir__)


### PR DESCRIPTION
Adds branch coverage to coverage report.

Also updates simplecov configuration to use new method names since the update to version 1.0.2. This removes deprecation warnings brought in by the upgrade: 
https://github.com/alphagov/search-api/actions/runs/29866977029/job/88757552706