### PR TITLE
Track total hits in search API

### DIFF
--- a/lib/elasticsearch_client.rb
+++ b/lib/elasticsearch_client.rb
@@ -29,7 +29,9 @@ module ElasticsearchClient
     end
 
     def search(index_name:, body:, client: Services.elasticsearch)
-      client.search(compatible_params(index: index_name, body:))
+      return client.search(index: index_name, track_total_hits: true, body: body) if es7?
+
+      client.search(index: index_name, type: "generic-document", body:)
     end
 
     def index(id:, index_name:, atts:, params: {}, client: Services.elasticsearch)

--- a/spec/unit/elasticsearch_client_spec.rb
+++ b/spec/unit/elasticsearch_client_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe ElasticsearchClient do
                                            search: {},
                                            indices: indices_client,
                                            delete: {},
-                                           info: version_info)
+                                           info: version_info,
+                                           track_total_hits: false)
       allow(indices_client).to receive_messages(put_mapping: {})
     end
 
@@ -57,6 +58,7 @@ RSpec.describe ElasticsearchClient do
         it "calls 'search' with the right parameters, without including type" do
           described_class.search(index_name: "index", body: { a: :b }, client: es_client)
           expect(es_client).to have_received(:search).with(index: "index",
+                                                           track_total_hits: true,
                                                            body: { a: :b })
         end
         it "calls 'index' with the right parameters, without including type" do
@@ -97,6 +99,7 @@ RSpec.describe ElasticsearchClient do
         it "calls 'search' with the right parameters, without including type" do
           described_class.search(index_name: "index", body: { a: :b }, client: es_client)
           expect(es_client).to have_received(:search).with(index: "index",
+                                                           track_total_hits: true,
                                                            body: { a: :b })
         end
         it "calls 'index' with the right parameters, without including type" do

--- a/spec/unit/elasticsearch_index_spec.rb
+++ b/spec/unit/elasticsearch_index_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SearchIndices::Index do
   end
 
   it "can be searched" do
-    stub_get = stub_request(:post, "http://example.com:9200/#{SearchConfig.govuk_index_name}/_search").with(
+    stub_get = stub_request(:post, "http://example.com:9200/#{SearchConfig.govuk_index_name}/_search?track_total_hits=true").with(
       body: %r{"query":"keyword search"},
     ).to_return(
       body: '{"hits":{"hits":[]}}',


### PR DESCRIPTION
Set track_total_hits: true so the Search API returns the exact number of matching documents.

Elasticsearch 7 changed the default to only count hits up to 10,000, returning relation: "gte" above that limit.

See: https://www.elastic.co/docs/solutions/search/the-search-api?track-total-hits

https://gov-uk.atlassian.net/browse/SCH-2304