### PR TITLE
Remove left-over shingle configuration.

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -17,12 +17,6 @@ index:
           filter: [asciifolding, lowercase, stop, stemmer_override, stemmer_english]
           char_filter: [normalize_quotes, strip_quotes]
 
-        # Analyzer used at query time for old-style shingle matching.
-        shingled_query_analyzer:
-          type: custom
-          tokenizer: standard
-          filter: [asciifolding, lowercase, stemmer_override, stemmer_english, bigrams]
-
         # This analyzer does not filter out these stopwords:
         # a, an, and, are, as, at, be, but, by,
         # for, if, in, into, is, it,
@@ -100,11 +94,6 @@ index:
         stemmer_english:
           type: stemmer
           name: porter2
-        bigrams:
-          type: shingle
-          max_shingle_size: 2
-          min_shingle_size: 2
-          output_unigrams: false
     # The following settings were in puppet, but now index config
     # can't be applied from the nodes, so they have to live here.
     # This means that we can no longer (easily) have ci-agents or the


### PR DESCRIPTION
Most of this was removed here: https://github.com/alphagov/search-api/pull/3658

https://gov-uk.atlassian.net/browse/SCH-2153