### PR TITLE
Pin untrusted GitHub Actions to a commit SHA

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -44,7 +44,7 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-elasticsearch@main
 
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: alphagov/search-api
           ref: ${{ inputs.ref }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,13 +25,13 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: alphagov/search-api
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: alphagov/publishing-api
           ref: ${{ inputs.publishingApiRef }}


### PR DESCRIPTION
Pin untrusted non-alphagov actions.

To reduce security risks such as supply chain attacks and unexpectedly breaking changes.

As per policy: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha
