### PR TITLE
Add VALOUR organisations to VSOs [WHIT-3883]

### DIFF
--- a/config/schema/elasticsearch_types/veterans_support_organisation.json
+++ b/config/schema/elasticsearch_types/veterans_support_organisation.json
@@ -10,6 +10,7 @@
     "veterans_support_organisation_region_england",
     "veterans_support_organisation_region_northern_ireland",
     "veterans_support_organisation_region_scotland",
-    "veterans_support_organisation_region_wales"
+    "veterans_support_organisation_region_wales",
+    "veterans_support_organisation_valour_organisations"
   ]
 }

--- a/config/schema/field_definitions.json
+++ b/config/schema/field_definitions.json
@@ -1091,6 +1091,10 @@
   "veterans_support_organisation_region_wales": {
     "type": "identifiers"
   },
+  "veterans_support_organisation_valour_organisations": {
+    "description": "List of VALOUR organisation types for this Veterans' support organisation",
+    "type": "identifiers"
+  },
   "sfo_case_state": {
     "description": "Whether a case is open or closed. Applies to SFO cases.",
     "type": "identifiers"

--- a/lib/govuk_index/presenters/elasticsearch_presenter.rb
+++ b/lib/govuk_index/presenters/elasticsearch_presenter.rb
@@ -269,6 +269,7 @@ module GovukIndex
         veterans_support_organisation_region_northern_ireland: specialist.veterans_support_organisation_region_northern_ireland,
         veterans_support_organisation_region_scotland: specialist.veterans_support_organisation_region_scotland,
         veterans_support_organisation_region_wales: specialist.veterans_support_organisation_region_wales,
+        veterans_support_organisation_valour_organisations: specialist.veterans_support_organisation_valour_organisations,
         view_count: common_fields.view_count,
         virus_strain: specialist.virus_strain,
         will_continue_on: specialist.will_continue_on,

--- a/lib/govuk_index/presenters/specialist_presenter.rb
+++ b/lib/govuk_index/presenters/specialist_presenter.rb
@@ -188,6 +188,7 @@ module GovukIndex
     delegate_to_payload :veterans_support_organisation_region_northern_ireland
     delegate_to_payload :veterans_support_organisation_region_scotland
     delegate_to_payload :veterans_support_organisation_region_wales
+    delegate_to_payload :veterans_support_organisation_valour_organisations
     delegate_to_payload :virus_strain
     delegate_to_payload :will_continue_on
     delegate_to_payload :withdrawn_date


### PR DESCRIPTION
Add the `valour_organisations` field to the Veterans Support Organisation finder, to service a support request (https://govuk.zendesk.com/agent/tickets/6784682).

Tested successfully in the integration env

https://gov-uk.atlassian.net/browse/WHIT-3883