### PR TITLE
Sch 1964 document search analytics pipeline custom service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Note that when you run the tests locally logs are output to `log/production.log`
 - [Search relevancy](docs/relevancy.md): how relevancy ordering works when performing a search
 - [Schemas](docs/schemas.md): how to work with schemas and the document types
 - [Autocomplete](docs/autocomplete.md): how to get autocomplete suggestions for search queries - **not currently used by finder-frontend**
-- [Popularity](docs/updating_popularity): how popularity is updated
-- [Quality-metrics](docs/search-quality-metrics): how to assess the quality of results
+- [Popularity](docs/updating_popularity.md): how popularity is updated
+- [Quality-metrics](docs/search-quality-metrics.md): how to assess the quality of results
 
 ## Licence
 

--- a/docs/updating_popularity.md
+++ b/docs/updating_popularity.md
@@ -5,7 +5,8 @@ The GOV.UK Search API maintains several fields related to document popularity. T
 - **`page_traffic`** — fetches and processes traffic data from Google Analytics 4 (GA4), storing the results in the _page_traffic_ Elasticsearch index.
 - **`update_popularity`** — reads the processed data from the _page_traffic_ index and updates the popularity-related fields on documents in the main search index.
 
-Access to the Google Analytics 4 API is controlled by the following environment variables:
+Access to the Google Analytics 4 API is controlled by the [search-analytics-pipeline service account](https://github.com/alphagov/govuk-data-infrastructure/blob/main/ga4-analytics/service_account.tf#L20)
+and the following environment variables:
 - GOOGLE_ACCOUNT_TYPE
 - GOOGLE_CLIENT_EMAIL
 - GOOGLE_PRIVATE_KEY


### PR DESCRIPTION
Adds a reference to the [search-analytics-pipeline service account](https://github.com/alphagov/govuk-data-infrastructure/blob/main/ga4-analytics/service_account.tf#L20) in the search-api docs. This service account gives permissions to search-api to access data stored in the GA4 Analytics GCP project, for the page_traffic job to run. Adding a reference here, because it's not clear from the name of the service account what it is used for, and we want that information to be more easily findable.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1964